### PR TITLE
Refactor data_collector and add locale compile in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -120,6 +120,9 @@ RUN set -eux; \
         done; \
     fi
 
+# Compile Django message catalogs (.po -> .mo) so runtime gettext works
+RUN python manage.py compilemessages -l zh_Hans -l en
+
 # Create necessary directories
 RUN mkdir -p /var/log/gunicorn /var/log/celery /var/cache/devmind
 

--- a/devmind/data_collector/services/providers/feishu.py
+++ b/devmind/data_collector/services/providers/feishu.py
@@ -16,11 +16,11 @@ import hashlib
 import json
 import logging
 import time
-from datetime import datetime, timezone
 from typing import Any
 
 import requests
 
+from data_collector.utils import from_unix_ms, to_unix_ms
 from .base import BaseProvider
 
 logger = logging.getLogger(__name__)
@@ -30,6 +30,8 @@ TENANT_TOKEN_URL = f"{FEISHU_BASE_URL}/open-apis/auth/v3/tenant_access_token/int
 APPROVAL_LIST_URL = f"{FEISHU_BASE_URL}/open-apis/approval/v4/approvals"
 # Use the newer instances query API to fetch approval instances
 INSTANCE_LIST_URL = f"{FEISHU_BASE_URL}/open-apis/approval/v4/instances/query"
+# Max pages per instances query to avoid unbounded loop (page_size=200 each)
+INSTANCE_LIST_MAX_PAGES = 500
 # Base path for approval instance detail API; final URL:
 #   {INSTANCE_DETAIL_URL}/{instance_code}
 INSTANCE_DETAIL_URL = f"{FEISHU_BASE_URL}/open-apis/approval/v4/instances"
@@ -38,48 +40,6 @@ FILE_DOWNLOAD_URL_TEMPLATE = (
 )
 # Contact API: get user name for approval timeline display
 CONTACT_USER_URL = f"{FEISHU_BASE_URL}/open-apis/contact/v3/users"
-
-
-def _to_unix_ms(dt: Any) -> int:
-    """
-    Convert datetime / ISO8601 string / timestamp to Feishu unix ms timestamp.
-    """
-    if isinstance(dt, (int, float)):
-        return int(dt * 1000)
-    if isinstance(dt, str):
-        try:
-            # 允许直接传 ISO8601 字符串
-            parsed = datetime.fromisoformat(dt.replace("Z", "+00:00"))
-            dt = parsed
-        except Exception:
-            return 0
-    if isinstance(dt, datetime):
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        return int(dt.timestamp() * 1000)
-    return 0
-
-
-def _from_unix_ms(value: Any) -> datetime | None:
-    """
-    Convert Feishu millisecond timestamp (str/int) to timezone-aware datetime.
-    Returns None if value is falsy or cannot be parsed.
-    """
-    if value is None:
-        return None
-    try:
-        if isinstance(value, str):
-            value = value.strip()
-            if not value:
-                return None
-        ms = int(value)
-    except (TypeError, ValueError):
-        return None
-    # Feishu uses epoch milliseconds
-    try:
-        return datetime.fromtimestamp(ms / 1000.0, tz=timezone.utc)
-    except (OverflowError, OSError, ValueError):
-        return None
 
 
 class FeishuProvider(BaseProvider):
@@ -147,8 +107,8 @@ class FeishuProvider(BaseProvider):
             return False
         try:
             logger.info(
-                "FeishuProvider.authenticate: validating app_id=%s",
-                (auth_config.get("app_id") or "").strip(),
+                f"FeishuProvider.authenticate: validating "
+                f"app_id={(auth_config.get('app_id') or '').strip()!r}",
             )
             self._get_tenant_access_token(auth_config)
             logger.info("FeishuProvider.authenticate: success")
@@ -183,8 +143,8 @@ class FeishuProvider(BaseProvider):
                     continue
                 out.append({"key": code, "id": str(code), "name": name})
             logger.info(
-                "FeishuProvider.list_projects: fetched %d approval definitions",
-                len(out),
+                f"FeishuProvider.list_projects: fetched {len(out)} approval "
+                "definitions",
             )
             return out
         except Exception as e:
@@ -202,14 +162,14 @@ class FeishuProvider(BaseProvider):
         Call Feishu approval instances query API and return raw instances.
         """
         headers = self._auth_headers(auth_config)
-        start_ms = _to_unix_ms(start_time)
-        end_ms = _to_unix_ms(end_time)
+        start_ms = to_unix_ms(start_time)
+        end_ms = to_unix_ms(end_time)
         if not start_ms or not end_ms:
             return []
 
         page_token = None
         instances: list[dict] = []
-        while True:
+        for _ in range(INSTANCE_LIST_MAX_PAGES):
             payload: dict[str, Any] = {
                 "approval_code": approval_code,
                 # Per Feishu docs, use instance_start_time_* fields for time range
@@ -234,17 +194,20 @@ class FeishuProvider(BaseProvider):
             d = data.get("data") or {}
             items = d.get("instance_list") or d.get("items") or []
             instances.extend(items)
+            page_preview = (d.get("page_token") or "")[:32]
             logger.info(
-                "FeishuProvider._list_instances_for_approval: approval_code=%s "
-                "fetched=%d, total_so_far=%d, page_token=%s",
-                approval_code,
-                len(items),
-                len(instances),
-                (d.get("page_token") or "")[:32],
+                f"FeishuProvider._list_instances_for_approval: "
+                f"approval_code={approval_code!r} fetched={len(items)}, "
+                f"total_so_far={len(instances)}, page_token={page_preview!r}",
             )
             page_token = d.get("page_token")
             if not page_token:
                 break
+        if page_token:
+            logger.warning(
+                "Feishu instances pagination reached INSTANCE_LIST_MAX_PAGES, "
+                "results may be truncated",
+            )
         return instances
 
     def _get_instance_detail(
@@ -263,9 +226,8 @@ class FeishuProvider(BaseProvider):
         if data.get("code", 0) != 0:
             msg = data.get("msg") or data.get("message") or "Feishu get instance failed"
             logger.warning(
-                "FeishuProvider._get_instance_detail: instance_code=%s error=%s",
-                instance_code,
-                msg,
+                f"FeishuProvider._get_instance_detail: instance_code="
+                f"{instance_code!r} error={msg!r}",
             )
             return None
         # Detail may be nested under data.instance or just data
@@ -334,9 +296,7 @@ class FeishuProvider(BaseProvider):
             data = resp.json() or {}
         except Exception as e:
             logger.warning(
-                "FeishuProvider._fetch_user_name failed user_id=%s: %s",
-                user_id,
-                e,
+                f"FeishuProvider._fetch_user_name failed user_id={user_id!r}: {e}",
             )
             return None
         if data.get("code", 0) != 0:
@@ -380,8 +340,8 @@ class FeishuProvider(BaseProvider):
             or instance.get("update_time")
             or instance.get("update_timestamp")
         )
-        start_time = _from_unix_ms(start_raw)
-        end_time = _from_unix_ms(end_raw)
+        start_time = from_unix_ms(start_raw)
+        end_time = from_unix_ms(end_raw)
 
         raw_data = {
             "approval": approval,
@@ -451,8 +411,8 @@ class FeishuProvider(BaseProvider):
                         ),
                         "file_type": str(file_type),
                         "file_size": int(file_size) if file_size else 0,
-                        "source_created_at": _from_unix_ms(created_raw),
-                        "source_updated_at": _from_unix_ms(updated_raw),
+                        "source_created_at": from_unix_ms(created_raw),
+                        "source_updated_at": from_unix_ms(updated_raw),
                     }
                 )
         return attachments
@@ -504,12 +464,8 @@ class FeishuProvider(BaseProvider):
                 return []
 
         logger.info(
-            "FeishuProvider.collect: start, approval_codes=%s, "
-            "start_time=%s, end_time=%s, user_id=%s",
-            approval_codes,
-            start_time,
-            end_time,
-            user_id,
+            f"FeishuProvider.collect: start, approval_codes={approval_codes!r}, "
+            f"start_time={start_time}, end_time={end_time}, user_id={user_id}",
         )
         items: list[dict] = []
         user_name_cache: dict[str, str | None] = {}
@@ -563,9 +519,8 @@ class FeishuProvider(BaseProvider):
                 if item:
                     items.append(item)
         logger.info(
-            "FeishuProvider.collect: done, approval_codes=%s, items=%d",
-            approval_codes,
-            len(items),
+            f"FeishuProvider.collect: done, approval_codes={approval_codes!r}, "
+            f"items={len(items)}",
         )
         return items
 

--- a/devmind/data_collector/services/providers/license.py
+++ b/devmind/data_collector/services/providers/license.py
@@ -5,38 +5,21 @@ License platform provider.
 - Step 2 exposes order collection only; step 3 config shape follows Jira
   (project_keys, initial_range, etc.).
 - Collect: GET /v1/order/list with is_paginate=false,
-  filter_start_time/filter_end_time as UTC strings "YYYY-MM-DD HH:MM:SS";
+  filter_update_start_time/filter_update_end_time as UTC strings "YYYY-MM-DD HH:MM:SS";
   source_unique_id uses the response field "code".
 """
 
 import hashlib
 import json
 import logging
-from datetime import datetime, timezone
 from typing import Any
 
 import requests
 
+from data_collector.utils import to_utc_datetime_str
 from .base import BaseProvider
 
 logger = logging.getLogger(__name__)
-
-
-def _to_utc_datetime_str(dt: Any) -> str:
-    """
-    Convert datetime to UTC string for filter_start_time/filter_end_time.
-    Format: "YYYY-MM-DD HH:MM:SS" (UTC).
-    """
-    if dt is None:
-        return ""
-    if isinstance(dt, str):
-        return dt
-    if isinstance(dt, datetime):
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        utc_dt = dt.astimezone(timezone.utc)
-        return utc_dt.strftime("%Y-%m-%d %H:%M:%S")
-    return str(dt)
 
 
 def _get_base_url(auth_config: dict) -> str:
@@ -151,7 +134,7 @@ class LicenseProvider(BaseProvider):
     ) -> list[dict]:
         """
         Fetch order list: GET /v1/order/list with is_paginate=false,
-        filter_start_time and filter_end_time as strings.
+        filter_update_start_time and filter_update_end_time as strings.
         """
         if not auth_config:
             return []
@@ -165,18 +148,16 @@ class LicenseProvider(BaseProvider):
 
         base_url = _get_base_url(auth_config)
         url = f"{base_url}/v1/order/list"
-        filter_start_time = _to_utc_datetime_str(start_time)
-        filter_end_time = _to_utc_datetime_str(end_time)
+        filter_update_start_time = to_utc_datetime_str(start_time)
+        filter_update_end_time = to_utc_datetime_str(end_time)
         params = {
             "is_paginate": "false",
-            "filter_start_time": filter_start_time,
-            "filter_end_time": filter_end_time,
+            "filter_update_start_time": filter_update_start_time,
+            "filter_update_end_time": filter_update_end_time,
         }
         headers = self._auth_headers(auth_config)
         logger.info(
-            "LicenseProvider.collect: GET %s params=%s",
-            url,
-            params,
+            f"LicenseProvider.collect: GET {url} params={params}",
         )
         resp = requests.get(url, headers=headers, params=params, timeout=60)
         resp.raise_for_status()
@@ -216,8 +197,8 @@ class LicenseProvider(BaseProvider):
             url = f"{base_url}/v1/order/list"
             params = {
                 "is_paginate": "false",
-                "filter_start_time": _to_utc_datetime_str(start_time),
-                "filter_end_time": _to_utc_datetime_str(end_time),
+                "filter_update_start_time": to_utc_datetime_str(start_time),
+                "filter_update_end_time": to_utc_datetime_str(end_time),
             }
             headers = self._auth_headers(auth_config)
             resp = requests.get(

--- a/devmind/data_collector/tasks.py
+++ b/devmind/data_collector/tasks.py
@@ -373,6 +373,7 @@ def run_collect(
     records_updated = 0
     records_skipped_no_sid = 0
     records_skipped_unchanged = 0
+    n_items = 0
     if provider_cls:
         provider = provider_cls()
         auth_config = value.get("auth") or {}
@@ -551,7 +552,6 @@ def run_collect(
         )
 
     if task_id:
-        n_collected = records_created + records_updated
         with translation.override(lang):
             msg = _("Collection done")
         TaskTracker.update_task_status(
@@ -560,7 +560,7 @@ def run_collect(
             result={
                 "records_created": records_created,
                 "records_updated": records_updated,
-                "records_collected": n_collected,
+                "records_collected": n_items,
             },
             metadata={
                 "progress_percent": 100,
@@ -571,7 +571,7 @@ def run_collect(
                 "config_key": config.key,
                 "records_created": records_created,
                 "records_updated": records_updated,
-                "records_collected": n_collected,
+                "records_collected": n_items,
             },
         )
 

--- a/devmind/data_collector/tests/test_providers_feishu.py
+++ b/devmind/data_collector/tests/test_providers_feishu.py
@@ -6,40 +6,37 @@ from unittest.mock import patch
 
 import pytest
 
-from data_collector.services.providers.feishu import (
-    FeishuProvider,
-    _from_unix_ms,
-    _to_unix_ms,
-)
+from data_collector.services.providers.feishu import FeishuProvider
+from data_collector.utils import from_unix_ms, to_unix_ms
 
 
 @pytest.mark.unit
 class TestFeishuTimeHelpers:
     def test_to_unix_ms_from_datetime_utc(self):
         dt = datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
-        ms = _to_unix_ms(dt)
+        ms = to_unix_ms(dt)
         assert isinstance(ms, int)
         assert ms == 1736942400000
 
     def test_to_unix_ms_from_iso_string(self):
-        ms = _to_unix_ms("2025-01-15T12:00:00+00:00")
+        ms = to_unix_ms("2025-01-15T12:00:00+00:00")
         assert isinstance(ms, int)
         assert ms == 1736942400000
 
     def test_to_unix_ms_from_timestamp_seconds(self):
-        ms = _to_unix_ms(1736942400)
+        ms = to_unix_ms(1736942400)
         assert ms == 1736942400000
 
     def test_from_unix_ms_returns_datetime(self):
-        dt = _from_unix_ms(1736942400000)
+        dt = from_unix_ms(1736942400000)
         assert dt is not None
         assert dt.year == 2025
         assert dt.month == 1
         assert dt.day == 15
 
     def test_from_unix_ms_none_for_invalid(self):
-        assert _from_unix_ms(None) is None
-        assert _from_unix_ms("") is None
+        assert from_unix_ms(None) is None
+        assert from_unix_ms("") is None
 
 
 @pytest.mark.unit

--- a/devmind/data_collector/tests/test_providers_license.py
+++ b/devmind/data_collector/tests/test_providers_license.py
@@ -1,5 +1,5 @@
 """
-Unit tests for License provider: _to_utc_datetime_str, _get_base_url,
+Unit tests for License provider: to_utc_datetime_str, _get_base_url,
 LicenseProvider.list_projects, _order_raw_to_item, authenticate, collect, validate, fetch_attachments.
 """
 from datetime import datetime, timezone
@@ -7,25 +7,22 @@ from unittest.mock import patch
 
 import pytest
 
-from data_collector.services.providers.license import (
-    LicenseProvider,
-    _get_base_url,
-    _to_utc_datetime_str,
-)
+from data_collector.services.providers.license import LicenseProvider, _get_base_url
+from data_collector.utils import to_utc_datetime_str
 
 
 @pytest.mark.unit
 class TestLicenseHelpers:
     def test_to_utc_datetime_str_from_datetime(self):
         dt = datetime(2025, 1, 15, 12, 30, 0, tzinfo=timezone.utc)
-        s = _to_utc_datetime_str(dt)
+        s = to_utc_datetime_str(dt)
         assert s == "2025-01-15 12:30:00"
 
     def test_to_utc_datetime_str_none_returns_empty(self):
-        assert _to_utc_datetime_str(None) == ""
+        assert to_utc_datetime_str(None) == ""
 
     def test_to_utc_datetime_str_string_passthrough(self):
-        assert _to_utc_datetime_str("2025-01-01 00:00:00") == "2025-01-01 00:00:00"
+        assert to_utc_datetime_str("2025-01-01 00:00:00") == "2025-01-01 00:00:00"
 
     def test_get_base_url_raises_when_empty(self):
         with pytest.raises(ValueError, match="base_url"):

--- a/devmind/data_collector/utils.py
+++ b/devmind/data_collector/utils.py
@@ -1,0 +1,63 @@
+"""
+Shared utilities for data_collector (time conversion, etc.).
+"""
+from datetime import datetime, timezone
+from typing import Any
+
+
+def to_unix_ms(dt: Any) -> int:
+    """
+    Convert datetime / ISO8601 string / timestamp to unix ms timestamp.
+    Used by Feishu provider for instance_start_time_from/to.
+    """
+    if isinstance(dt, (int, float)):
+        return int(dt * 1000)
+    if isinstance(dt, str):
+        try:
+            parsed = datetime.fromisoformat(dt.replace("Z", "+00:00"))
+            dt = parsed
+        except Exception:
+            return 0
+    if isinstance(dt, datetime):
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return int(dt.timestamp() * 1000)
+    return 0
+
+
+def from_unix_ms(value: Any) -> datetime | None:
+    """
+    Convert millisecond timestamp (str/int) to timezone-aware datetime (UTC).
+    Returns None if value is falsy or cannot be parsed.
+    """
+    if value is None:
+        return None
+    try:
+        if isinstance(value, str):
+            value = value.strip()
+            if not value:
+                return None
+        ms = int(value)
+    except (TypeError, ValueError):
+        return None
+    try:
+        return datetime.fromtimestamp(ms / 1000.0, tz=timezone.utc)
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+def to_utc_datetime_str(dt: Any) -> str:
+    """
+    Convert datetime to UTC string for filter_start_time/filter_end_time.
+    Format: "YYYY-MM-DD HH:MM:SS" (UTC).
+    """
+    if dt is None:
+        return ""
+    if isinstance(dt, str):
+        return dt
+    if isinstance(dt, datetime):
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        utc_dt = dt.astimezone(timezone.utc)
+        return utc_dt.strftime("%Y-%m-%d %H:%M:%S")
+    return str(dt)

--- a/devmind/data_collector/views/config.py
+++ b/devmind/data_collector/views/config.py
@@ -88,7 +88,12 @@ class CollectorConfigViewSet(viewsets.ModelViewSet):
             uniq_violation = const_uniq in str(e)
             if uniq_violation or "unique" in err_str:
                 raise ValidationError(
-                    {"platform": "该平台下已存在采集配置，每个平台仅可添加一条。"}
+                    {
+                        "platform": (
+                            "A collector config already exists for this "
+                            "platform; only one config per platform is allowed."
+                        )
+                    }
                 )
             raise
 


### PR DESCRIPTION
- data_collector: add shared utils (data_collector/utils.py) with to_unix_ms, from_unix_ms, to_utc_datetime_str; Feishu and License providers use these instead of local helpers.
- feishu.py: cap instances pagination with INSTANCE_LIST_MAX_PAGES (500) to avoid unbounded loop; log warning when limit hit; switch logging to f-strings.
- license.py: use filter_update_start_time/filter_update_end_time for order list API; use shared to_utc_datetime_str; f-strings.
- tasks.py: set records_collected from provider-returned total (n_items) instead of records_created + records_updated.
- views/config.py: use English ValidationError for platform unique.
- Dockerfile: run compilemessages for zh_Hans and en so gettext works at runtime.
- tests: update feishu and license provider tests for new imports.