### PR TITLE
fix: suppress celery redis reconnect noise

### DIFF
--- a/backend/core/sentry.py
+++ b/backend/core/sentry.py
@@ -8,6 +8,9 @@ POSTGRES_DNS_ERROR = (
     "Temporary failure in name resolution"
 )
 CELERY_BEAT_LOGGER = "django_celery_beat.schedulers"
+CELERY_CONSUMER_LOGGER = "celery.worker.consumer.consumer"
+REDIS_BROKER_RECONNECT_PREFIX = "consumer: Cannot connect to redis://"
+CELERY_RETRY_MESSAGE = "Trying again in"
 
 
 def before_send(event, hint):
@@ -15,6 +18,8 @@ def before_send(event, hint):
     Drop expected transient infrastructure logs before sending to Sentry.
     """
     if _is_celery_beat_postgres_dns_error(event):
+        return None
+    if _is_celery_redis_broker_reconnect_log(event):
         return None
     return event
 
@@ -24,6 +29,17 @@ def _is_celery_beat_postgres_dns_error(event):
         return False
 
     return _exception_matches(event) or _logentry_matches(event)
+
+
+def _is_celery_redis_broker_reconnect_log(event):
+    if event.get("logger") != CELERY_CONSUMER_LOGGER:
+        return False
+
+    message = _logentry_message(event)
+    return (
+        REDIS_BROKER_RECONNECT_PREFIX in message
+        and CELERY_RETRY_MESSAGE in message
+    )
 
 
 def _exception_matches(event):
@@ -37,9 +53,12 @@ def _exception_matches(event):
 
 
 def _logentry_matches(event):
+    return POSTGRES_DNS_ERROR in _logentry_message(event)
+
+
+def _logentry_message(event):
     logentry = event.get("logentry") or {}
-    message = " ".join(
+    return " ".join(
         str(logentry.get(key, ""))
         for key in ("message", "formatted")
     )
-    return POSTGRES_DNS_ERROR in message

--- a/backend/tests/test_sentry.py
+++ b/backend/tests/test_sentry.py
@@ -10,6 +10,8 @@ spec = importlib.util.spec_from_file_location(
     "core_sentry_for_tests",
     SENTRY_MODULE_PATH,
 )
+assert spec is not None
+assert spec.loader is not None
 core_sentry = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(core_sentry)
 
@@ -31,6 +33,33 @@ def test_before_send_drops_celery_beat_postgres_dns_errors():
     }
 
     assert core_sentry.before_send(event, {}) is None
+
+
+def test_before_send_drops_celery_redis_broker_reconnect_logs():
+    event = {
+        "logger": "celery.worker.consumer.consumer",
+        "logentry": {
+            "message": "consumer: Cannot connect to %s: %s.\n%s\n",
+            "formatted": (
+                "consumer: Cannot connect to redis://redis:6379/0: "
+                "Error 111 connecting to redis:6379. Connection refused..\n"
+                "Trying again in 2.00 seconds... (1/None)\n"
+            ),
+        },
+    }
+
+    assert core_sentry.before_send(event, {}) is None
+
+
+def test_before_send_keeps_non_broker_celery_consumer_errors():
+    event = {
+        "logger": "celery.worker.consumer.consumer",
+        "logentry": {
+            "formatted": "consumer: Unexpected unrecoverable worker error",
+        },
+    }
+
+    assert core_sentry.before_send(event, {}) is event
 
 
 def test_before_send_keeps_postgres_dns_errors_from_other_loggers():


### PR DESCRIPTION
## Summary
- Handle Sentry TOWER-S by filtering recoverable Celery Redis broker reconnect logs in `before_send`.
- Add regression coverage for the Redis reconnect event and a guard that unrelated Celery consumer errors are still sent.
- Local `worklog.md` records Sentry triage, verification, and release constraints; it is intentionally not part of this PR.

## Sentry
- Project: `sentry/tower`
- Issue: `TOWER-S` / `57`
- Level: error
- Latest event: `2026-06-23T02:31:39Z`
- Assessment: transient Celery broker disconnect surfaced as a retrying consumer log, matching existing transient infra filtering policy.

## Verification
- PASS: `.venv/bin/python -m pytest backend/tests/test_sentry.py`
- PASS: `.venv/bin/ruff check backend/core/sentry.py backend/tests/test_sentry.py`
- PASS: `MYPYPATH=backend .venv/bin/python -m mypy --explicit-package-bases --ignore-missing-imports --follow-imports=skip backend/core/sentry.py backend/tests/test_sentry.py`

## Known Existing Blockers
- Full `.venv/bin/python -m pytest` fails during collection outside this change due to initialized submodule test conflicts, app test settings missing apps in `INSTALLED_APPS`, and stale `hyperbdr_dashboard` imports.
- Full `.venv/bin/ruff check .` reports 178 existing lint errors outside this change.

## Release Notes
- No direct deploy performed.
- Do not resolve Sentry or close Jira until production verification passes.