### PR TITLE
Harden collectors against transient runtime failures

### DIFF
--- a/backend/ai_pricehub/parser_agent.py
+++ b/backend/ai_pricehub/parser_agent.py
@@ -4,6 +4,7 @@ import json
 import logging
 import mimetypes
 import re
+import time
 import uuid
 from pathlib import Path
 from typing import Any
@@ -18,6 +19,52 @@ logger = logging.getLogger(__name__)
 
 RESOURCE_TEXT_CHAR_LIMIT = 18000
 RESOURCE_URL_LIMIT = 5
+HTTP_RETRY_ATTEMPTS = 3
+HTTP_RETRY_BASE_DELAY_SECONDS = 1
+
+
+def _is_transient_http_error(exc: Exception) -> bool:
+    """Return whether an HTTP fetch failure is worth retrying."""
+    if isinstance(exc, requests.HTTPError):
+        response = exc.response
+        status_code = response.status_code if response is not None else None
+        return status_code in {429, 500, 502, 503, 504}
+    return isinstance(
+        exc,
+        (
+            requests.ConnectionError,
+            requests.Timeout,
+        ),
+    )
+
+
+def _get_with_retry(url: str, *, timeout: int) -> requests.Response:
+    """Fetch a URL with short exponential retry for transient failures."""
+    last_error = None
+    for attempt_idx in range(HTTP_RETRY_ATTEMPTS):
+        try:
+            response = requests.get(url, timeout=timeout)
+            response.raise_for_status()
+            return response
+        except requests.RequestException as exc:
+            last_error = exc
+            if (
+                attempt_idx >= HTTP_RETRY_ATTEMPTS - 1
+                or not _is_transient_http_error(exc)
+            ):
+                raise
+            delay = HTTP_RETRY_BASE_DELAY_SECONDS * (2 ** attempt_idx)
+            logger.warning(
+                "ai_pricehub parser transient fetch error "
+                "url=%s attempt=%s/%s error=%s retrying_in=%.1fs",
+                url,
+                attempt_idx + 1,
+                HTTP_RETRY_ATTEMPTS,
+                exc,
+                delay,
+            )
+            time.sleep(delay)
+    raise last_error
 
 
 class ParserAgentService:
@@ -124,8 +171,7 @@ class ParserAgentService:
         return evidence
 
     def _fetch_resource(self, url: str, *, job_dir: Path) -> dict[str, Any]:
-        response = requests.get(url, timeout=30)
-        response.raise_for_status()
+        response = _get_with_retry(url, timeout=30)
         content_type = response.headers.get("content-type", "").lower()
         text = response.text
         suffix = self._guess_suffix(url=url, content_type=content_type)

--- a/backend/ai_pricehub/services.py
+++ b/backend/ai_pricehub/services.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import time
 from typing import Any
 from urllib.parse import urlencode, urlsplit, urlunsplit
 
@@ -19,6 +20,52 @@ from .source_config_store import (
 )
 
 logger = logging.getLogger(__name__)
+HTTP_RETRY_ATTEMPTS = 3
+HTTP_RETRY_BASE_DELAY_SECONDS = 1
+
+
+def _is_transient_http_error(exc: Exception) -> bool:
+    """Return whether an HTTP fetch failure is worth retrying."""
+    if isinstance(exc, requests.HTTPError):
+        response = exc.response
+        status_code = response.status_code if response is not None else None
+        return status_code in {429, 500, 502, 503, 504}
+    return isinstance(
+        exc,
+        (
+            requests.ConnectionError,
+            requests.Timeout,
+        ),
+    )
+
+
+def _get_with_retry(url: str, *, timeout: int) -> requests.Response:
+    """Fetch a URL with short exponential retry for transient failures."""
+    last_error = None
+    for attempt_idx in range(HTTP_RETRY_ATTEMPTS):
+        try:
+            response = requests.get(url, timeout=timeout)
+            response.raise_for_status()
+            return response
+        except requests.RequestException as exc:
+            last_error = exc
+            if (
+                attempt_idx >= HTTP_RETRY_ATTEMPTS - 1
+                or not _is_transient_http_error(exc)
+            ):
+                raise
+            delay = HTTP_RETRY_BASE_DELAY_SECONDS * (2 ** attempt_idx)
+            logger.warning(
+                "[ai_pricehub] transient fetch error "
+                "url=%s attempt=%s/%s error=%s retrying_in=%.1fs",
+                url,
+                attempt_idx + 1,
+                HTTP_RETRY_ATTEMPTS,
+                exc,
+                delay,
+            )
+            time.sleep(delay)
+    raise last_error
 
 
 class AIPriceHubService:
@@ -276,8 +323,7 @@ class AIPriceHubService:
 
     def _fetch_primary_vendor_models(self, vendor: dict[str, Any]) -> dict[str, Any]:
         url = vendor.get("models_source", {}).get("url") or vendor.get("pricing_url")
-        response = requests.get(url, timeout=30)
-        response.raise_for_status()
+        response = _get_with_retry(url, timeout=30)
         payload = response.json()
         records = self._extract_agione_records(payload)
         logger.info(
@@ -353,8 +399,7 @@ class AIPriceHubService:
             meta_model_id=meta_model_id,
         )
         try:
-            response = requests.get(detail_url, timeout=15)
-            response.raise_for_status()
+            response = _get_with_retry(detail_url, timeout=15)
             payload = response.json()
         except Exception as exc:
             logger.warning(

--- a/backend/ai_pricehub/tests/test_services.py
+++ b/backend/ai_pricehub/tests/test_services.py
@@ -1,4 +1,5 @@
 import pytest
+import requests
 
 from ai_pricehub.services import AIPriceHubService
 
@@ -77,6 +78,43 @@ def test_fetch_primary_vendor_models_supports_new_agione_square_list_payload(mon
             "is_aggregate": False,
         }
     ]
+
+
+def test_fetch_primary_vendor_models_retries_transient_http_error(monkeypatch):
+    service = AIPriceHubService()
+    vendor = {
+        "slug": "agione",
+        "name": "AGIOne",
+        "platform_slug": "agione",
+        "currency": "CNY",
+        "points_per_currency_unit": 10.0,
+        "models_source": {
+            "url": "https://agione.cc/hyperone/xapi/models/square/list"
+        },
+    }
+    calls = {"count": 0}
+    payload = {"status": 200, "result": []}
+
+    class DummyResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return payload
+
+    def fake_get(url, *args, **kwargs):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise requests.ConnectionError("temporary failure")
+        return DummyResponse()
+
+    monkeypatch.setattr("ai_pricehub.services.time.sleep", lambda delay: None)
+    monkeypatch.setattr("ai_pricehub.services.requests.get", fake_get)
+
+    catalog = service._fetch_primary_vendor_models(vendor)  # noqa: SLF001
+
+    assert catalog["raw_payload"]["record_count"] == 0
+    assert calls["count"] == 2
 
 
 def test_fetch_primary_vendor_models_maps_qwen_to_aliyun_source_vendor(monkeypatch):

--- a/backend/core/settings/celery.py
+++ b/backend/core/settings/celery.py
@@ -48,7 +48,13 @@ CELERY_BROKER_TRANSPORT_OPTIONS = {
     'visibility_timeout': 43200,
     'fanout_prefix': True,
     'fanout_patterns': True,
+    'retry_on_timeout': True,
 }
+
+# Keep workers alive across transient Redis DNS or connection failures.
+CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
+CELERY_BROKER_CONNECTION_RETRY = True
+CELERY_BROKER_CONNECTION_MAX_RETRIES = None
 
 # Task execution time limits
 # CELERY_TASK_TIME_LIMIT: Hard limit (s); worker killed if exceeded.

--- a/backend/data_collector/tasks.py
+++ b/backend/data_collector/tasks.py
@@ -5,10 +5,13 @@ All use agentcore-task TaskTracker and report progress/counts in metadata.
 import hashlib
 import logging
 import os
+import random
 import uuid as uuid_module
 from datetime import timedelta
 
+import requests
 from django.conf import settings
+from django.db import InterfaceError, OperationalError
 from django.db import transaction
 from django.db.models import Prefetch
 from django.utils import timezone
@@ -36,6 +39,106 @@ from .services.storage import (
 logger = logging.getLogger(__name__)
 
 MODULE_NAME = "data_collector"
+RUN_COLLECT_MAX_RETRIES = 3
+RUN_COLLECT_RETRY_BASE_DELAY_SECONDS = 60
+RUN_COLLECT_RETRY_MAX_DELAY_SECONDS = 300
+
+
+def _is_transient_collect_error(exc: Exception) -> bool:
+    """
+    Return whether a collection failure should be retried by Celery.
+    """
+    if isinstance(
+        exc,
+        (
+            InterfaceError,
+            OperationalError,
+            requests.ConnectionError,
+            requests.Timeout,
+        ),
+    ):
+        return True
+    if isinstance(exc, requests.HTTPError):
+        response = exc.response
+        status_code = response.status_code if response is not None else None
+        return status_code in {429, 500, 502, 503, 504}
+
+    detail = str(exc).lower()
+    return any(
+        token in detail
+        for token in (
+            "connection error",
+            "connection reset",
+            "temporary failure",
+            "temporarily unavailable",
+            "timed out",
+            "timeout",
+            "could not translate host name",
+            "name resolution",
+            "rate limit",
+            "too many requests",
+            "502",
+            "503",
+            "504",
+        )
+    )
+
+
+def _retry_collect_if_transient(
+    *,
+    exc: Exception,
+    task_id: str | None,
+    config_uuid: str,
+    config_platform: str,
+    config_key: str,
+) -> bool:
+    """
+    Schedule a retry for transient collection failures when running in Celery.
+    """
+    task = current_task
+    request = getattr(task, "request", None) if task else None
+    retry = getattr(task, "retry", None) if task else None
+    if not request or not callable(retry):
+        return False
+    if not _is_transient_collect_error(exc):
+        return False
+
+    retries = int(getattr(request, "retries", 0) or 0)
+    if retries >= RUN_COLLECT_MAX_RETRIES:
+        return False
+
+    countdown = min(
+        RUN_COLLECT_RETRY_BASE_DELAY_SECONDS * (2 ** retries),
+        RUN_COLLECT_RETRY_MAX_DELAY_SECONDS,
+    )
+    countdown = min(
+        countdown + random.uniform(0, min(30, countdown * 0.2)),
+        RUN_COLLECT_RETRY_MAX_DELAY_SECONDS,
+    )
+    metadata = {
+        "config_uuid": config_uuid,
+        "config_platform": config_platform,
+        "config_key": config_key,
+        "progress_percent": 10,
+        "progress_step": "retry",
+        "retry_count": retries + 1,
+        "max_retries": RUN_COLLECT_MAX_RETRIES,
+        "retry_countdown_seconds": countdown,
+    }
+    if task_id:
+        TaskTracker.update_task_status(
+            task_id,
+            TaskStatus.RETRY,
+            error=str(exc),
+            metadata=metadata,
+        )
+    logger.warning(
+        f"[data_collector] run_collect transient failure, scheduling retry "
+        f"config_uuid={config_uuid}, retry={retries + 1}/"
+        f"{RUN_COLLECT_MAX_RETRIES}, countdown={countdown}s, error={exc}"
+    )
+    retry(exc=exc, countdown=countdown, max_retries=RUN_COLLECT_MAX_RETRIES)
+    return True
 
 
 def _sync_attachments_for_record(provider, auth_config, raw_record):
@@ -212,7 +315,10 @@ def _register_and_start(
         )
 
 
-@shared_task(name="data_collector.tasks.run_collect")
+@shared_task(
+    name="data_collector.tasks.run_collect",
+    max_retries=RUN_COLLECT_MAX_RETRIES,
+)
 @prevent_duplicate_task(
     "data_collector_run_collect", lock_param="config_uuid", timeout=3600
 )
@@ -396,6 +502,14 @@ def run_collect(
                 task_id=task_id,
             )
         except Exception as e:
+            if _retry_collect_if_transient(
+                exc=e,
+                task_id=task_id,
+                config_uuid=config_uuid,
+                config_platform=config.platform,
+                config_key=config.key,
+            ):
+                return {"success": False, "status": "retrying"}
             logger.exception(
                 f"[data_collector] run_collect provider.collect failed: {e}"
             )

--- a/backend/data_collector/tests/test_tasks.py
+++ b/backend/data_collector/tests/test_tasks.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
 import pytest
+import requests
 from django.utils import timezone
 
 from data_collector.models import CollectorConfig, RawDataRecord
@@ -23,6 +24,52 @@ class TestRunCollect:
         assert result["success"] is False
         assert "not found" in result.get("error", "").lower() or "Config" in result.get("error", "")
         mock_get_provider.assert_not_called()
+
+    @patch("data_collector.tasks.TaskTracker.update_task_status")
+    @patch("data_collector.tasks.TaskTracker.register_task")
+    @patch("data_collector.tasks.get_provider")
+    def test_run_collect_retries_transient_provider_failure(
+        self,
+        mock_get_provider,
+        mock_register_task,
+        mock_update_task_status,
+        collector_config,
+        monkeypatch,
+    ):
+        class RetryScheduled(Exception):
+            pass
+
+        retry_kwargs = {}
+
+        def fake_retry(**kwargs):
+            retry_kwargs.update(kwargs)
+            raise RetryScheduled()
+
+        mock_provider = MagicMock()
+        mock_provider.collect.side_effect = requests.ConnectionError(
+            "temporary failure"
+        )
+        mock_get_provider.return_value = MagicMock(return_value=mock_provider)
+        monkeypatch.setattr(
+            "data_collector.tasks.current_task",
+            SimpleNamespace(
+                request=SimpleNamespace(id="task-retry", retries=0),
+                retry=fake_retry,
+            ),
+        )
+        monkeypatch.setattr(
+            "data_collector.tasks.random.uniform",
+            lambda lower, upper: 0,
+        )
+
+        with pytest.raises(RetryScheduled):
+            run_collect(str(collector_config.uuid))
+
+        assert retry_kwargs["countdown"] == 60
+        assert retry_kwargs["max_retries"] == 3
+        assert isinstance(retry_kwargs["exc"], requests.ConnectionError)
+        mock_register_task.assert_called_once()
+        assert mock_update_task_status.call_args_list[-1].args[1] == "RETRY"
 
     @patch("data_collector.tasks.get_provider")
     def test_run_collect_invalid_time_format_returns_error(

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -22,7 +22,8 @@ services:
     networks:
       - backend_network
     depends_on:
-      - postgresql
+      postgresql:
+        condition: service_healthy
     command: development
     healthcheck:
       test: ["CMD", "curl", "-f", "http://127.0.0.1:8000/health"]
@@ -47,9 +48,12 @@ services:
     networks:
       - backend_network
     depends_on:
-      - backend-api
-      - postgresql
-      - redis
+      backend-api:
+        condition: service_started
+      postgresql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     command: celery
 
   backend-scheduler:
@@ -67,9 +71,9 @@ services:
       backend-api:
         condition: service_started
       postgresql:
-        condition: service_started
+        condition: service_healthy
       redis:
-        condition: service_started
+        condition: service_healthy
     command: celery-beat
 
   postgresql:
@@ -116,6 +120,12 @@ services:
       - ./data.dev/logs/redis:/var/log/redis
     networks:
       - backend_network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
 
   flower:
     image: devmind-backend:dev
@@ -129,7 +139,7 @@ services:
       backend-api:
         condition: service_started
       redis:
-        condition: service_started
+        condition: service_healthy
     command: flower
     networks:
       - backend_network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,9 +47,9 @@ services:
       backend-api:
         condition: service_started
       postgresql:
-        condition: service_started
+        condition: service_healthy
       redis:
-        condition: service_started
+        condition: service_healthy
     command: celery
 
   backend-scheduler:
@@ -67,9 +67,9 @@ services:
       backend-api:
         condition: service_started
       postgresql:
-        condition: service_started
+        condition: service_healthy
       redis:
-        condition: service_started
+        condition: service_healthy
     command: celery-beat
 
   frontend:
@@ -164,6 +164,12 @@ services:
       - ./data/logs/redis:/var/log/redis
     networks:
       - backend_network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
 
 networks:
   backend_network:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -23,6 +23,7 @@ CELERY_LOG="/var/log/celery/celery.log"
 WORKERS=${WORKERS:-1}
 THREADS=${THREADS:-1}
 REDIS_URL=${REDIS_URL:-redis://redis:6379/0}
+REDIS_HEALTHCHECK_URL=${REDIS_HEALTHCHECK_URL:-${CELERY_BROKER_URL:-$REDIS_URL}}
 DB_ENGINE=${DB_ENGINE:-sqlite}
 
 # --- Ensure log directories exist ---
@@ -64,6 +65,25 @@ wait_for_db() {
             log "Using SQLite (no health check required)."
             ;;
     esac
+}
+
+wait_for_redis() {
+    log "Waiting for Redis..."
+    until python - <<PY
+import os
+import redis
+
+client = redis.from_url(
+    os.environ.get("REDIS_HEALTHCHECK_URL", "redis://redis:6379/0"),
+    socket_connect_timeout=2,
+    socket_timeout=2,
+)
+client.ping()
+PY
+    do
+        sleep 2
+    done
+    log "Redis is ready!"
 }
 
 # --- Django Management Tasks ---
@@ -181,13 +201,16 @@ case "$1" in
         ;;
     celery)
         wait_for_db
+        wait_for_redis
         start_celery_worker
         ;;
     celery-beat)
         wait_for_db
+        wait_for_redis
         start_celery_beat
         ;;
     flower)
+        wait_for_redis
         start_flower
         ;;
     development)


### PR DESCRIPTION
## Summary
- Add Redis readiness checks and healthy dependency gates for Celery, Beat, and Flower startup
- Enable Celery broker retry behavior for transient Redis connection failures
- Add retry handling for transient AI price source HTTP failures and data collector task failures
- Update agentcore-metering submodule to include LiteLLM transient retry support

## Dependency
- Requires/uses agentcore-metering PR: https://github.com/cloud2ai/agentcore-metering/pull/2

## Test plan
- [x] PYTHONPYCACHEPREFIX=/private/tmp/devmind_pycache python3 -m py_compile backend/data_collector/tasks.py backend/data_collector/tests/test_tasks.py
- [x] .venv/bin/python -m pytest backend/data_collector/tests/test_tasks.py
- [x] .venv/bin/python -m pytest backend/ai_pricehub/tests/test_services.py::test_fetch_primary_vendor_models_retries_transient_http_error backend/ai_pricehub/tests/test_tracked_llm.py
- [x] .venv/bin/python -m pytest backend/agentcore/agentcore-metering/tests/test_llm_tracker.py::TestTransientCompletionRetry

## Notes
- Existing unrelated local changes in agentcore-notifier and untracked local files were not included.