### PR TITLE
Preserve daily billing history

### DIFF
--- a/devmind/cloud_billing/dashboard.py
+++ b/devmind/cloud_billing/dashboard.py
@@ -166,8 +166,16 @@ def _recent_spend_from_snapshots(account_rows, now) -> float:
         rows_by_period[row_period].append(row)
 
     for period_rows in rows_by_period.values():
-        first_row = period_rows[0]
-        last_row = period_rows[-1]
+        ordered_period_rows = sorted(
+            period_rows,
+            key=lambda row: (
+                getattr(row, 'day', None) or datetime.min.date(),
+                getattr(row, 'collected_at', None) or datetime.min.replace(tzinfo=dt_timezone.utc),
+                getattr(row, 'hour', -1),
+            ),
+        )
+        first_row = ordered_period_rows[0]
+        last_row = ordered_period_rows[-1]
         first_total = _total_cost_value(first_row)
         first_increment = _hourly_cost_value(first_row)
         baseline_total = max(first_total - first_increment, 0.0)
@@ -186,10 +194,12 @@ def _recent_collected_days_from_snapshots(account_rows, now, local_tz) -> int:
     collected_days = set()
 
     for row in account_rows:
-        collected_at = getattr(row, 'collected_at', None)
-        if collected_at is None:
-            continue
-        row_day = collected_at.astimezone(local_tz).date()
+        row_day = getattr(row, 'day', None)
+        if row_day is None:
+            collected_at = getattr(row, 'collected_at', None)
+            if collected_at is None:
+                continue
+            row_day = collected_at.astimezone(local_tz).date()
         if recent_window_start <= row_day <= today:
             collected_days.add(row_day)
 
@@ -202,7 +212,7 @@ def _daily_rows_for_current_month(local_tz):
     rows = BillingData.objects.select_related('provider').filter(
         provider__is_active=True,
         collected_at__gte=month_start.astimezone(dt_timezone.utc),
-    ).order_by('provider_id', 'account_id', 'period', 'hour', 'collected_at')
+    ).order_by('provider_id', 'account_id', 'day', 'hour', 'collected_at')
     return now, month_start, list(rows)
 
 
@@ -219,7 +229,7 @@ def _billing_rows_for_current_year(local_tz):
     rows = BillingData.objects.select_related('provider').filter(
         provider__is_active=True,
         collected_at__gte=year_start.astimezone(dt_timezone.utc),
-    ).order_by('provider_id', 'account_id', 'period', 'hour', 'collected_at')
+    ).order_by('provider_id', 'account_id', 'day', 'hour', 'collected_at')
     return now, year_start, list(rows)
 
 
@@ -234,7 +244,7 @@ def _billing_rows_for_recent_days(local_tz, days: int = 30):
     rows = BillingData.objects.select_related('provider').filter(
         provider__is_active=True,
         collected_at__gte=window_start.astimezone(dt_timezone.utc),
-    ).order_by('provider_id', 'account_id', 'period', 'hour', 'collected_at')
+    ).order_by('provider_id', 'account_id', 'day', 'hour', 'collected_at')
     return now, window_start, list(rows)
 
 
@@ -246,6 +256,7 @@ def _latest_billings():
     billings = BillingData.objects.select_related('provider').order_by(
         'provider_id',
         'account_id',
+        '-day',
         '-collected_at',
         '-period',
         '-hour',
@@ -503,6 +514,28 @@ def _risk_for_days(days_remaining: int) -> str:
     if days_remaining <= 30:
         return 'medium'
     return 'low'
+
+
+def _account_sort_key(account: dict[str, object]):
+    has_reference = bool(account.get('has_days_remaining_reference'))
+    if has_reference:
+        return (
+            0,
+            int(account.get('days_remaining') or 0),
+            -_to_float(account.get('cost')),
+        )
+
+    raw_balance = account.get('balance')
+    fallback_balance = (
+        _to_float(raw_balance)
+        if raw_balance is not None
+        else _to_float(account.get('display_funds'))
+    )
+    return (
+        1,
+        fallback_balance,
+        -_to_float(account.get('cost')),
+    )
 
 
 def _build_account_detail(
@@ -825,6 +858,7 @@ def _build_accounts(
             now,
             local_tz,
         )
+        has_days_remaining_reference = recent_collected_days >= 7
         daily_burn = (
             recent_spend / recent_collected_days
             if recent_spend and recent_collected_days > 0
@@ -884,6 +918,8 @@ def _build_accounts(
                 'display_funds': funds['display_funds'],
                 'display_funds_currency': funds['display_funds_currency'],
                 'days_remaining': days_remaining,
+                'recent_collected_days': recent_collected_days,
+                'has_days_remaining_reference': has_days_remaining_reference,
                 'type': payment_type,
                 'usage_rate': None,
                 'account_id': billing.account_id or '',
@@ -905,7 +941,7 @@ def _build_accounts(
             }
         )
 
-    accounts.sort(key=lambda item: (item['days_remaining'], -item['cost']))
+    accounts.sort(key=_account_sort_key)
     return accounts
 
 
@@ -920,9 +956,19 @@ def _build_financial_health(accounts):
         provider_balances[provider_key] = _to_float(item.get('balance'))
 
     total_funds = round(sum(provider_balances.values()), 2)
-    total_days = min((item['days_remaining'] for item in accounts), default=0)
+    referenced_accounts = [
+        item for item in accounts if item.get('has_days_remaining_reference')
+    ]
+    total_days = min(
+        (item['days_remaining'] for item in referenced_accounts),
+        default=None,
+    )
     bottleneck = next(
-        (item['name'] for item in accounts if item['days_remaining'] == total_days),
+        (
+            item['name']
+            for item in referenced_accounts
+            if item['days_remaining'] == total_days
+        ),
         '',
     )
     recharge_alerts = [
@@ -933,6 +979,11 @@ def _build_financial_health(accounts):
             'notes': item['notes'],
             'tags': item.get('tags', []),
             'days_remaining': item['days_remaining'],
+            'recent_collected_days': item.get('recent_collected_days', 0),
+            'has_days_remaining_reference': item.get(
+                'has_days_remaining_reference',
+                False,
+            ),
         }
         for item in accounts
     ]

--- a/devmind/cloud_billing/migrations/0012_add_day_to_billingdata.py
+++ b/devmind/cloud_billing/migrations/0012_add_day_to_billingdata.py
@@ -1,0 +1,61 @@
+from django.db import migrations, models
+from django.utils import timezone
+
+
+def populate_day_from_collected_at(apps, schema_editor):
+    BillingData = apps.get_model("cloud_billing", "BillingData")
+    for row in BillingData.objects.all().iterator():
+        collected_at = row.collected_at
+        day = timezone.localtime(collected_at).date() if collected_at else timezone.localdate()
+        BillingData.objects.filter(id=row.id).update(day=day)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("cloud_billing", "0011_add_days_remaining_thresholds"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="billingdata",
+            name="day",
+            field=models.DateField(
+                blank=True,
+                db_index=True,
+                help_text="Collection day in local timezone",
+                null=True,
+            ),
+        ),
+        migrations.RunPython(
+            populate_day_from_collected_at,
+            migrations.RunPython.noop,
+        ),
+        migrations.AlterField(
+            model_name="billingdata",
+            name="day",
+            field=models.DateField(
+                db_index=True,
+                default=timezone.localdate,
+                help_text="Collection day in local timezone",
+            ),
+        ),
+        migrations.AlterUniqueTogether(
+            name="billingdata",
+            unique_together={("provider", "account_id", "period", "day", "hour")},
+        ),
+        migrations.AddIndex(
+            model_name="billingdata",
+            index=models.Index(
+                fields=["provider", "account_id", "day", "hour"],
+                name="cloud_billi_provide_5d6967_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="billingdata",
+            index=models.Index(
+                fields=["provider", "day", "hour"],
+                name="cloud_billi_provide_2811e7_idx",
+            ),
+        ),
+    ]

--- a/devmind/cloud_billing/models.py
+++ b/devmind/cloud_billing/models.py
@@ -5,6 +5,7 @@ Data models for cloud billing management.
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.utils import timezone
 
 from .constants import (
     WEBHOOK_STATUS_FAILED,
@@ -178,16 +179,29 @@ class BillingData(models.Model):
     account_id = models.CharField(
         max_length=100, blank=True, help_text="Account ID"
     )
+    day = models.DateField(
+        default=timezone.localdate,
+        db_index=True,
+        help_text="Collection day in local timezone",
+    )
     collected_at = models.DateTimeField(auto_now_add=True, db_index=True)
 
     class Meta:
         db_table = "cloud_billing_data"
         verbose_name = "Billing Data"
         verbose_name_plural = "Billing Data"
-        unique_together = [("provider", "account_id", "period", "hour")]
+        unique_together = [("provider", "account_id", "period", "day", "hour")]
         indexes = [
             models.Index(fields=["provider", "account_id", "period", "hour"]),
+            models.Index(
+                fields=["provider", "account_id", "day", "hour"],
+                name="cloud_billi_provide_5d6967_idx",
+            ),
             models.Index(fields=["provider", "period", "hour"]),
+            models.Index(
+                fields=["provider", "day", "hour"],
+                name="cloud_billi_provide_2811e7_idx",
+            ),
             models.Index(fields=["period", "hour"]),
             models.Index(fields=["collected_at"]),
         ]

--- a/devmind/cloud_billing/tasks.py
+++ b/devmind/cloud_billing/tasks.py
@@ -4,7 +4,7 @@ Celery tasks for cloud billing collection and alert checking.
 
 import logging
 import traceback
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone as dt_timezone
 from decimal import Decimal
 from typing import Dict, Optional
 
@@ -74,6 +74,7 @@ def _get_latest_known_balance(
     provider: CloudProvider,
     account_id: str,
     current_period: str,
+    current_day,
     current_hour: int,
 ):
     """Return the most recent non-null balance before the current collection."""
@@ -83,9 +84,27 @@ def _get_latest_known_balance(
         balance__isnull=False,
     ).exclude(
         period=current_period,
+        day=current_day,
         hour=current_hour,
-    ).order_by('-collected_at', '-period', '-hour')
+    ).order_by('-day', '-hour', '-collected_at')
     return queryset.values_list('balance', flat=True).first()
+
+
+def _get_previous_billing_snapshot(
+    provider: CloudProvider,
+    account_id: str,
+    current_day,
+    current_hour: int,
+):
+    return (
+        BillingData.objects.filter(
+            provider=provider,
+            account_id=account_id,
+        )
+        .exclude(day=current_day, hour=current_hour)
+        .order_by('-day', '-hour', '-collected_at')
+        .first()
+    )
 
 
 def _recent_spend_from_snapshots(rows, now) -> Decimal:
@@ -105,8 +124,17 @@ def _recent_spend_from_snapshots(rows, now) -> Decimal:
         rows_by_period.setdefault(row.period, []).append(row)
 
     for period_rows in rows_by_period.values():
-        first_row = period_rows[0]
-        last_row = period_rows[-1]
+        ordered_period_rows = sorted(
+            period_rows,
+            key=lambda row: (
+                getattr(row, "day", None) or datetime.min.date(),
+                getattr(row, "collected_at", None)
+                or datetime.min.replace(tzinfo=dt_timezone.utc),
+                getattr(row, "hour", -1),
+            ),
+        )
+        first_row = ordered_period_rows[0]
+        last_row = ordered_period_rows[-1]
         first_total = Decimal(str(first_row.total_cost))
         first_increment = Decimal(str(first_row.hourly_cost or 0))
         baseline_total = max(first_total - first_increment, Decimal("0"))
@@ -129,7 +157,7 @@ def _estimate_days_remaining(provider, current_billing, now) -> tuple[Decimal, i
             provider=provider,
             account_id=account_id,
             collected_at__gte=window_start,
-        ).order_by("period", "hour", "collected_at")
+        ).order_by("day", "hour", "collected_at")
     )
     recent_spend = _recent_spend_from_snapshots(recent_rows, now)
     if recent_spend <= 0:
@@ -254,6 +282,7 @@ def collect_billing_data(
         provider_service = ProviderService()
         now = timezone.now()
         current_period = now.strftime("%Y-%m")
+        current_day = timezone.localdate(now)
         current_hour = now.hour
 
         for provider in providers:
@@ -336,6 +365,7 @@ def collect_billing_data(
                         provider=provider,
                         account_id=account_id,
                         current_period=current_period,
+                        current_day=current_day,
                         current_hour=current_hour,
                     )
                     if fallback_balance is not None:
@@ -348,7 +378,7 @@ def collect_billing_data(
                             account_id=account_id,
                             period=current_period,
                         )
-                        .order_by("-hour", "-collected_at")
+                        .order_by("-day", "-hour", "-collected_at")
                         .values_list("total_cost", flat=True)
                         .first()
                     )
@@ -382,45 +412,21 @@ def collect_billing_data(
                         f"balance={balance}, balance_debug={balance_debug})"
                     )
 
-                # Calculate hourly incremental cost
-                # Rule: If this month has no data yet, hourly_cost = total_cost
-                # Otherwise, calculate increment from previous hour
-                has_data_this_period = BillingData.objects.filter(
-                    provider=provider, period=current_period
-                ).exists()
+                previous_billing = _get_previous_billing_snapshot(
+                    provider=provider,
+                    account_id=account_id,
+                    current_day=current_day,
+                    current_hour=current_hour,
+                )
 
-                if not has_data_this_period:
-                    # First collection for this month,
-                    # hourly_cost equals total_cost
+                if previous_billing is None:
                     hourly_cost = total_cost
                 else:
-                    # This month has data, try to get previous hour's record
-                    previous_hour = current_hour - 1
-                    previous_period = current_period
-
-                    # Handle cross-month case
-                    # (hour 0 -> previous month hour 23)
-                    if previous_hour < 0:
-                        previous_hour = 23
-                        prev_date = timezone.now() - timedelta(days=1)
-                        previous_period = prev_date.strftime("%Y-%m")
-
-                    try:
-                        previous_billing = BillingData.objects.get(
-                            provider=provider,
-                            account_id=account_id,
-                            period=previous_period,
-                            hour=previous_hour,
-                        )
-                        # Calculate incremental cost: current - previous
+                    if previous_billing.period == current_period:
                         hourly_cost = total_cost - previous_billing.total_cost
-                        # Ensure hourly_cost is not negative (safety check)
                         if hourly_cost < 0:
                             hourly_cost = Decimal("0")
-                    except BillingData.DoesNotExist:
-                        # Previous hour not found, use total_cost as fallback
-                        # This should rarely happen if data collection
-                        # is regular
+                    else:
                         hourly_cost = total_cost
 
                 with transaction.atomic():
@@ -429,6 +435,7 @@ def collect_billing_data(
                             provider=provider,
                             account_id=account_id,
                             period=current_period,
+                            day=current_day,
                             hour=current_hour,
                             defaults={
                                 "total_cost": total_cost,
@@ -449,6 +456,7 @@ def collect_billing_data(
                         billing_record.currency = currency
                         billing_record.service_costs = service_costs
                         billing_record.account_id = account_id
+                        billing_record.day = current_day
 
                         # Update collected_at to reflect the latest
                         # collection time
@@ -464,6 +472,7 @@ def collect_billing_data(
                                 "currency",
                                 "service_costs",
                                 "account_id",
+                                "day",
                                 "collected_at",
                             ]
                         )
@@ -705,12 +714,13 @@ def check_alert_for_provider(
 
         now = timezone.now()
         current_period = now.strftime("%Y-%m")
+        current_day = timezone.localdate(now)
         current_hour = now.hour
 
         # Get all current billing records for this provider
         # (may have multiple accounts)
         current_billings = BillingData.objects.filter(
-            provider=provider, period=current_period, hour=current_hour
+            provider=provider, day=current_day, hour=current_hour
         )
 
         if not current_billings.exists():
@@ -729,14 +739,6 @@ def check_alert_for_provider(
                 )
             return result
 
-        previous_hour = current_hour - 1
-        previous_period = current_period
-
-        if previous_hour < 0:
-            previous_hour = 23
-            prev_date = timezone.now() - timedelta(days=1)
-            previous_period = prev_date.strftime("%Y-%m")
-
         # Check alerts for each account_id separately
         alerts_created = []
         for current_billing in current_billings:
@@ -750,21 +752,21 @@ def check_alert_for_provider(
             )
             previous_billing = None
             previous_cost = Decimal("0")
-            try:
-                previous_billing = BillingData.objects.get(
-                    provider=provider,
-                    account_id=account_id,
-                    period=previous_period,
-                    hour=previous_hour,
-                )
+            previous_billing = _get_previous_billing_snapshot(
+                provider=provider,
+                account_id=account_id,
+                current_day=current_day,
+                current_hour=current_hour,
+            )
+            if previous_billing is not None:
                 previous_cost = Decimal(str(previous_billing.total_cost))
-            except BillingData.DoesNotExist:
+            else:
                 logger.info(
                     f"Task check_alert_for_provider: "
                     f"No previous billing data found "
                     f"(provider_id={provider.id}, name={provider.name}, "
-                    f"account_id={account_id}, period={previous_period}, "
-                    f"hour={previous_hour})"
+                    f"account_id={account_id}, day={current_day}, "
+                    f"hour={current_hour})"
                 )
 
             if previous_cost <= 0 and current_balance is None:
@@ -773,8 +775,7 @@ def check_alert_for_provider(
                     f"Previous cost is zero or negative "
                     f"(provider_id={provider.id}, name={provider.name}, "
                     f"account_id={account_id}, "
-                    f"previous_cost={previous_cost}, "
-                    f"period={previous_period}, hour={previous_hour})"
+                    f"previous_cost={previous_cost})"
                 )
                 continue
 
@@ -820,20 +821,13 @@ def check_alert_for_provider(
                 or alert_rule.growth_amount_threshold is not None
             )
             if needs_previous_billing:
-                try:
-                    previous_billing = BillingData.objects.get(
-                        provider=provider,
-                        account_id=account_id,
-                        period=previous_period,
-                        hour=previous_hour,
-                    )
-                except BillingData.DoesNotExist:
+                if previous_billing is None:
                     logger.info(
                         f"Task check_alert_for_provider: "
                         f"No previous billing data found "
                         f"(provider_id={provider.id}, name={provider.name}, "
-                        f"account_id={account_id}, period={previous_period}, "
-                        f"hour={previous_hour})"
+                        f"account_id={account_id}, day={current_day}, "
+                        f"hour={current_hour})"
                     )
                     if not should_alert:
                         continue
@@ -846,8 +840,7 @@ def check_alert_for_provider(
                             f"Previous cost is zero or negative "
                             f"(provider_id={provider.id}, name={provider.name}, "
                             f"account_id={account_id}, "
-                            f"previous_cost={previous_cost}, "
-                            f"period={previous_period}, hour={previous_hour})"
+                            f"previous_cost={previous_cost})"
                         )
                         if not cost_threshold_triggered:
                             continue

--- a/devmind/cloud_billing/tests/test_dashboard.py
+++ b/devmind/cloud_billing/tests/test_dashboard.py
@@ -13,6 +13,7 @@ from cloud_billing.dashboard import (
     _build_currency_breakdown,
     _build_exchange_rate_info,
     _build_financial_health,
+    _recent_spend_from_snapshots,
     _payment_type_for_provider,
     _build_trend_ranges,
 )
@@ -290,6 +291,241 @@ class AccountFundsTests(SimpleTestCase):
         self.assertEqual(
             financial_health['recharge_alerts'][0]['tags'],
             ['生产', '核心'],
+        )
+
+    @patch('cloud_billing.dashboard.get_balance_support_info')
+    def test_accounts_expose_reference_days_for_days_remaining(
+        self,
+        mock_balance_support,
+    ):
+        mock_balance_support.return_value = {'supported': True}
+
+        provider = SimpleNamespace(
+            id=29,
+            provider_type='zhipu',
+            display_name='智谱 AI',
+            tags=[],
+            notes='',
+            config={},
+            balance=Decimal('300.00'),
+            balance_currency='CNY',
+        )
+        latest_billings = [
+            SimpleNamespace(
+                provider=provider,
+                account_id='acct-9',
+                total_cost=Decimal('90.00'),
+                currency='CNY',
+            )
+        ]
+        recent_rows = [
+            SimpleNamespace(
+                provider_id=29,
+                account_id='acct-9',
+                hourly_cost=Decimal('30.00'),
+                total_cost=Decimal('30.00'),
+                collected_at=datetime(2026, 3, 2, 8, 0, tzinfo=dt_timezone.utc),
+                period='2026-03',
+                hour=8,
+            ),
+            SimpleNamespace(
+                provider_id=29,
+                account_id='acct-9',
+                hourly_cost=Decimal('60.00'),
+                total_cost=Decimal('90.00'),
+                collected_at=datetime(2026, 3, 5, 8, 0, tzinfo=dt_timezone.utc),
+                period='2026-03',
+                hour=8,
+            ),
+        ]
+
+        accounts = _build_accounts(
+            latest_billings,
+            recent_rows,
+            recent_rows=recent_rows,
+            local_tz=dt_timezone.utc,
+            now=datetime(2026, 3, 20, 0, 0, tzinfo=dt_timezone.utc),
+        )
+        financial_health = _build_financial_health(accounts)
+
+        self.assertEqual(accounts[0]['recent_collected_days'], 2)
+        self.assertFalse(accounts[0]['has_days_remaining_reference'])
+        self.assertIsNone(financial_health['total_days'])
+
+    @patch('cloud_billing.dashboard.get_balance_support_info')
+    def test_accounts_without_reference_sort_by_balance(
+        self,
+        mock_balance_support,
+    ):
+        mock_balance_support.return_value = {'supported': True}
+
+        provider_a = SimpleNamespace(
+            id=30,
+            provider_type='zhipu',
+            display_name='智谱 A',
+            tags=[],
+            notes='',
+            config={},
+            balance=Decimal('500.00'),
+            balance_currency='CNY',
+        )
+        provider_b = SimpleNamespace(
+            id=31,
+            provider_type='zhipu',
+            display_name='智谱 B',
+            tags=[],
+            notes='',
+            config={},
+            balance=Decimal('100.00'),
+            balance_currency='CNY',
+        )
+        provider_c = SimpleNamespace(
+            id=32,
+            provider_type='alibaba',
+            display_name='阿里云',
+            tags=[],
+            notes='',
+            config={},
+            balance=Decimal('900.00'),
+            balance_currency='CNY',
+        )
+
+        latest_billings = [
+            SimpleNamespace(
+                provider=provider_a,
+                account_id='acct-a',
+                total_cost=Decimal('90.00'),
+                currency='CNY',
+            ),
+            SimpleNamespace(
+                provider=provider_b,
+                account_id='acct-b',
+                total_cost=Decimal('60.00'),
+                currency='CNY',
+            ),
+            SimpleNamespace(
+                provider=provider_c,
+                account_id='acct-c',
+                total_cost=Decimal('300.00'),
+                currency='CNY',
+            ),
+        ]
+        recent_rows = [
+            SimpleNamespace(
+                provider_id=30,
+                account_id='acct-a',
+                hourly_cost=Decimal('30.00'),
+                total_cost=Decimal('30.00'),
+                collected_at=datetime(2026, 3, 2, 8, 0, tzinfo=dt_timezone.utc),
+                period='2026-03',
+                hour=8,
+            ),
+            SimpleNamespace(
+                provider_id=30,
+                account_id='acct-a',
+                hourly_cost=Decimal('60.00'),
+                total_cost=Decimal('90.00'),
+                collected_at=datetime(2026, 3, 5, 8, 0, tzinfo=dt_timezone.utc),
+                period='2026-03',
+                hour=8,
+            ),
+            SimpleNamespace(
+                provider_id=31,
+                account_id='acct-b',
+                hourly_cost=Decimal('20.00'),
+                total_cost=Decimal('20.00'),
+                collected_at=datetime(2026, 3, 2, 8, 0, tzinfo=dt_timezone.utc),
+                period='2026-03',
+                hour=8,
+            ),
+            SimpleNamespace(
+                provider_id=31,
+                account_id='acct-b',
+                hourly_cost=Decimal('40.00'),
+                total_cost=Decimal('60.00'),
+                collected_at=datetime(2026, 3, 4, 8, 0, tzinfo=dt_timezone.utc),
+                period='2026-03',
+                hour=8,
+            ),
+        ]
+        daily_rows = [
+            *recent_rows,
+            SimpleNamespace(
+                provider_id=32,
+                account_id='acct-c',
+                hourly_cost=Decimal('10.00'),
+                total_cost=Decimal('10.00'),
+                collected_at=datetime(2026, 3, 1, 8, 0, tzinfo=dt_timezone.utc),
+                period='2026-03',
+                hour=8,
+            ),
+            SimpleNamespace(
+                provider_id=32,
+                account_id='acct-c',
+                hourly_cost=Decimal('10.00'),
+                total_cost=Decimal('20.00'),
+                collected_at=datetime(2026, 3, 2, 8, 0, tzinfo=dt_timezone.utc),
+                period='2026-03',
+                hour=8,
+            ),
+            SimpleNamespace(
+                provider_id=32,
+                account_id='acct-c',
+                hourly_cost=Decimal('10.00'),
+                total_cost=Decimal('30.00'),
+                collected_at=datetime(2026, 3, 3, 8, 0, tzinfo=dt_timezone.utc),
+                period='2026-03',
+                hour=8,
+            ),
+            SimpleNamespace(
+                provider_id=32,
+                account_id='acct-c',
+                hourly_cost=Decimal('10.00'),
+                total_cost=Decimal('40.00'),
+                collected_at=datetime(2026, 3, 4, 8, 0, tzinfo=dt_timezone.utc),
+                period='2026-03',
+                hour=8,
+            ),
+            SimpleNamespace(
+                provider_id=32,
+                account_id='acct-c',
+                hourly_cost=Decimal('10.00'),
+                total_cost=Decimal('50.00'),
+                collected_at=datetime(2026, 3, 5, 8, 0, tzinfo=dt_timezone.utc),
+                period='2026-03',
+                hour=8,
+            ),
+            SimpleNamespace(
+                provider_id=32,
+                account_id='acct-c',
+                hourly_cost=Decimal('10.00'),
+                total_cost=Decimal('60.00'),
+                collected_at=datetime(2026, 3, 6, 8, 0, tzinfo=dt_timezone.utc),
+                period='2026-03',
+                hour=8,
+            ),
+            SimpleNamespace(
+                provider_id=32,
+                account_id='acct-c',
+                hourly_cost=Decimal('10.00'),
+                total_cost=Decimal('70.00'),
+                collected_at=datetime(2026, 3, 7, 8, 0, tzinfo=dt_timezone.utc),
+                period='2026-03',
+                hour=8,
+            ),
+        ]
+
+        accounts = _build_accounts(
+            latest_billings,
+            daily_rows,
+            recent_rows=daily_rows,
+            local_tz=dt_timezone.utc,
+            now=datetime(2026, 3, 20, 0, 0, tzinfo=dt_timezone.utc),
+        )
+
+        self.assertEqual(
+            [account['account_id'] for account in accounts],
+            ['acct-c', 'acct-b', 'acct-a'],
         )
 
     @patch('cloud_billing.dashboard.get_balance_support_info')
@@ -632,3 +868,42 @@ class DashboardTimezoneTests(SimpleTestCase):
         self.assertEqual(week_points['03-25']['usd'], 12.5)
         self.assertEqual(recent_points['03-24']['cny'], 88.0)
         self.assertEqual(recent_points['03-25']['usd'], 12.5)
+
+
+class RecentSpendSnapshotTests(SimpleTestCase):
+    def test_uses_real_collection_time_not_hour_slot_order(self):
+        now = datetime(2026, 4, 8, 8, 10, tzinfo=dt_timezone.utc)
+        rows = [
+            SimpleNamespace(
+                period='2026-04',
+                hour=0,
+                total_cost=Decimal('22.46'),
+                hourly_cost=Decimal('0.00'),
+                collected_at=datetime(2026, 4, 6, 0, 11, tzinfo=dt_timezone.utc),
+            ),
+            SimpleNamespace(
+                period='2026-04',
+                hour=7,
+                total_cost=Decimal('125.79'),
+                hourly_cost=Decimal('89.89'),
+                collected_at=datetime(2026, 4, 8, 7, 59, tzinfo=dt_timezone.utc),
+            ),
+            SimpleNamespace(
+                period='2026-04',
+                hour=8,
+                total_cost=Decimal('128.10'),
+                hourly_cost=Decimal('2.31'),
+                collected_at=datetime(2026, 4, 8, 8, 10, tzinfo=dt_timezone.utc),
+            ),
+            SimpleNamespace(
+                period='2026-04',
+                hour=23,
+                total_cost=Decimal('22.50'),
+                hourly_cost=Decimal('0.00'),
+                collected_at=datetime(2026, 4, 6, 23, 13, tzinfo=dt_timezone.utc),
+            ),
+        ]
+
+        spend = _recent_spend_from_snapshots(rows, now)
+
+        self.assertAlmostEqual(spend, 105.64, places=2)

--- a/devmind/cloud_billing/tests/test_models.py
+++ b/devmind/cloud_billing/tests/test_models.py
@@ -1,6 +1,7 @@
 """
 Tests for cloud billing models.
 """
+import datetime
 import pytest
 from decimal import Decimal
 from django.contrib.auth.models import User
@@ -99,7 +100,8 @@ class TestBillingData:
         cloud_provider
     ):
         """
-        Test that (provider, period, hour) must be unique.
+        Test that the same provider/account/month/hour can be stored on
+        different collection days.
         """
         period = '2025-01'
         hour = 10
@@ -108,16 +110,19 @@ class TestBillingData:
             period=period,
             hour=hour,
             total_cost=Decimal('100.50'),
-            currency='USD'
+            currency='USD',
+            account_id='acct-1',
+            day=datetime.date(2025, 1, 1),
         )
-        with pytest.raises(Exception):
-            BillingData.objects.create(
-                provider=cloud_provider,
-                period=period,
-                hour=hour,
-                total_cost=Decimal('200.00'),
-                currency='USD'
-            )
+        BillingData.objects.create(
+            provider=cloud_provider,
+            period=period,
+            hour=hour,
+            total_cost=Decimal('200.00'),
+            currency='USD',
+            account_id='acct-1',
+            day=datetime.date(2025, 1, 2),
+        )
 
     def test_billing_data_str(self, billing_data):
         """

--- a/devmind/cloud_billing/tests/test_tasks.py
+++ b/devmind/cloud_billing/tests/test_tasks.py
@@ -3,6 +3,7 @@ Unit tests for cloud_billing Celery tasks: collect_billing_data,
 check_alert_for_provider, send_alert_notification.
 """
 
+import datetime
 import pytest
 from decimal import Decimal
 from unittest.mock import patch, MagicMock
@@ -589,6 +590,67 @@ class TestCollectBillingData:
             cloud_provider.id,
             cloud_provider.provider_type,
         )
+
+    @patch("cloud_billing.tasks.check_alert_for_provider.delay")
+    @patch("cloud_billing.tasks.ProviderService")
+    @patch("cloud_billing.tasks.timezone.now")
+    def test_sync_keeps_same_hour_snapshots_on_different_days(
+        self,
+        mock_timezone_now,
+        mock_provider_service_class,
+        mock_check_alert_delay,
+        cloud_provider,
+    ):
+        first_now = timezone.make_aware(
+            datetime.datetime(2026, 4, 6, 8, 0, 0)
+        )
+        second_now = timezone.make_aware(
+            datetime.datetime(2026, 4, 7, 8, 0, 0)
+        )
+
+        mock_provider_service = MagicMock()
+        mock_provider_service.get_billing_info.side_effect = [
+            {
+                "status": "success",
+                "data": {
+                    "total_cost": 22.5,
+                    "balance": 100.0,
+                    "currency": "CNY",
+                    "account_id": "acct-zhipu",
+                    "service_costs": {"智谱 AI": 22.5},
+                },
+            },
+            {
+                "status": "success",
+                "data": {
+                    "total_cost": 128.1,
+                    "balance": 80.0,
+                    "currency": "CNY",
+                    "account_id": "acct-zhipu",
+                    "service_costs": {"智谱 AI": 128.1},
+                },
+            },
+        ]
+        mock_provider_service_class.return_value = mock_provider_service
+
+        mock_timezone_now.return_value = first_now
+        collect_billing_data(provider_id=cloud_provider.id, user_id=1)
+        mock_timezone_now.return_value = second_now
+        collect_billing_data(provider_id=cloud_provider.id, user_id=1)
+
+        rows = list(
+            BillingData.objects.filter(
+                provider=cloud_provider,
+                account_id="acct-zhipu",
+                hour=8,
+            ).order_by("day")
+        )
+
+        assert len(rows) == 2
+        assert rows[0].day.isoformat() == "2026-04-06"
+        assert rows[0].total_cost == Decimal("22.50")
+        assert rows[1].day.isoformat() == "2026-04-07"
+        assert rows[1].total_cost == Decimal("128.10")
 
 
 @pytest.mark.django_db

--- a/devmind/cloud_billing/tests/test_views.py
+++ b/devmind/cloud_billing/tests/test_views.py
@@ -319,7 +319,10 @@ class TestBillingDataViewSet:
         """
         cloud_provider.balance = Decimal("88.00")
         cloud_provider.balance_currency = "USD"
-        cloud_provider.save(update_fields=["balance", "balance_currency"])
+        cloud_provider.notes = "生产账号"
+        cloud_provider.save(
+            update_fields=["balance", "balance_currency", "notes"]
+        )
         url = (
             f"/api/v1/cloud-billing/billing-data/stats/"
             f"?provider_id={cloud_provider.id}"
@@ -331,6 +334,9 @@ class TestBillingDataViewSet:
         assert "average_cost" in response.data
         assert "count" in response.data
         assert "cost_by_period" in response.data
+        by_provider = response.data["by_provider"]
+        first_row = next(iter(by_provider.values()))
+        assert first_row["provider_notes"] == "生产账号"
 
     def test_list_excludes_inactive_provider_data(
         self, api_client, cloud_provider_inactive

--- a/devmind/cloud_billing/views/billing.py
+++ b/devmind/cloud_billing/views/billing.py
@@ -85,7 +85,7 @@ class BillingDataViewSet(viewsets.ReadOnlyModelViewSet):
                 collected_at__lt=end_datetime
             )
 
-        return queryset.order_by('-period', '-hour')
+        return queryset.order_by('-day', '-hour', '-collected_at')
 
     @extend_schema(
         tags=['cloud-billing'],
@@ -126,7 +126,7 @@ class BillingDataViewSet(viewsets.ReadOnlyModelViewSet):
         # Order by hour descending to get the last hour of each period
         latest_billings = {}
         for billing in queryset.order_by(
-            'provider_id', 'account_id', 'period', '-hour',
+            'provider_id', 'account_id', 'period', '-day', '-hour',
             '-collected_at'
         ):
             key = (
@@ -244,6 +244,9 @@ class BillingDataViewSet(viewsets.ReadOnlyModelViewSet):
                 by_provider[provider_key] = {
                     'provider_id': billing.provider_id,
                     'provider_name': billing.provider.display_name,
+                    'provider_notes': (
+                        (billing.provider.notes or '').strip()
+                    ),
                     'account_id': billing.account_id or '',
                     'total_cost': 0,
                     'count': 0,
@@ -337,7 +340,7 @@ class BillingDataViewSet(viewsets.ReadOnlyModelViewSet):
         latest_ids = BillingData.objects.filter(
             provider_id=OuterRef('provider_id'),
             account_id=OuterRef('account_id')
-        ).order_by('-collected_at').values('id')[:1]
+        ).order_by('-day', '-hour', '-collected_at').values('id')[:1]
 
         latest_records = queryset.filter(
             id__in=Subquery(latest_ids)


### PR DESCRIPTION
Track cloud billing snapshots with a day dimension so repeated hourly collections on different days no longer overwrite each other. This keeps recent-burn calculations and month-over-month billing views aligned with the actual collection timeline.

Update dashboard ordering and reference metadata to distinguish accounts with enough sample days from those that should fall back to balance-based handling. The stats endpoint now also exposes provider notes for downstream UI labeling.

Constraint: Existing snapshot rows needed a safe day backfill from collected_at during migration
Rejected: Keep period+hour uniqueness and infer days in memory | it would preserve the 48-slot cap and unstable recent-burn math Confidence: high
Scope-risk: moderate
Directive: Any future query that wants the latest snapshot must sort by day before hour to avoid reintroducing slot-order bugs Tested: cloud_billing dashboard/model/task/view targeted pytest suites
Not-tested: Full cloud_billing test suite and production migration on large historical tables