### PR TITLE
Fix approval logging and API startup

### DIFF
--- a/backend/cloud_billing/agents/recharge_approval/definition.py
+++ b/backend/cloud_billing/agents/recharge_approval/definition.py
@@ -44,7 +44,9 @@ def _is_local_mode() -> bool:
 
 def _load_skill_tools_module():
     """Load the skill tools module dynamically using importlib."""
-    import importlib.util, sys
+    import importlib.util
+    import sys
+
     from cloud_billing.services.recharge_approval import _approval_skill_path
 
     tools_path = _approval_skill_path() / "tools.py"
@@ -304,7 +306,8 @@ def _local_feishu_token() -> str:
 
 
 def _local_api(url: str, payload: Dict[str, Any], token: str, method: str = "POST") -> Dict[str, Any]:
-    import urllib.error, urllib.request
+    import urllib.error
+    import urllib.request
 
     body = json.dumps(payload, ensure_ascii=False).encode()
     headers = {
@@ -433,9 +436,21 @@ def _local_create_instance(
                 approval_code, user_id[:8] if len(user_id) > 8 else user_id)
     return _local_api(
         f"{base_url}/approval/openapi/v2/instance/create",
-        {"approval_code": approval_code, "user_id": user_id, "form": json.dumps(form_payload, ensure_ascii=False)},
+        _local_create_instance_payload(approval_code, user_id, form_payload),
         token,
     )
+
+
+def _local_create_instance_payload(
+    approval_code: str,
+    user_id: str,
+    form_payload: list,
+) -> Dict[str, Any]:
+    return {
+        "approval_code": approval_code,
+        "user_id": user_id,
+        "form": json.dumps(form_payload, ensure_ascii=False),
+    }
 
 
 def _local_resolve_user_id(identifier: str, token: str) -> str:
@@ -486,6 +501,34 @@ def _build_remark(payee: Dict[str, Any]) -> str:
         f"银行地区：{payee.get('bank_region', '')}",
         f"支行：{payee.get('bank_branch', '')}",
     ])
+
+
+def _build_remark_with_payee(data: Dict[str, Any]) -> str:
+    remark = str(data.get("remark") or "").strip()
+    payee = data.get("payee")
+    if not isinstance(payee, dict):
+        return remark
+
+    payee_keys = (
+        "type",
+        "account_name",
+        "account_number",
+        "bank_name",
+        "bank_region",
+        "bank_branch",
+    )
+    has_payee_value = any(
+        str(payee.get(key) or "").strip() for key in payee_keys
+    )
+    if not has_payee_value:
+        return remark
+
+    payee_remark = _build_remark(payee).strip()
+    if not remark:
+        return payee_remark
+    if payee_remark and payee_remark not in remark:
+        return f"{remark}\n{payee_remark}"
+    return remark
 
 
 def _split_amount(value: Any) -> tuple:
@@ -568,12 +611,11 @@ def _build_form_payload(data: Dict[str, Any], schema: Dict[str, Dict[str, Any]])
         if not str(data.get(field_key) or "").strip():
             raise RuntimeError(f"Missing required field: {label}")
 
-    payee = data.get("payee", {})
     payment_type = str(data.get("payment_type", "仅充值")).strip()
     payment_way = str(data.get("payment_way", "公司支付")).strip()
     remit_method = str(data.get("remit_method", "转账")).strip()
     payment_note = str(data.get("payment_note", "")).strip()
-    remark = str(data.get("remark") or _build_remark(payee))
+    remark = _build_remark_with_payee(data)
     expected_date = str(data.get("expected_date") or _default_expected_date()).strip()
 
     form_payload: list = []
@@ -738,6 +780,11 @@ def _execute_local(
         logger.info("[LocalExecutor] Form built with %d fields", len(form_payload))
 
         # Step 6: submit or deduplicate
+        feishu_request_payload = _local_create_instance_payload(
+            approval_code,
+            resolved_user_id,
+            form_payload,
+        )
         if existing:
             instance_code = str(existing.get("instance_code", ""))
             serial = str(existing.get("serial_number", ""))
@@ -821,6 +868,7 @@ def _execute_local(
             "resolved_submitter_user_id": resolved_user_id,
             "submitter_user_label": submitter_user_label,
             "request_payload": parsed_payload,
+            "feishu_request_payload": feishu_request_payload,
             "submission_payload": record.response_payload,
             "notification_message": notification_msg,
             "success": True,

--- a/backend/cloud_billing/clouds/azure_provider.py
+++ b/backend/cloud_billing/clouds/azure_provider.py
@@ -13,7 +13,7 @@ from datetime import datetime, timedelta
 import requests
 from azure.identity import ClientSecretCredential
 from azure.mgmt.consumption import ConsumptionManagementClient
-from azure.mgmt.resource import ResourceManagementClient
+from azure.mgmt.resource.resources import ResourceManagementClient
 from django.utils import timezone
 
 from ..utils.logging import mask_sensitive_config_object

--- a/backend/cloud_billing/clouds/service.py
+++ b/backend/cloud_billing/clouds/service.py
@@ -4,20 +4,11 @@ This module provides base classes for cloud services and a factory
 for creating cloud provider instances.
 """
 
+import importlib
 import logging
 from typing import Dict, Any, Optional
 
 from ..utils.logging import mask_sensitive_config
-
-from .aws_provider import AWSConfig, AWSCloud
-from .huawei_provider import HuaweiConfig, HuaweiCloud
-from .huawei_intl_provider import HuaweiIntlConfig, HuaweiIntlCloud
-from .alibaba_provider import AlibabaConfig, AlibabaCloud
-from .azure_provider import AzureConfig, AzureCloud
-from .tencent_provider import TencentConfig, TencentCloud
-from .volcengine_provider import VolcengineConfig, VolcengineCloud
-from .baidu_provider import BaiduConfig, BaiduCloud
-from .zhipu_provider import ZhipuConfig, ZhipuCloud
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -25,36 +16,51 @@ logger = logging.getLogger(__name__)
 
 def _build_provider_mapping():
     mapping = {
-        "aws": {"config_class": AWSConfig, "provider_class": AWSCloud},
+        "aws": {
+            "module": "cloud_billing.clouds.aws_provider",
+            "config_class": "AWSConfig",
+            "provider_class": "AWSCloud",
+        },
         "huawei": {
-            "config_class": HuaweiConfig,
-            "provider_class": HuaweiCloud,
+            "module": "cloud_billing.clouds.huawei_provider",
+            "config_class": "HuaweiConfig",
+            "provider_class": "HuaweiCloud",
         },
         "huawei-intl": {
-            "config_class": HuaweiIntlConfig,
-            "provider_class": HuaweiIntlCloud,
+            "module": "cloud_billing.clouds.huawei_intl_provider",
+            "config_class": "HuaweiIntlConfig",
+            "provider_class": "HuaweiIntlCloud",
         },
         "alibaba": {
-            "config_class": AlibabaConfig,
-            "provider_class": AlibabaCloud,
+            "module": "cloud_billing.clouds.alibaba_provider",
+            "config_class": "AlibabaConfig",
+            "provider_class": "AlibabaCloud",
         },
-        "azure": {"config_class": AzureConfig, "provider_class": AzureCloud},
+        "azure": {
+            "module": "cloud_billing.clouds.azure_provider",
+            "config_class": "AzureConfig",
+            "provider_class": "AzureCloud",
+        },
         "volcengine": {
-            "config_class": VolcengineConfig,
-            "provider_class": VolcengineCloud,
+            "module": "cloud_billing.clouds.volcengine_provider",
+            "config_class": "VolcengineConfig",
+            "provider_class": "VolcengineCloud",
         },
         "baidu": {
-            "config_class": BaiduConfig,
-            "provider_class": BaiduCloud,
+            "module": "cloud_billing.clouds.baidu_provider",
+            "config_class": "BaiduConfig",
+            "provider_class": "BaiduCloud",
         },
         "zhipu": {
-            "config_class": ZhipuConfig,
-            "provider_class": ZhipuCloud,
+            "module": "cloud_billing.clouds.zhipu_provider",
+            "config_class": "ZhipuConfig",
+            "provider_class": "ZhipuCloud",
         },
     }
     mapping["tencentcloud"] = {
-        "config_class": TencentConfig,
-        "provider_class": TencentCloud,
+        "module": "cloud_billing.clouds.tencent_provider",
+        "config_class": "TencentConfig",
+        "provider_class": "TencentCloud",
     }
     return mapping
 
@@ -85,8 +91,9 @@ class ProviderFactory:
             raise ValueError(f"Unsupported provider: {provider_name}")
 
         provider_info = cls.PROVIDER_MAPPING[provider_name]
-        config_class = provider_info["config_class"]
-        provider_class = provider_info["provider_class"]
+        module = importlib.import_module(provider_info["module"])
+        config_class = getattr(module, provider_info["config_class"])
+        provider_class = getattr(module, provider_info["provider_class"])
 
         # Create provider instance with validated config
         # Add fallback to empty dict if config is None

--- a/backend/cloud_billing/services/recharge_approval.py
+++ b/backend/cloud_billing/services/recharge_approval.py
@@ -4,21 +4,46 @@ Service helpers for recharge approval submission and callback tracking.
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import logging
 import os
 import re
 import threading
 import time
-import uuid
-import importlib.util
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, Dict, List, Optional, Tuple
+
+
+from django.contrib.auth.models import User
+from django.core.cache import cache
+from django.db.models import Q
+from django.utils import timezone
+from langchain_core.callbacks.base import BaseCallbackHandler
+from langchain_core.outputs import LLMResult
+from langchain_core.tools import tool
+from pydantic import BaseModel, Field
+
+from cloud_billing.models import (
+    CloudProvider,
+    RechargeApprovalEvent,
+    RechargeApprovalLLMRun,
+    RechargeApprovalRecord,
+)
+from cloud_billing.services.parser_llm_config import (
+    resolve_parser_llm_settings,
+)
+
+if TYPE_CHECKING:
+    from agentcore_metering.adapters.django.models import LLMUsage
+
+logger = logging.getLogger(__name__)
 
 
 class MissingRechargeFieldsError(ValueError):
     """
     Raised when recharge info is missing required fields.
+
     Carries the list of missing field names for structured error responses.
     """
 
@@ -30,35 +55,6 @@ class MissingRechargeFieldsError(ValueError):
         )
         super().__init__(message or default_message)
 
-from langchain_core.callbacks.base import BaseCallbackHandler
-from langchain_core.outputs import LLMResult
-from langchain_core.tools import tool
-from pydantic import BaseModel, Field
-
-from agentcore_metering.adapters.django.models import LLMUsage
-from cloud_billing.services.parser_llm_config import resolve_parser_llm_settings
-from django.contrib.auth.models import User
-from django.core.cache import cache
-from django.db.models import Q
-from django.utils import timezone
-from langchain_anthropic import ChatAnthropic
-from langchain_google_genai import ChatGoogleGenerativeAI
-from langchain_openai import AzureChatOpenAI, ChatOpenAI
-
-from cloud_billing.models import (
-    CloudProvider,
-    RechargeApprovalEvent,
-    RechargeApprovalLLMRun,
-    RechargeApprovalRecord,
-)
-from cloud_billing.tracked_llm import (
-    build_tracking_state,
-    invoke_tracked_structured_llm,
-)
-from agent_runner import AgentRunner, SkillSpec
-from agent_runner.observability.langfuse import create_langfuse_observer
-
-logger = logging.getLogger(__name__)
 
 CLOUD_TYPE_LABELS = {
     "aws": "AWS",
@@ -97,7 +93,6 @@ RECHARGE_INFO_KEY_MAP = {
     "remark": "remark",
     "备注": "remark",
     "payee.type": "payee.type",
-    "账户类型": "payee.type",
     "账户类型": "payee.type",
     "收款账户类型": "payee.type",
     "payee.account_name": "payee.account_name",
@@ -1684,11 +1679,6 @@ def _enrich_user_details(token: str, users: List[Dict[str, str]]) -> None:
     import urllib.request
     import urllib.error
 
-    base_user_url = (
-        FEISHU_LIST_USERS_URL.split("?")[0]
-        + "?user_id_type=user_id&department_id=0&page_size=50"
-    )
-
     for user in users:
         if user.get("email") or user.get("mobile"):
             continue
@@ -2198,20 +2188,29 @@ class RechargeApprovalAgentCallbackHandler(BaseCallbackHandler):
         user_id: Optional[int],
         langfuse_runtime: Any | None = None,
     ) -> None:
+        if langfuse_runtime is None:
+            from agent_runner.observability.langfuse import (
+                create_langfuse_observer,
+            )
+
+            langfuse_runtime = create_langfuse_observer(
+                name="RechargeApprovalAgentRunner",
+                trace_seed=str(getattr(record, "trace_id", "") or ""),
+                user_id=str(user_id) if user_id else None,
+                session_id=str(getattr(record, "id", "") or ""),
+                metadata={
+                    "record_id": getattr(record, "id", None),
+                    "record_trace_id": str(
+                        getattr(record, "trace_id", "") or ""
+                    ),
+                    "component": "recharge_approval_callback",
+                },
+                tags=["agent", "recharge_approval", "tool"],
+            )
+
         self.record = record
         self.user_id = user_id
-        self.langfuse_runtime = langfuse_runtime or create_langfuse_observer(
-            name="RechargeApprovalAgentRunner",
-            trace_seed=str(getattr(record, "trace_id", "") or ""),
-            user_id=str(user_id) if user_id else None,
-            session_id=str(getattr(record, "id", "") or ""),
-            metadata={
-                "record_id": getattr(record, "id", None),
-                "record_trace_id": str(getattr(record, "trace_id", "") or ""),
-                "component": "recharge_approval_callback",
-            },
-            tags=["agent", "recharge_approval", "tool"],
-        )
+        self.langfuse_runtime = langfuse_runtime
         self.starts: Dict[str, Any] = {}
         self.inputs: Dict[str, str] = {}
         self._tool_starts: Dict[str, Dict[str, Any]] = {}
@@ -2249,6 +2248,8 @@ class RechargeApprovalAgentCallbackHandler(BaseCallbackHandler):
         tags=None,
         **kwargs,
     ) -> Any:
+        from agentcore_metering.adapters.django.models import LLMUsage
+
         key = str(run_id)
         started_at = self.starts.get(key) or timezone.now()
         finished_at = timezone.now()
@@ -2600,6 +2601,10 @@ class RechargeApprovalAgentCallbackHandler(BaseCallbackHandler):
                 if callable(safe_flush):
                     safe_flush()
 def build_deep_agent_model(user_id: Optional[int] = None):
+    from langchain_anthropic import ChatAnthropic
+    from langchain_google_genai import ChatGoogleGenerativeAI
+    from langchain_openai import AzureChatOpenAI, ChatOpenAI
+
     llm_settings = resolve_parser_llm_settings(None)
     provider = str(llm_settings.get("provider") or "openai").strip().lower()
     model_name = str(llm_settings.get("model") or "").strip()
@@ -2880,7 +2885,17 @@ def refresh_recharge_approval_record_status(
             "detail": None,
         }
 
-    detail = _request_feishu_approval_instance_detail(
+    token = _get_feishu_access_token()
+    if not token:
+        return {
+            "is_ongoing": record.status in ONGOING_RECHARGE_APPROVAL_STATUSES,
+            "live_status": record.status,
+            "live_status_text": record.status_message or "",
+            "detail": None,
+        }
+
+    detail = _feishu_get_instance(
+        token,
         approval_code,
         instance_code,
         approval_base_url=approval_base_url,
@@ -3260,6 +3275,8 @@ def latest_usage_for_trace(
     stage: str,
     user_id: Optional[int],
 ) -> Optional[LLMUsage]:
+    from agentcore_metering.adapters.django.models import LLMUsage
+
     queryset = LLMUsage.objects.filter(
         metadata__trace_id=str(trace_id),
         metadata__source_record_id=record_id,
@@ -3319,6 +3336,11 @@ def parse_recharge_info_with_tracking(
             payload=payload,
         )
         return payload
+
+    from cloud_billing.tracked_llm import (
+        build_tracking_state,
+        invoke_tracked_structured_llm,
+    )
 
     llm_state = {
         **build_tracking_state(

--- a/backend/cloud_billing/tasks.py
+++ b/backend/cloud_billing/tasks.py
@@ -66,6 +66,7 @@ from .clouds.service import BillingService
 from .services.recharge_approval import (
     CLOUD_TYPE_LABELS,
     _looks_like_legacy_submitter_identifier,
+    _redact_feishu_payload_for_log,
     check_ongoing_recharge_approval_submission,
     create_recharge_approval_event,
     execute_recharge_approval_agent,
@@ -1958,7 +1959,6 @@ def submit_recharge_approval(
             ),
         )
 
-    started_at = timezone.now()
     try:
         log_collector.info(
             "Executing recharge approval agent "
@@ -1985,6 +1985,14 @@ def submit_recharge_approval(
         )
         finished_at = timezone.now()
         output_payload = agent_payload.get("submission_payload") or {}
+        feishu_request_payload = (
+            agent_payload.get("feishu_request_payload") or {}
+        )
+        feishu_request_payload_redacted = None
+        if feishu_request_payload:
+            feishu_request_payload_redacted = _redact_feishu_payload_for_log(
+                feishu_request_payload,
+            )
         instance_code = agent_payload.get("instance_code")
         approval_code = agent_payload.get("approval_code")
         normalized_status = normalize_feishu_status(
@@ -2042,13 +2050,21 @@ def submit_recharge_approval(
                 "updated_at",
             ],
         )
+        agent_event_payload = dict(agent_payload)
+        if feishu_request_payload:
+            agent_event_payload["feishu_request_payload"] = (
+                feishu_request_payload_redacted
+            )
+            agent_event_payload["feishu_request_payload_redacted"] = (
+                feishu_request_payload_redacted
+            )
         create_recharge_approval_event(
             record=record,
             event_type="approval_agent_finished",
             stage="agent_execute",
             source=trigger_source,
             message="Recharge approval agent completed successfully.",
-            payload=agent_payload,
+            payload=agent_event_payload,
             operator=trigger_user,
         )
         result = {
@@ -2063,6 +2079,12 @@ def submit_recharge_approval(
             f"(record_id={record.id}, instance_code={instance_code or ''}, "
             f"approval_code={approval_code or ''}, status={normalized_status})"
         )
+        if feishu_request_payload:
+            log_collector.info(
+                "Feishu approval instance create request payload "
+                "(redacted): "
+                f"{json.dumps(feishu_request_payload_redacted, ensure_ascii=False)}"
+            )
         if task_id:
             TaskTracker.update_task_status(
                 task_id=task_id,
@@ -2074,6 +2096,8 @@ def submit_recharge_approval(
                     recharge_approval_record_id=record.id,
                     feishu_instance_code=instance_code or "",
                     feishu_approval_code=approval_code or "",
+                    feishu_request_payload=feishu_request_payload_redacted,
+                    feishu_request_payload_redacted=feishu_request_payload_redacted,
                     recharge_approval_status=normalized_status,
                 ),
             )

--- a/backend/cloud_billing/tests/test_azure_provider.py
+++ b/backend/cloud_billing/tests/test_azure_provider.py
@@ -101,6 +101,21 @@ class TestAzureCloud:
         assert data["currency"] == "EUR"
         assert data["account_id"] == "sub"
 
+    def test_resource_client_uses_resource_management_client(self):
+        provider = self._make_provider()
+        provider._resource_client = None
+
+        with patch(
+            "cloud_billing.clouds.azure_provider.ResourceManagementClient"
+        ) as client_cls:
+            resource_client = provider.resource_client
+
+        assert resource_client == client_cls.return_value
+        client_cls.assert_called_once_with(
+            credential=provider.credential,
+            subscription_id="sub",
+        )
+
     def test_get_balance_prefers_available_balance_endpoint(self):
         provider = self._make_provider()
         provider._management_get = Mock(

--- a/backend/cloud_billing/tests/test_recharge_approval_service.py
+++ b/backend/cloud_billing/tests/test_recharge_approval_service.py
@@ -22,7 +22,6 @@ import cloud_billing.services.recharge_approval as recharge_service
 from cloud_billing.services.recharge_approval import (
     RechargeApprovalAgentCallbackHandler,
     build_notification_message_from_payload,
-    _get_feishu_access_token,
     _redact_feishu_body_for_log,
     _redact_feishu_payload_for_log,
     _skill_root_path,
@@ -32,7 +31,6 @@ from cloud_billing.services.recharge_approval import (
     parse_recharge_info,
     parse_recharge_info_with_tracking,
     prepare_recharge_request_payload,
-    refresh_recharge_approval_record_status,
     sanitize_recharge_request_payload,
     validate_recharge_request_payload,
 )
@@ -68,7 +66,7 @@ def test_agent_runner_package_exports_core_symbols():
 def test_feishu_log_redaction_handles_nested_form_json_strings():
     form_payload = [
         {"id": "cloud", "type": "input", "value": "智谱"},
-        {"id": "account", "type": "input", "value": "18017606559"},
+        {"id": "account", "type": "input", "value": "demo-account-001"},
         {"id": "amount", "type": "amount", "value": 200},
         {"id": "remark", "type": "textarea", "value": "账号：1109385104"},
     ]
@@ -81,7 +79,7 @@ def test_feishu_log_redaction_handles_nested_form_json_strings():
     redacted_payload = _redact_feishu_payload_for_log(payload)
     redacted_text = json.dumps(redacted_payload, ensure_ascii=False)
 
-    assert "18017606559" not in redacted_text
+    assert "demo-account-001" not in redacted_text
     assert "1109385104" not in redacted_text
     assert '"value": "***REDACTED***"' in redacted_text
     assert redacted_payload["form"][0]["id"] == "cloud"
@@ -118,17 +116,17 @@ def test_parse_recharge_info_with_tracking_uses_heuristic_parser(cloud_provider)
     cloud_provider.recharge_info = json.dumps(
         {
             "cloud_type": "智谱",
-            "recharge_customer_name": "深圳壹铂云科技有限公司",
-            "recharge_account": "18017606559",
-            "payment_company": "深圳壹铂云科技有限公司",
+            "recharge_customer_name": "示例云科技有限公司",
+            "recharge_account": "demo-account-001",
+            "payment_company": "示例云科技有限公司",
             "amount": 200,
             "payee": {
                 "type": "对公账户",
-                "account_name": "北京智谱华章科技股份有限公司",
-                "account_number": "11093851041070210011884",
-                "bank_name": "招商银行",
+                "account_name": "示例收款有限公司",
+                "account_number": "00000000000000000000",
+                "bank_name": "示例银行",
                 "bank_region": "北京市/北京市",
-                "bank_branch": "招商银行股份有限公司北京上地支行",
+                "bank_branch": "示例银行示例支行",
             },
         },
         ensure_ascii=False,
@@ -144,7 +142,7 @@ def test_parse_recharge_info_with_tracking_uses_heuristic_parser(cloud_provider)
         record=record,
     )
 
-    assert payload["recharge_account"] == "18017606559"
+    assert payload["recharge_account"] == "demo-account-001"
     run = record.llm_runs.get()
     assert run.runner_type == "agent"
     assert run.model == "heuristic-parser"
@@ -154,20 +152,20 @@ def test_validate_recharge_request_payload_requires_cloud_type():
     with pytest.raises(ValueError, match="cloud_type"):
         validate_recharge_request_payload(
             {
-                "recharge_customer_name": "深圳壹铂云科技有限公司",
+                "recharge_customer_name": "示例云科技有限公司",
                 "recharge_account": "acct-288",
-                "payment_company": "深圳壹铂云科技有限公司",
+                "payment_company": "示例云科技有限公司",
                 "payment_way": "公司支付",
                 "payment_type": "仅充值",
                 "remit_method": "转账",
                 "currency": "CNY",
                 "payee": {
                     "type": "对公账户",
-                    "account_name": "北京智谱华章科技股份有限公司",
-                    "account_number": "11093851041070210011884",
-                    "bank_name": "招商银行",
+                    "account_name": "示例收款有限公司",
+                    "account_number": "00000000000000000000",
+                    "bank_name": "示例银行",
                     "bank_region": "北京市/北京市",
-                    "bank_branch": "招商银行股份有限公司北京上地支行",
+                    "bank_branch": "示例银行示例支行",
                 },
             }
         )
@@ -177,20 +175,20 @@ def test_prepare_recharge_request_payload_injects_cloud_type():
     payload = prepare_recharge_request_payload(
         json.dumps(
             {
-                "recharge_customer_name": "深圳壹铂云科技有限公司",
+                "recharge_customer_name": "示例云科技有限公司",
                 "recharge_account": "acct-288",
-                "payment_company": "深圳壹铂云科技有限公司",
+                "payment_company": "示例云科技有限公司",
                 "payment_way": "公司支付",
                 "payment_type": "仅充值",
                 "remit_method": "转账",
                 "currency": "CNY",
                 "payee": {
                     "type": "对公账户",
-                    "account_name": "北京智谱华章科技股份有限公司",
-                    "account_number": "11093851041070210011884",
-                    "bank_name": "招商银行",
+                    "account_name": "示例收款有限公司",
+                    "account_number": "00000000000000000000",
+                    "bank_name": "示例银行",
                     "bank_region": "北京市/北京市",
-                    "bank_branch": "招商银行股份有限公司北京上地支行",
+                    "bank_branch": "示例银行示例支行",
                 },
             },
             ensure_ascii=False,
@@ -207,20 +205,20 @@ def test_validate_recharge_request_payload_allows_missing_amount():
     payload = validate_recharge_request_payload(
         {
             "cloud_type": "阿里云",
-            "recharge_customer_name": "深圳壹铂云科技有限公司",
+            "recharge_customer_name": "示例云科技有限公司",
             "recharge_account": "acct-288",
-            "payment_company": "深圳壹铂云科技有限公司",
+            "payment_company": "示例云科技有限公司",
             "payment_way": "公司支付",
             "payment_type": "仅充值",
             "remit_method": "转账",
             "currency": "CNY",
             "payee": {
                 "type": "对公账户",
-                "account_name": "北京智谱华章科技股份有限公司",
-                "account_number": "11093851041070210011884",
-                "bank_name": "招商银行",
+                "account_name": "示例收款有限公司",
+                "account_number": "00000000000000000000",
+                "bank_name": "示例银行",
                 "bank_region": "北京市/北京市",
-                "bank_branch": "招商银行股份有限公司北京上地支行",
+                "bank_branch": "示例银行示例支行",
             },
         }
     )
@@ -234,16 +232,16 @@ def test_validate_recharge_request_payload_requires_payee_fields():
     with pytest.raises(ValueError, match="payee\\.account_number"):
         validate_recharge_request_payload(
             {
-                "recharge_customer_name": "深圳壹铂云科技有限公司",
+                "recharge_customer_name": "示例云科技有限公司",
                 "recharge_account": "acct-288",
-                "payment_company": "深圳壹铂云科技有限公司",
+                "payment_company": "示例云科技有限公司",
                 "currency": "CNY",
                 "payee": {
                     "type": "对公账户",
-                    "account_name": "北京智谱华章科技股份有限公司",
-                    "bank_name": "招商银行",
+                    "account_name": "示例收款有限公司",
+                    "bank_name": "示例银行",
                     "bank_region": "北京市/北京市",
-                    "bank_branch": "招商银行股份有限公司北京上地支行",
+                    "bank_branch": "示例银行示例支行",
                 },
             }
         )
@@ -255,17 +253,17 @@ def test_parse_recharge_info_moves_remit_value_out_of_payment_type():
             [
                 "cloud_type: 智谱",
                 "payment_type: 转账",
-                "recharge_customer_name: 深圳壹铂云科技有限公司",
+                "recharge_customer_name: 示例云科技有限公司",
                 "recharge_account: acct-188",
                 "payment_way: 公司支付",
-                "payment_company: 深圳壹铂云科技有限公司",
+                "payment_company: 示例云科技有限公司",
                 "amount: 188",
                 "payee.type: 对公账户",
-                "payee.account_name: 北京智谱华章科技股份有限公司",
-                "payee.account_number: 11093851041070210011884",
-                "payee.bank_name: 招商银行",
+                "payee.account_name: 示例收款有限公司",
+                "payee.account_number: 00000000000000000000",
+                "payee.bank_name: 示例银行",
                 "payee.bank_region: 北京市/北京市",
-                "payee.bank_branch: 招商银行股份有限公司北京上地支行",
+                "payee.bank_branch: 示例银行示例支行",
             ]
         )
     )
@@ -298,7 +296,7 @@ def test_parse_recharge_info_accepts_alternating_label_value_lines():
                 "支付类型",
                 "仅充值",
                 "充值客户名称",
-                "深圳壹铂云科技有限公司",
+                "示例云科技有限公司",
                 "充值云账号",
                 "13301962892",
                 "付款说明",
@@ -306,7 +304,7 @@ def test_parse_recharge_info_accepts_alternating_label_value_lines():
                 "支付方式",
                 "公司支付",
                 "付款公司",
-                "深圳壹铂云科技有限公司",
+                "示例云科技有限公司",
                 "付款方式",
                 "转账",
                 "付款金额",
@@ -317,15 +315,15 @@ def test_parse_recharge_info_accepts_alternating_label_value_lines():
                 "账户类型",
                 "对公账户",
                 "户名",
-                "北京智谱华章科技股份有限公司",
+                "示例收款有限公司",
                 "账号",
                 "1109 3851 0410 7021 0011 884",
                 "银行",
-                "招商银行",
+                "示例银行",
                 "银行所在地区",
                 "北京市/北京市",
                 "银行支行",
-                "招商银行股份有限公司北京上地支行",
+                "示例银行示例支行",
             ]
         )
     )
@@ -336,9 +334,9 @@ def test_parse_recharge_info_accepts_alternating_label_value_lines():
     assert payload["amount"] == 200.0
     assert payload["currency"] == "CNY"
     assert payload["payee"]["type"] == "对公账户"
-    assert payload["payee"]["account_number"] == "11093851041070210011884"
+    assert payload["payee"]["account_number"] == "00000000000000000000"
     assert payload["payee"]["bank_region"] == "北京市/北京市"
-    assert payload["payee"]["bank_branch"] == "招商银行股份有限公司北京上地支行"
+    assert payload["payee"]["bank_branch"] == "示例银行示例支行"
 
 
 def test_parse_recharge_info_splits_amount_and_currency_from_value():
@@ -346,17 +344,17 @@ def test_parse_recharge_info_splits_amount_and_currency_from_value():
         json.dumps(
             {
                 "cloud_type": "智谱",
-                "recharge_customer_name": "深圳壹铂云科技有限公司",
-                "recharge_account": "18017606559",
-                "payment_company": "深圳壹铂云科技有限公司",
+                "recharge_customer_name": "示例云科技有限公司",
+                "recharge_account": "demo-account-001",
+                "payment_company": "示例云科技有限公司",
                 "amount": "200.00 CNY",
                 "payee": {
                     "type": "对公账户",
-                    "account_name": "北京智谱华章科技股份有限公司",
-                    "account_number": "11093851041070210011884",
-                    "bank_name": "招商银行",
+                    "account_name": "示例收款有限公司",
+                    "account_number": "00000000000000000000",
+                    "bank_name": "示例银行",
                     "bank_region": "北京市/北京市",
-                    "bank_branch": "招商银行股份有限公司北京上地支行",
+                    "bank_branch": "示例银行示例支行",
                 },
             },
             ensure_ascii=False,
@@ -378,7 +376,7 @@ def test_parse_recharge_info_with_tracking_falls_back_to_llm(
     user,
     monkeypatch,
 ):
-    cloud_provider.recharge_info = "客户=深圳壹铂云科技有限公司\n账号=18017606559"
+    cloud_provider.recharge_info = "客户=示例云科技有限公司\n账号=demo-account-001"
     cloud_provider.save(update_fields=["recharge_info"])
     record = RechargeApprovalRecord.objects.create(
         provider=cloud_provider,
@@ -399,17 +397,17 @@ def test_parse_recharge_info_with_tracking_falls_back_to_llm(
         lambda **kwargs: (
             kwargs["schema"](
                 cloud_type="智谱",
-                recharge_customer_name="深圳壹铂云科技有限公司",
-                recharge_account="18017606559",
-                payment_company="深圳壹铂云科技有限公司",
+                recharge_customer_name="示例云科技有限公司",
+                recharge_account="demo-account-001",
+                payment_company="示例云科技有限公司",
                 amount=200,
                 payee={
                     "type": "对公账户",
-                    "account_name": "北京智谱华章科技股份有限公司",
-                    "account_number": "11093851041070210011884",
-                    "bank_name": "招商银行",
-                    "bank_region": "北京市/北京市",
-                    "bank_branch": "招商银行股份有限公司北京上地支行",
+                    "account_name": "示例收款有限公司",
+                    "account_number": "0000 0000 0000 0000",
+                    "bank_name": "示例银行",
+                    "bank_region": "示例省/示例市",
+                    "bank_branch": "示例银行示例支行",
                 },
             ),
             {"model": "gpt-4o-mini", "total_tokens": 321},
@@ -627,7 +625,7 @@ def test_run_skill_script_records_sanitized_script_execution_trace(
         json.dumps(
             {
                 "amount": 188,
-                "recharge_account": "11093851041070210011884",
+                "recharge_account": "00000000000000000000",
                 "secret_note": "should not leak",
             },
             ensure_ascii=False,
@@ -689,7 +687,7 @@ def test_run_skill_script_records_sanitized_script_execution_trace(
     assert trace["env"]["FEISHU_APP_SECRET"] == "***REDACTED***"
     assert trace["env"]["FEISHU_APP_ID"] == "cli_test"
     assert "super-secret" not in run.input_snapshot
-    assert "11093851041070210011884" not in run.input_snapshot
+    assert "00000000000000000000" not in run.input_snapshot
 
 
 @pytest.mark.django_db
@@ -762,17 +760,17 @@ def test_plan_recharge_approval_workflow_generates_account_scoped_json_file(
     """Plan step writes JSON before execution using an account-scoped filename."""
     payload = {
         "cloud_type": "智谱",
-        "recharge_customer_name": "深圳壹铂云科技有限公司",
+        "recharge_customer_name": "示例云科技有限公司",
         "recharge_account": "acct-188",
-        "payment_company": "深圳壹铂云科技有限公司",
+        "payment_company": "示例云科技有限公司",
         "amount": "188.00 CNY",
         "payee": {
             "type": "对公账户",
-            "account_name": "北京智谱华章科技股份有限公司",
-            "account_number": "11093851041070210011884",
-            "bank_name": "招商银行",
+            "account_name": "示例收款有限公司",
+            "account_number": "00000000000000000000",
+            "bank_name": "示例银行",
             "bank_region": "北京市/北京市",
-            "bank_branch": "招商银行股份有限公司北京上地支行",
+            "bank_branch": "示例银行示例支行",
         },
     }
     record = RechargeApprovalRecord.objects.create(
@@ -807,7 +805,7 @@ def test_plan_recharge_approval_workflow_generates_account_scoped_json_file(
     assert generated["amount"] == 188.0
     assert generated["currency"] == "CNY"
     assert "payee" not in generated
-    assert "账号：11093851041070210011884" in generated["remark"]
+    assert "账号：00000000000000000000" in generated["remark"]
 
 
 @pytest.mark.django_db
@@ -902,17 +900,17 @@ def test_execute_recharge_approval_plan_retains_generated_request_json(
 ):
     payload = {
         "cloud_type": "智谱",
-        "recharge_customer_name": "深圳壹铂云科技有限公司",
+        "recharge_customer_name": "示例云科技有限公司",
         "recharge_account": "acct-debug",
-        "payment_company": "深圳壹铂云科技有限公司",
+        "payment_company": "示例云科技有限公司",
         "amount": 188,
         "payee": {
             "type": "对公账户",
-            "account_name": "北京智谱华章科技股份有限公司",
-            "account_number": "11093851041070210011884",
-            "bank_name": "招商银行",
+            "account_name": "示例收款有限公司",
+            "account_number": "00000000000000000000",
+            "bank_name": "示例银行",
             "bank_region": "北京市/北京市",
-            "bank_branch": "招商银行股份有限公司北京上地支行",
+            "bank_branch": "示例银行示例支行",
         },
     }
     record = RechargeApprovalRecord.objects.create(
@@ -968,7 +966,7 @@ def test_execute_recharge_approval_plan_retains_generated_request_json(
     assert generated["amount"] == 188
     assert generated["currency"] == "CNY"
     assert "payee" not in generated
-    assert "账号：11093851041070210011884" in generated["remark"]
+    assert "账号：00000000000000000000" in generated["remark"]
 
 
 # Removed: test_run_skill_script_materializes_missing_recharge_request_file
@@ -1681,21 +1679,21 @@ def test_recharge_approval_script_builds_request_from_history(monkeypatch):
     history_form = [
         {"name": "公有云类型", "value": "智谱"},
         {"name": "支付类型", "value": "仅充值"},
-        {"name": "充值客户名称", "value": "深圳壹铂云科技有限公司"},
-        {"name": "充值云账号", "value": "18017606559"},
+        {"name": "充值客户名称", "value": "示例云科技有限公司"},
+        {"name": "充值云账号", "value": "demo-account-001"},
         {"name": "支付方式", "value": "公司支付"},
-        {"name": "付款公司", "value": "深圳壹铂云科技有限公司"},
+        {"name": "付款公司", "value": "示例云科技有限公司"},
         {"name": "付款方式", "value": "转账"},
         {"name": "付款金额", "value": 200},
         {
             "name": "备注",
             "value": (
                 "账户类型：对公账户\n"
-                "户名：北京智谱华章科技股份有限公司\n"
-                "账号：11093851041070210011884\n"
-                "银行：招商银行\n"
+                "户名：示例收款有限公司\n"
+                "账号：00000000000000000000\n"
+                "银行：示例银行\n"
                 "银行地区：北京市/北京市\n"
-                "支行：招商银行股份有限公司北京上地支行"
+                "支行：示例银行示例支行"
             ),
         },
     ]
@@ -1723,14 +1721,14 @@ def test_recharge_approval_script_builds_request_from_history(monkeypatch):
         "token",
         "approval",
         "智谱",
-        "18017606559",
+        "demo-account-001",
         365,
         5,
     )
 
     assert result["found"] is True
-    assert result["request_data"]["recharge_account"] == "18017606559"
-    assert result["request_data"]["payee"]["account_number"] == "11093851041070210011884"
+    assert result["request_data"]["recharge_account"] == "demo-account-001"
+    assert result["request_data"]["payee"]["account_number"] == "00000000000000000000"
     assert "expected_date" not in result["request_data"]
 
 
@@ -1742,21 +1740,21 @@ def test_recharge_approval_script_pages_history_in_ten_item_batches_and_skips_de
     history_form = [
         {"name": "公有云类型", "value": "智谱"},
         {"name": "支付类型", "value": "仅充值"},
-        {"name": "充值客户名称", "value": "深圳壹铂云科技有限公司"},
-        {"name": "充值云账号", "value": "18017606559"},
+        {"name": "充值客户名称", "value": "示例云科技有限公司"},
+        {"name": "充值云账号", "value": "demo-account-001"},
         {"name": "支付方式", "value": "公司支付"},
-        {"name": "付款公司", "value": "深圳壹铂云科技有限公司"},
+        {"name": "付款公司", "value": "示例云科技有限公司"},
         {"name": "付款方式", "value": "转账"},
         {"name": "付款金额", "value": 200},
         {
             "name": "备注",
             "value": (
                 "账户类型：对公账户\n"
-                "户名：北京智谱华章科技股份有限公司\n"
-                "账号：11093851041070210011884\n"
-                "银行：招商银行\n"
+                "户名：示例收款有限公司\n"
+                "账号：00000000000000000000\n"
+                "银行：示例银行\n"
                 "银行地区：北京市/北京市\n"
-                "支行：招商银行股份有限公司北京上地支行"
+                "支行：示例银行示例支行"
             ),
         },
     ]
@@ -1842,7 +1840,7 @@ def test_recharge_approval_script_pages_history_in_ten_item_batches_and_skips_de
         "token",
         "approval",
         "智谱",
-        "18017606559",
+        "demo-account-001",
         90,
         5,
     )
@@ -1858,24 +1856,24 @@ def test_build_notification_message_bolds_keys_and_skips_empty_expected_date():
     message = build_notification_message_from_payload(
         {
             "recharge_account": "acct-188",
-            "recharge_customer_name": "深圳壹铂云科技有限公司",
+            "recharge_customer_name": "示例云科技有限公司",
             "amount": 188.5,
             "currency": "CNY",
-            "payment_company": "深圳壹铂云科技有限公司",
+            "payment_company": "示例云科技有限公司",
             "payment_way": "公司支付",
             "payment_type": "仅充值",
             "remit_method": "转账",
             "payee": {
-                "account_name": "北京智谱华章科技股份有限公司",
-                "bank_name": "招商银行",
+                "account_name": "示例收款有限公司",
+                "bank_name": "示例银行",
             },
             "remark": (
                 "账户类型：对公账户\n"
-                "户名：北京智谱华章科技股份有限公司\n"
-                "账号：11093851041070210011884\n"
-                "银行：招商银行\n"
+                "户名：示例收款有限公司\n"
+                "账号：00000000000000000000\n"
+                "银行：示例银行\n"
                 "银行地区：北京市/北京市\n"
-                "支行：招商银行股份有限公司北京上地支行"
+                "支行：示例银行示例支行"
             ),
         },
         trigger_source="manual",
@@ -1890,7 +1888,7 @@ def test_build_notification_message_bolds_keys_and_skips_empty_expected_date():
     assert "**触发人**: testuser" in message
     assert "**期望到账时间**" not in message
     assert "**收款信息**" in message
-    assert "  - 户名: 北京智谱华章科技股份有限公司" in message
+    assert "  - 户名: 示例收款有限公司" in message
     assert "**备注**" not in message
 
 
@@ -1899,11 +1897,11 @@ def test_build_notification_message_parses_ascii_colon_payee_remark():
         {
             "remark": (
                 "账户类型: 对公账户\n"
-                "户名: 北京智谱华章科技股份有限公司\n"
-                "账号: 11093851041070210011884\n"
-                "银行: 招商银行\n"
+                "户名: 示例收款有限公司\n"
+                "账号: 00000000000000000000\n"
+                "银行: 示例银行\n"
                 "银行地区: 北京市/北京市\n"
-                "支行: 招商银行股份有限公司北京上地支行"
+                "支行: 示例银行示例支行"
             ),
         },
         trigger_source="manual",
@@ -1914,7 +1912,7 @@ def test_build_notification_message_parses_ascii_colon_payee_remark():
     )
 
     assert "**收款信息**" in message
-    assert "  - 户名: 北京智谱华章科技股份有限公司" in message
+    assert "  - 户名: 示例收款有限公司" in message
 
 
 @pytest.mark.django_db
@@ -2009,7 +2007,7 @@ def test_recharge_approval_puts_payee_in_remark_for_company_pay():
             ],
         },
         "付款公司": {"id": "f_payment_company", "name": "付款公司", "type": "radioV2",
-                     "option": [{"value": "sz-yibo", "text": "深圳壹铂云科技有限公司"}]},
+                     "option": [{"value": "demo-company", "text": "示例云科技有限公司"}]},
         "付款方式": {"id": "f_remit_method", "name": "付款方式", "type": "radioV2",
                      "option": [{"value": "transfer", "text": "转账"}]},
         "充值客户名称": {"id": "f_customer", "name": "充值客户名称", "type": "input", "option": []},
@@ -2022,19 +2020,19 @@ def test_recharge_approval_puts_payee_in_remark_for_company_pay():
     request_data = {
         "cloud_type": "智谱",
         "payment_type": "仅充值",
-        "recharge_customer_name": "深圳壹铂云科技有限公司",
-        "recharge_account": "18017606559",
+        "recharge_customer_name": "示例云科技有限公司",
+        "recharge_account": "demo-account-001",
         "payment_way": "公司支付",
-        "payment_company": "深圳壹铂云科技有限公司",
+        "payment_company": "示例云科技有限公司",
         "remit_method": "转账",
         "amount": 200,
         "payee": {
             "type": "对公账户",
-            "account_name": "北京智谱华章科技股份有限公司",
-            "account_number": "11093851041070210011884",
-            "bank_name": "招商银行",
+            "account_name": "示例收款有限公司",
+            "account_number": "00000000000000000000",
+            "bank_name": "示例银行",
             "bank_region": "北京市/北京市",
-            "bank_branch": "招商银行股份有限公司北京上地支行",
+            "bank_branch": "示例银行示例支行",
         },
     }
 
@@ -2047,9 +2045,9 @@ def test_recharge_approval_puts_payee_in_remark_for_company_pay():
     # 收款账户 info must be encoded in 备注
     remark = remark_item["value"]
     assert "对公账户" in remark
-    assert "北京智谱华章科技股份有限公司" in remark
-    assert "11093851041070210011884" in remark
-    assert "招商银行" in remark
+    assert "示例收款有限公司" in remark
+    assert "00000000000000000000" in remark
+    assert "示例银行" in remark
     # 说明 1 field should be present with fixed instruction text
     note1_item = next(
         (item for item in form_payload if item["id"] == "f_note1"),
@@ -2066,6 +2064,124 @@ def test_recharge_approval_puts_payee_in_remark_for_company_pay():
     assert account_item["type"] == "input", "充值云账号 should be input type"
 
 
+def test_local_recharge_approval_appends_payee_to_existing_remark():
+    from cloud_billing.agents.recharge_approval.definition import (
+        _build_form_payload,
+    )
+
+    schema_by_name = {
+        "公有云类型": {
+            "id": "f_cloud_type",
+            "name": "公有云类型",
+            "type": "radioV2",
+            "option": [
+                {
+                    "value": "huawei_partner",
+                    "text": "示例云-测试伙伴",
+                }
+            ],
+        },
+        "支付类型": {
+            "id": "f_payment_type",
+            "name": "支付类型",
+            "type": "radioV2",
+            "option": [{"value": "recharge-only", "text": "仅充值"}],
+        },
+        "支付方式": {
+            "id": "f_payment_way",
+            "name": "支付方式",
+            "type": "radioV2",
+            "option": [{"value": "company-pay", "text": "公司支付"}],
+        },
+        "付款公司": {
+            "id": "f_payment_company",
+            "name": "付款公司",
+            "type": "radioV2",
+            "option": [
+                {
+                    "value": "customer",
+                    "text": "示例客户有限公司",
+                }
+            ],
+        },
+        "付款方式": {
+            "id": "f_remit_method",
+            "name": "付款方式",
+            "type": "radioV2",
+            "option": [{"value": "transfer", "text": "转账"}],
+        },
+        "充值客户名称": {
+            "id": "f_customer",
+            "name": "充值客户名称",
+            "type": "input",
+            "option": [],
+        },
+        "充值云账号": {
+            "id": "f_account",
+            "name": "充值云账号",
+            "type": "input",
+            "option": [],
+        },
+        "付款说明": {
+            "id": "f_payment_note",
+            "name": "付款说明",
+            "type": "input",
+            "option": [],
+        },
+        "付款金额": {
+            "id": "f_amount",
+            "name": "付款金额",
+            "type": "amount",
+            "option": [],
+        },
+        "期望到账时间": {
+            "id": "f_date",
+            "name": "期望到账时间",
+            "type": "date",
+            "option": [],
+        },
+        "备注": {
+            "id": "f_remark",
+            "name": "备注",
+            "type": "input",
+            "option": [],
+        },
+    }
+    request_data = {
+        "cloud_type": "示例云-测试伙伴",
+        "payment_type": "仅充值",
+        "recharge_customer_name": "示例客户有限公司",
+        "recharge_account": "example-account",
+        "payment_way": "公司支付",
+        "payment_company": "示例客户有限公司",
+        "remit_method": "转账",
+        "amount": 200,
+        "expected_date": "2026-04-13",
+        "payment_note": "示例测试用途",
+        "remark": "示例业务备注",
+        "payee": {
+            "type": "对公账户",
+            "account_name": "示例收款方有限公司",
+            "account_number": "0000000000000000000",
+            "bank_name": "示例银行",
+            "bank_region": "示例省/示例市",
+            "bank_branch": "示例银行示例支行",
+        },
+    }
+
+    form_payload = _build_form_payload(request_data, schema_by_name)
+    values_by_id = {item["id"]: item["value"] for item in form_payload}
+    remark = values_by_id["f_remark"]
+
+    assert "示例业务备注" in remark
+    assert "账户类型：对公账户" in remark
+    assert "户名：示例收款方有限公司" in remark
+    assert "账号：0000000000000000000" in remark
+    assert "银行：示例银行" in remark
+    assert "银行地区：示例省/示例市" in remark
+    assert "支行：示例银行示例支行" in remark
+
+
 def test_recharge_approval_recovers_remit_method_from_payment_type():
     module = _load_skill_module(
         "submit_recharge_approval_payment_type_recovery",
@@ -2079,7 +2195,7 @@ def test_recharge_approval_recovers_remit_method_from_payment_type():
         "支付方式": {"id": "f_payment_way", "name": "支付方式", "type": "radioV2",
                      "option": [{"value": "company-pay", "text": "公司支付"}]},
         "付款公司": {"id": "f_payment_company", "name": "付款公司", "type": "radioV2",
-                     "option": [{"value": "sz-yibo", "text": "深圳壹铂云科技有限公司"}]},
+                     "option": [{"value": "demo-company", "text": "示例云科技有限公司"}]},
         "付款方式": {"id": "f_remit_method", "name": "付款方式", "type": "radioV2",
                      "option": [{"value": "transfer", "text": "转账"}]},
         "充值客户名称": {"id": "f_customer", "name": "充值客户名称", "type": "input", "option": []},
@@ -2091,18 +2207,18 @@ def test_recharge_approval_recovers_remit_method_from_payment_type():
     request_data = {
         "cloud_type": "智谱",
         "payment_type": "转账",
-        "recharge_customer_name": "深圳壹铂云科技有限公司",
-        "recharge_account": "18017606559",
+        "recharge_customer_name": "示例云科技有限公司",
+        "recharge_account": "demo-account-001",
         "payment_way": "公司支付",
-        "payment_company": "深圳壹铂云科技有限公司",
+        "payment_company": "示例云科技有限公司",
         "amount": 200,
         "payee": {
             "type": "对公账户",
-            "account_name": "北京智谱华章科技股份有限公司",
-            "account_number": "11093851041070210011884",
-            "bank_name": "招商银行",
+            "account_name": "示例收款有限公司",
+            "account_number": "00000000000000000000",
+            "bank_name": "示例银行",
             "bank_region": "北京市/北京市",
-            "bank_branch": "招商银行股份有限公司北京上地支行",
+            "bank_branch": "示例银行示例支行",
         },
     }
 
@@ -2124,27 +2240,27 @@ def test_recharge_approval_hydrates_payee_from_remark_only_request():
     request_data = {
         "cloud_type": "智谱",
         "payment_type": "仅充值",
-        "recharge_customer_name": "深圳壹铂云科技有限公司",
-        "recharge_account": "18017606559",
+        "recharge_customer_name": "示例云科技有限公司",
+        "recharge_account": "demo-account-001",
         "payment_way": "公司支付",
-        "payment_company": "深圳壹铂云科技有限公司",
+        "payment_company": "示例云科技有限公司",
         "remit_method": "转账",
         "amount": 200,
         "remark": (
             "账户类型：对公账户\n"
-            "户名：北京智谱华章科技股份有限公司\n"
-            "账号：11093851041070210011884\n"
-            "银行：招商银行\n"
+            "户名：示例收款有限公司\n"
+            "账号：00000000000000000000\n"
+            "银行：示例银行\n"
             "银行地区：北京市/北京市\n"
-            "支行：招商银行股份有限公司北京上地支行"
+            "支行：示例银行示例支行"
         ),
     }
 
     module.validate_request(request_data)
 
     assert "payee" in request_data
-    assert request_data["payee"]["account_number"] == "11093851041070210011884"
-    assert request_data["payee"]["bank_branch"] == "招商银行股份有限公司北京上地支行"
+    assert request_data["payee"]["account_number"] == "00000000000000000000"
+    assert request_data["payee"]["bank_branch"] == "示例银行示例支行"
 
 
 def test_recharge_approval_rejects_required_account_widget_when_api_cannot_fill():
@@ -2176,7 +2292,7 @@ def test_recharge_approval_resolves_user_id_with_query_param_and_include_resigne
 ):
     cloud_provider.recharge_info = '{"amount": 188, "recharge_account": "acct-188"}'
     cloud_provider.save(update_fields=["recharge_info"])
-    record = RechargeApprovalRecord.objects.create(
+    RechargeApprovalRecord.objects.create(
         provider=cloud_provider,
         raw_recharge_info=cloud_provider.recharge_info,
     )
@@ -2207,14 +2323,14 @@ def test_recharge_approval_resolves_user_id_with_query_param_and_include_resigne
     )
 
     result = _resolve_user_id_by_email_or_mobile(
-        "zhengwei@oneprocloud.cn",
+        "reviewer@example.test",
         "t-token",
     )
 
     assert result == ("ou_123", "")
     assert captured["url"].endswith("/open-apis/contact/v3/users/batch_get_id?user_id_type=user_id")
     assert captured["body"]["include_resigned"] is True
-    assert captured["body"]["emails"] == ["zhengwei@oneprocloud.cn"]
+    assert captured["body"]["emails"] == ["reviewer@example.test"]
     assert captured["body"]["mobiles"] == []
     assert "Authorization" in captured["headers"]
 
@@ -2230,17 +2346,17 @@ def test_resolve_submitter_identity_prefers_feishu_user_name(
     monkeypatch.setattr(
         recharge_service,
         "_resolve_user_id_by_email_or_mobile",
-        lambda identifier, access_token: ("ou_456", "郑伟"),
+        lambda identifier, access_token: ("ou_456", "示例用户"),
     )
 
     identifier, label, user_id = resolve_submitter_identity(
-        provider_config={"recharge_approval": {"submitter_identifier": "zhengwei@oneprocloud.cn"}},
+        provider_config={"recharge_approval": {"submitter_identifier": "reviewer@example.test"}},
         explicit_identifier="",
         explicit_label="财务机器人",
     )
 
-    assert identifier == "zhengwei@oneprocloud.cn"
-    assert label == "郑伟"
+    assert identifier == "reviewer@example.test"
+    assert label == "示例用户"
     assert user_id == "ou_456"
 
 
@@ -2260,10 +2376,10 @@ def test_submit_recharge_skill_resolves_user_id_with_query_param():
 
     module.api_request = fake_api_request
 
-    assert module._resolve_user_id("https://open.feishu.cn", "tok_abc", "zhengwei@oneprocloud.cn") == "ou_456"
+    assert module._resolve_user_id("https://open.feishu.cn", "tok_abc", "reviewer@example.test") == "ou_456"
     assert captured["url"].endswith("/open-apis/contact/v3/users/batch_get_id?user_id_type=user_id")
     assert captured["payload"]["include_resigned"] is True
-    assert captured["payload"]["emails"] == ["zhengwei@oneprocloud.cn"]
+    assert captured["payload"]["emails"] == ["reviewer@example.test"]
     assert captured["payload"]["mobiles"] == []
     assert captured["headers"]["Authorization"] == "Bearer tok_abc"
 
@@ -2408,21 +2524,21 @@ def test_submit_recharge_skill_inspects_ongoing_account_state():
         {
             "cloud_type": "智谱",
             "payment_type": "仅充值",
-            "recharge_customer_name": "深圳壹铂云科技有限公司",
+            "recharge_customer_name": "示例云科技有限公司",
             "recharge_account": "acct-188",
             "payment_way": "公司支付",
-            "payment_company": "深圳壹铂云科技有限公司",
+            "payment_company": "示例云科技有限公司",
             "remit_method": "转账",
             "amount": 188,
             "expected_date": "2025-01-08",
             "remark": "测试",
             "payee": {
                 "type": "对公账户",
-                "account_name": "北京智谱华章科技股份有限公司",
-                "account_number": "11093851041070210011884",
-                "bank_name": "招商银行",
+                "account_name": "示例收款有限公司",
+                "account_number": "00000000000000000000",
+                "bank_name": "示例银行",
                 "bank_region": "北京市/北京市",
-                "bank_branch": "招商银行股份有限公司北京上地支行",
+                "bank_branch": "示例银行示例支行",
             },
         },
         30,
@@ -2476,21 +2592,21 @@ def test_submit_recharge_skill_inspects_finished_account_state():
         {
             "cloud_type": "智谱",
             "payment_type": "仅充值",
-            "recharge_customer_name": "深圳壹铂云科技有限公司",
+            "recharge_customer_name": "示例云科技有限公司",
             "recharge_account": "acct-188",
             "payment_way": "公司支付",
-            "payment_company": "深圳壹铂云科技有限公司",
+            "payment_company": "示例云科技有限公司",
             "remit_method": "转账",
             "amount": 188,
             "expected_date": "2025-01-08",
             "remark": "测试",
             "payee": {
                 "type": "对公账户",
-                "account_name": "北京智谱华章科技股份有限公司",
-                "account_number": "11093851041070210011884",
-                "bank_name": "招商银行",
+                "account_name": "示例收款有限公司",
+                "account_number": "00000000000000000000",
+                "bank_name": "示例银行",
                 "bank_region": "北京市/北京市",
-                "bank_branch": "招商银行股份有限公司北京上地支行",
+                "bank_branch": "示例银行示例支行",
             },
         },
         30,
@@ -2552,21 +2668,21 @@ def test_submit_recharge_skill_prefers_latest_account_state():
         {
             "cloud_type": "智谱",
             "payment_type": "仅充值",
-            "recharge_customer_name": "深圳壹铂云科技有限公司",
+            "recharge_customer_name": "示例云科技有限公司",
             "recharge_account": "acct-188",
             "payment_way": "公司支付",
-            "payment_company": "深圳壹铂云科技有限公司",
+            "payment_company": "示例云科技有限公司",
             "remit_method": "转账",
             "amount": 188,
             "expected_date": "2025-01-08",
             "remark": "测试",
             "payee": {
                 "type": "对公账户",
-                "account_name": "北京智谱华章科技股份有限公司",
-                "account_number": "11093851041070210011884",
-                "bank_name": "招商银行",
+                "account_name": "示例收款有限公司",
+                "account_number": "00000000000000000000",
+                "bank_name": "示例银行",
                 "bank_region": "北京市/北京市",
-                "bank_branch": "招商银行股份有限公司北京上地支行",
+                "bank_branch": "示例银行示例支行",
             },
         },
         30,
@@ -2620,21 +2736,21 @@ def test_submit_recharge_skill_ignores_same_account_with_different_cloud_type():
         {
             "cloud_type": "智谱",
             "payment_type": "仅充值",
-            "recharge_customer_name": "深圳壹铂云科技有限公司",
+            "recharge_customer_name": "示例云科技有限公司",
             "recharge_account": "acct-188",
             "payment_way": "公司支付",
-            "payment_company": "深圳壹铂云科技有限公司",
+            "payment_company": "示例云科技有限公司",
             "remit_method": "转账",
             "amount": 188,
             "expected_date": "2025-01-08",
             "remark": "测试",
             "payee": {
                 "type": "对公账户",
-                "account_name": "北京智谱华章科技股份有限公司",
-                "account_number": "11093851041070210011884",
-                "bank_name": "招商银行",
+                "account_name": "示例收款有限公司",
+                "account_number": "00000000000000000000",
+                "bank_name": "示例银行",
                 "bank_region": "北京市/北京市",
-                "bank_branch": "招商银行股份有限公司北京上地支行",
+                "bank_branch": "示例银行示例支行",
             },
         },
         30,

--- a/backend/cloud_billing/tests/test_tasks.py
+++ b/backend/cloud_billing/tests/test_tasks.py
@@ -10,11 +10,9 @@ from decimal import Decimal
 from unittest.mock import patch, MagicMock
 from types import SimpleNamespace
 
-from django.contrib.auth.models import User
 from django.utils import timezone
 
 from cloud_billing.models import (
-    CloudProvider,
     BillingData,
     AlertRule,
     AlertRecord,
@@ -874,8 +872,27 @@ class TestSubmitRechargeApproval:
         """
         cloud_provider.recharge_info = '{"amount": 188, "recharge_account": "acct-188"}'
         cloud_provider.save(update_fields=["recharge_info"])
+        feishu_request_payload = {
+            "approval_code": "approval_188",
+            "user_id": "ou_submitter_188",
+            "form": json.dumps(
+                [
+                    {
+                        "id": "f_remark",
+                        "type": "input",
+                        "value": (
+                            "示例业务备注\n"
+                            "户名：示例收款方有限公司\n"
+                            "账号：0000000000000000000"
+                        ),
+                    }
+                ],
+                ensure_ascii=False,
+            ),
+        }
         mock_execute_agent.return_value = {
             "request_payload": {"amount": 188, "recharge_account": "acct-188"},
+            "feishu_request_payload": feishu_request_payload,
             "submission_payload": {"ok": True},
             "submitter_identifier": "",
             "resolved_submitter_user_id": "",
@@ -901,6 +918,23 @@ class TestSubmitRechargeApproval:
         assert any("Created recharge approval record" in item for item in messages)
         assert any("Executing recharge approval agent" in item for item in messages)
         assert any("Recharge approval agent completed successfully" in item for item in messages)
+        assert any(
+            "Feishu approval instance create request payload" in item
+            and "***REDACTED***" in item
+            and "示例收款方有限公司" not in item
+            and "0000000000000000000" not in item
+            for item in messages
+        )
+        assert (
+            execution.metadata["feishu_request_payload"]["form"][0]["value"]
+            == "***REDACTED***"
+        )
+        assert (
+            execution.metadata["feishu_request_payload_redacted"]["form"][0][
+                "value"
+            ]
+            == "***REDACTED***"
+        )
         assert execution.metadata["log_summary"]["total"] >= 5
 
     @patch("cloud_billing.tasks.execute_recharge_approval_agent")
@@ -1058,9 +1092,9 @@ class TestSubmitRechargeApproval:
         labels even when the caller does not pass a human operator.
         """
         cloud_provider.recharge_info = (
-            '{"recharge_account": "18017606559", '
-            '"recharge_customer_name": "深圳壹铂云科技有限公司", '
-            '"payment_company": "深圳壹铂云科技有限公司", '
+            '{"recharge_account": "demo-account-001", '
+            '"recharge_customer_name": "示例云科技有限公司", '
+            '"payment_company": "示例云科技有限公司", '
             '"payment_way": "公司支付", '
             '"payment_type": "仅充值", '
             '"remit_method": "转账"}'
@@ -1084,11 +1118,11 @@ class TestSubmitRechargeApproval:
         )
         mock_execute_agent.return_value = {
             "request_payload": {
-                "recharge_account": "18017606559",
-                "recharge_customer_name": "深圳壹铂云科技有限公司",
+                "recharge_account": "demo-account-001",
+                "recharge_customer_name": "示例云科技有限公司",
                 "amount": 358,
                 "currency": "CNY",
-                "payment_company": "深圳壹铂云科技有限公司",
+                "payment_company": "示例云科技有限公司",
                 "payment_way": "公司支付",
                 "payment_type": "仅充值",
                 "remit_method": "转账",

--- a/backend/cloud_billing/views/provider.py
+++ b/backend/cloud_billing/views/provider.py
@@ -24,7 +24,6 @@ from ..services.provider_service import ProviderService
 from ..services.recharge_approval import (
     parse_recharge_info,
 )
-from ..tasks import submit_recharge_approval
 from ..utils.logging import mask_sensitive_config
 
 logger = logging.getLogger(__name__)
@@ -725,6 +724,8 @@ class CloudProviderViewSet(viewsets.ModelViewSet):
             currency=request.data.get("currency") or "",
             expected_date=request.data.get("expected_date") or "",
         )
+        from ..tasks import submit_recharge_approval
+
         task = submit_recharge_approval.delay(
             provider.id,
             trigger_source="manual",

--- a/backend/cloud_billing/views/task.py
+++ b/backend/cloud_billing/views/task.py
@@ -13,8 +13,6 @@ from agentcore_task.adapters.django import (
     TaskTracker,
 )
 
-from ..tasks import collect_billing_data
-
 
 class BillingTaskViewSet(viewsets.ViewSet):
     """
@@ -62,6 +60,8 @@ class BillingTaskViewSet(viewsets.ViewSet):
                     ),
                     'reason': 'task_already_running',
                 }, status=status.HTTP_409_CONFLICT)
+
+            from ..tasks import collect_billing_data
 
             task = collect_billing_data.delay(
                 provider_id_int, user_id=user_id

--- a/backend/core/__init__.py
+++ b/backend/core/__init__.py
@@ -1,11 +1,3 @@
-import os
-
-from .celery import app as celery_app
-
-# __all__ is a list that specifies the public objects of the module
-__all__ = ('celery_app',)
-
-
 def _init_sentry():
     """Initialize Sentry error tracking if configured."""
     from core.settings.sentry import (

--- a/backend/data_collector/views/config.py
+++ b/backend/data_collector/views/config.py
@@ -25,7 +25,6 @@ from agentcore_task.adapters.django import TaskStatus, register_task_execution
 
 from ..services.beat_sync import sync_config_to_beat, unsync_config_from_beat
 from ..services.providers import get_provider
-from ..tasks import run_collect, run_validate
 
 
 HYPERBDR_PLATFORM = "hyperbdr"
@@ -297,6 +296,8 @@ class CollectorConfigViewSet(viewsets.ModelViewSet):
         if start_time is not None and end_time is not None:
             task_kwargs["start_time"] = start_time
             task_kwargs["end_time"] = end_time
+        from ..tasks import run_collect
+
         task = run_collect.delay(**task_kwargs)
         register_task_execution(
             task_id=task.id,
@@ -514,6 +515,8 @@ class CollectorConfigViewSet(viewsets.ModelViewSet):
                 {"detail": "start_time and end_time are required."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
+        from ..tasks import run_validate
+
         task = run_validate.delay(
             config_uuid=str(config.uuid),
             start_time=start_time,

--- a/backend/hyperbdr_dashboard/views.py
+++ b/backend/hyperbdr_dashboard/views.py
@@ -18,7 +18,6 @@ from .serializers import (
 )
 from . import services as dashboard_services
 from .services.analyzer import build_dashboard_stats
-from .tasks import run_collection_for_data_source
 from accounts.access import get_effective_feature_keys
 
 logger = logging.getLogger(__name__)
@@ -177,6 +176,8 @@ class DataSourceCollectAPIView(APIView):
             start_time=timezone.now(),
             trigger_mode="manual",
         )
+        from .tasks import run_collection_for_data_source
+
         celery_task = run_collection_for_data_source.delay(data_source.id, task.id, "manual")
         task.celery_task_id = celery_task.id
         task.save(update_fields=["celery_task_id", "updated_at"])
@@ -288,6 +289,8 @@ class TriggerCollectionAPIView(APIView):
         else:
             targets = list(DataSource.objects.filter(is_active=True))
         scheduled = []
+        from .tasks import run_collection_for_data_source
+
         for source in targets:
             task = CollectionTask.objects.create(
                 data_source=source,

--- a/backend/sals/views.py
+++ b/backend/sals/views.py
@@ -5,8 +5,7 @@ import logging
 import re
 from collections import Counter
 
-from django.db.models import Avg, Count, Q, Sum, Case, When, Value, CharField, IntegerField, FloatField
-from django.db.models.functions import Coalesce
+from django.db.models import Avg, Count, Q, Sum, Case, When, Value, CharField, IntegerField
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
@@ -24,7 +23,6 @@ from .serializers import (
     UserSerializer,
 )
 from .services import etl
-from .tasks import sync_incidents
 
 logger = logging.getLogger(__name__)
 
@@ -741,6 +739,8 @@ class InitDbAPIView(APIView):
             )
 
         try:
+            from .tasks import sync_incidents
+
             result = sync_incidents.delay(
                 full_sync=full_sync,
                 user_id=request.user.id,

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,4 +1,24 @@
 services:
+  backend-init:
+    image: devmind-backend:dev
+    container_name: backend-init-dev
+    restart: "no"
+    env_file:
+      - ./.env.dev
+    volumes:
+      - ./data.dev/django/staticfiles:/opt/backend/core/staticfiles
+      - ./data.dev/logs/api:/var/log/gunicorn
+      - ./backend:/opt/backend
+      - ./cache.dev:/opt/cache
+      - ./docker/nginx/certs:/opt/backend/docker/nginx/certs
+      - ./data.dev/storage:/opt/storage
+    networks:
+      - backend_network
+    depends_on:
+      postgresql:
+        condition: service_healthy
+    command: init
+
   backend-api:
     image: devmind-backend:dev
     container_name: backend-api-dev
@@ -22,6 +42,8 @@ services:
     networks:
       - backend_network
     depends_on:
+      backend-init:
+        condition: service_completed_successfully
       postgresql:
         condition: service_healthy
     command: development

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,23 @@
 services:
+  backend-init:
+    image: registry.cn-beijing.aliyuncs.com/hypermotion_dockers/devmind-backend:${APP_VERSION:?APP_VERSION is required}
+    container_name: backend-init
+    restart: "no"
+    env_file:
+      - ./.env
+    volumes:
+      - ./data/django/staticfiles:/opt/backend/core/staticfiles
+      - ./data/logs/api:/var/log/gunicorn
+      - ./data/storage:/opt/storage
+      - ./cache:/opt/cache
+      - ./docker/nginx/certs:/opt/backend/docker/nginx/certs
+    networks:
+      - backend_network
+    depends_on:
+      postgresql:
+        condition: service_healthy
+    command: init
+
   backend-api:
     image: registry.cn-beijing.aliyuncs.com/hypermotion_dockers/devmind-backend:${APP_VERSION:?APP_VERSION is required}
     container_name: backend-api
@@ -21,6 +40,8 @@ services:
     networks:
       - backend_network
     depends_on:
+      backend-init:
+        condition: service_completed_successfully
       postgresql:
         condition: service_healthy
     command: gunicorn

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -25,6 +25,7 @@ THREADS=${THREADS:-1}
 REDIS_URL=${REDIS_URL:-redis://redis:6379/0}
 REDIS_HEALTHCHECK_URL=${REDIS_HEALTHCHECK_URL:-${CELERY_BROKER_URL:-$REDIS_URL}}
 DB_ENGINE=${DB_ENGINE:-sqlite}
+RUN_STARTUP_MAINTENANCE=${RUN_STARTUP_MAINTENANCE:-false}
 
 # --- Ensure log directories exist ---
 mkdir -p $LOG_BASE_DIR /var/log/celery
@@ -127,6 +128,11 @@ collect_static() {
     python manage.py collectstatic --noinput
 }
 
+run_startup_maintenance() {
+    run_migrations
+    collect_static
+}
+
 # --- Process Starters ---
 start_gunicorn() {
     log "Starting Gunicorn..."
@@ -160,7 +166,7 @@ start_celery_worker() {
     # - Waits for currently running tasks to complete
     # - Docker stop_grace_period (600s) allows time for tasks to finish
     # - CELERY_TASK_ACKS_LATE=True ensures tasks are only acknowledged after completion
-    exec celery -A core worker \
+    exec celery -A core.celery:app worker \
         --loglevel=${CELERY_LOG_LEVEL:-INFO} \
         --concurrency=$DEFAULT_CONCURRENCY \
         --max-tasks-per-child=${CELERY_MAX_TASKS_PER_CHILD:-1000} \
@@ -170,7 +176,7 @@ start_celery_worker() {
 
 start_celery_beat() {
     log "Starting Celery beat with DatabaseScheduler..."
-    exec celery -A core beat \
+    exec celery -A core.celery:app beat \
         --scheduler django_celery_beat.schedulers:DatabaseScheduler \
         --loglevel=${CELERY_LOG_LEVEL:-INFO} \
         --logfile=/var/log/celery/beat.log
@@ -178,7 +184,7 @@ start_celery_beat() {
 
 start_flower() {
     log "Starting Flower..."
-    exec celery -A core flower \
+    exec celery -A core.celery:app flower \
         --port=${FLOWER_PORT:-5555} \
         --address=0.0.0.0 \
         --broker="$REDIS_URL" \
@@ -193,10 +199,18 @@ start_development() {
 
 # --- Main Entrypoint ---
 case "$1" in
+    init)
+        wait_for_db
+        run_startup_maintenance
+        ;;
     gunicorn)
         wait_for_db
-        run_migrations
-        collect_static
+        if [ "$RUN_STARTUP_MAINTENANCE" = "true" ]; then
+            log "RUN_STARTUP_MAINTENANCE=true; running maintenance before Gunicorn..."
+            run_startup_maintenance
+        else
+            log "Skipping startup maintenance before Gunicorn."
+        fi
         start_gunicorn
         ;;
     celery)
@@ -215,8 +229,12 @@ case "$1" in
         ;;
     development)
         wait_for_db
-        run_migrations
-        collect_static
+        if [ "$RUN_STARTUP_MAINTENANCE" = "true" ]; then
+            log "RUN_STARTUP_MAINTENANCE=true; running maintenance before runserver..."
+            run_startup_maintenance
+        else
+            log "Skipping startup maintenance before runserver."
+        fi
         start_development
         ;;
     *)


### PR DESCRIPTION
## Summary
- Preserve existing recharge remarks while appending payee bank details in local Feishu approval mode.
- Record Feishu approval request evidence in task metadata using redacted persisted/logged payloads.
- Speed up API startup by moving maintenance work into init services and lazy-loading heavy Celery/provider imports.
- Replace real-looking customer/bank test fixtures with explicit sample data.

## Test plan
- [x] uvx ruff check on changed Python files
- [x] python3 -m py_compile on changed Python files
- [x] bash -n docker/entrypoint.sh
- [x] docker compose config for production and dev compose files
- [x] codex review after security fixes
- [ ] pytest blocked: dependency download failed from configured PyPI mirror
- [ ] mypy blocked: mypy download stalled in uvx

## Notes
- No deployment performed.
- Sentry resolve and Jira closure should wait for production verification.
- auto_workflow logs are intentionally not committed.