### PR TITLE
Fix Volcengine billing timeout Sentry noise

### DIFF
--- a/backend/cloud_billing/clouds/provider.py
+++ b/backend/cloud_billing/clouds/provider.py
@@ -8,7 +8,7 @@ allowing for extensibility beyond just billing functionality.
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Dict, Optional, Tuple
+from typing import Any, Optional
 
 
 # Configure logging
@@ -53,9 +53,7 @@ class BaseCloudProvider(ABC):
         self.config = config
 
     @abstractmethod
-    def get_billing_info(
-        self, period: Optional[str] = None
-    ) -> Tuple[float, str, Dict[str, float]]:
+    def get_billing_info(self, period: Optional[str] = None) -> Any:
         """Get billing information for a specific period.
 
         Args:

--- a/backend/cloud_billing/clouds/volcengine_provider.py
+++ b/backend/cloud_billing/clouds/volcengine_provider.py
@@ -112,9 +112,10 @@ class VolcengineCloud(BaseCloudProvider):
 
     def __init__(self, config: VolcengineConfig):
         super().__init__(config)
+        self.config: VolcengineConfig = config
         self.name = "volcengine"
         self._session = requests.Session()
-        self._last_balance_debug = {}
+        self._last_balance_debug: Dict[str, Any] = {}
         sanitized_config = mask_sensitive_config_object(config)
         logger.info(
             f"Initialized Volcengine Cloud provider with config: "
@@ -200,10 +201,10 @@ class VolcengineCloud(BaseCloudProvider):
         )
         # Match Volcengine OpenAPI signer:
         # HMAC(secret, date) -> region -> service -> request.
-        signing_key = self._hmac_sha256(
-            self.config.api_secret.encode("utf-8"),
-            short_date,
-        )
+        api_secret = self.config.api_secret
+        if api_secret is None:
+            raise ValueError("Volcengine secret key is required.")
+        signing_key = self._hmac_sha256(api_secret.encode("utf-8"), short_date)
         signing_key = self._hmac_sha256(signing_key, self.config.region or "")
         signing_key = self._hmac_sha256(signing_key, self.config.service or "")
         signing_key = self._hmac_sha256(signing_key, "request")
@@ -524,10 +525,10 @@ class VolcengineCloud(BaseCloudProvider):
             data["balance_debug"] = self._last_balance_debug
             return {"status": "success", "data": data, "error": None}
         except requests.HTTPError as exc:
-            logger.error(f"Volcengine billing HTTP error: {exc}")
+            logger.warning(f"Volcengine billing HTTP error: {exc}")
             return {"status": "error", "data": None, "error": str(exc)}
         except (requests.RequestException, ValueError, RuntimeError) as exc:
-            logger.error(f"Volcengine billing error: {exc}")
+            logger.warning(f"Volcengine billing error: {exc}")
             return {"status": "error", "data": None, "error": str(exc)}
         except Exception as exc:
             logger.exception(f"Unexpected Volcengine billing error: {exc}")

--- a/backend/cloud_billing/tests/test_volcengine_provider.py
+++ b/backend/cloud_billing/tests/test_volcengine_provider.py
@@ -1,5 +1,6 @@
 """Tests for the Volcengine cloud billing provider."""
 
+import logging
 from unittest.mock import Mock, patch
 
 import pytest
@@ -197,6 +198,38 @@ class TestVolcengineCloud:
 
         assert result["status"] == "success"
         assert mock_get.call_count == 3
+
+    @patch("cloud_billing.clouds.volcengine_provider.requests.Session.get")
+    def test_get_billing_info_logs_service_timeout_as_warning(
+        self, mock_get, caplog
+    ):
+        provider = self._make_provider()
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {
+            "ResponseMetadata": {
+                "Error": {
+                    "Code": "InternalServiceTimeout",
+                    "Message": (
+                        "Internal Service is timeout. "
+                        "Pls Contact With Admin"
+                    ),
+                },
+            }
+        }
+        mock_get.return_value = response
+
+        with caplog.at_level(logging.WARNING):
+            result = provider.get_billing_info("2026-06")
+
+        error_logs = [
+            record for record in caplog.records
+            if record.levelno >= logging.ERROR
+        ]
+        assert result["status"] == "error"
+        assert "InternalServiceTimeout" in result["error"]
+        assert not error_logs
+        assert "Volcengine billing error" in caplog.text
 
     def test_get_account_id_uses_payer_id(self):
         provider = self._make_provider()


### PR DESCRIPTION
## Summary
- Downgrade expected Volcengine billing HTTP/API/request failures from error logs to warning logs.
- Keep unexpected Volcengine billing exceptions logged with stack traces.
- Add a regression test for `InternalServiceTimeout` so it no longer emits error-level logs.
- Align the base cloud provider billing return type with existing dict-returning implementations.

Sentry: TOWER-3X

## Test plan
- [x] `.venv/bin/python -m pytest backend/cloud_billing/tests/test_volcengine_provider.py`
- [x] `.venv/bin/python -m ruff check backend/cloud_billing/clouds/provider.py backend/cloud_billing/clouds/volcengine_provider.py backend/cloud_billing/tests/test_volcengine_provider.py`
- [x] `PYTHONPATH=backend .venv/bin/python -m mypy --ignore-missing-imports backend/cloud_billing/clouds/provider.py backend/cloud_billing/clouds/volcengine_provider.py backend/cloud_billing/tests/test_volcengine_provider.py`

## Full-suite blockers observed locally
- `PYTHONPATH=backend DJANGO_SETTINGS_MODULE=core.settings .venv/bin/python -m pytest` fails during collection in `backend/hyperbdr_dashboard/tests` because tests import missing symbols: `register_periodic_tasks`, `Host`, and `Tenant`.
- `.venv/bin/python -m ruff check .` reports 163 existing lint errors outside this fix.
- `PYTHONPATH=backend .venv/bin/python -m mypy backend` reports 671 existing type errors across 198 files.

## Notes
- No production deployment was performed.
- Sentry should only be resolved after production verification.
- Jira should only be closed after production verification.