### PR TITLE
Fix dev runtime and recharge approval status sync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,14 +18,24 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 RUN set -eux; \
     if [ "$USE_MIRROR" = "true" ]; then \
         echo "Setting up Chinese mirrors for Ubuntu 24.04 LTS..."; \
-        # Backup original sources
-        cp /etc/apt/sources.list /etc/apt/sources.list.backup; \
-        # Replace with Chinese mirrors
-        echo "deb https://mirrors.tuna.tsinghua.edu.cn/ubuntu/ noble main restricted universe multiverse" > /etc/apt/sources.list; \
-        echo "deb https://mirrors.tuna.tsinghua.edu.cn/ubuntu/ noble-updates main restricted universe multiverse" >> /etc/apt/sources.list; \
-        echo "deb https://mirrors.tuna.tsinghua.edu.cn/ubuntu/ noble-backports main restricted universe multiverse" >> /etc/apt/sources.list; \
-        echo "deb https://mirrors.tuna.tsinghua.edu.cn/ubuntu/ noble-security main restricted universe multiverse" >> /etc/apt/sources.list; \
+        arch="$(dpkg --print-architecture)"; \
+        mirror_path="ubuntu"; \
+        if [ "$arch" != "amd64" ]; then \
+            mirror_path="ubuntu-ports"; \
+        fi; \
+        if [ -f /etc/apt/sources.list ]; then \
+            cp /etc/apt/sources.list /etc/apt/sources.list.backup; \
+        fi; \
+        if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then \
+            cp /etc/apt/sources.list.d/ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources.backup; \
+            rm -f /etc/apt/sources.list.d/ubuntu.sources; \
+        fi; \
+        echo "deb https://mirrors.aliyun.com/${mirror_path}/ noble main restricted universe multiverse" > /etc/apt/sources.list; \
+        echo "deb https://mirrors.aliyun.com/${mirror_path}/ noble-updates main restricted universe multiverse" >> /etc/apt/sources.list; \
+        echo "deb https://mirrors.aliyun.com/${mirror_path}/ noble-backports main restricted universe multiverse" >> /etc/apt/sources.list; \
+        echo "deb https://mirrors.aliyun.com/${mirror_path}/ noble-security main restricted universe multiverse" >> /etc/apt/sources.list; \
         echo "✓ Chinese mirrors configured for Ubuntu 24.04 LTS (Noble Numbat)"; \
+        echo "Architecture: ${arch}; mirror path: ${mirror_path}"; \
         echo "Current sources.list content:"; \
         cat /etc/apt/sources.list; \
     else \
@@ -73,10 +83,12 @@ RUN rm -f /usr/lib/python3.12/EXTERNALLY-MANAGED
 RUN set -eux; \
     if [ "$USE_MIRROR" = "true" ]; then \
         echo "Installing uv with Chinese PyPI mirror"; \
-        pip install --index-url https://pypi.tuna.tsinghua.edu.cn/simple --trusted-host pypi.tuna.tsinghua.edu.cn uv; \
+        pip install --retries 5 --timeout 120 --progress-bar off \
+            --index-url https://mirrors.aliyun.com/pypi/simple \
+            --trusted-host mirrors.aliyun.com uv; \
     else \
         echo "Installing uv with default PyPI"; \
-        pip install uv; \
+        pip install --retries 5 --timeout 120 --progress-bar off uv; \
     fi; \
     echo 'export PATH="/root/.local/bin:$PATH"' >> /root/.bashrc; \
     export PATH="/root/.local/bin:$PATH"

--- a/backend/cloud_billing/tests/test_views.py
+++ b/backend/cloud_billing/tests/test_views.py
@@ -963,12 +963,16 @@ class TestRechargeApprovalEndpoints:
     """
 
     def test_list_recharge_approvals_serializes_llm_usage_id(
-        self, api_client, cloud_provider
+        self, api_client, cloud_provider, mocker
     ):
         """
         List endpoint should serialize approval records without DRF source
         assertion errors.
         """
+        mocked_refresh = mocker.patch(
+            "cloud_billing.views.recharge_approval."
+            "refresh_recharge_approval_record_status"
+        )
         record = RechargeApprovalRecord.objects.create(
             provider=cloud_provider,
             trigger_source=RechargeApprovalRecord.TRIGGER_SOURCE_MANUAL,
@@ -984,6 +988,57 @@ class TestRechargeApprovalEndpoints:
         assert response.data["results"][0]["id"] == record.id
         assert "latest_llm_usage_id" in response.data["results"][0]
         assert response.data["results"][0]["latest_llm_usage_id"] is None
+        mocked_refresh.assert_called_once_with(record)
+
+    def test_list_recharge_approvals_skips_final_status_refresh(
+        self, api_client, cloud_provider, mocker
+    ):
+        """
+        List endpoint should not re-query Feishu for final records.
+        """
+        mocked_refresh = mocker.patch(
+            "cloud_billing.views.recharge_approval."
+            "refresh_recharge_approval_record_status"
+        )
+        RechargeApprovalRecord.objects.create(
+            provider=cloud_provider,
+            trigger_source=RechargeApprovalRecord.TRIGGER_SOURCE_MANUAL,
+            raw_recharge_info='{"amount": 188}',
+            request_payload={"amount": 188},
+            status=RechargeApprovalRecord.STATUS_APPROVED,
+        )
+
+        url = "/api/v1/cloud-billing/recharge-approvals/"
+        response = api_client.get(url)
+
+        assert response.status_code == 200
+        mocked_refresh.assert_not_called()
+
+    def test_retrieve_recharge_approval_refreshes_ongoing_status(
+        self, api_client, cloud_provider, mocker
+    ):
+        """
+        Detail endpoint should refresh ongoing approval status before
+        serialization.
+        """
+        mocked_refresh = mocker.patch(
+            "cloud_billing.views.recharge_approval."
+            "refresh_recharge_approval_record_status"
+        )
+        record = RechargeApprovalRecord.objects.create(
+            provider=cloud_provider,
+            trigger_source=RechargeApprovalRecord.TRIGGER_SOURCE_MANUAL,
+            raw_recharge_info='{"amount": 188}',
+            request_payload={"amount": 188},
+            status=RechargeApprovalRecord.STATUS_SUBMITTED,
+        )
+
+        url = f"/api/v1/cloud-billing/recharge-approvals/{record.id}/"
+        response = api_client.get(url)
+
+        assert response.status_code == 200
+        assert response.data["id"] == record.id
+        mocked_refresh.assert_called_once_with(record)
 
     def test_submit_recharge_approval_endpoint(self, api_client, cloud_provider, mocker):
         """

--- a/backend/cloud_billing/views/recharge_approval.py
+++ b/backend/cloud_billing/views/recharge_approval.py
@@ -4,22 +4,26 @@ Views for recharge approval callbacks and records.
 
 from __future__ import annotations
 
+import logging
 import os
 from hmac import compare_digest
 
 from django.utils import timezone
 from drf_spectacular.utils import extend_schema
+from rest_framework import generics
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from rest_framework import generics
 
 from ..models import RechargeApprovalRecord
 from ..serializers import RechargeApprovalRecordSerializer
 from ..services.recharge_approval import (
     create_recharge_approval_event,
     normalize_feishu_status,
+    refresh_recharge_approval_record_status,
 )
+
+logger = logging.getLogger(__name__)
 
 # Final statuses that trigger a notification
 FINAL_RECHARGE_STATUSES = {
@@ -28,6 +32,26 @@ FINAL_RECHARGE_STATUSES = {
     RechargeApprovalRecord.STATUS_CANCELED,
     RechargeApprovalRecord.STATUS_FAILED,
 }
+ONGOING_RECHARGE_STATUSES = {
+    RechargeApprovalRecord.STATUS_PENDING,
+    RechargeApprovalRecord.STATUS_SUBMITTED,
+}
+
+
+def _refresh_ongoing_recharge_approvals(records) -> None:
+    for record in records:
+        if record.status not in ONGOING_RECHARGE_STATUSES:
+            continue
+        try:
+            refresh_recharge_approval_record_status(record)
+        except Exception:
+            logger.warning(
+                "Failed to refresh recharge approval status "
+                "(record_id=%s, instance_code=%s).",
+                record.id,
+                record.feishu_instance_code,
+                exc_info=True,
+            )
 
 
 def _get_callback_verification_token() -> str:
@@ -78,6 +102,19 @@ class RechargeApprovalListView(generics.ListAPIView):
             queryset = queryset.filter(provider_id=provider_id)
         return queryset
 
+    def list(self, request, *args, **kwargs):
+        queryset = self.filter_queryset(self.get_queryset())
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            _refresh_ongoing_recharge_approvals(page)
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        records = list(queryset)
+        _refresh_ongoing_recharge_approvals(records)
+        serializer = self.get_serializer(records, many=True)
+        return Response(serializer.data)
+
 
 class RechargeApprovalDetailView(generics.RetrieveAPIView):
     queryset = RechargeApprovalRecord.objects.select_related(
@@ -89,6 +126,12 @@ class RechargeApprovalDetailView(generics.RetrieveAPIView):
     ).prefetch_related("events", "llm_runs")
     serializer_class = RechargeApprovalRecordSerializer
     permission_classes = [IsAuthenticated]
+
+    def retrieve(self, request, *args, **kwargs):
+        instance = self.get_object()
+        _refresh_ongoing_recharge_approvals([instance])
+        serializer = self.get_serializer(instance)
+        return Response(serializer.data)
 
 
 class RechargeApprovalFeishuCallbackView(APIView):

--- a/backend/core/__init__.py
+++ b/backend/core/__init__.py
@@ -37,3 +37,10 @@ def _init_sentry():
 
 
 _init_sentry()
+
+# Load the project Celery app when Django imports the project package.
+# Without this, shared_task.delay() in web requests can fall back to Celery's
+# default app and publish messages to the default "celery" queue.
+from .celery import app as celery_app
+
+__all__ = ("celery_app",)

--- a/backend/core/celery.py
+++ b/backend/core/celery.py
@@ -36,11 +36,21 @@ app.conf.update(
     result_backend='django-db',
     beat_scheduler='django_celery_beat.schedulers:DatabaseScheduler',
     imports=tuple(app.conf.get("imports", ())) + (
+        # First-party business tasks must be imported in the worker main
+        # process before the consumer starts. If they are only discovered in
+        # child processes, the parent can discard early messages as
+        # "unregistered task" before a child ever sees them.
+        "cloud_billing.tasks",
+        "data_collector.tasks",
+        "hyperbdr_dashboard.tasks",
+        "llm_ops.tasks",
+        "sals.tasks",
         # Each entry must be a fully-qualified module that exposes its
         # ``@shared_task`` definitions at import time. Listing only the
         # package name is not enough: submodules of that package need to
         # be imported explicitly so their task names land in
         # ``app.tasks`` before celery beat starts dispatching.
+        "agentcore_task.adapters.django.tasks",
         "agentcore_notifier.adapters.django.tasks",
         "agentcore_notifier.adapters.django.tasks.cleanup",
         "agentcore_metering.adapters.django.tasks",

--- a/backend/tests/test_celery_task_registration.py
+++ b/backend/tests/test_celery_task_registration.py
@@ -1,3 +1,10 @@
+def test_django_project_import_loads_celery_app():
+    import core
+
+    assert hasattr(core, "celery_app")
+    assert core.celery_app.conf.task_default_queue == "backend"
+
+
 def test_business_tasks_are_registered_before_worker_consumes():
     from core.celery import app
 

--- a/backend/tests/test_celery_task_registration.py
+++ b/backend/tests/test_celery_task_registration.py
@@ -1,0 +1,9 @@
+def test_business_tasks_are_registered_before_worker_consumes():
+    from core.celery import app
+
+    app.loader.import_default_modules()
+
+    assert "cloud_billing.tasks.submit_recharge_approval" in app.tasks
+    assert "cloud_billing.tasks.collect_billing_data" in app.tasks
+    assert "data_collector.tasks.run_collect" in app.tasks
+    assert "sals.tasks.sync_incidents" in app.tasks

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,6 +3,13 @@ services:
     image: devmind-backend:dev
     container_name: backend-init-dev
     restart: "no"
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: backend
+      args:
+        USE_MIRROR: ${USE_MIRROR:-true}
+        DEV_MODE: "1"
     env_file:
       - ./.env.dev
     volumes:


### PR DESCRIPTION
## Summary
- fix backend init/dev image rebuild command handling
- fix Ubuntu 24.04 mirror setup for ARM builds
- register business Celery tasks before worker consumption
- load the project Celery app for web task dispatch so shared tasks route to the backend queue
- refresh ongoing recharge approval status on list/detail reads

## Verification
- docker run py_compile for changed backend Python files
- docker run manage.py check with valid CORS_ALLOWED_ORIGINS override
- pytest not run: pytest is not installed in the backend image
