### PR TITLE
Add Feishu and License providers and serializers

### DIFF
--- a/devmind/core/settings/base.py
+++ b/devmind/core/settings/base.py
@@ -405,6 +405,38 @@ FILE_UPLOAD_MAX_NUMBER_FILES = 100
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 # ============================
+# Logging Configuration
+# ============================
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "level": "INFO",
+        },
+    },
+    "root": {
+        "handlers": ["console"],
+        "level": "WARNING",
+    },
+    "loggers": {
+        # Data collector tasks (Celery workers)
+        "data_collector.tasks": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": False,
+        },
+        # Feishu provider (API + workers)
+        "data_collector.services.providers.feishu": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": False,
+        },
+    },
+}
+
+# ============================
 # URL Configuration
 # ============================
 # APPEND_SLASH: Controls Django's URL trailing slash behavior.

--- a/devmind/data_collector/serializers.py
+++ b/devmind/data_collector/serializers.py
@@ -99,8 +99,11 @@ class CollectorConfigSerializer(serializers.ModelSerializer):
 
 class CollectorConfigListSerializer(serializers.ModelSerializer):
     """
-    List view: uuid, platform, key, is_enabled, version, updated_at.
+    List view: uuid, platform, key, is_enabled, version, updated_at,
+    schedule_cron (from value, for list display).
     """
+
+    schedule_cron = serializers.SerializerMethodField()
 
     class Meta:
         model = CollectorConfig
@@ -111,7 +114,12 @@ class CollectorConfigListSerializer(serializers.ModelSerializer):
             "is_enabled",
             "version",
             "updated_at",
+            "schedule_cron",
         ]
+
+    def get_schedule_cron(self, obj):
+        value = getattr(obj, "value", None) or {}
+        return value.get("schedule_cron") or "0 */2 * * *"
 
 
 def _record_display_title(raw_data, source_unique_id, platform):
@@ -127,6 +135,21 @@ def _record_display_title(raw_data, source_unique_id, platform):
         summary = fields.get("summary")
         if summary:
             return summary
+    elif platform == "feishu":
+        # For Feishu we prefer approval (definition) name as title.
+        approval = raw_data.get("approval") or {}
+        title = approval.get("name")
+        if title:
+            return str(title)
+    elif platform == "license":
+        order = raw_data.get("order") or {}
+        code = order.get("code")
+        if code:
+            return str(code)
+        category = order.get("category") or {}
+        name = category.get("name") if isinstance(category, dict) else None
+        if name:
+            return str(name)
     return source_unique_id or ""
 
 

--- a/devmind/data_collector/services/providers/__init__.py
+++ b/devmind/data_collector/services/providers/__init__.py
@@ -2,12 +2,14 @@
 Platform providers for data collection. Use get_provider(platform) to resolve.
 """
 from .base import BaseProvider
-from .jira import JiraProvider
 from .feishu import FeishuProvider
+from .jira import JiraProvider
+from .license import LicenseProvider
 
 PROVIDER_MAPPING = {
-    "jira": JiraProvider,
     "feishu": FeishuProvider,
+    "jira": JiraProvider,
+    "license": LicenseProvider,
 }
 
 

--- a/devmind/data_collector/services/providers/feishu.py
+++ b/devmind/data_collector/services/providers/feishu.py
@@ -1,22 +1,478 @@
 """
-Feishu (Lark) approval provider. Placeholder implementation; collect/validate
-will call Feishu API when implemented.
+Feishu (Lark) approval provider.
+
+Design notes (aligned with JiraProvider):
+- Authentication: use app_id / app_secret to obtain tenant_access_token.
+- Step 2 "project list": reuse the fetch-projects endpoint to return approval
+  definitions as selectable items.
+- collect: for the configured approval definitions (project_keys) and time
+  range, pull approval instances and build the RawDataRecord payload shape.
+- validate: check each instance id via detail API; treat failures as deleted.
+- Attachments: extract file fields from the instance form, return attachment
+  metadata; download_attachment_content performs the actual download.
 """
+
+import hashlib
+import json
+import logging
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+import requests
+
 from .base import BaseProvider
+
+logger = logging.getLogger(__name__)
+
+FEISHU_BASE_URL = "https://open.feishu.cn"
+TENANT_TOKEN_URL = f"{FEISHU_BASE_URL}/open-apis/auth/v3/tenant_access_token/internal"
+APPROVAL_LIST_URL = f"{FEISHU_BASE_URL}/open-apis/approval/v4/approvals"
+# Use the newer instances query API to fetch approval instances
+INSTANCE_LIST_URL = f"{FEISHU_BASE_URL}/open-apis/approval/v4/instances/query"
+# Base path for approval instance detail API; final URL:
+#   {INSTANCE_DETAIL_URL}/{instance_code}
+INSTANCE_DETAIL_URL = f"{FEISHU_BASE_URL}/open-apis/approval/v4/instances"
+FILE_DOWNLOAD_URL_TEMPLATE = (
+    FEISHU_BASE_URL + "/open-apis/drive/v1/files/{file_token}/download"
+)
+# Contact API: get user name for approval timeline display
+CONTACT_USER_URL = f"{FEISHU_BASE_URL}/open-apis/contact/v3/users"
+
+
+def _to_unix_ms(dt: Any) -> int:
+    """
+    Convert datetime / ISO8601 string / timestamp to Feishu unix ms timestamp.
+    """
+    if isinstance(dt, (int, float)):
+        return int(dt * 1000)
+    if isinstance(dt, str):
+        try:
+            # 允许直接传 ISO8601 字符串
+            parsed = datetime.fromisoformat(dt.replace("Z", "+00:00"))
+            dt = parsed
+        except Exception:
+            return 0
+    if isinstance(dt, datetime):
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return int(dt.timestamp() * 1000)
+    return 0
+
+
+def _from_unix_ms(value: Any) -> datetime | None:
+    """
+    Convert Feishu millisecond timestamp (str/int) to timezone-aware datetime.
+    Returns None if value is falsy or cannot be parsed.
+    """
+    if value is None:
+        return None
+    try:
+        if isinstance(value, str):
+            value = value.strip()
+            if not value:
+                return None
+        ms = int(value)
+    except (TypeError, ValueError):
+        return None
+    # Feishu uses epoch milliseconds
+    try:
+        return datetime.fromtimestamp(ms / 1000.0, tz=timezone.utc)
+    except (OverflowError, OSError, ValueError):
+        return None
 
 
 class FeishuProvider(BaseProvider):
     """
     Feishu approval data collection provider.
+
+    Expected auth_config:
+    {
+        "app_id": "...",
+        "app_secret": "...",
+        # Optional: future extensions like tenant_key, user mapping, etc.
+    }
     """
+
+    def __init__(self) -> None:
+        self._tenant_access_token: str | None = None
+        self._tenant_token_expire_at: float | None = None
+
+    # ---------- Internal HTTP / token helpers ----------
+
+    def _get_tenant_access_token(self, auth_config: dict) -> str:
+        app_id = (auth_config.get("app_id") or "").strip()
+        app_secret = (auth_config.get("app_secret") or "").strip()
+        if not app_id or not app_secret:
+            raise ValueError("Feishu app_id and app_secret are required")
+
+        now = time.time()
+        if (
+            self._tenant_access_token
+            and self._tenant_token_expire_at
+            and now < self._tenant_token_expire_at - 60
+        ):
+            return self._tenant_access_token
+
+        resp = requests.post(
+            TENANT_TOKEN_URL,
+            json={"app_id": app_id, "app_secret": app_secret},
+            timeout=15,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        code = data.get("code", data.get("code", -1))
+        if code != 0:
+            msg = data.get("msg") or data.get("message") or "Feishu auth failed"
+            raise ValueError(f"Feishu authentication failed: {msg}")
+        token = data.get("tenant_access_token") or data.get("tenant_accessToken")
+        if not token:
+            raise ValueError("Feishu auth response missing tenant_access_token")
+        expire = data.get("expire") or data.get("expire_in") or 3600
+        self._tenant_access_token = token
+        self._tenant_token_expire_at = now + int(expire)
+        return token
+
+    def _auth_headers(self, auth_config: dict) -> dict:
+        token = self._get_tenant_access_token(auth_config)
+        return {"Authorization": f"Bearer {token}"}
+
+    # ---------- Public API: auth / definitions / collect / validate ----------
 
     def authenticate(self, auth_config: dict) -> bool:
         """
-        Verify Feishu app credentials (app_id, app_secret, etc.).
+        Verify Feishu application credentials (app_id, app_secret).
         """
         if not auth_config:
             return False
-        return True
+        try:
+            logger.info(
+                "FeishuProvider.authenticate: validating app_id=%s",
+                (auth_config.get("app_id") or "").strip(),
+            )
+            self._get_tenant_access_token(auth_config)
+            logger.info("FeishuProvider.authenticate: success")
+            return True
+        except Exception as e:
+            logger.warning(f"FeishuProvider.authenticate failed: {e}")
+            return False
+
+    def list_projects(self, auth_config: dict) -> list[dict]:
+        """
+        Used by frontend step 2: return approval definition list.
+
+        To reuse the existing fetch-projects endpoint, we return:
+        [{\"key\": approval_code, \"id\": approval_code, \"name\": approval_name}, ...]
+        """
+        headers = self._auth_headers(auth_config)
+        logger.info("FeishuProvider.list_projects: fetching approval definitions")
+        try:
+            resp = requests.get(APPROVAL_LIST_URL, headers=headers, timeout=15)
+            resp.raise_for_status()
+            data = resp.json() or {}
+            items = (
+                (data.get("data") or {}).get("approvals")
+                or (data.get("data") or {}).get("items")
+                or []
+            )
+            out: list[dict] = []
+            for item in items:
+                code = item.get("approval_code") or item.get("code")
+                name = item.get("name") or item.get("approval_name") or code
+                if not code:
+                    continue
+                out.append({"key": code, "id": str(code), "name": name})
+            logger.info(
+                "FeishuProvider.list_projects: fetched %d approval definitions",
+                len(out),
+            )
+            return out
+        except Exception as e:
+            logger.warning(f"FeishuProvider.list_projects failed: {e}")
+            raise
+
+    def _list_instances_for_approval(
+        self,
+        auth_config: dict,
+        approval_code: str,
+        start_time,
+        end_time,
+    ) -> list[dict]:
+        """
+        Call Feishu approval instances query API and return raw instances.
+        """
+        headers = self._auth_headers(auth_config)
+        start_ms = _to_unix_ms(start_time)
+        end_ms = _to_unix_ms(end_time)
+        if not start_ms or not end_ms:
+            return []
+
+        page_token = None
+        instances: list[dict] = []
+        while True:
+            payload: dict[str, Any] = {
+                "approval_code": approval_code,
+                # Per Feishu docs, use instance_start_time_* fields for time range
+                "instance_start_time_from": start_ms,
+                "instance_start_time_to": end_ms,
+                # Per Feishu docs, page_size max is 200
+                "page_size": 200,
+            }
+            if page_token:
+                payload["page_token"] = page_token
+            resp = requests.post(
+                INSTANCE_LIST_URL,
+                headers=headers,
+                json=payload,
+                timeout=30,
+            )
+            resp.raise_for_status()
+            data = resp.json() or {}
+            if data.get("code", 0) != 0:
+                msg = data.get("msg") or data.get("message") or "Feishu list instances failed"
+                raise ValueError(msg)
+            d = data.get("data") or {}
+            items = d.get("instance_list") or d.get("items") or []
+            instances.extend(items)
+            logger.info(
+                "FeishuProvider._list_instances_for_approval: approval_code=%s "
+                "fetched=%d, total_so_far=%d, page_token=%s",
+                approval_code,
+                len(items),
+                len(instances),
+                (d.get("page_token") or "")[:32],
+            )
+            page_token = d.get("page_token")
+            if not page_token:
+                break
+        return instances
+
+    def _get_instance_detail(
+        self,
+        auth_config: dict,
+        instance_code: str,
+    ) -> dict | None:
+        """
+        Fetch single approval instance detail (for validate or enrichment).
+        """
+        headers = self._auth_headers(auth_config)
+        url = f"{INSTANCE_DETAIL_URL}/{instance_code}"
+        resp = requests.get(url, headers=headers, timeout=15)
+        resp.raise_for_status()
+        data = resp.json() or {}
+        if data.get("code", 0) != 0:
+            msg = data.get("msg") or data.get("message") or "Feishu get instance failed"
+            logger.warning(
+                "FeishuProvider._get_instance_detail: instance_code=%s error=%s",
+                instance_code,
+                msg,
+            )
+            return None
+        # Detail may be nested under data.instance or just data
+        d = data.get("data") or {}
+        detail = d.get("instance") or d
+        if not isinstance(detail, dict):
+            return None
+        return detail
+
+    def _collect_timeline_user_ids(self, instance: dict) -> list[str]:
+        """
+        Collect all unique user IDs from instance timeline (and CC ext.user_id_list).
+        Used to fetch display names via contact API.
+        """
+        timeline = (
+            instance.get("timeline")
+            or instance.get("time_line")
+            or instance.get("approval_timeline")
+            or []
+        )
+        if not isinstance(timeline, list):
+            return []
+        ids: set[str] = set()
+        for node in timeline:
+            if not isinstance(node, dict):
+                continue
+            for key in ("user_id", "userId", "operator_id", "operatorId"):
+                val = node.get(key)
+                if val is not None and str(val).strip():
+                    ids.add(str(val).strip())
+            user = node.get("user")
+            if isinstance(user, dict) and user.get("user_id"):
+                ids.add(str(user["user_id"]))
+            operator = node.get("operator")
+            if isinstance(operator, dict) and operator.get("user_id"):
+                ids.add(str(operator["user_id"]))
+            # CC node: ext.user_id_list or ext.user_id (ext may be dict or JSON string)
+            raw_type = node.get("type") or node.get("result") or ""
+            if str(raw_type).upper() == "CC":
+                ext = node.get("ext")
+                if not isinstance(ext, dict):
+                    ext = {}
+                id_list = ext.get("user_id_list") or node.get("user_id_list")
+                if id_list is None and ext.get("user_id") is not None:
+                    id_list = [ext["user_id"]]
+                if id_list is not None:
+                    for uid in id_list if isinstance(id_list, list) else [id_list]:
+                        if uid is not None and str(uid).strip():
+                            ids.add(str(uid).strip())
+        return list(ids)
+
+    def _fetch_user_name(self, auth_config: dict, user_id: str) -> str | None:
+        """
+        Fetch user display name from Feishu contact API.
+        Requires app scope contact:user.base (or similar). Returns None on failure.
+        """
+        if not user_id or not str(user_id).strip():
+            return None
+        user_id = str(user_id).strip()
+        headers = self._auth_headers(auth_config)
+        url = f"{CONTACT_USER_URL}/{user_id}"
+        params = {"user_id_type": "user_id"}
+        try:
+            resp = requests.get(url, headers=headers, params=params, timeout=10)
+            resp.raise_for_status()
+            data = resp.json() or {}
+        except Exception as e:
+            logger.warning(
+                "FeishuProvider._fetch_user_name failed user_id=%s: %s",
+                user_id,
+                e,
+            )
+            return None
+        if data.get("code", 0) != 0:
+            return None
+        user = (data.get("data") or {}).get("user")
+        if not isinstance(user, dict):
+            return None
+        name = user.get("name") or user.get("en_name") or user.get("nickname")
+        if name is not None and str(name).strip():
+            return str(name).strip()
+        return None
+
+    def _instance_to_item(
+        self,
+        approval_code: str,
+        approval: dict,
+        group: dict,
+        instance: dict,
+        attachments: list[dict],
+    ) -> dict | None:
+        """
+        Convert a Feishu approval instance into the RawDataRecord item shape.
+        """
+        if not isinstance(instance, dict):
+            return None
+        instance_code = (
+            instance.get("instance_code")
+            or instance.get("instance_id")
+            or instance.get("id")
+        )
+        if not instance_code:
+            return None
+        status = instance.get("status") or instance.get("approval_status")
+        start_raw = (
+            instance.get("start_time")
+            or instance.get("create_time")
+            or instance.get("create_timestamp")
+        )
+        end_raw = (
+            instance.get("end_time")
+            or instance.get("update_time")
+            or instance.get("update_timestamp")
+        )
+        start_time = _from_unix_ms(start_raw)
+        end_time = _from_unix_ms(end_raw)
+
+        raw_data = {
+            "approval": approval,
+            "group": group,
+            "instance": instance,
+            "approval_code": approval_code,
+            "attachments": attachments or [],
+        }
+        payload = json.dumps(raw_data, sort_keys=True, default=str)
+        data_hash = hashlib.sha256(payload.encode()).hexdigest()
+        approval_name = (approval or {}).get("name")
+        filter_metadata = {
+            "approval_code": approval_code,
+            "approval_name": approval_name,
+            "status": status,
+        }
+        return {
+            "source_unique_id": str(instance_code),
+            "raw_data": raw_data,
+            "filter_metadata": filter_metadata,
+            "data_hash": data_hash,
+            "source_created_at": start_time,
+            "source_updated_at": end_time,
+        }
+
+    def _extract_attachments(self, instance: dict) -> list[dict]:
+        """
+        Extract file-type fields from the instance form and build attachment
+        metadata.
+
+        Typical (simplified) structure:
+        form = [
+            {"type": "file", "name": "Attachment", "value": [{"file_token": "..."}]},
+            ...
+        ]
+        """
+        form = instance.get("form") or instance.get("form_content") or []
+        if not isinstance(form, list):
+            return []
+        attachments: list[dict] = []
+        for field in form:
+            if not isinstance(field, dict):
+                continue
+            f_type = field.get("type")
+            if f_type not in ("file", "attachment"):
+                continue
+            values = field.get("value") or []
+            if not isinstance(values, list):
+                values = [values]
+            for v in values:
+                if not isinstance(v, dict):
+                    continue
+                file_token = v.get("file_token") or v.get("fileKey") or v.get("token")
+                if not file_token:
+                    continue
+                file_name = v.get("name") or v.get("file_name") or file_token
+                file_type = v.get("mime_type") or v.get("type") or ""
+                file_size = v.get("size") or 0
+                created_raw = instance.get("start_time") or instance.get("create_time")
+                updated_raw = instance.get("end_time") or instance.get("update_time")
+                attachments.append(
+                    {
+                        "source_file_id": str(file_token),
+                        "file_name": str(file_name),
+                        "file_url": FILE_DOWNLOAD_URL_TEMPLATE.format(
+                            file_token=file_token
+                        ),
+                        "file_type": str(file_type),
+                        "file_size": int(file_size) if file_size else 0,
+                        "source_created_at": _from_unix_ms(created_raw),
+                        "source_updated_at": _from_unix_ms(updated_raw),
+                    }
+                )
+        return attachments
+
+    def _extract_attachments_from_detail(self, detail: dict) -> list[dict]:
+        """
+        Extract attachments from instance detail response.
+
+        Detail may be either:
+        - the instance object itself (with form/form_content), or
+        - a wrapper containing an "instance" key.
+        """
+        if not isinstance(detail, dict):
+            return []
+        # If detail has an "instance" key that is a dict, drill into it
+        inst = detail.get("instance")
+        if isinstance(inst, dict):
+            return self._extract_attachments(inst)
+        # Otherwise treat detail as the instance object
+        return self._extract_attachments(detail)
 
     def collect(
         self,
@@ -28,9 +484,90 @@ class FeishuProvider(BaseProvider):
         **kwargs,
     ) -> list[dict]:
         """
-        Fetch Feishu approval instances in time range. Placeholder returns [].
+        Collect approval instances within the given time window.
+
+        kwargs:
+        - project_keys: List[str], approval definition codes selected in step 2.
         """
-        return []
+        if not auth_config:
+            return []
+        approval_codes: list[str] = kwargs.get("project_keys") or []
+        if not approval_codes:
+            # If not explicitly configured, default to all approval definitions.
+            try:
+                defs = self.list_projects(auth_config)
+                approval_codes = [d["key"] for d in defs if d.get("key")]
+            except Exception as e:
+                logger.warning(
+                    f"FeishuProvider.collect list_projects failed: {e}"
+                )
+                return []
+
+        logger.info(
+            "FeishuProvider.collect: start, approval_codes=%s, "
+            "start_time=%s, end_time=%s, user_id=%s",
+            approval_codes,
+            start_time,
+            end_time,
+            user_id,
+        )
+        items: list[dict] = []
+        user_name_cache: dict[str, str | None] = {}
+        for code in approval_codes:
+            try:
+                instances = self._list_instances_for_approval(
+                    auth_config, code, start_time, end_time
+                )
+            except Exception as e:
+                logger.warning(
+                    f"FeishuProvider.collect list instances failed "
+                    f"approval_code={code}: {e}"
+                )
+                continue
+            for wrapper in instances:
+                if not isinstance(wrapper, dict):
+                    continue
+                approval = wrapper.get("approval") or {}
+                group = wrapper.get("group") or {}
+                inst_meta = wrapper.get("instance") or {}
+                instance_code = inst_meta.get("code")
+                if not instance_code:
+                    continue
+                # Fetch full instance detail to enrich data and extract attachments
+                detail = self._get_instance_detail(auth_config, instance_code)
+                full_instance = inst_meta
+                if isinstance(detail, dict):
+                    # Prefer detail.instance if present, else detail itself
+                    inst_from_detail = detail.get("instance")
+                    if isinstance(inst_from_detail, dict):
+                        full_instance = inst_from_detail
+                    else:
+                        full_instance = detail
+                attachments = self._extract_attachments_from_detail(full_instance)
+                # Enrich instance with user_map (user_id -> name) for approval flow display
+                user_ids = self._collect_timeline_user_ids(full_instance)
+                user_map: dict[str, str] = {}
+                for uid in user_ids:
+                    if uid not in user_name_cache:
+                        user_name_cache[uid] = self._fetch_user_name(auth_config, uid)
+                    if user_name_cache.get(uid):
+                        user_map[uid] = user_name_cache[uid]
+                full_instance["user_map"] = user_map
+                item = self._instance_to_item(
+                    code,
+                    approval,
+                    group,
+                    full_instance,
+                    attachments,
+                )
+                if item:
+                    items.append(item)
+        logger.info(
+            "FeishuProvider.collect: done, approval_codes=%s, items=%d",
+            approval_codes,
+            len(items),
+        )
+        return items
 
     def validate(
         self,
@@ -42,12 +579,63 @@ class FeishuProvider(BaseProvider):
         source_unique_ids: list[str],
     ) -> list[str]:
         """
-        Return approval instance ids that no longer exist. Placeholder: [].
+        Check whether the given instance ids still exist on Feishu.
+
+        Simple implementation: query each instance detail; if the API errors or
+        returns nothing, treat the instance as deleted.
         """
-        return []
+        if not auth_config or not source_unique_ids:
+            return []
+        missing: list[str] = []
+        for sid in source_unique_ids:
+            try:
+                inst = self._get_instance_detail(auth_config, sid)
+            except Exception:
+                inst = None
+            if not inst:
+                missing.append(sid)
+        return missing
 
     def fetch_attachments(self, auth_config: dict, raw_record) -> list[dict]:
         """
-        Fetch attachments for a Feishu approval. Placeholder returns [].
+        Return attachment metadata list from RawDataRecord.raw_data.
+
+        RawDataRecord.raw_data structure:
+        {
+            "instance": {...},
+            "approval_code": "...",
+            "attachments": [...]
+        }
         """
-        return []
+        raw_data = getattr(raw_record, "raw_data", None) or {}
+        if not isinstance(raw_data, dict):
+            return []
+        attachments = raw_data.get("attachments") or []
+        if not isinstance(attachments, list):
+            return []
+        return attachments
+
+    def download_attachment_content(
+        self,
+        auth_config: dict,
+        attachment_meta: dict,
+    ) -> bytes | None:
+        """
+        Download Feishu attachment file content using file_url.
+        """
+        if not attachment_meta:
+            return None
+        url = attachment_meta.get("file_url")
+        if not url:
+            return None
+        headers = self._auth_headers(auth_config)
+        try:
+            resp = requests.get(url, headers=headers, timeout=60)
+            resp.raise_for_status()
+            return resp.content
+        except Exception as e:
+            logger.warning(
+                "FeishuProvider.download_attachment_content failed "
+                f"url={url[:80]}: {e}"
+            )
+            return None

--- a/devmind/data_collector/services/providers/license.py
+++ b/devmind/data_collector/services/providers/license.py
@@ -1,0 +1,250 @@
+"""
+License platform provider.
+
+- Auth: base_url + username + password; POST /v1/auth/login to get api_key.
+- Step 2 exposes order collection only; step 3 config shape follows Jira
+  (project_keys, initial_range, etc.).
+- Collect: GET /v1/order/list with is_paginate=false,
+  filter_start_time/filter_end_time as UTC strings "YYYY-MM-DD HH:MM:SS";
+  source_unique_id uses the response field "code".
+"""
+
+import hashlib
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+import requests
+
+from .base import BaseProvider
+
+logger = logging.getLogger(__name__)
+
+
+def _to_utc_datetime_str(dt: Any) -> str:
+    """
+    Convert datetime to UTC string for filter_start_time/filter_end_time.
+    Format: "YYYY-MM-DD HH:MM:SS" (UTC).
+    """
+    if dt is None:
+        return ""
+    if isinstance(dt, str):
+        return dt
+    if isinstance(dt, datetime):
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        utc_dt = dt.astimezone(timezone.utc)
+        return utc_dt.strftime("%Y-%m-%d %H:%M:%S")
+    return str(dt)
+
+
+def _get_base_url(auth_config: dict) -> str:
+    base_url = (auth_config.get("base_url") or "").rstrip("/")
+    if not base_url:
+        raise ValueError("base_url (auth URL) is required")
+    return base_url
+
+
+class LicenseProvider(BaseProvider):
+    """
+    License platform data collection: order collection only.
+
+    Expected auth_config:
+    {
+        "base_url": "https://auth.example.com",
+        "username": "...",
+        "password": "...",
+    }
+    """
+
+    def __init__(self) -> None:
+        self._api_key: str | None = None
+        self._api_key_base_url: str | None = None
+
+    def _get_api_key(self, auth_config: dict) -> str:
+        base_url = _get_base_url(auth_config)
+        username = (auth_config.get("username") or "").strip()
+        password = (auth_config.get("password") or "").strip()
+        if not username or not password:
+            raise ValueError("License requires username and password")
+
+        if self._api_key and self._api_key_base_url == base_url:
+            return self._api_key
+
+        url = f"{base_url}/v1/auth/login"
+        payload = {"username": username, "password": password}
+        resp = requests.post(url, json=payload, timeout=15)
+        resp.raise_for_status()
+        data = resp.json() or {}
+        api_key = data.get("api_key")
+        if not api_key:
+            raise ValueError("Login response missing api_key")
+        self._api_key = api_key
+        self._api_key_base_url = base_url
+        return api_key
+
+    def _auth_headers(self, auth_config: dict) -> dict:
+        api_key = self._get_api_key(auth_config)
+        return {"Authorization": api_key}
+
+    def authenticate(self, auth_config: dict) -> bool:
+        """Verify connection using base_url, username, and password."""
+        if not auth_config:
+            return False
+        try:
+            self._get_api_key(auth_config)
+            logger.info("LicenseProvider.authenticate: success")
+            return True
+        except Exception as e:
+            logger.warning(f"LicenseProvider.authenticate failed: {e}")
+            return False
+
+    def list_projects(self, auth_config: dict) -> list[dict]:
+        """
+        Step 2: order collection only; return a single option for the frontend.
+        Shape aligned with Jira/Feishu: key, id, name.
+        """
+        return [
+            {"key": "order", "id": "order", "name": "Order collection"},
+        ]
+
+    def _order_raw_to_item(self, order: dict) -> dict | None:
+        """Convert raw order dict to collection item; source_unique_id=code."""
+        code = order.get("code")
+        if not code:
+            return None
+        raw_data = {"order": order}
+        payload = json.dumps(raw_data, sort_keys=True, default=str)
+        data_hash = hashlib.sha256(payload.encode()).hexdigest()
+        created_at = order.get("created_at")
+        updated_at = order.get("approval_at") or order.get("created_at")
+        category = order.get("category") or {}
+        category_id = (
+            category.get("id")
+            if isinstance(category, dict) and category.get("id") is not None
+            else order.get("category_id")
+        )
+        third_id = order.get("third_id")
+        filter_metadata = {}
+        if category_id is not None:
+            filter_metadata["category"] = category_id
+        if third_id is not None:
+            filter_metadata["third_id"] = third_id
+        return {
+            "source_unique_id": code,
+            "raw_data": raw_data,
+            "filter_metadata": filter_metadata,
+            "data_hash": data_hash,
+            "source_created_at": created_at,
+            "source_updated_at": updated_at,
+        }
+
+    def collect(
+        self,
+        auth_config: dict,
+        start_time: Any,
+        end_time: Any,
+        user_id: int,
+        platform: str,
+        **kwargs: Any,
+    ) -> list[dict]:
+        """
+        Fetch order list: GET /v1/order/list with is_paginate=false,
+        filter_start_time and filter_end_time as strings.
+        """
+        if not auth_config:
+            return []
+        project_keys = kwargs.get("project_keys") or []
+        if project_keys and "order" not in project_keys:
+            logger.info(
+                f"LicenseProvider.collect: project_keys={project_keys} "
+                f"does not include order, skip",
+            )
+            return []
+
+        base_url = _get_base_url(auth_config)
+        url = f"{base_url}/v1/order/list"
+        filter_start_time = _to_utc_datetime_str(start_time)
+        filter_end_time = _to_utc_datetime_str(end_time)
+        params = {
+            "is_paginate": "false",
+            "filter_start_time": filter_start_time,
+            "filter_end_time": filter_end_time,
+        }
+        headers = self._auth_headers(auth_config)
+        logger.info(
+            "LicenseProvider.collect: GET %s params=%s",
+            url,
+            params,
+        )
+        resp = requests.get(url, headers=headers, params=params, timeout=60)
+        resp.raise_for_status()
+        data = resp.json() or {}
+        items_raw = (
+            data.get("items") or data.get("data", {}).get("items") or []
+        )
+        out: list[dict] = []
+        for order in items_raw:
+            if not isinstance(order, dict):
+                continue
+            item = self._order_raw_to_item(order)
+            if item:
+                out.append(item)
+        logger.info(
+            f"LicenseProvider.collect: done, returning {len(out)} orders",
+        )
+        return out
+
+    def validate(
+        self,
+        auth_config: dict,
+        start_time: Any,
+        end_time: Any,
+        user_id: int,
+        platform: str,
+        source_unique_ids: list[str],
+    ) -> list[str]:
+        """
+        Check which orders still exist. Re-fetches list and compares codes
+        when no single-order detail API exists.
+        """
+        if not auth_config or not source_unique_ids:
+            return []
+        try:
+            base_url = _get_base_url(auth_config)
+            url = f"{base_url}/v1/order/list"
+            params = {
+                "is_paginate": "false",
+                "filter_start_time": _to_utc_datetime_str(start_time),
+                "filter_end_time": _to_utc_datetime_str(end_time),
+            }
+            headers = self._auth_headers(auth_config)
+            resp = requests.get(
+                url, headers=headers, params=params, timeout=60
+            )
+            resp.raise_for_status()
+            data = resp.json() or {}
+            items_raw = (
+                data.get("items")
+                or data.get("data", {}).get("items")
+                or []
+            )
+            existing_codes = {
+                str(o.get("code", ""))
+                for o in items_raw
+                if isinstance(o, dict) and o.get("code")
+            }
+            missing = [
+                sid for sid in source_unique_ids if sid not in existing_codes
+            ]
+            return missing
+        except Exception as e:
+            logger.warning(f"LicenseProvider.validate failed: {e}")
+            return []
+
+    def fetch_attachments(
+        self, auth_config: dict, raw_record: Any
+    ) -> list[dict]:
+        """Order collection has no attachments; return empty list."""
+        return []

--- a/devmind/data_collector/tasks.py
+++ b/devmind/data_collector/tasks.py
@@ -10,14 +10,14 @@ from datetime import timedelta
 
 from django.conf import settings
 from django.db import transaction
+from django.db.models import Prefetch
+from django.utils import timezone
+from django.utils.dateparse import parse_datetime
 from django.utils import translation
 from django.utils.translation import gettext as _
 
 from celery import current_task
 from celery import shared_task
-from django.db.models import Prefetch
-from django.utils import timezone
-from django.utils.dateparse import parse_datetime
 
 from agentcore_task.adapters.django import (
     TaskStatus,
@@ -170,27 +170,45 @@ def _sync_attachments_for_record(provider, auth_config, raw_record):
     return synced, removed
 
 
-def _register_and_start(task_id, config_uuid, lang=None):
+def _register_and_start(
+    task_id,
+    config_uuid,
+    lang=None,
+    platform: str | None = None,
+    config_key: str | None = None,
+    created_by=None,
+):
     if task_id:
+        metadata = {"config_uuid": config_uuid}
+        if platform:
+            metadata["config_platform"] = platform
+        if config_key:
+            metadata["config_key"] = config_key
         TaskTracker.register_task(
             task_id=task_id,
             task_name=MODULE_NAME + ".tasks.run_collect",
             module=MODULE_NAME,
             task_kwargs={"config_uuid": config_uuid},
-            metadata={"config_uuid": config_uuid},
+            metadata=metadata,
             initial_status=TaskStatus.STARTED,
+            created_by=created_by,
         )
         with translation.override(lang or settings.LANGUAGE_CODE):
             msg = _("Start collection")
+        metadata = {
+            "progress_percent": 0,
+            "progress_message": msg,
+            "progress_step": "start",
+            "config_uuid": config_uuid,
+        }
+        if platform:
+            metadata["config_platform"] = platform
+        if config_key:
+            metadata["config_key"] = config_key
         TaskTracker.update_task_status(
             task_id,
             TaskStatus.STARTED,
-            metadata={
-                "progress_percent": 0,
-                "progress_message": msg,
-                "progress_step": "start",
-                "config_uuid": config_uuid,
-            },
+            metadata=metadata,
         )
 
 
@@ -211,7 +229,7 @@ def run_collect(
     task_id = current_task.request.id if current_task else None
     logger.info(
         f"[data_collector] run_collect started, config_uuid={config_uuid}, "
-        f"task_id={task_id}, start_time={start_time}, end_time={end_time}"
+        f"task_id={task_id}, start_time={start_time}, end_time={end_time}",
     )
     try:
         config = CollectorConfig.objects.get(uuid=config_uuid)
@@ -231,7 +249,14 @@ def run_collect(
 
     value = config.value or {}
     lang = value.get("language") or settings.LANGUAGE_CODE
-    _register_and_start(task_id, config_uuid, lang)
+    _register_and_start(
+        task_id,
+        config_uuid,
+        lang,
+        platform=config.platform,
+        config_key=config.key,
+        created_by=config.user,
+    )
 
     logger.info(
         f"[data_collector] run_collect config loaded: "
@@ -252,7 +277,11 @@ def run_collect(
                     task_id,
                     TaskStatus.FAILURE,
                     error=err,
-                    metadata={"config_uuid": config_uuid},
+                    metadata={
+                        "config_uuid": config_uuid,
+                        "config_platform": config.platform,
+                        "config_key": config.key,
+                    },
                 )
             return {
                 "success": False,
@@ -269,7 +298,11 @@ def run_collect(
                     task_id,
                     TaskStatus.FAILURE,
                     error=err,
-                    metadata={"config_uuid": config_uuid},
+                    metadata={
+                        "config_uuid": config_uuid,
+                        "config_platform": config.platform,
+                        "config_key": config.key,
+                    },
                 )
             return {
                 "success": False,
@@ -282,12 +315,15 @@ def run_collect(
         start_time = start_dt
         end_time = end_dt
     elif runtime.get("first_collect_at") is None:
-        if initial_range == "1m":
-            start_time = now - timedelta(days=30)
-        elif initial_range == "3m":
-            start_time = now - timedelta(days=90)
-        else:
-            start_time = now - timedelta(days=30)
+        # First run: lookback from initial_range; supports "m" and "d" styles.
+        lookback_days = 30
+        if initial_range in ("1m", "30d"):
+            lookback_days = 30
+        elif initial_range in ("3m", "90d"):
+            lookback_days = 90
+        elif initial_range == "10d":
+            lookback_days = 10
+        start_time = now - timedelta(days=lookback_days)
         end_time = now
         logger.info(
             f"[data_collector] run_collect first run, "
@@ -340,6 +376,9 @@ def run_collect(
     if provider_cls:
         provider = provider_cls()
         auth_config = value.get("auth") or {}
+        base_url = value.get("base_url") or auth_config.get("base_url")
+        if base_url:
+            auth_config = {**auth_config, "base_url": base_url}
         logger.info(
             f"[data_collector] run_collect calling provider.collect "
             f"platform={config.platform}, start={start_time}, end={end_time}"
@@ -363,7 +402,11 @@ def run_collect(
                     task_id,
                     TaskStatus.FAILURE,
                     error=str(e),
-                    metadata={"config_uuid": config_uuid},
+                    metadata={
+                        "config_uuid": config_uuid,
+                        "config_platform": config.platform,
+                        "config_key": config.key,
+                    },
                 )
             raise
 
@@ -524,6 +567,8 @@ def run_collect(
                 "progress_message": msg,
                 "progress_step": "done",
                 "config_uuid": config_uuid,
+                "config_platform": config.platform,
+                "config_key": config.key,
                 "records_created": records_created,
                 "records_updated": records_updated,
                 "records_collected": n_collected,
@@ -552,6 +597,11 @@ def run_cleanup(config_uuid: str):
     update runtime_state.last_cleanup_at. Uses TaskTracker and metadata.
     """
     task_id = current_task.request.id if current_task else None
+    try:
+        config = CollectorConfig.objects.get(uuid=config_uuid)
+    except CollectorConfig.DoesNotExist:
+        config = None
+
     if task_id:
         TaskTracker.register_task(
             task_id=task_id,
@@ -560,8 +610,13 @@ def run_cleanup(config_uuid: str):
             task_kwargs={"config_uuid": config_uuid},
             metadata={"config_uuid": config_uuid},
             initial_status=TaskStatus.STARTED,
+            created_by=config.user if config else None,
         )
-        with translation.override(settings.LANGUAGE_CODE):
+        lang_override = (
+            (config.value or {}).get("language") if config
+            else settings.LANGUAGE_CODE
+        )
+        with translation.override(lang_override):
             msg = _("Start cleanup")
         TaskTracker.update_task_status(
             task_id,
@@ -574,9 +629,7 @@ def run_cleanup(config_uuid: str):
             },
         )
 
-    try:
-        config = CollectorConfig.objects.get(uuid=config_uuid)
-    except CollectorConfig.DoesNotExist:
+    if not config:
         if task_id:
             TaskTracker.update_task_status(
                 task_id,
@@ -604,8 +657,11 @@ def run_cleanup(config_uuid: str):
                     try:
                         if os.path.isfile(att.file_path):
                             os.remove(att.file_path)
-                    except OSError:
-                        pass
+                    except OSError as e:
+                        logger.warning(
+                            f"[data_collector] run_cleanup remove file "
+                            f"failed path={att.file_path[:80]}: {e}"
+                        )
             rec.delete()
         runtime["last_cleanup_at"] = timezone.now().isoformat()
         value["runtime_state"] = runtime
@@ -624,6 +680,8 @@ def run_cleanup(config_uuid: str):
                 "progress_message": msg,
                 "records_deleted": count,
                 "config_uuid": config_uuid,
+                "config_platform": config.platform,
+                "config_key": config.key,
             },
         )
 
@@ -637,6 +695,11 @@ def run_validate(config_uuid: str, start_time: str, end_time: str):
     Uses TaskTracker and metadata.
     """
     task_id = current_task.request.id if current_task else None
+    try:
+        config = CollectorConfig.objects.get(uuid=config_uuid)
+    except CollectorConfig.DoesNotExist:
+        config = None
+
     if task_id:
         TaskTracker.register_task(
             task_id=task_id,
@@ -649,11 +712,10 @@ def run_validate(config_uuid: str, start_time: str, end_time: str):
             },
             metadata={"config_uuid": config_uuid},
             initial_status=TaskStatus.STARTED,
+            created_by=config.user if config else None,
         )
 
-    try:
-        config = CollectorConfig.objects.get(uuid=config_uuid)
-    except CollectorConfig.DoesNotExist:
+    if not config:
         if task_id:
             TaskTracker.update_task_status(
                 task_id,
@@ -672,6 +734,22 @@ def run_validate(config_uuid: str, start_time: str, end_time: str):
         if isinstance(end_time, str)
         else end_time
     )
+    if st is None or et is None:
+        err = "Invalid start_time or end_time format."
+        if task_id:
+            value = config.value or {}
+            TaskTracker.update_task_status(
+                task_id,
+                TaskStatus.FAILURE,
+                error=err,
+                metadata={
+                    "config_uuid": config_uuid,
+                    "config_platform": config.platform,
+                    "config_key": config.key,
+                },
+            )
+        return {"success": False, "error": err}
+
     records = list(
         RawDataRecord.objects.filter(
             user_id=config.user_id,
@@ -686,7 +764,11 @@ def run_validate(config_uuid: str, start_time: str, end_time: str):
     missing = []
     if provider_cls:
         provider = provider_cls()
-        auth_config = (config.value or {}).get("auth") or {}
+        value = config.value or {}
+        auth_config = value.get("auth") or {}
+        base_url = value.get("base_url") or auth_config.get("base_url")
+        if base_url:
+            auth_config = {**auth_config, "base_url": base_url}
         missing = provider.validate(
             auth_config,
             st,
@@ -716,6 +798,8 @@ def run_validate(config_uuid: str, start_time: str, end_time: str):
                 "records_validated": len(records),
                 "records_marked_deleted": len(missing),
                 "config_uuid": config_uuid,
+                "config_platform": config.platform,
+                "config_key": config.key,
             },
         )
 

--- a/devmind/data_collector/tests/test_apps.py
+++ b/devmind/data_collector/tests/test_apps.py
@@ -1,0 +1,18 @@
+"""
+Unit tests for data_collector app config.
+"""
+import pytest
+
+from data_collector.apps import DataCollectorConfig
+
+
+@pytest.mark.unit
+class TestDataCollectorConfig:
+    def test_app_name(self):
+        assert DataCollectorConfig.name == "data_collector"
+
+    def test_verbose_name(self):
+        assert DataCollectorConfig.verbose_name == "Data Collector"
+
+    def test_default_auto_field(self):
+        assert DataCollectorConfig.default_auto_field == "django.db.models.BigAutoField"

--- a/devmind/data_collector/tests/test_conf.py
+++ b/devmind/data_collector/tests/test_conf.py
@@ -1,0 +1,19 @@
+"""
+Unit tests for data_collector conf (get_data_collector_root).
+"""
+import pytest
+
+from data_collector.conf import DATA_COLLECTOR_ROOT, get_data_collector_root
+
+
+@pytest.mark.unit
+class TestConf:
+    def test_get_data_collector_root_returns_root(self):
+        root = get_data_collector_root()
+        assert root == DATA_COLLECTOR_ROOT
+        assert isinstance(root, str)
+        assert len(root) > 0
+
+    def test_data_collector_root_defined(self):
+        assert DATA_COLLECTOR_ROOT is not None
+        assert isinstance(DATA_COLLECTOR_ROOT, str)

--- a/devmind/data_collector/tests/test_providers_feishu.py
+++ b/devmind/data_collector/tests/test_providers_feishu.py
@@ -1,0 +1,102 @@
+"""
+Unit tests for Feishu provider: time helpers, authenticate, list_projects, fetch_attachments.
+"""
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+from data_collector.services.providers.feishu import (
+    FeishuProvider,
+    _from_unix_ms,
+    _to_unix_ms,
+)
+
+
+@pytest.mark.unit
+class TestFeishuTimeHelpers:
+    def test_to_unix_ms_from_datetime_utc(self):
+        dt = datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        ms = _to_unix_ms(dt)
+        assert isinstance(ms, int)
+        assert ms == 1736942400000
+
+    def test_to_unix_ms_from_iso_string(self):
+        ms = _to_unix_ms("2025-01-15T12:00:00+00:00")
+        assert isinstance(ms, int)
+        assert ms == 1736942400000
+
+    def test_to_unix_ms_from_timestamp_seconds(self):
+        ms = _to_unix_ms(1736942400)
+        assert ms == 1736942400000
+
+    def test_from_unix_ms_returns_datetime(self):
+        dt = _from_unix_ms(1736942400000)
+        assert dt is not None
+        assert dt.year == 2025
+        assert dt.month == 1
+        assert dt.day == 15
+
+    def test_from_unix_ms_none_for_invalid(self):
+        assert _from_unix_ms(None) is None
+        assert _from_unix_ms("") is None
+
+
+@pytest.mark.unit
+class TestFeishuProviderAuthenticate:
+    def test_authenticate_returns_false_when_empty_config(self):
+        provider = FeishuProvider()
+        assert provider.authenticate({}) is False
+
+    @patch("data_collector.services.providers.feishu.requests.post")
+    def test_authenticate_success(self, mock_post):
+        mock_post.return_value.json.return_value = {
+            "code": 0,
+            "tenant_access_token": "t",
+            "expire": 7200,
+        }
+        mock_post.return_value.raise_for_status = lambda: None
+        provider = FeishuProvider()
+        assert provider.authenticate({"app_id": "id", "app_secret": "secret"}) is True
+
+    @patch("data_collector.services.providers.feishu.requests.post")
+    def test_authenticate_failure_returns_false(self, mock_post):
+        mock_post.side_effect = ValueError("invalid credentials")
+        provider = FeishuProvider()
+        assert provider.authenticate({"app_id": "id", "app_secret": "wrong"}) is False
+
+
+@pytest.mark.unit
+class TestFeishuProviderListProjects:
+    @patch("data_collector.services.providers.feishu.requests.post")
+    @patch("data_collector.services.providers.feishu.requests.get")
+    def test_list_projects_returns_approval_definitions(self, mock_get, mock_post):
+        mock_post.return_value.json.return_value = {
+            "code": 0,
+            "tenant_access_token": "t",
+            "expire": 7200,
+        }
+        mock_post.return_value.raise_for_status = lambda: None
+        mock_get.return_value.json.return_value = {
+            "data": {
+                "approvals": [
+                    {"approval_code": "leave", "name": "请假"},
+                    {"approval_code": "expense", "name": "报销"},
+                ]
+            }
+        }
+        mock_get.return_value.raise_for_status = lambda: None
+        provider = FeishuProvider()
+        projects = provider.list_projects({"app_id": "id", "app_secret": "secret"})
+        assert len(projects) == 2
+        assert projects[0]["key"] == "leave"
+        assert projects[0]["name"] == "请假"
+
+
+@pytest.mark.unit
+class TestFeishuProviderFetchAttachments:
+    def test_fetch_attachments_returns_list_from_form(self):
+        provider = FeishuProvider()
+        record = type("Rec", (), {"raw_data": {}})()
+        out = provider.fetch_attachments({}, record)
+        assert isinstance(out, list)

--- a/devmind/data_collector/tests/test_providers_license.py
+++ b/devmind/data_collector/tests/test_providers_license.py
@@ -1,0 +1,163 @@
+"""
+Unit tests for License provider: _to_utc_datetime_str, _get_base_url,
+LicenseProvider.list_projects, _order_raw_to_item, authenticate, collect, validate, fetch_attachments.
+"""
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+from data_collector.services.providers.license import (
+    LicenseProvider,
+    _get_base_url,
+    _to_utc_datetime_str,
+)
+
+
+@pytest.mark.unit
+class TestLicenseHelpers:
+    def test_to_utc_datetime_str_from_datetime(self):
+        dt = datetime(2025, 1, 15, 12, 30, 0, tzinfo=timezone.utc)
+        s = _to_utc_datetime_str(dt)
+        assert s == "2025-01-15 12:30:00"
+
+    def test_to_utc_datetime_str_none_returns_empty(self):
+        assert _to_utc_datetime_str(None) == ""
+
+    def test_to_utc_datetime_str_string_passthrough(self):
+        assert _to_utc_datetime_str("2025-01-01 00:00:00") == "2025-01-01 00:00:00"
+
+    def test_get_base_url_raises_when_empty(self):
+        with pytest.raises(ValueError, match="base_url"):
+            _get_base_url({})
+        with pytest.raises(ValueError, match="base_url"):
+            _get_base_url({"base_url": ""})
+
+    def test_get_base_url_strips_trailing_slash(self):
+        assert _get_base_url({"base_url": "https://auth.example.com/"}) == "https://auth.example.com"
+
+
+@pytest.mark.unit
+class TestLicenseProviderListProjects:
+    def test_list_projects_returns_order_option(self):
+        provider = LicenseProvider()
+        projects = provider.list_projects({})
+        assert len(projects) == 1
+        assert projects[0]["key"] == "order"
+        assert projects[0]["name"] == "Order collection"
+
+
+@pytest.mark.unit
+class TestLicenseProviderOrderRawToItem:
+    def test_order_raw_to_item_returns_none_when_no_code(self):
+        provider = LicenseProvider()
+        assert provider._order_raw_to_item({}) is None
+        assert provider._order_raw_to_item({"code": ""}) is None
+
+    def test_order_raw_to_item_returns_item_with_code_and_hash(self):
+        provider = LicenseProvider()
+        order = {
+            "code": "ORD-001",
+            "created_at": "2025-01-01T00:00:00Z",
+            "approval_at": "2025-01-02T00:00:00Z",
+            "category": {"id": 1},
+            "third_id": "ext-1",
+        }
+        item = provider._order_raw_to_item(order)
+        assert item is not None
+        assert item["source_unique_id"] == "ORD-001"
+        assert item["raw_data"]["order"] == order
+        assert len(item["data_hash"]) == 64
+        assert item["filter_metadata"].get("category") == 1
+        assert item["filter_metadata"].get("third_id") == "ext-1"
+
+
+@pytest.mark.unit
+class TestLicenseProviderAuthenticate:
+    def test_authenticate_returns_false_when_empty_config(self):
+        provider = LicenseProvider()
+        assert provider.authenticate({}) is False
+
+    @patch("data_collector.services.providers.license.requests.post")
+    def test_authenticate_success(self, mock_post):
+        mock_post.return_value.json.return_value = {"api_key": "key123"}
+        mock_post.return_value.raise_for_status = lambda: None
+        provider = LicenseProvider()
+        assert provider.authenticate({
+            "base_url": "https://auth.example.com",
+            "username": "u",
+            "password": "p",
+        }) is True
+
+
+@pytest.mark.unit
+class TestLicenseProviderCollect:
+    @patch("data_collector.services.providers.license.requests.post")
+    @patch("data_collector.services.providers.license.requests.get")
+    def test_collect_returns_orders_from_api(self, mock_get, mock_post):
+        mock_post.return_value.json.return_value = {"api_key": "k"}
+        mock_post.return_value.raise_for_status = lambda: None
+        mock_get.return_value.json.return_value = {
+            "items": [
+                {"code": "ORD-1", "created_at": None, "approval_at": None},
+            ]
+        }
+        mock_get.return_value.raise_for_status = lambda: None
+        provider = LicenseProvider()
+        start = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        end = datetime(2025, 1, 2, tzinfo=timezone.utc)
+        items = provider.collect(
+            {"base_url": "https://auth.example.com", "username": "u", "password": "p"},
+            start,
+            end,
+            user_id=1,
+            platform="license",
+            project_keys=["order"],
+        )
+        assert len(items) == 1
+        assert items[0]["source_unique_id"] == "ORD-1"
+
+    def test_collect_skips_when_project_keys_exclude_order(self):
+        provider = LicenseProvider()
+        items = provider.collect(
+            {"base_url": "https://x.com", "username": "u", "password": "p"},
+            None,
+            None,
+            user_id=1,
+            platform="license",
+            project_keys=["other"],
+        )
+        assert items == []
+
+
+@pytest.mark.unit
+class TestLicenseProviderValidate:
+    @patch("data_collector.services.providers.license.requests.post")
+    @patch("data_collector.services.providers.license.requests.get")
+    def test_validate_returns_missing_codes(self, mock_get, mock_post):
+        mock_post.return_value.json.return_value = {"api_key": "k"}
+        mock_post.return_value.raise_for_status = lambda: None
+        mock_get.return_value.json.return_value = {
+            "items": [{"code": "ORD-1"}],
+        }
+        mock_get.return_value.raise_for_status = lambda: None
+        provider = LicenseProvider()
+        start = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        end = datetime(2025, 1, 2, tzinfo=timezone.utc)
+        missing = provider.validate(
+            {"base_url": "https://auth.example.com", "username": "u", "password": "p"},
+            start,
+            end,
+            user_id=1,
+            platform="license",
+            source_unique_ids=["ORD-1", "ORD-2"],
+        )
+        assert missing == ["ORD-2"]
+
+
+@pytest.mark.unit
+class TestLicenseProviderFetchAttachments:
+    def test_fetch_attachments_returns_empty(self):
+        provider = LicenseProvider()
+        record = type("Rec", (), {"raw_data": {}})()
+        assert provider.fetch_attachments({}, record) == []

--- a/devmind/data_collector/tests/test_serializers.py
+++ b/devmind/data_collector/tests/test_serializers.py
@@ -1,0 +1,225 @@
+"""
+Unit tests for data_collector serializers and Conflict exception.
+"""
+import pytest
+from rest_framework.exceptions import ValidationError
+
+from data_collector.models import CollectorConfig, RawDataAttachment, RawDataRecord
+from data_collector.serializers import (
+    Conflict,
+    CollectorConfigListSerializer,
+    CollectorConfigSerializer,
+    RawDataAttachmentSerializer,
+    RawDataRecordDetailSerializer,
+    RawDataRecordListSerializer,
+)
+
+
+@pytest.mark.unit
+class TestConflict:
+    def test_conflict_status_code(self):
+        assert Conflict.status_code == 409
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+class TestCollectorConfigSerializer:
+    def test_validate_value_accepts_dict(self, user):
+        ser = CollectorConfigSerializer()
+        data = ser.validate_value({"schedule_cron": "0 * * * *"})
+        assert data["schedule_cron"] == "0 * * * *"
+        assert "runtime_state" in data
+        assert data["runtime_state"]["first_collect_at"] is None
+
+    def test_validate_value_none_becomes_empty_dict(self, user):
+        from data_collector.serializers import _default_runtime_state
+        ser = CollectorConfigSerializer()
+        data = ser.validate_value(None)
+        assert "runtime_state" in data
+        assert set(data["runtime_state"].keys()) == set(_default_runtime_state().keys())
+
+    def test_validate_value_rejects_non_dict(self, user):
+        ser = CollectorConfigSerializer()
+        with pytest.raises(ValidationError) as exc_info:
+            ser.validate_value("not a dict")
+        assert "value must be a JSON object" in str(exc_info.value.detail)
+
+    def test_validate_value_runtime_state_must_be_dict(self, user):
+        ser = CollectorConfigSerializer()
+        with pytest.raises(ValidationError) as exc_info:
+            ser.validate_value({"runtime_state": "invalid"})
+        assert "runtime_state" in str(exc_info.value.detail)
+
+    def test_update_raises_conflict_on_version_mismatch(self, user, collector_config):
+        ser = CollectorConfigSerializer(instance=collector_config, data={
+            "platform": collector_config.platform,
+            "key": collector_config.key,
+            "value": collector_config.value,
+            "is_enabled": True,
+            "version": 999,
+        }, partial=True)
+        ser.is_valid(raise_exception=True)
+        with pytest.raises(Conflict):
+            ser.save()
+
+    def test_update_merges_value_and_preserves_auth_password(self, user, collector_config):
+        collector_config.value = {
+            "auth": {"username": "u", "password": "secret", "base_url": "https://jira.example.com"},
+            "runtime_state": {},
+        }
+        collector_config.save()
+        ser = CollectorConfigSerializer(instance=collector_config, data={
+            "platform": collector_config.platform,
+            "key": collector_config.key,
+            "value": {"schedule_cron": "0 9 * * *"},
+            "is_enabled": True,
+            "version": collector_config.version,
+        }, partial=True)
+        ser.is_valid(raise_exception=True)
+        updated = ser.save()
+        assert updated.value.get("auth", {}).get("password") == "secret"
+        assert updated.value.get("schedule_cron") == "0 9 * * *"
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+class TestCollectorConfigListSerializer:
+    def test_get_schedule_cron_from_value(self, collector_config):
+        collector_config.value = {"schedule_cron": "5 * * * *", "runtime_state": {}}
+        collector_config.save()
+        data = CollectorConfigListSerializer(instance=collector_config).data
+        assert data["schedule_cron"] == "5 * * * *"
+
+    def test_get_schedule_cron_default(self, collector_config):
+        collector_config.value = {}
+        collector_config.save()
+        data = CollectorConfigListSerializer(instance=collector_config).data
+        assert data["schedule_cron"] == "0 */2 * * *"
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+class TestRawDataRecordListSerializer:
+    def test_display_title_jira_summary(self, user):
+        record = RawDataRecord.objects.create(
+            user=user,
+            platform="jira",
+            source_unique_id="PROJ-1",
+            raw_data={
+                "issue": {"fields": {"summary": "Fix login bug"}},
+            },
+            filter_metadata={},
+            data_hash="h",
+        )
+        data = RawDataRecordListSerializer(instance=record).data
+        assert data["display_title"] == "Fix login bug"
+
+    def test_display_title_jira_fallback_to_source_id(self, user):
+        record = RawDataRecord.objects.create(
+            user=user,
+            platform="jira",
+            source_unique_id="PROJ-2",
+            raw_data={"issue": {"fields": {}}},
+            filter_metadata={},
+            data_hash="h",
+        )
+        data = RawDataRecordListSerializer(instance=record).data
+        assert data["display_title"] == "PROJ-2"
+
+    def test_display_title_feishu_approval_name(self, user):
+        record = RawDataRecord.objects.create(
+            user=user,
+            platform="feishu",
+            source_unique_id="inst-1",
+            raw_data={"approval": {"name": "请假申请"}},
+            filter_metadata={},
+            data_hash="h",
+        )
+        data = RawDataRecordListSerializer(instance=record).data
+        assert data["display_title"] == "请假申请"
+
+    def test_display_title_license_order_code(self, user):
+        record = RawDataRecord.objects.create(
+            user=user,
+            platform="license",
+            source_unique_id="ORD-001",
+            raw_data={"order": {"code": "ORD-001", "category": {"name": "License"}}},
+            filter_metadata={},
+            data_hash="h",
+        )
+        data = RawDataRecordListSerializer(instance=record).data
+        assert data["display_title"] == "ORD-001"
+
+    def test_attachment_count_from_raw_data(self, user):
+        record = RawDataRecord.objects.create(
+            user=user,
+            platform="jira",
+            source_unique_id="X-1",
+            raw_data={"attachments": [{"id": "a1"}, {"id": "a2"}]},
+            filter_metadata={},
+            data_hash="h",
+        )
+        data = RawDataRecordListSerializer(instance=record).data
+        assert data["attachment_count"] == 2
+
+    def test_attachment_count_non_list_returns_zero(self, user):
+        record = RawDataRecord.objects.create(
+            user=user,
+            platform="jira",
+            source_unique_id="X-2",
+            raw_data={"attachments": "not-a-list"},
+            filter_metadata={},
+            data_hash="h",
+        )
+        data = RawDataRecordListSerializer(instance=record).data
+        assert data["attachment_count"] == 0
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+class TestRawDataRecordDetailSerializer:
+    def test_get_attachments_returns_list_with_uuid_and_file_name(self, user):
+        record = RawDataRecord.objects.create(
+            user=user,
+            platform="jira",
+            source_unique_id="R-1",
+            raw_data={},
+            filter_metadata={},
+            data_hash="h",
+        )
+        RawDataAttachment.objects.create(
+            raw_record=record,
+            file_name="doc.pdf",
+            file_path="/opt/x/doc.pdf",
+            file_url="/media/x/doc.pdf",
+            file_type="application/pdf",
+            file_size=100,
+        )
+        data = RawDataRecordDetailSerializer(instance=record).data
+        assert len(data["attachments"]) == 1
+        assert data["attachments"][0]["file_name"] == "doc.pdf"
+        assert "uuid" in data["attachments"][0]
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+class TestRawDataAttachmentSerializer:
+    def test_serialize_attachment(self, user):
+        record = RawDataRecord.objects.create(
+            user=user,
+            platform="jira",
+            source_unique_id="R-1",
+            raw_data={},
+            data_hash="h",
+        )
+        att = RawDataAttachment.objects.create(
+            raw_record=record,
+            file_name="f.txt",
+            file_path="/p/f.txt",
+            file_url="/media/p/f.txt",
+            file_type="text/plain",
+            file_size=42,
+        )
+        data = RawDataAttachmentSerializer(instance=att).data
+        assert data["file_name"] == "f.txt"
+        assert data["file_size"] == 42

--- a/devmind/data_collector/tests/test_services.py
+++ b/devmind/data_collector/tests/test_services.py
@@ -10,12 +10,14 @@ from data_collector.models import RawDataRecord
 from data_collector.services.beat_sync import (
     CLEANUP_TASK_NAME_PREFIX,
     COLLECT_TASK_NAME_PREFIX,
+    _crontab_from_string,
     sync_config_to_beat,
     unsync_config_from_beat,
 )
 from data_collector.services.providers import get_provider
-from data_collector.services.providers.jira import JiraProvider
 from data_collector.services.providers.feishu import FeishuProvider
+from data_collector.services.providers.jira import JiraProvider
+from data_collector.services.providers.license import LicenseProvider
 from data_collector.services.storage import (
     attachment_file_path,
     attachment_file_url,
@@ -38,7 +40,9 @@ class TestStorage:
             filter_metadata={},
             data_hash="h",
         )
-        with patch("data_collector.services.storage.get_data_collector_root") as m:
+        with patch(
+            "data_collector.services.storage.get_data_collector_root"
+        ) as m:
             m.return_value = "/opt/storage/data_collector"
             path = get_raw_data_attachment_dir(record)
             root = "/opt/storage/data_collector"
@@ -56,7 +60,9 @@ class TestStorage:
             filter_metadata={},
             data_hash="h",
         )
-        with patch("data_collector.services.storage.get_data_collector_root") as m:
+        with patch(
+            "data_collector.services.storage.get_data_collector_root"
+        ) as m:
             m.return_value = "/opt/storage/data_collector"
             path = attachment_file_path(record, "att-123")
             root = "/opt/storage/data_collector"
@@ -86,7 +92,9 @@ class TestStorage:
             filter_metadata={},
             data_hash="h",
         )
-        with patch("data_collector.services.storage.get_data_collector_root") as m:
+        with patch(
+            "data_collector.services.storage.get_data_collector_root"
+        ) as m:
             m.return_value = str(tmp_path)
             out = ensure_attachment_dir(record)
             expected_dir = tmp_path / "raw_data" / str(record.uuid)
@@ -168,12 +176,30 @@ class TestBeatSync:
 
 
 @pytest.mark.unit
+@pytest.mark.django_db
+class TestCrontabFromString:
+    def test_crontab_from_string_valid_five_fields(self):
+        crontab = _crontab_from_string("5 */3 * * *")
+        assert crontab is not None
+        assert crontab.minute == "5"
+        assert crontab.hour == "*/3"
+
+    def test_crontab_from_string_invalid_returns_none(self):
+        assert _crontab_from_string("") is None
+        assert _crontab_from_string("1 2 3") is None
+        assert _crontab_from_string("invalid") is None
+
+
+@pytest.mark.unit
 class TestGetProvider:
     def test_get_provider_jira_returns_jira_provider_class(self):
         assert get_provider("jira") is JiraProvider
 
     def test_get_provider_feishu_returns_feishu_provider_class(self):
         assert get_provider("feishu") is FeishuProvider
+
+    def test_get_provider_license_returns_license_provider_class(self):
+        assert get_provider("license") is LicenseProvider
 
     def test_get_provider_unknown_returns_none(self):
         assert get_provider("unknown_platform") is None

--- a/devmind/data_collector/tests/test_urls.py
+++ b/devmind/data_collector/tests/test_urls.py
@@ -1,0 +1,31 @@
+"""
+Unit tests for data_collector URL resolution.
+"""
+import pytest
+from django.urls import resolve, reverse
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+class TestApiUrls:
+    def test_config_list_resolves(self):
+        match = resolve("/api/v1/data-collector/configs/")
+        assert match.url_name == "config-list"
+
+    def test_config_detail_resolves(self):
+        # UUID is path arg
+        match = resolve("/api/v1/data-collector/configs/00000000-0000-0000-0000-000000000001/")
+        assert match.url_name == "config-detail"
+        assert "uuid" in match.kwargs
+
+    def test_records_list_resolves(self):
+        match = resolve("/api/v1/data-collector/records/")
+        assert match.url_name == "record-list"
+
+    def test_stats_resolves(self):
+        match = resolve("/api/v1/data-collector/stats/")
+        assert match.func is not None
+
+    def test_attachments_list_resolves(self):
+        match = resolve("/api/v1/data-collector/attachments/")
+        assert match.url_name == "attachment-list"

--- a/devmind/data_collector/tests/test_views.py
+++ b/devmind/data_collector/tests/test_views.py
@@ -1,10 +1,12 @@
 """
 Tests for data_collector API views.
 """
+from unittest.mock import patch
+
 import pytest
 from django.contrib.auth.models import User
 
-from data_collector.models import CollectorConfig, RawDataRecord
+from data_collector.models import CollectorConfig, RawDataAttachment, RawDataRecord
 
 
 @pytest.mark.django_db
@@ -57,6 +59,109 @@ class TestCollectorConfigViewSet:
         assert response.status_code == 204
         assert not CollectorConfig.objects.filter(uuid=collector_config.uuid).exists()
 
+    def test_create_duplicate_platform_returns_400(self, api_client, user):
+        CollectorConfig.objects.create(
+            user=user,
+            platform="jira",
+            key="first",
+            value={},
+        )
+        payload = {
+            "platform": "jira",
+            "key": "second",
+            "value": {},
+            "is_enabled": True,
+        }
+        response = api_client.post("/api/v1/data-collector/configs/", payload, format="json")
+        assert response.status_code == 400
+        assert "platform" in response.data or "该平台" in str(response.data)
+
+    @patch("data_collector.views.config.run_collect")
+    def test_collect_action_returns_202_and_task_id(self, mock_run_collect, api_client, collector_config):
+        mock_run_collect.delay.return_value = type("Task", (), {"id": "task-123"})()
+        uuid = str(collector_config.uuid)
+        response = api_client.post(
+            f"/api/v1/data-collector/configs/{uuid}/collect/",
+            {},
+            format="json",
+        )
+        assert response.status_code == 202
+        assert response.data.get("task_id") == "task-123"
+
+    def test_validate_config_payload_missing_platform_returns_400(self, api_client):
+        response = api_client.post(
+            "/api/v1/data-collector/configs/validate-config/",
+            {"value": {}},
+            format="json",
+        )
+        assert response.status_code == 400
+
+    def test_validate_config_payload_unknown_platform_returns_200_invalid(self, api_client):
+        response = api_client.post(
+            "/api/v1/data-collector/configs/validate-config/",
+            {"platform": "unknown_platform", "value": {}},
+            format="json",
+        )
+        assert response.status_code == 200
+        assert response.data.get("valid") is False
+
+    @patch("data_collector.views.config.get_provider")
+    def test_validate_config_payload_calls_authenticate(self, mock_get_provider, api_client):
+        mock_instance = type("Provider", (), {"authenticate": lambda self, auth: True})()
+        mock_get_provider.return_value = lambda: mock_instance
+        response = api_client.post(
+            "/api/v1/data-collector/configs/validate-config/",
+            {"platform": "jira", "value": {"auth": {"base_url": "https://jira.example.com"}}},
+            format="json",
+        )
+        assert response.status_code == 200
+        assert response.data.get("valid") is True
+
+    def test_fetch_projects_missing_platform_returns_400(self, api_client):
+        response = api_client.post(
+            "/api/v1/data-collector/configs/fetch-projects/",
+            {"value": {}},
+            format="json",
+        )
+        assert response.status_code == 400
+
+    @patch("data_collector.views.config.get_provider")
+    def test_fetch_projects_license_returns_projects(self, mock_get_provider, api_client):
+        mock_instance = type(
+            "Provider",
+            (),
+            {"list_projects": lambda self, auth: [{"key": "order", "name": "Order"}]},
+        )()
+        mock_get_provider.return_value = lambda: mock_instance
+        response = api_client.post(
+            "/api/v1/data-collector/configs/fetch-projects/",
+            {"platform": "license", "value": {}},
+            format="json",
+        )
+        assert response.status_code == 200
+        assert "projects" in response.data
+
+    def test_validate_action_requires_start_end_time(self, api_client, collector_config):
+        uuid = str(collector_config.uuid)
+        response = api_client.post(
+            f"/api/v1/data-collector/configs/{uuid}/validate/",
+            {},
+            format="json",
+        )
+        assert response.status_code == 400
+
+    @patch("data_collector.views.config.run_validate")
+    def test_validate_action_returns_202(self, mock_run_validate, api_client, collector_config):
+        mock_run_validate.delay.return_value = type("Task", (), {"id": "validate-1"})()
+        uuid = str(collector_config.uuid)
+        response = api_client.post(
+            f"/api/v1/data-collector/configs/{uuid}/validate/",
+            {"start_time": "2025-01-01T00:00:00Z", "end_time": "2025-01-02T00:00:00Z"},
+            format="json",
+        )
+        assert response.status_code == 202
+        assert response.data.get("task_id") == "validate-1"
+
 
 @pytest.mark.django_db
 class TestStatsAPIView:
@@ -100,3 +205,96 @@ class TestRawDataRecordViewSet:
         results = response.data.get("results", response.data) if isinstance(response.data, dict) else response.data
         if isinstance(results, list):
             assert len(results) >= 1
+
+    def test_list_records_filter_by_platform(self, api_client, user):
+        RawDataRecord.objects.create(
+            user=user,
+            platform="jira",
+            source_unique_id="J-1",
+            raw_data={},
+            data_hash="j1",
+        )
+        RawDataRecord.objects.create(
+            user=user,
+            platform="feishu",
+            source_unique_id="F-1",
+            raw_data={},
+            data_hash="f1",
+        )
+        response = api_client.get("/api/v1/data-collector/records/?platform=feishu")
+        assert response.status_code == 200
+        results = response.data.get("results", response.data) if isinstance(response.data, dict) else response.data
+        if isinstance(results, list):
+            assert all(r.get("platform") == "feishu" for r in results)
+
+    def test_retrieve_record_returns_detail_with_attachments(self, api_client, user):
+        record = RawDataRecord.objects.create(
+            user=user,
+            platform="jira",
+            source_unique_id="D-1",
+            raw_data={"issue": {"fields": {"summary": "Detail"}}},
+            data_hash="d1",
+        )
+        response = api_client.get(f"/api/v1/data-collector/records/{record.uuid}/")
+        assert response.status_code == 200
+        assert response.data["source_unique_id"] == "D-1"
+        assert "attachments" in response.data
+
+
+@pytest.mark.django_db
+class TestRawDataAttachmentViewSet:
+    def test_list_attachments_empty(self, api_client):
+        response = api_client.get("/api/v1/data-collector/attachments/")
+        assert response.status_code == 200
+
+    def test_retrieve_attachment(self, api_client, user):
+        record = RawDataRecord.objects.create(
+            user=user,
+            platform="jira",
+            source_unique_id="R-1",
+            raw_data={},
+            data_hash="h",
+        )
+        att = RawDataAttachment.objects.create(
+            raw_record=record,
+            file_name="test.pdf",
+            file_path="/nonexistent/test.pdf",
+            file_url="/media/test.pdf",
+        )
+        response = api_client.get(f"/api/v1/data-collector/attachments/{att.uuid}/")
+        assert response.status_code == 200
+        assert response.data["file_name"] == "test.pdf"
+
+    def test_download_attachment_no_file_path_returns_404(self, api_client, user):
+        record = RawDataRecord.objects.create(
+            user=user,
+            platform="jira",
+            source_unique_id="R-1",
+            raw_data={},
+            data_hash="h",
+        )
+        att = RawDataAttachment.objects.create(
+            raw_record=record,
+            file_name="x.txt",
+            file_path="",
+            file_url="/media/x.txt",
+        )
+        response = api_client.get(f"/api/v1/data-collector/attachments/{att.uuid}/download/")
+        assert response.status_code == 404
+
+    def test_download_attachment_file_not_found_returns_404(self, api_client, user):
+        record = RawDataRecord.objects.create(
+            user=user,
+            platform="jira",
+            source_unique_id="R-1",
+            raw_data={},
+            data_hash="h",
+        )
+        att = RawDataAttachment.objects.create(
+            raw_record=record,
+            file_name="missing.txt",
+            file_path="/nonexistent/missing.txt",
+            file_url="/media/missing.txt",
+        )
+        response = api_client.get(f"/api/v1/data-collector/attachments/{att.uuid}/download/")
+        assert response.status_code == 404

--- a/devmind/data_collector/views/config.py
+++ b/devmind/data_collector/views/config.py
@@ -153,7 +153,12 @@ class CollectorConfigViewSet(viewsets.ModelViewSet):
             if start_dt >= end_dt:
                 raise ValidationError("start_time must be before end_time.")
             delta = end_dt - start_dt
-            if delta.days > 90:
+            max_days = 30 if config.platform == "feishu" else 90
+            if delta.days > max_days:
+                if config.platform == "feishu":
+                    raise ValidationError(
+                        "Collect range for Feishu must not exceed 30 days."
+                    )
                 raise ValidationError(
                     "Collect range must not exceed 3 months (90 days)."
                 )
@@ -168,7 +173,11 @@ class CollectorConfigViewSet(viewsets.ModelViewSet):
             module="data_collector",
             task_kwargs=task_kwargs,
             created_by=request.user,
-            metadata={"config_uuid": config_uuid_str},
+            metadata={
+                "config_uuid": config_uuid_str,
+                "config_platform": config.platform,
+                "config_key": config.key,
+            },
             initial_status=TaskStatus.PENDING,
         )
         return Response(


### PR DESCRIPTION
- Add LOGGING in base settings for data_collector.tasks and data_collector.services.providers.feishu (INFO to console).
- Serializers: expose schedule_cron on CollectorConfigListSerializer from value; extend _record_display_title for feishu (approval name) and license (order code or category name).
- Register LicenseProvider in providers __init__ and implement FeishuProvider (tenant token, list approvals, query instances, validate, attachment metadata and download).
- Add LicenseProvider implementation and wire collect/validate in tasks; extend config views for platform-specific behaviour.
- Tests: update test_apps, test_conf, add test_providers_feishu and test_providers_license, extend test_serializers, test_services, test_urls, test_views.