### PR TITLE
feat(cloud_billing): return structured missing_fields in recharge inf…

### DIFF
--- a/backend/cloud_billing/serializers.py
+++ b/backend/cloud_billing/serializers.py
@@ -19,6 +19,7 @@ from .models import (
 )
 from .services.recharge_approval import (
     CLOUD_TYPE_LABELS,
+    MissingRechargeFieldsError,
     prepare_recharge_request_payload,
     serialize_recharge_request_payload,
 )
@@ -316,6 +317,10 @@ class CloudProviderSerializer(serializers.ModelSerializer):
                 cloud_type=cloud_type,
                 require_cloud_type=True,
             )
+        except MissingRechargeFieldsError as exc:
+            raise serializers.ValidationError(
+                {"missing_fields": exc.missing_fields}
+            ) from exc
         except ValueError as exc:
             raise serializers.ValidationError(str(exc)) from exc
 

--- a/backend/cloud_billing/services/recharge_approval.py
+++ b/backend/cloud_billing/services/recharge_approval.py
@@ -14,6 +14,21 @@ import importlib.util
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, Dict, List, Optional, Tuple
 
+
+class MissingRechargeFieldsError(ValueError):
+    """
+    Raised when recharge info is missing required fields.
+    Carries the list of missing field names for structured error responses.
+    """
+
+    def __init__(self, missing_fields: List[str], message: str = ""):
+        self.missing_fields = missing_fields
+        default_message = (
+            "Recharge info is missing required fields: "
+            + ", ".join(missing_fields)
+        )
+        super().__init__(message or default_message)
+
 from langchain_core.callbacks.base import BaseCallbackHandler
 from langchain_core.outputs import LLMResult
 from langchain_core.tools import tool
@@ -577,10 +592,7 @@ def validate_recharge_request_payload(
                 missing_fields.append(f"payee.{key}")
 
     if missing_fields:
-        raise ValueError(
-            "Recharge info is missing required fields: "
-            + ", ".join(missing_fields)
-        )
+        raise MissingRechargeFieldsError(missing_fields)
     return normalized
 
 

--- a/frontend/src/components/cloud-billing/ProviderRechargeModal.vue
+++ b/frontend/src/components/cloud-billing/ProviderRechargeModal.vue
@@ -838,11 +838,7 @@ const handleSave = async ({ emitSaved = true } = {}) => {
         .map((f) => RECHARGE_INFO_FIELD_LABELS[f] || f)
         .join('、')
       if (fieldLabels) {
-        showError(
-          t('cloudBilling.providers.rechargeInfoSaveErrorMissingFields', {
-            fields: fieldLabels
-          })
-        )
+        showError(t('cloudBilling.providers.rechargeInfoSaveError') + '，缺少以下必填字段：' + fieldLabels)
       } else {
         showError(t('cloudBilling.providers.rechargeInfoSaveError'))
       }

--- a/frontend/src/components/cloud-billing/rechargeApprovalErrors.js
+++ b/frontend/src/components/cloud-billing/rechargeApprovalErrors.js
@@ -28,8 +28,17 @@ export function getRechargeApprovalSubmitErrorContext(error) {
 export function getRechargeInfoSaveErrorContext(error) {
   const responseData = error?.response?.data
 
-  // Primary: { recharge_info: ["missing required fields: ..."] }
-  const fieldError = responseData?.recharge_info
+  // Unified response format: { code, message, data: { recharge_info: {...} } }
+  // recharge_info is always inside responseData.data, not directly in responseData
+  const innerData = responseData?.data
+
+  // New structured format: { recharge_info: { missing_fields: [...] } }
+  const fieldError = innerData?.recharge_info
+  if (fieldError?.missing_fields && Array.isArray(fieldError.missing_fields)) {
+    return { missingFields: fieldError.missing_fields }
+  }
+
+  // Legacy string format fallback: { recharge_info: ["Recharge info is missing required fields: ..."] }
   let inner = null
   if (fieldError !== undefined) {
     inner = Array.isArray(fieldError)
@@ -38,7 +47,7 @@ export function getRechargeInfoSaveErrorContext(error) {
         ? fieldError
         : [fieldError]
   } else {
-    inner = Array.isArray(responseData) ? responseData : [responseData]
+    inner = Array.isArray(innerData) ? innerData : [innerData]
   }
 
   let missingFields = []
@@ -71,7 +80,5 @@ export function getRechargeInfoSaveErrorContext(error) {
     }
   }
 
-  return {
-    missingFields: missingFields.filter(Boolean)
-  }
+  return { missingFields: missingFields.filter(Boolean) }
 }


### PR DESCRIPTION
    feat(cloud_billing): return structured missing_fields in recharge info validation error

    Replace plain ValueError with MissingRechargeFieldsError so the backend
    returns { missing_fields: [...] } instead of a raw string. Frontend parses
    the structured response and falls back to legacy string format.

    Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>