### PR TITLE
feat(cloud_billing): add minimum cost threshold for cost/growth alert…

### DIFF
--- a/backend/cloud_billing/tasks.py
+++ b/backend/cloud_billing/tasks.py
@@ -72,6 +72,24 @@ MIN_DAYS_REMAINING_REFERENCE_DAYS = 7
 User = get_user_model()
 
 
+def _get_alert_min_cost_threshold() -> Decimal:
+    """
+    Return the minimum cost threshold for sending cost/growth alerts.
+    Returns Decimal("0") when the env var is not set or invalid.
+    """
+    raw = os.getenv("CLOUD_BILLING_ALERT_MIN_COST_THRESHOLD", "").strip()
+    if not raw:
+        return Decimal("0")
+    try:
+        return Decimal(str(raw))
+    except Exception:
+        logger.warning(
+            f"Invalid CLOUD_BILLING_ALERT_MIN_COST_THRESHOLD value: {raw!r}; "
+            f"defaulting to 0"
+        )
+        return Decimal("0")
+
+
 def _inject_recharge_fields(
     raw_recharge_info: str,
     account_id: str,
@@ -1103,6 +1121,24 @@ def check_alert_for_provider(
                 alert_type = AlertRecord.ALERT_TYPE_COST
             else:
                 alert_type = AlertRecord.ALERT_TYPE_GROWTH
+
+            # Apply minimum cost threshold for cost/growth alerts.
+            # Balance and days_remaining alerts are not subject to this check.
+            if alert_type in (
+                AlertRecord.ALERT_TYPE_COST,
+                AlertRecord.ALERT_TYPE_GROWTH,
+            ):
+                min_cost_threshold = _get_alert_min_cost_threshold()
+                if min_cost_threshold > 0 and current_cost <= min_cost_threshold:
+                    logger.info(
+                        f"Task check_alert_for_provider: "
+                        f"Alert suppressed by min cost threshold "
+                        f"(provider_id={provider.id}, name={provider.name}, "
+                        f"account_id={account_id}, "
+                        f"current_cost={current_cost}, "
+                        f"min_cost_threshold={min_cost_threshold})"
+                    )
+                    continue
 
             language = _resolve_notification_language(provider)
 

--- a/env.sample
+++ b/env.sample
@@ -317,6 +317,15 @@ FEISHU_USER_ID=
 FEISHU_USER_IDENTIFIER=
 
 # ============================================================================
+# Cloud Billing Alert Configuration
+# ============================================================================
+# Minimum cost threshold for sending cost/growth alerts.
+# Alerts will only be sent when the current cost exceeds this value.
+# Set to 0 to disable this check (default: 0).
+# Example: CLOUD_BILLING_ALERT_MIN_COST_THRESHOLD=100
+CLOUD_BILLING_ALERT_MIN_COST_THRESHOLD=0
+
+# ============================================================================
 # Langfuse Observability
 # ============================================================================
 # Enable Langfuse tracing for agent runs.


### PR DESCRIPTION
… notifications

Introduce CLOUD_BILLING_ALERT_MIN_COST_THRESHOLD to suppress low-cost alerts. When set, cost and growth type alerts are only sent when the hourly cost exceeds the configured value. Balance and days_remaining alerts are unaffected.

Changes:
- tasks.py: add _get_alert_min_cost_threshold() helper to read the env var
- tasks.py: add early continue in check_alert_for_provider() when threshold is configured and current_cost does not exceed it
- env.sample: document CLOUD_BILLING_ALERT_MIN_COST_THRESHOLD (default 0)

Co-authored-by: Claude Code(MiniMax-M2.7-highspeed) <noreply@minimax.io>
