### PR TITLE
Support tag search for cloud providers

### DIFF
--- a/frontend/e2e/cloud-billing.spec.js
+++ b/frontend/e2e/cloud-billing.spec.js
@@ -221,6 +221,93 @@ test.describe('Cloud Billing Settings', () => {
     await expect(page).toHaveURL(/\/cloud-billing\/settings/)
   })
 
+  test('Settings search filters providers by tag', async ({ page }) => {
+    await page.route('**/v1/cloud-billing/providers**', async (route) => {
+      const url = new URL(route.request().url())
+      const pathname = url.pathname
+      const method = route.request().method()
+
+      if (method === 'GET' && pathname === '/v1/cloud-billing/providers/') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            results: [
+              {
+                id: 1,
+                name: 'Primary Provider',
+                provider_type: 'aws',
+                display_name: 'Primary Provider',
+                auth_identifier: 'primary@example.com',
+                is_active: true,
+                created_at: '2026-04-21T00:00:00Z',
+                tags: ['production', 'critical'],
+                config: {}
+              },
+              {
+                id: 2,
+                name: 'Archive Provider',
+                provider_type: 'azure',
+                display_name: 'Archive Provider',
+                auth_identifier: 'archive@example.com',
+                is_active: true,
+                created_at: '2026-04-21T00:00:00Z',
+                tags: ['backup'],
+                config: {}
+              }
+            ],
+            count: 2
+          })
+        })
+        return
+      }
+
+      if (
+        method === 'GET' &&
+        pathname === '/v1/cloud-billing/providers/tags/'
+      ) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ tags: ['production', 'critical', 'backup'] })
+        })
+        return
+      }
+
+      await route.continue()
+    })
+
+    await page.route('**/v1/cloud-billing/alert-rules**', async (route) => {
+      const request = route.request()
+      if (
+        request.method() === 'GET' &&
+        new URL(request.url()).pathname === '/v1/cloud-billing/alert-rules/'
+      ) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ results: [] })
+        })
+        return
+      }
+
+      await route.continue()
+    })
+
+    await page.goto('/cloud-billing/settings')
+    await page.waitForLoadState('networkidle')
+
+    await expect(page.getByText('Primary Provider').first()).toBeVisible()
+    await expect(page.getByText('Archive Provider').first()).toBeVisible()
+
+    await page
+      .locator('input[placeholder*="标签"], input[placeholder*="tag" i]')
+      .fill('critical')
+
+    await expect(page.getByText('Primary Provider').first()).toBeVisible()
+    await expect(page.getByText('Archive Provider')).not.toBeVisible()
+  })
+
   test('Recharge info save requires submitter identifier', async ({ page }) => {
     let patchCalls = 0
 

--- a/frontend/src/components/cloud-billing/ProviderAuthentication.vue
+++ b/frontend/src/components/cloud-billing/ProviderAuthentication.vue
@@ -642,12 +642,15 @@ const pageSize = ref(10)
 
 const getSearchableProviderTexts = (provider) => {
   const config = provider?.config || {}
+  const tags = Array.isArray(provider?.tags) ? provider.tags : []
+
   return [
     provider?.display_name,
     provider?.displayName,
     provider?.name,
     provider?.notes,
     provider?.auth_identifier,
+    ...tags,
     config.username,
     config.zhipu_username,
     config.ZHIPU_USERNAME,
@@ -973,7 +976,7 @@ const editAuthConfig = async (provider) => {
   try {
     const response = await cloudBillingApi.getProvider(provider.id)
     const data = extractResponseData(response)
-    editingProvider.value = data?.id ? data : (data?.data || data)
+    editingProvider.value = data?.id ? data : data?.data || data
   } catch {
     showError(t('errors.serverError'))
     editingProvider.value = provider


### PR DESCRIPTION
## Summary
- Include cloud provider tags in the settings search index
- Add E2E coverage for filtering providers by tag
- Clean up one Prettier warning in the touched component

## Test plan
- [x] npm --prefix frontend run build
- [x] frontend/node_modules/.bin/eslint frontend/e2e/cloud-billing.spec.js frontend/src/components/cloud-billing/ProviderAuthentication.vue
- [ ] Playwright E2E not run locally; no service available at http://localhost:10080