### PR TITLE
Fix backend startup missing pkg_resources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "flower==2.0.1",
     "redis",
     "sentry-sdk>=1.40.0",  # Error tracking and performance monitoring
+    "setuptools>=61.0",  # Runtime dependency for Gunicorn 20 pkg_resources
     "channels>=4.1,<4.2",
     "daphne>=4.1,<4.2",
     "channels_redis>=4.2,<4.3",


### PR DESCRIPTION
## Summary
- Add `setuptools>=61.0` as an explicit runtime dependency
- Fix Gunicorn 20 startup in Python 3.12 images when `pkg_resources` is missing

## Test plan
- [x] `git diff --check`
- [x] Verified Gunicorn 20 imports `pkg_resources` in a minimal environment
- [x] Verified `setuptools` provides `pkg_resources`

## Notes
- No linked GitHub issue was provided for auto-close.