### PR TITLE
fix(sals): harden user sync request handling for TOWER-1Y

### DIFF
--- a/backend/sals/services/etl.py
+++ b/backend/sals/services/etl.py
@@ -31,6 +31,9 @@ API_BASE_URL = os.getenv("ONEPRO_API_BASE_URL", "https://support.oneprocloud.com
 API_USERNAME = os.getenv("ONEPRO_USERNAME", "")
 API_PASSWORD = os.getenv("ONEPRO_PASSWORD", "")
 API_SYNC_LIMIT = int(os.getenv("API_SYNC_LIMIT", "500"))
+API_REQUEST_MAX_ATTEMPTS = int(
+    os.getenv("ONEPRO_API_MAX_ATTEMPTS", "3")
+)
 
 _STATE_MAP = {
     1: "New",
@@ -196,6 +199,73 @@ def _build_headers(token: str) -> Dict[str, str]:
     }
 
 
+def _is_transient_request_error(exc: Exception) -> bool:
+    """Return whether a request failure looks transient."""
+    if isinstance(exc, (requests.ConnectionError, requests.Timeout)):
+        return True
+
+    detail = str(exc).lower()
+    return any(
+        token in detail
+        for token in (
+            "connection aborted",
+            "connection error",
+            "connection reset",
+            "max retries exceeded",
+            "name resolution",
+            "temporary failure",
+            "timed out",
+            "timeout",
+        )
+    )
+
+
+def _request_with_retry(
+    *,
+    url: str,
+    headers: Dict[str, str],
+    params: Dict[str, Any],
+    context: str,
+    partial_ok: bool,
+) -> Optional[requests.Response]:
+    """Issue a GET request with retry for transient failures."""
+    last_error: Optional[Exception] = None
+
+    for attempt in range(1, API_REQUEST_MAX_ATTEMPTS + 1):
+        try:
+            return requests.get(
+                url,
+                headers=headers,
+                params=params,
+                timeout=60,
+                verify=False,
+            )
+        except Exception as exc:
+            last_error = exc
+            is_transient = _is_transient_request_error(exc)
+            is_last_attempt = attempt == API_REQUEST_MAX_ATTEMPTS
+
+            if not is_transient or is_last_attempt:
+                if partial_ok and is_transient:
+                    log = logger.warning
+                else:
+                    log = logger.error
+                log("%s: %s", context, exc)
+                return None
+
+            logger.warning(
+                "%s (attempt %s/%s): %s",
+                context,
+                attempt,
+                API_REQUEST_MAX_ATTEMPTS,
+                exc,
+            )
+
+    if last_error is not None:
+        logger.error("%s: %s", context, last_error)
+    return None
+
+
 def _parse_raw_incident(raw: dict) -> Optional[dict]:
     """Extract structured fields from a single API record."""
     if not isinstance(raw, dict):
@@ -293,11 +363,15 @@ def fetch_users_from_api(token: str, limit: int = 500) -> List[Dict[str, Any]]:
             "sysparm_limit": min(200, limit - len(all_records)),
             "sysparm_offset": offset,
         }
-        url = "https://support.oneprocloud.com/api/hyper/table/sys_user"
-        try:
-            resp = requests.get(url, headers=headers, params=params, timeout=60, verify=False)
-        except Exception as e:
-            logger.error("User API request exception at offset %s: %s", offset, e)
+        url = f"{API_BASE_URL}/api/hyper/table/sys_user"
+        resp = _request_with_retry(
+            url=url,
+            headers=headers,
+            params=params,
+            context=f"User API request exception at offset {offset}",
+            partial_ok=bool(all_records),
+        )
+        if resp is None:
             break
 
         if resp.status_code != 200:
@@ -329,7 +403,7 @@ def fetch_users_from_api(token: str, limit: int = 500) -> List[Dict[str, Any]]:
             })
 
         logger.info("Fetched %s user records (offset=%s)", len(all_records), offset)
-        offset += batch_size
+        offset += len(records)
         if len(records) < batch_size:
             break
         if len(all_records) >= limit:

--- a/backend/sals/test_etl.py
+++ b/backend/sals/test_etl.py
@@ -1,0 +1,113 @@
+"""Regression tests for SALS ETL request handling."""
+
+from unittest.mock import Mock, patch
+
+import requests
+
+from sals.services import etl
+
+
+def _build_user_record(index: int) -> dict:
+    """Build a minimal user payload from the remote API."""
+    return {
+        "record_data_map": {
+            "sys_id": f"user-{index}",
+            "name": f"User {index}",
+        }
+    }
+
+
+def _build_response(records: list[dict], status_code: int = 200) -> Mock:
+    """Build a mocked requests response."""
+    response = Mock()
+    response.status_code = status_code
+    response.json.return_value = {"data": records}
+    response.text = "mocked"
+    return response
+
+
+def _expected_user(index: int) -> dict:
+    """Build the expected normalized user payload."""
+    return {
+        "sys_id": f"user-{index}",
+        "name": f"User {index}",
+        "email": None,
+        "user_name": None,
+        "department": None,
+        "phone": None,
+        "mobile_phone": None,
+        "title": None,
+        "active": None,
+    }
+
+
+@patch.object(etl, "API_REQUEST_MAX_ATTEMPTS", 2)
+def test_fetch_users_retries_transient_request_before_success():
+    """Transient user API failures should retry before succeeding."""
+    first_page = [_build_user_record(1)]
+    transient_error = requests.ConnectionError(
+        "temporary failure in name resolution"
+    )
+
+    with (
+        patch(
+            "sals.services.etl.requests.get",
+            side_effect=[
+                transient_error,
+                _build_response(first_page),
+            ],
+        ) as mock_get,
+        patch("sals.services.etl.logger") as mock_logger,
+    ):
+        records = etl.fetch_users_from_api("token", limit=1)
+
+    assert records == [_expected_user(1)]
+    assert mock_get.call_count == 2
+    mock_logger.warning.assert_called()
+    mock_logger.error.assert_not_called()
+
+
+@patch.object(etl, "API_REQUEST_MAX_ATTEMPTS", 2)
+def test_fetch_users_warns_on_partial_follow_up_failure():
+    """Handled follow-up page failures should not be logged as errors."""
+    first_page = [_build_user_record(index) for index in range(200)]
+    transient_error = requests.ConnectionError(
+        "temporary failure in name resolution"
+    )
+
+    with (
+        patch(
+            "sals.services.etl.requests.get",
+            side_effect=[
+                _build_response(first_page),
+                transient_error,
+                transient_error,
+            ],
+        ),
+        patch("sals.services.etl.logger") as mock_logger,
+    ):
+        records = etl.fetch_users_from_api("token", limit=500)
+
+    assert len(records) == 200
+    mock_logger.warning.assert_called()
+    mock_logger.error.assert_not_called()
+
+
+@patch.object(etl, "API_REQUEST_MAX_ATTEMPTS", 2)
+def test_fetch_users_logs_error_when_initial_page_fails():
+    """Initial user API failures should remain errors."""
+    transient_error = requests.ConnectionError(
+        "temporary failure in name resolution"
+    )
+
+    with (
+        patch(
+            "sals.services.etl.requests.get",
+            side_effect=[transient_error, transient_error],
+        ),
+        patch("sals.services.etl.logger") as mock_logger,
+    ):
+        records = etl.fetch_users_from_api("token", limit=1)
+
+    assert records == []
+    mock_logger.error.assert_called_once()


### PR DESCRIPTION
## Summary
- add transient request retry handling to SALS user sync requests
- downgrade follow-up page failures with already-fetched user data from error to warning to avoid noisy Sentry events
- stop advancing user pagination by a fixed batch size when the upstream API returns more rows than requested
- add regression tests covering retry success, partial follow-up failure, and initial hard failure paths

## Sentry
- Targets `TOWER-1Y` in project `tower`
- Latest seen on June 16, 2026 in release `1.6.4`
- Leaves infra-only issues like `TOWER-K` untouched because they require environment fixes, not code changes

## Test plan
- [x] `python3 -m py_compile backend/sals/services/etl.py backend/sals/test_etl.py`
- [x] `PYTHONPATH=backend uv run --no-project --with 'django==5.1.4' --with 'djangorestframework==3.15.2' --with 'django-celery-beat==2.7.0' --with 'requests>=2.31.0' --with 'pytest>=7.0.0' python - <<'PY' ... pytest.main(['--noconftest', 'backend/sals/test_etl.py']) ... PY`