### PR TITLE
Hide days remaining without 7-day history

### DIFF
--- a/devmind/cloud_billing/dashboard.py
+++ b/devmind/cloud_billing/dashboard.py
@@ -27,6 +27,7 @@ EXCHANGE_RATE_SOURCE_URL = 'https://www.exchangerate-api.com/'
 EXCHANGE_RATE_CACHE_PREFIX = 'cloud_billing:exchange_rate'
 EXCHANGE_RATE_CACHE_TTL = 60 * 60 * 24
 RECENT_BURN_WINDOW_DAYS = 30
+MIN_DAYS_REMAINING_REFERENCE_DAYS = 7
 PROVIDER_PAYMENT_TYPES = {
     'aws': 'postpaid',
     'azure': 'postpaid',
@@ -508,7 +509,9 @@ def _build_currency_breakdown(accounts, exchange_rate: float | None = None):
     return items
 
 
-def _risk_for_days(days_remaining: int) -> str:
+def _risk_for_days(days_remaining: int | None) -> str:
+    if days_remaining is None:
+        return 'unknown'
     if days_remaining <= 10:
         return 'high'
     if days_remaining <= 30:
@@ -793,7 +796,9 @@ def _build_account_detail(
 
     peak_daily_cost = max((item['value'] for item in recent_trend), default=0.0)
     recommended_recharge = round(max(daily_burn * 30 - display_funds, 0), 2)
-    if payment_type == 'postpaid':
+    if days_remaining is None:
+        recommendation_status = 'unknown'
+    elif payment_type == 'postpaid':
         recommendation_status = 'healthy' if days_remaining > 14 else 'attention'
     else:
         recommendation_status = 'healthy' if days_remaining > 21 else 'attention'
@@ -858,10 +863,16 @@ def _build_accounts(
             now,
             local_tz,
         )
-        has_days_remaining_reference = recent_collected_days >= 7
+        has_days_remaining_reference = (
+            recent_collected_days >= MIN_DAYS_REMAINING_REFERENCE_DAYS
+        )
         daily_burn = (
             recent_spend / recent_collected_days
-            if recent_spend and recent_collected_days > 0
+            if (
+                has_days_remaining_reference
+                and recent_spend
+                and recent_collected_days > 0
+            )
             else 0.0
         )
         balance_info = get_balance_support_info(provider)
@@ -871,7 +882,9 @@ def _build_accounts(
         )
         funds = _normalize_account_funds(provider, billing, payment_type)
         display_funds = float(funds['display_funds'])
-        if funds['uses_credit_limit_days'] and display_funds > 0 and daily_burn > 0:
+        if not has_days_remaining_reference:
+            days_remaining = None
+        elif funds['uses_credit_limit_days'] and display_funds > 0 and daily_burn > 0:
             days_remaining = max(int(display_funds / daily_burn), 1)
         elif float(funds['balance']) > 0 and daily_burn > 0:
             days_remaining = max(int(float(funds['balance']) / daily_burn), 1)

--- a/devmind/cloud_billing/tasks.py
+++ b/devmind/cloud_billing/tasks.py
@@ -46,6 +46,7 @@ from .services.provider_service import ProviderService
 
 logger = logging.getLogger(__name__)
 RECENT_BURN_WINDOW_DAYS = 30
+MIN_DAYS_REMAINING_REFERENCE_DAYS = 7
 
 
 def _resolve_notification_language(provider: CloudProvider) -> str:
@@ -144,6 +145,27 @@ def _recent_spend_from_snapshots(rows, now) -> Decimal:
     return spend
 
 
+def _recent_collected_days_from_snapshots(rows, now) -> int:
+    if not rows:
+        return 0
+
+    recent_window_start = (now - timedelta(days=RECENT_BURN_WINDOW_DAYS - 1)).date()
+    recent_dates = set()
+    for row in rows:
+        collected_at = getattr(row, "collected_at", None)
+        if collected_at is None:
+            continue
+        if timezone.is_naive(collected_at):
+            collected_at = timezone.make_aware(
+                collected_at,
+                dt_timezone.utc,
+            )
+        collected_date = collected_at.astimezone(dt_timezone.utc).date()
+        if collected_date >= recent_window_start:
+            recent_dates.add(collected_date)
+    return len(recent_dates)
+
+
 def _estimate_days_remaining(provider, current_billing, now) -> tuple[Decimal, int | None]:
     account_id = current_billing.account_id or ""
     window_start = (now - timedelta(days=RECENT_BURN_WINDOW_DAYS - 1)).replace(
@@ -160,10 +182,16 @@ def _estimate_days_remaining(provider, current_billing, now) -> tuple[Decimal, i
         ).order_by("day", "hour", "collected_at")
     )
     recent_spend = _recent_spend_from_snapshots(recent_rows, now)
+    recent_collected_days = _recent_collected_days_from_snapshots(
+        recent_rows,
+        now,
+    )
+    if recent_collected_days < MIN_DAYS_REMAINING_REFERENCE_DAYS:
+        return Decimal("0"), None
     if recent_spend <= 0:
         return Decimal("0"), None
 
-    daily_burn = recent_spend / Decimal(str(RECENT_BURN_WINDOW_DAYS))
+    daily_burn = recent_spend / Decimal(str(recent_collected_days))
     if daily_burn <= 0:
         daily_burn = Decimal("0")
 

--- a/devmind/cloud_billing/tests/test_dashboard.py
+++ b/devmind/cloud_billing/tests/test_dashboard.py
@@ -252,7 +252,8 @@ class AccountFundsTests(SimpleTestCase):
         self.assertEqual(account['balance_currency'], '')
         self.assertEqual(account['credit_limit'], 200.0)
         self.assertEqual(account['credit_limit_currency'], 'USD')
-        self.assertEqual(account['days_remaining'], 45)
+        self.assertIsNone(account['days_remaining'])
+        self.assertFalse(account['has_days_remaining_reference'])
 
     @patch('cloud_billing.dashboard.get_balance_support_info')
     def test_account_tags_are_exposed_to_dashboard(self, mock_balance_support):
@@ -350,6 +351,7 @@ class AccountFundsTests(SimpleTestCase):
 
         self.assertEqual(accounts[0]['recent_collected_days'], 2)
         self.assertFalse(accounts[0]['has_days_remaining_reference'])
+        self.assertIsNone(accounts[0]['days_remaining'])
         self.assertIsNone(financial_health['total_days'])
 
     @patch('cloud_billing.dashboard.get_balance_support_info')
@@ -825,9 +827,10 @@ class AccountFundsTests(SimpleTestCase):
             now=datetime(2026, 3, 20, 0, 0, tzinfo=dt_timezone.utc),
         )
 
-        self.assertEqual(accounts[0]['detail']['daily_average'], 45.0)
-        self.assertEqual(accounts[0]['change'], 45.0)
-        self.assertEqual(accounts[0]['days_remaining'], 6)
+        self.assertEqual(accounts[0]['detail']['daily_average'], 0)
+        self.assertEqual(accounts[0]['change'], 0)
+        self.assertIsNone(accounts[0]['days_remaining'])
+        self.assertFalse(accounts[0]['has_days_remaining_reference'])
 
 
 class DashboardTimezoneTests(SimpleTestCase):

--- a/devmind/cloud_billing/tests/test_tasks.py
+++ b/devmind/cloud_billing/tests/test_tasks.py
@@ -345,6 +345,23 @@ class TestCheckAlertForProvider:
     ):
         mock_channel = SimpleNamespace(config={"language": "en"})
         mock_get_default_webhook_channel.return_value = (mock_channel, {})
+        now = timezone.now()
+
+        for offset in range(1, 7):
+            collected_at = now - datetime.timedelta(days=offset)
+            row = BillingData.objects.create(
+                provider=cloud_provider,
+                period=collected_at.strftime("%Y-%m"),
+                day=collected_at.date(),
+                hour=collected_at.hour,
+                total_cost=Decimal("10.00") * Decimal(7 - offset),
+                hourly_cost=Decimal("10.00"),
+                balance=Decimal("520.00"),
+                currency="USD",
+                account_id="123456789012",
+            )
+            BillingData.objects.filter(pk=row.pk).update(collected_at=collected_at)
+
         AlertRule.objects.create(
             provider=cloud_provider,
             days_remaining_threshold=200,
@@ -363,6 +380,33 @@ class TestCheckAlertForProvider:
         assert record.days_remaining_threshold == 200
         assert "estimated days remaining" in record.alert_message.lower()
         mock_send_alert.assert_called_once_with(record.id)
+
+    @patch("cloud_billing.tasks.send_alert_notification.delay")
+    @patch("cloud_billing.tasks.get_default_webhook_channel")
+    def test_days_remaining_threshold_does_not_trigger_without_7_days_history(
+        self,
+        mock_get_default_webhook_channel,
+        mock_send_alert,
+        cloud_provider,
+        user,
+        billing_data,
+    ):
+        mock_channel = SimpleNamespace(config={"language": "en"})
+        mock_get_default_webhook_channel.return_value = (mock_channel, {})
+        AlertRule.objects.create(
+            provider=cloud_provider,
+            days_remaining_threshold=200,
+            is_active=True,
+            created_by=user,
+            updated_by=user,
+        )
+
+        result = check_alert_for_provider(cloud_provider.id)
+
+        assert result["checked"] is True
+        assert result["alerted"] is False
+        assert AlertRecord.objects.count() == 0
+        mock_send_alert.assert_not_called()
 
     def test_skipped_when_lock_held(self, cloud_provider):
         """


### PR DESCRIPTION
Require at least seven collected days before dashboard and alert flows\nproduce estimated remaining days. When the sample is smaller, return\nunknown risk/no reference data instead of a numeric estimate, and lock\nthe behavior with focused dashboard/task tests.

Constraint: Estimated days remaining must stay hidden when history covers fewer than 7 days

Rejected: Keep computing fallback 45/120 day defaults | contradicts the product rule and leaks false precision

Confidence: high

Scope-risk: moderate

Directive: Do not reintroduce days_remaining fallback values unless the <7 day product rule changes end-to-end

Tested: ./\.venv/bin/pytest devmind/cloud_billing/tests/test_dashboard.py::AccountFundsTests::test_accounts_expose_reference_days_for_days_remaining devmind/cloud_billing/tests/test_dashboard.py::AccountFundsTests::test_daily_average_uses_recent_collected_days_for_account -q; ./\.venv/bin/pytest devmind/cloud_billing/tests/test_tasks.py::TestCheckAlertForProvider::test_days_remaining_threshold_triggers_alert devmind/cloud_billing/tests/test_tasks.py::TestCheckAlertForProvider::test_days_remaining_threshold_does_not_trigger_without_7_days_history -q

Not-tested: Full cloud_billing test suite; unrelated notification-language task tests are still failing in the current tree