### PR TITLE
fix: classify Volcengine billing timeouts

### DIFF
--- a/backend/cloud_billing/services/provider_service.py
+++ b/backend/cloud_billing/services/provider_service.py
@@ -367,6 +367,20 @@ class ProviderService:
             )
             billing_service = BillingService(provider_type, normalized_config)
             result = billing_service.get_billing_info(period=period)
+            error_msg = result.get("error")
+            if result.get("status") == "error" and error_msg:
+                classification = self._classify_error(
+                    provider_type, str(error_msg)
+                )
+                error_type = classification.get("error_type")
+                result["error_code"] = classification.get("error_code")
+                result["required_permissions"] = classification.get(
+                    "required_permissions", []
+                )
+                if error_type == "permission_error":
+                    result["is_permission_error"] = True
+                elif error_type == "service_error":
+                    result["is_api_error"] = True
             return result
         except ValueError as e:
             # Configuration errors should not be reported as system errors
@@ -447,18 +461,24 @@ class ProviderService:
                         f"error={str(e)})"
                     )
 
+            if not is_valid and error_classification is None:
+                error_classification = self._classify_error(
+                    provider_type, error_message
+                )
+
+            classification = error_classification if not is_valid else None
             result = {
                 "valid": is_valid,
                 "error_code": (
-                    error_classification["error_code"] if not is_valid else None
+                    classification["error_code"] if classification else None
                 ),
                 "account_id": account_id,
                 "error_type": (
-                    error_classification["error_type"] if not is_valid else None
+                    classification["error_type"] if classification else None
                 ),
                 "required_permissions": (
-                    error_classification["required_permissions"]
-                    if not is_valid
+                    classification["required_permissions"]
+                    if classification
                     else []
                 ),
             }

--- a/backend/cloud_billing/tests/test_services.py
+++ b/backend/cloud_billing/tests/test_services.py
@@ -2,15 +2,17 @@
 Tests for cloud billing services.
 """
 
-import pytest
 from decimal import Decimal
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch
+
+import pytest
+
+from cloud_billing.models import AlertRecord, RechargeApprovalRecord
 from cloud_billing.services.notification_service import (
     CloudBillingNotificationService,
     RechargeApprovalNotificationService,
 )
 from cloud_billing.services.provider_service import ProviderService
-from cloud_billing.models import CloudProvider, AlertRecord, RechargeApprovalRecord
 
 
 @pytest.mark.django_db
@@ -87,6 +89,36 @@ class TestProviderService:
         service = ProviderService()
         with pytest.raises(Exception):
             service.get_billing_info("aws", {}, period="2025-01")
+
+    @patch("cloud_billing.services.provider_service.BillingService")
+    def test_get_billing_info_classifies_volcengine_timeout(
+        self, mock_billing_service
+    ):
+        """
+        Volcengine service timeouts should be treated as cloud API errors.
+        """
+        mock_instance = Mock()
+        mock_instance.get_billing_info.return_value = {
+            "status": "error",
+            "data": None,
+            "error": (
+                "InternalServiceTimeout: Internal Service is timeout. "
+                "Pls Contact With Admin"
+            ),
+        }
+        mock_billing_service.return_value = mock_instance
+
+        service = ProviderService()
+        result = service.get_billing_info(
+            "volcengine",
+            {"api_key": "test", "api_secret": "test"},
+            period="2026-06",
+        )
+
+        assert result["status"] == "error"
+        assert result["error_code"] == "volcengine_timeout"
+        assert result["is_api_error"] is True
+        assert result["required_permissions"] == []
 
     @patch("cloud_billing.services.provider_service.ProviderFactory")
     def test_create_provider_volcengine_normalizes_config(self, mock_factory):
@@ -197,7 +229,7 @@ class TestProviderService:
         mock_factory.create_provider.return_value = mock_provider_instance
 
         service = ProviderService()
-        result = service.create_provider(
+        service.create_provider(
             "baidu",
             {
                 "BAIDU_ACCESS_KEY_ID": "test_key",

--- a/worklog.md
+++ b/worklog.md
@@ -31,3 +31,4 @@
 - Full `ruff check backend` failed on 147 existing lint errors.
 - Full `mypy backend` failed on 695 existing type/import-stub errors.
 - No deploy, Sentry resolve, or Jira close was performed.
+- Created PR: https://github.com/HyperBDR/devmind/pull/50.

--- a/worklog.md
+++ b/worklog.md
@@ -1,0 +1,33 @@
+# Worklog
+
+## 2026-06-24 09:06 CST
+
+- Started Sentry triage for project `tower` on branch
+  `fengren/auto-tower-sentry-bug-fix-run-7-20260624T0105`.
+- Ran `sentry-cli issues list -p tower`; no `fatal` issues were visible.
+- Selected one issue: `TOWER-3Y`, latest unresolved `error`.
+- Treated `TOWER-3X` only as related context for the same Volcengine
+  billing timeout signature.
+- `sentry-cli issue view` is unavailable in this installed CLI, so
+  investigation used `sentry-cli issues` output plus local code.
+- Root cause found in `ProviderService.get_billing_info()`: Volcengine
+  `InternalServiceTimeout` was classifiable as a service error, but
+  provider-returned `status=error` results were not annotated with
+  `is_api_error`, causing `collect_billing_data` to log an app `error`.
+- Implemented classification reuse in `ProviderService.get_billing_info()`
+  and added a regression test for `volcengine_timeout`.
+- Built local Python 3.11 `.venv`; system Python 3.9 could not install
+  Django 5.1.4.
+- Installed project dev dependencies and `ruff` in `.venv`.
+- Passed targeted verification:
+  `.venv/bin/pytest backend/cloud_billing/tests/test_services.py::TestProviderService::test_get_billing_info_classifies_volcengine_timeout -q`.
+- Passed scoped lint:
+  `.venv/bin/ruff check --target-version py311 backend/cloud_billing/services/provider_service.py backend/cloud_billing/tests/test_services.py`.
+- Passed scoped typing:
+  `PYTHONPATH=backend .venv/bin/mypy --ignore-missing-imports backend/cloud_billing/services/provider_service.py backend/cloud_billing/tests/test_services.py`.
+- Full `pytest` failed on existing unrelated collection/test failures:
+  app-specific Django settings conflict, removed `hyperbdr_dashboard`
+  symbols, and 21 existing `cloud_billing` failures.
+- Full `ruff check backend` failed on 147 existing lint errors.
+- Full `mypy backend` failed on 695 existing type/import-stub errors.
+- No deploy, Sentry resolve, or Jira close was performed.


### PR DESCRIPTION
## Summary
- Fixes Sentry issue TOWER-3Y by classifying Volcengine `InternalServiceTimeout` provider errors as cloud API errors.
- Reuses existing `ProviderService._classify_error()` logic so `collect_billing_data` logs these provider timeouts as warnings instead of app errors.
- Adds `worklog.md` with triage and verification notes.

## Verification
Passed:
- `.venv/bin/pytest backend/cloud_billing/tests/test_services.py::TestProviderService::test_get_billing_info_classifies_volcengine_timeout -q`
- `.venv/bin/ruff check --target-version py311 backend/cloud_billing/services/provider_service.py backend/cloud_billing/tests/test_services.py`
- `PYTHONPATH=backend .venv/bin/mypy --ignore-missing-imports backend/cloud_billing/services/provider_service.py backend/cloud_billing/tests/test_services.py`

Attempted but blocked by existing unrelated repo failures:
- `pytest`: app-specific Django settings conflicts plus unrelated hyperbdr/cloud_billing failures.
- `ruff check backend`: 147 existing lint errors.
- `mypy backend`: 695 existing type/import-stub errors.

## SRE Notes
- No deploy performed.
- Did not resolve Sentry or close Jira; those remain gated on production validation.