### PR TITLE
Slim backend Docker image build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -49,6 +49,7 @@ docker-compose.*.yml
 
 # Other
 .env
+.env.*
 *.bak
 *.tmp
 *.temp
@@ -59,7 +60,28 @@ yarn-error.log*
 
 # Project specific
 data/
+data.dev/
 cache/
+cache.dev/
+docker_runtime/
+output/
+samples/
+
+# Tool caches and analysis output
+.codegraph/
+.mypy_cache/
+.nox/
+.pytest_cache/
+.ruff_cache/
+.tox/
+.understand-anything/
+htmlcov/
+**/.codegraph/
+**/.mypy_cache/
+**/.pytest_cache/
+**/.ruff_cache/
+**/.tox/
+**/__pycache__/
 
 # Frontend workspace
 frontend/node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,85 +1,63 @@
-# Use official Python 3.12 on Ubuntu 24.04 LTS
-FROM ubuntu:24.04 AS backend
+# syntax=docker/dockerfile:1.6
+
+# -----------------------------------------------------------------------------
+# Backend builder image
+# -----------------------------------------------------------------------------
+
+FROM python:3.12-slim-bookworm AS backend-builder
 
 # Build argument to control mirror usage
 ARG USE_MIRROR=false
 
 # Set environment variables
-ENV PYTHONUNBUFFERED=1 \
-    PYTHONDONTWRITEBYTECODE=1 \
-    PIP_NO_CACHE_DIR=1 \
+ENV DEBIAN_FRONTEND=noninteractive \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
-    DEBIAN_FRONTEND=noninteractive
+    PIP_NO_CACHE_DIR=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    UV_LINK_MODE=copy
 
-# Install ca-certificates first to avoid SSL certificate issues
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
-
-# Setup mirrors based on build argument (before installing packages)
+# Setup mirrors based on build argument before installing packages.
 RUN set -eux; \
     if [ "$USE_MIRROR" = "true" ]; then \
-        echo "Setting up Chinese mirrors for Ubuntu 24.04 LTS..."; \
-        arch="$(dpkg --print-architecture)"; \
-        mirror_path="ubuntu"; \
-        if [ "$arch" != "amd64" ]; then \
-            mirror_path="ubuntu-ports"; \
-        fi; \
-        if [ -f /etc/apt/sources.list ]; then \
-            cp /etc/apt/sources.list /etc/apt/sources.list.backup; \
-        fi; \
-        if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then \
-            cp /etc/apt/sources.list.d/ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources.backup; \
-            rm -f /etc/apt/sources.list.d/ubuntu.sources; \
-        fi; \
-        echo "deb https://mirrors.aliyun.com/${mirror_path}/ noble main restricted universe multiverse" > /etc/apt/sources.list; \
-        echo "deb https://mirrors.aliyun.com/${mirror_path}/ noble-updates main restricted universe multiverse" >> /etc/apt/sources.list; \
-        echo "deb https://mirrors.aliyun.com/${mirror_path}/ noble-backports main restricted universe multiverse" >> /etc/apt/sources.list; \
-        echo "deb https://mirrors.aliyun.com/${mirror_path}/ noble-security main restricted universe multiverse" >> /etc/apt/sources.list; \
-        echo "✓ Chinese mirrors configured for Ubuntu 24.04 LTS (Noble Numbat)"; \
-        echo "Architecture: ${arch}; mirror path: ${mirror_path}"; \
-        echo "Current sources.list content:"; \
-        cat /etc/apt/sources.list; \
+        printf '%s\n' \
+            'Types: deb' \
+            'URIs: https://mirrors.aliyun.com/debian' \
+            'Suites: bookworm bookworm-updates bookworm-backports' \
+            'Components: main contrib non-free non-free-firmware' \
+            'Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg' \
+            '' \
+            'Types: deb' \
+            'URIs: https://mirrors.aliyun.com/debian-security' \
+            'Suites: bookworm-security' \
+            'Components: main contrib non-free non-free-firmware' \
+            'Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg' \
+            > /etc/apt/sources.list.d/debian.sources; \
+        echo "Chinese Debian mirrors configured"; \
     else \
-        echo "Using default Ubuntu sources"; \
+        echo "Using default Debian sources"; \
     fi; \
     apt-get update
 
-# Install Python 3.12, pip and system dependencies in one step
-# libmagic is for python-magic which is a library for file type detection
-# gettext is for Django i18n (makemessages, compilemessages)
-# postgresql-client is for PostgreSQL database support
+# Install build-only system dependencies.
+# libmagic is for python-magic file type detection.
+# gettext is for Django i18n commands.
 RUN apt-get install -y --no-install-recommends \
-    python3.12 \
-    python3.12-dev \
-    python3-pip \
+    ca-certificates \
     build-essential \
-    git \
     curl \
+    git \
     default-libmysqlclient-dev \
     libpq-dev \
-    postgresql-client \
-    pkg-config \
+    libmagic-dev \
     libxml2-dev \
     libxslt1-dev \
-    zlib1g-dev \
-    libmagic1 \
-    libmagic-dev \
     gettext \
-    procps \
-    htop \
-    net-tools \
-    iputils-ping \
-    dnsutils \
-    mariadb-client \
-    # Note: MySQL/MariaDB packages are kept for backward compatibility
-    # PostgreSQL is the recommended database (postgresql-client, libpq-dev)
-    && rm -rf /var/lib/apt/lists/* \
-    && update-alternatives --install /usr/bin/python python /usr/bin/python3.12 1 \
-    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1
+    pkg-config \
+    zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /root/.cache
 
-# Disable externally-managed-environment restriction for container environment
-RUN rm -f /usr/lib/python3.12/EXTERNALLY-MANAGED
-
-# Install uv using pip with mirror selection
+# Install uv using pip with mirror selection.
 RUN set -eux; \
     if [ "$USE_MIRROR" = "true" ]; then \
         echo "Installing uv with Chinese PyPI mirror"; \
@@ -90,57 +68,106 @@ RUN set -eux; \
         echo "Installing uv with default PyPI"; \
         pip install --retries 5 --timeout 120 --progress-bar off uv; \
     fi; \
-    echo 'export PATH="/root/.local/bin:$PATH"' >> /root/.bashrc; \
-    export PATH="/root/.local/bin:$PATH"
+    python -m venv /opt/venv
 
-# Set working directory
+ENV PATH="/opt/venv/bin:$PATH" \
+    VIRTUAL_ENV=/opt/venv
+
 WORKDIR /opt/backend
 
-# Copy project files
+# Copy project files.
 COPY backend /opt/backend
 COPY pyproject.toml /opt/backend/
 
-# Install project dependencies with mirror selection
+# Install project dependencies with mirror selection.
 RUN set -eux; \
-    export PATH="/root/.local/bin:$PATH"; \
     if [ "$USE_MIRROR" = "true" ]; then \
         echo "Using Chinese PyPI mirror for dependencies"; \
-        uv pip compile pyproject.toml -o requirements.txt --index-url https://mirrors.aliyun.com/pypi/simple; \
-        uv pip install --system -r requirements.txt --index-url https://mirrors.aliyun.com/pypi/simple; \
+        uv pip compile pyproject.toml -o requirements.txt \
+            --index-url https://mirrors.aliyun.com/pypi/simple; \
+        uv pip install --python /opt/venv/bin/python -r requirements.txt \
+            --index-url https://mirrors.aliyun.com/pypi/simple; \
     else \
         echo "Using default PyPI for dependencies"; \
         uv pip compile pyproject.toml -o requirements.txt; \
-        uv pip install --system -r requirements.txt; \
+        uv pip install --python /opt/venv/bin/python -r requirements.txt; \
     fi
 
-# Dev mode: after unified deps, overlay agentcore from image copy in editable mode.
-# Without DEV_MODE=1, agentcore-task/agentcore-metering come from GitHub only (see
-# pyproject.toml). Use DEV_MODE=1 when building to pick up local agentcore fixes
-# (e.g. django __getattr__ recursion fix) without publishing to GitHub first.
-# COPY backend /opt/backend puts agentcore at /opt/backend/agentcore/, so loop uses agentcore/*/
+# Dev mode overlays local agentcore packages after unified dependencies.
+# Without DEV_MODE=1, agentcore packages come from GitHub in pyproject.toml.
 ARG DEV_MODE=0
 RUN set -eux; \
     if [ "$DEV_MODE" = "1" ]; then \
-        export PATH="/root/.local/bin:$PATH"; \
         for d in agentcore/*/; do \
             if [ -f "${d}pyproject.toml" ]; then \
                 echo "Dev mode: pip install -e $d"; \
-                (cd "$d" && uv pip install --system -e .); \
+                (cd "$d" && uv pip install \
+                    --python /opt/venv/bin/python -e .); \
             fi; \
         done; \
     fi
 
-# Compile Django message catalogs (.po -> .mo) so runtime gettext works
+# Compile Django message catalogs (.po -> .mo) so runtime gettext works.
 RUN python manage.py compilemessages -l zh_Hans -l en
 
-# Create necessary directories
+RUN rm -rf /root/.cache /tmp/* \
+    && find /opt/venv -type d -name __pycache__ -prune -exec rm -rf {} + \
+    && find /opt/backend -type d -name __pycache__ -prune -exec rm -rf {} +
+
+# -----------------------------------------------------------------------------
+# Backend runtime image
+# -----------------------------------------------------------------------------
+
+FROM python:3.12-slim-bookworm AS backend
+
+ARG USE_MIRROR=false
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PATH="/opt/venv/bin:$PATH" \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    VIRTUAL_ENV=/opt/venv
+
+RUN set -eux; \
+    if [ "$USE_MIRROR" = "true" ]; then \
+        printf '%s\n' \
+            'Types: deb' \
+            'URIs: https://mirrors.aliyun.com/debian' \
+            'Suites: bookworm bookworm-updates bookworm-backports' \
+            'Components: main contrib non-free non-free-firmware' \
+            'Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg' \
+            '' \
+            'Types: deb' \
+            'URIs: https://mirrors.aliyun.com/debian-security' \
+            'Suites: bookworm-security' \
+            'Components: main contrib non-free non-free-firmware' \
+            'Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg' \
+            > /etc/apt/sources.list.d/debian.sources; \
+        echo "Chinese Debian mirrors configured"; \
+    else \
+        echo "Using default Debian sources"; \
+    fi; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /root/.cache
+
+WORKDIR /opt/backend
+
+COPY --from=backend-builder /opt/venv /opt/venv
+COPY --from=backend-builder /opt/backend /opt/backend
+
+# Create necessary directories.
 RUN mkdir -p /var/log/gunicorn /var/log/celery /var/cache/backend
 
-# Copy entrypoint script
+# Copy entrypoint script.
 COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-# Set default command
 ENTRYPOINT ["/entrypoint.sh"]
 
 # -----------------------------------------------------------------------------

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -43,21 +43,58 @@ wait_for_db() {
             HOST=${MYSQL_HOST:-localhost}
             PORT=${MYSQL_PORT:-3306}
             log "Waiting for MySQL at $HOST:$PORT..."
-            until mysqladmin ping -h "$HOST" -P "$PORT" --silent; do
+            until python - <<PY
+import os
+import sys
+
+import pymysql
+
+try:
+    connection = pymysql.connect(
+        host=os.environ.get("MYSQL_HOST", "localhost"),
+        port=int(os.environ.get("MYSQL_PORT", "3306")),
+        user=os.environ.get("MYSQL_USER", "root"),
+        password=os.environ.get("MYSQL_PASSWORD", ""),
+        database=os.environ.get("MYSQL_DATABASE", "app"),
+        connect_timeout=2,
+        read_timeout=2,
+        write_timeout=2,
+    )
+    connection.close()
+except Exception:
+    sys.exit(1)
+PY
+            do
                 sleep 2
             done
             log "MySQL is ready!"
             ;;
         postgresql|postgres)
-            # In Docker Compose, use service name 'postgresql' as default host
-            # For local development, use 'localhost'
+            # In Docker Compose, use service name 'postgresql' as default host.
+            # For local development, use 'localhost'.
             HOST=${POSTGRES_HOST:-postgresql}
             PORT=${POSTGRES_PORT:-5432}
-            USER=${POSTGRES_USER:-postgres}
-            DB=${POSTGRES_DB:-postgres}
             log "Waiting for PostgreSQL at $HOST:$PORT..."
-            # pg_isready doesn't require authentication, just checks if server is accepting connections
-            until pg_isready -h "$HOST" -p "$PORT" > /dev/null 2>&1; do
+            until python - <<PY
+import os
+import sys
+
+import psycopg2
+
+try:
+    connection = psycopg2.connect(
+        host=os.environ.get("POSTGRES_HOST", "postgresql"),
+        port=int(os.environ.get("POSTGRES_PORT", "5432")),
+        user=os.environ.get("POSTGRES_USER", "postgres"),
+        password=os.environ.get("POSTGRES_PASSWORD", ""),
+        dbname=os.environ.get("POSTGRES_DB", "postgres"),
+        connect_timeout=2,
+    )
+    connection.close()
+except Exception:
+    sys.exit(1)
+PY
+            do
                 sleep 2
             done
             log "PostgreSQL is ready!"


### PR DESCRIPTION
## Summary
- Switch backend Docker build to a slim Python builder/runtime layout
- Keep build tools and native headers out of the runtime image
- Replace runtime DB client binaries with Python driver based readiness checks
- Expand `.dockerignore` to reduce build context noise

## Test plan
- [x] `docker build --target backend --build-arg USE_MIRROR=true --build-arg DEV_MODE=0 -t devmind-backend:size-test .`
- [x] `docker run --rm devmind-backend:size-test python manage.py check`
- [x] `docker run --rm devmind-backend:size-test python -c "import psycopg2, pymysql; print('db drivers ok')"`
- [x] `docker build --target frontend --build-arg VITE_API_BASE_URL=http://localhost:8000 -t devmind-frontend:size-test .`
- [x] `git diff --check`

## Image size
- Backend test image: `749MB`
- Previous local `devmind-backend:dev`: `2.13GB`
- Previous registry `devmind-backend:1.5.3`: `2.22GB`