### PR TITLE
Fix duplicate prepaid cloud accounts

### DIFF
--- a/backend/cloud_billing/dashboard.py
+++ b/backend/cloud_billing/dashboard.py
@@ -974,8 +974,28 @@ def _build_financial_health(accounts):
         provider_balances[provider_key] = _to_float(item.get('balance'))
 
     total_funds = round(sum(provider_balances.values()), 2)
+    health_accounts = []
+    prepaid_provider_keys = set()
+    for item in accounts:
+        if item.get('type') != 'prepaid':
+            health_accounts.append(item)
+            continue
+
+        provider_key = item.get('provider_id')
+        if provider_key in (None, ''):
+            provider_key = item.get('id')
+        if provider_key in (None, ''):
+            health_accounts.append(item)
+            continue
+        if provider_key in prepaid_provider_keys:
+            continue
+
+        prepaid_provider_keys.add(provider_key)
+        health_accounts.append(item)
+
     referenced_accounts = [
-        item for item in accounts if item.get('has_days_remaining_reference')
+        item for item in health_accounts
+        if item.get('has_days_remaining_reference')
     ]
     total_days = min(
         (item['days_remaining'] for item in referenced_accounts),
@@ -1022,7 +1042,7 @@ def _build_financial_health(accounts):
                 False,
             ),
         }
-        for item in accounts
+        for item in health_accounts
     ]
     return {
         'total_funds': total_funds,

--- a/backend/cloud_billing/tests/test_dashboard.py
+++ b/backend/cloud_billing/tests/test_dashboard.py
@@ -176,6 +176,7 @@ class PaymentTypeTests(SimpleTestCase):
             {
                 'provider_id': 1,
                 'id': '1-acct-a',
+                'type': 'prepaid',
                 'balance': Decimal('200.00'),
                 'days_remaining': 8,
                 'name': 'AWS Main',
@@ -187,6 +188,7 @@ class PaymentTypeTests(SimpleTestCase):
             {
                 'provider_id': 1,
                 'id': '1-acct-b',
+                'type': 'prepaid',
                 'balance': Decimal('200.00'),
                 'days_remaining': 12,
                 'name': 'AWS Main',
@@ -198,6 +200,7 @@ class PaymentTypeTests(SimpleTestCase):
             {
                 'provider_id': 2,
                 'id': '2-default',
+                'type': 'prepaid',
                 'balance': Decimal('50.00'),
                 'days_remaining': 5,
                 'name': 'Baidu',
@@ -211,6 +214,69 @@ class PaymentTypeTests(SimpleTestCase):
         financial_health = _build_financial_health(accounts)
 
         self.assertEqual(financial_health['total_funds'], 250.0)
+
+    def test_financial_health_deduplicates_prepaid_recharge_alerts(self):
+        accounts = [
+            {
+                'provider_id': 1,
+                'id': '1-acct-a',
+                'type': 'prepaid',
+                'balance': Decimal('200.00'),
+                'days_remaining': 8,
+                'name': 'Baidu',
+                'category': 'Cloud',
+                'account_id': 'acct-a',
+                'notes': '',
+                'tags': [],
+            },
+            {
+                'provider_id': 1,
+                'id': '1-acct-b',
+                'type': 'prepaid',
+                'balance': Decimal('200.00'),
+                'days_remaining': 12,
+                'name': 'Baidu',
+                'category': 'Cloud',
+                'account_id': 'acct-b',
+                'notes': '',
+                'tags': [],
+            },
+            {
+                'provider_id': 2,
+                'id': '2-acct-a',
+                'type': 'postpaid',
+                'balance': Decimal('0.00'),
+                'days_remaining': 45,
+                'name': 'AWS',
+                'category': 'Cloud',
+                'account_id': 'acct-a',
+                'notes': '',
+                'tags': [],
+            },
+            {
+                'provider_id': 2,
+                'id': '2-acct-b',
+                'type': 'postpaid',
+                'balance': Decimal('0.00'),
+                'days_remaining': 45,
+                'name': 'AWS',
+                'category': 'Cloud',
+                'account_id': 'acct-b',
+                'notes': '',
+                'tags': [],
+            },
+        ]
+
+        financial_health = _build_financial_health(accounts)
+        alert_keys = [
+            (item['provider_id'], item['account_id'])
+            for item in financial_health['recharge_alerts']
+        ]
+
+        self.assertEqual(
+            alert_keys,
+            [(1, 'acct-a'), (2, 'acct-a'), (2, 'acct-b')],
+        )
 
 
 class AccountFundsTests(SimpleTestCase):

--- a/frontend/src/components/cloud-billing/CloudBillingOverviewPanel.vue
+++ b/frontend/src/components/cloud-billing/CloudBillingOverviewPanel.vue
@@ -2497,9 +2497,26 @@ const groupedRows = computed(() => {
   }))
 })
 
-const prepaidAccounts = computed(() =>
-  (overview.value.accounts || []).filter((item) => item.type === 'prepaid')
-)
+const prepaidAccounts = computed(() => {
+  const accountsByProvider = new Map()
+
+  ;(overview.value.accounts || []).forEach((item) => {
+    if (item.type !== 'prepaid') {
+      return
+    }
+
+    const providerKey = providerLevelAccountKey(item)
+    if (!providerKey || accountsByProvider.has(providerKey)) {
+      return
+    }
+
+    accountsByProvider.set(providerKey, item)
+  })
+
+  return Array.from(accountsByProvider.values()).sort(
+    compareAccountsByAvailability
+  )
+})
 
 const postpaidAccounts = computed(() =>
   (overview.value.accounts || []).filter((item) => item.type === 'postpaid')
@@ -2621,6 +2638,22 @@ function normalizedBalanceForSort(account) {
     account?.display_funds_currency || account?.balance_currency || 'CNY',
     'CNY'
   )
+}
+
+function providerLevelAccountKey(account) {
+  const providerId = String(account?.provider_id || '').trim()
+  if (providerId) {
+    return `provider:${providerId}`
+  }
+
+  const providerName = String(account?.provider || account?.name || '')
+    .trim()
+    .toLowerCase()
+  if (providerName) {
+    return `provider-name:${providerName}`
+  }
+
+  return String(account?.id || account?.account_id || '').trim()
 }
 
 function compareAccountsByAvailability(a, b) {


### PR DESCRIPTION
## Summary
- Deduplicate prepaid provider entries in operations financial health alerts.
- Deduplicate prepaid account cards by provider in the operations overview UI.
- Add dashboard regression coverage for prepaid alert deduplication while preserving postpaid multi-account rows.

## Test plan
- [x] python3 -m compileall -q backend/cloud_billing/dashboard.py backend/cloud_billing/tests/test_dashboard.py
- [x] git diff --check
- [x] npx eslint src/components/cloud-billing/CloudBillingOverviewPanel.vue --quiet
- [x] npm run build

## Notes
- `pytest backend/cloud_billing/tests/test_dashboard.py` could not run in this local environment because Django is not installed.