### PR TITLE
Register hyperbdr_dashboard app and dedupe auth check race conditions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -271,3 +271,4 @@ requirements-dev.txt
 
 devmind/images
 .brv/*
+backend/ai_pricehub/runtime/

--- a/backend/core/settings/base.py
+++ b/backend/core/settings/base.py
@@ -169,6 +169,8 @@ INSTALLED_APPS += [
     'ai_pricehub',
     'cloud_billing',
     'data_collector',
+    'hyperbdr_dashboard',
+    'hyperbdr_monitor',
     'agentcore_metering.adapters.django',
     'agentcore_task.adapters.django',
     'agentcore_notifier.adapters.django',

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -43,6 +43,9 @@ urlpatterns = [
     # Data collector routes (raw data collection from JIRA, Feishu, etc.)
     path('api/v1/data-collector/', include('data_collector.urls')),
 
+    # HyperBDR Dashboard routes
+    path('api/v1/hyperbdr-dashboard/', include('hyperbdr_dashboard.urls')),
+
     # Task management routes (agentcore-task)
     path('api/v1/tasks/', include('agentcore_task.adapters.django.urls')),
 

--- a/backend/hyperbdr_dashboard/services.py
+++ b/backend/hyperbdr_dashboard/services.py
@@ -1,7 +1,7 @@
 """
 Dashboard aggregation service for the HyperBDR Data Operations Dashboard.
 
-This module builds the dashboard payload from existing onepro_monitor models,
+This module builds the dashboard payload from existing hyperbdr_monitor models,
 reshaping the data into the product-facing dashboard contract.
 
 Business rules (from spec):
@@ -20,7 +20,7 @@ from django.db.models import IntegerField, Sum
 from django.db.models.functions import Coalesce
 from django.utils import timezone
 
-from onepro_monitor.models import DataSource, Host, License, Tenant
+from hyperbdr_monitor.models import DataSource, Host, License, Tenant
 
 
 def _prefetch_licenses(tenants):
@@ -94,7 +94,7 @@ def _is_poc(tenant: Tenant, licenses: list[dict]) -> bool:
 
 
 def _build_dashboard_stats():
-    """Return raw counts and aggregates from onepro_monitor models."""
+    """Return raw counts and aggregates from hyperbdr_monitor models."""
     tenant_qs = Tenant.objects.filter(data_source__is_active=True)
     license_qs = License.objects.filter(data_source__is_active=True).select_related("tenant")
     host_qs = Host.objects.filter(data_source__is_active=True)
@@ -304,7 +304,6 @@ def _build_tenant_rows_from_tenants(tenants: list, licenses_by_tenant: dict) -> 
 
         scenes = list({lic.get("scene") or "" for lic in licenses})
         scene_display = ", ".join(scenes) if scenes else "-"
-
         rows.append({
             "id": tenant.source_tenant_id,
             "name": tenant.name,

--- a/backend/hyperbdr_dashboard/tests/settings.py
+++ b/backend/hyperbdr_dashboard/tests/settings.py
@@ -10,7 +10,6 @@ INSTALLED_APPS = [
     "rest_framework",
     "accounts",
     "hyperbdr_monitor",
-    "hyperbdr_dashboard",
 ]
 
 DATABASES = {

--- a/frontend/src/constants/hyperbdrDashboard.js
+++ b/frontend/src/constants/hyperbdrDashboard.js
@@ -38,7 +38,7 @@ export const KPIS = [
     value: '34.6%',
     trend: 'up',
     trendPercent: '+5.4%',
-    type: 'gradient'
+    type: 'accent'
   }
 ]
 

--- a/frontend/src/pages/HyperBDRDashboard.vue
+++ b/frontend/src/pages/HyperBDRDashboard.vue
@@ -1415,7 +1415,7 @@ const dynamicKPIS = computed(() => {
       key: 'conversionRate',
       labelKey: 'hyperbdrDashboard.conversionRate',
       value: `${convRate}%`,
-      type: 'gradient',
+      type: 'accent',
       progress: parseFloat(convRate),
       progressLabelKey: 'hyperbdrDashboard.conversionRate',
       trend: convRate > 0 ? `+${convRate}%` : null,

--- a/frontend/src/store/user.js
+++ b/frontend/src/store/user.js
@@ -13,6 +13,7 @@ export const useUserStore = defineStore('user', () => {
   const token = ref(localStorage.getItem('access_token'))
   const loading = ref(false)
   const error = ref(null)
+  let pendingAuthCheck = Promise.resolve()
 
   // Getters
   const isAuthenticated = computed(() => !!token.value && !!user.value)
@@ -53,7 +54,6 @@ export const useUserStore = defineStore('user', () => {
       }
 
       await loadUserPreferences()
-      await checkAuthStatus()
 
       return data
     } catch (err) {
@@ -70,6 +70,7 @@ export const useUserStore = defineStore('user', () => {
   const clearAuthState = () => {
     user.value = null
     token.value = null
+    pendingAuthCheck = Promise.resolve()
     localStorage.removeItem('access_token')
     localStorage.removeItem('refresh_token')
   }
@@ -87,55 +88,70 @@ export const useUserStore = defineStore('user', () => {
   }
 
   const checkAuth = async () => {
-    // Check if we have a token in localStorage
     const storedToken = localStorage.getItem('access_token')
     if (!storedToken) {
       clearAuthState()
       return false
     }
 
-    // Update token if it's not already set
     if (!token.value) {
       token.value = storedToken
     }
 
-    try {
-      const response = await authApi.getProfile()
-      // Handle the actual response format from backend
-      const data = response.data.data || response.data
-      user.value = data
-
-      await loadUserPreferences()
-
+    if (user.value) {
       return true
-    } catch (err) {
-      clearAuthState()
-      return false
     }
+
+    await pendingAuthCheck
+    if (user.value) {
+      return true
+    }
+
+    pendingAuthCheck = (async () => {
+      try {
+        const response = await authApi.getProfile()
+        const data = response.data.data || response.data
+        user.value = data
+        await loadUserPreferences()
+        return true
+      } catch (err) {
+        clearAuthState()
+        return false
+      }
+    })()
+
+    return pendingAuthCheck
   }
 
   const checkAuthStatus = async () => {
-    try {
-      const response = await authApi.getProfile()
-      const data = response.data.data || response.data
-
-      user.value = data
-
-      if (!token.value && localStorage.getItem('access_token')) {
-        token.value = localStorage.getItem('access_token')
-      }
-
-      await loadUserPreferences()
-
-      return data
-    } catch (err) {
-      // Silently handle 502 errors (backend service unavailable)
-      // Only log other errors for debugging
-      if (err?.response?.status !== 502 && err?.code !== 'ERR_BAD_RESPONSE') {
-        console.error('Check auth status failed:', err)
-      }
-      return null
+    if (user.value) {
+      return user.value
     }
+
+    await pendingAuthCheck
+    if (user.value) {
+      return user.value
+    }
+
+    pendingAuthCheck = (async () => {
+      try {
+        const response = await authApi.getProfile()
+        const data = response.data.data || response.data
+        user.value = data
+        if (!token.value && localStorage.getItem('access_token')) {
+          token.value = localStorage.getItem('access_token')
+        }
+        await loadUserPreferences()
+        return data
+      } catch (err) {
+        if (err?.response?.status !== 502 && err?.code !== 'ERR_BAD_RESPONSE') {
+          console.error('Check auth status failed:', err)
+        }
+        return null
+      }
+    })()
+
+    return pendingAuthCheck
   }
 
   const updateProfile = async (profileData) => {


### PR DESCRIPTION
Backend:
- Add hyperbdr_dashboard and hyperbdr_monitor to INSTALLED_APPS
- Mount /api/v1/hyperbdr-dashboard/ URL routes
- Rename onepro_monitor import to hyperbdr_monitor in services.py
- Remove hyperbdr_dashboard from test settings INSTALLED_APPS

Frontend:
- Update KPI type from 'gradient' to 'accent' in dashboard constants and HyperBDRDashboard.vue
- Deduplicate concurrent auth checks in user store via pendingAuthCheck promise to avoid redundant API calls and race conditions

Misc:
- Add backend/ai_pricehub/runtime/ to .gitignore