### PR TITLE
Suppress transient celery beat database DNS noise

### DIFF
--- a/backend/core/__init__.py
+++ b/backend/core/__init__.py
@@ -26,6 +26,8 @@ def _init_sentry():
     from sentry_sdk.integrations.django import DjangoIntegration
     from sentry_sdk.integrations.redis import RedisIntegration
 
+    from .sentry import before_send
+
     sentry_sdk.init(
         dsn=SENTRY_DSN,
         environment=SENTRY_ENVIRONMENT,
@@ -38,6 +40,7 @@ def _init_sentry():
             CeleryIntegration(),
             RedisIntegration(),
         ],
+        before_send=before_send,
     )
 
 

--- a/backend/core/sentry.py
+++ b/backend/core/sentry.py
@@ -1,0 +1,45 @@
+"""
+Sentry event filtering helpers.
+"""
+
+
+POSTGRES_DNS_ERROR = (
+    'could not translate host name "postgresql" to address: '
+    "Temporary failure in name resolution"
+)
+CELERY_BEAT_LOGGER = "django_celery_beat.schedulers"
+
+
+def before_send(event, hint):
+    """
+    Drop expected transient infrastructure logs before sending to Sentry.
+    """
+    if _is_celery_beat_postgres_dns_error(event):
+        return None
+    return event
+
+
+def _is_celery_beat_postgres_dns_error(event):
+    if event.get("logger") != CELERY_BEAT_LOGGER:
+        return False
+
+    return _exception_matches(event) or _logentry_matches(event)
+
+
+def _exception_matches(event):
+    values = event.get("exception", {}).get("values") or []
+    for value in values:
+        if value.get("type") != "OperationalError":
+            continue
+        if POSTGRES_DNS_ERROR in str(value.get("value", "")):
+            return True
+    return False
+
+
+def _logentry_matches(event):
+    logentry = event.get("logentry") or {}
+    message = " ".join(
+        str(logentry.get(key, ""))
+        for key in ("message", "formatted")
+    )
+    return POSTGRES_DNS_ERROR in message

--- a/backend/tests/test_sentry.py
+++ b/backend/tests/test_sentry.py
@@ -1,0 +1,68 @@
+import importlib.util
+from pathlib import Path
+
+
+SENTRY_MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "core" / "sentry.py"
+)
+
+spec = importlib.util.spec_from_file_location(
+    "core_sentry_for_tests",
+    SENTRY_MODULE_PATH,
+)
+core_sentry = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(core_sentry)
+
+
+def test_before_send_drops_celery_beat_postgres_dns_errors():
+    event = {
+        "logger": "django_celery_beat.schedulers",
+        "exception": {
+            "values": [
+                {
+                    "type": "OperationalError",
+                    "value": (
+                        'could not translate host name "postgresql" '
+                        "to address: Temporary failure in name resolution\n"
+                    ),
+                }
+            ]
+        },
+    }
+
+    assert core_sentry.before_send(event, {}) is None
+
+
+def test_before_send_keeps_postgres_dns_errors_from_other_loggers():
+    event = {
+        "logger": "cloud_billing.tasks",
+        "exception": {
+            "values": [
+                {
+                    "type": "OperationalError",
+                    "value": (
+                        'could not translate host name "postgresql" '
+                        "to address: Temporary failure in name resolution\n"
+                    ),
+                }
+            ]
+        },
+    }
+
+    assert core_sentry.before_send(event, {}) is event
+
+
+def test_before_send_keeps_other_celery_beat_database_errors():
+    event = {
+        "logger": "django_celery_beat.schedulers",
+        "exception": {
+            "values": [
+                {
+                    "type": "OperationalError",
+                    "value": "connection to server at postgresql timed out",
+                }
+            ]
+        },
+    }
+
+    assert core_sentry.before_send(event, {}) is event

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,8 @@ services:
     networks:
       - backend_network
     depends_on:
-      - postgresql
+      postgresql:
+        condition: service_healthy
     command: gunicorn
     healthcheck:
       test: ["CMD", "curl", "-f", "http://127.0.0.1:8000/health"]


### PR DESCRIPTION
## Summary
- Filter the handled django-celery-beat PostgreSQL DNS log that created Sentry TOWER-K.
- Keep other loggers and non-DNS database errors reporting to Sentry.
- Wait for PostgreSQL health before starting the production API container.

Sentry: TOWER-K

## Test plan
- [x] python3 -m pytest backend/tests/test_sentry.py -q
- [x] python3 -m py_compile backend/core/sentry.py backend/tests/test_sentry.py
- [x] APP_VERSION=test docker compose -f docker-compose.yml config

## Notes
- black and isort are not installed in this local Python environment.