### PR TITLE
Split backend initialization phases

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,11 +121,15 @@ Periodic (cron-like) tasks are **not** auto-discovered by Celery alone. They mus
 
 | Container | Behavior |
 |---|---|
-| gunicorn / development | `wait_for_db` → `migrate` → `register_periodic_tasks` → start service |
+| backend-init | `wait_for_db` → `migrate` |
+| backend-runtime-init | `wait_for_db` → bootstrap runtime catalogs → `register_periodic_tasks` → optional `collectstatic` |
+| gunicorn / development | `wait_for_db` → start service |
 | celery | `wait_for_db` → start worker (`autodiscover_tasks` loads tasks) |
-| celery-beat | `wait_for_db` → start beat (`DatabaseScheduler` reads schedule from DB) |
+| celery-beat | waits for `backend-runtime-init` → start beat (`DatabaseScheduler` reads schedule from DB) |
 
-In a typical multi-container setup, the gunicorn container runs `register_periodic_tasks` once; celery and celery-beat share the same database and see the registered tasks without running the command again.
+In a typical multi-container setup, API startup only waits for migrations.
+Runtime maintenance runs in a separate one-shot container, and celery-beat
+starts after periodic tasks have been registered.
 
 ## Design Principles
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -121,11 +121,14 @@ done
 
 | 容器 | 行为 |
 |---|---|
-| gunicorn / development | `wait_for_db` → `migrate` → `register_periodic_tasks` → 启动服务 |
+| backend-init | `wait_for_db` → `migrate` |
+| backend-runtime-init | `wait_for_db` → 引导运行时目录数据 → `register_periodic_tasks` → 可选 `collectstatic` |
+| gunicorn / development | `wait_for_db` → 启动服务 |
 | celery | `wait_for_db` → 启动 worker（`autodiscover_tasks` 加载 tasks） |
-| celery-beat | `wait_for_db` → 启动 beat（`DatabaseScheduler` 从数据库读取调度表） |
+| celery-beat | 等待 `backend-runtime-init` → 启动 beat（`DatabaseScheduler` 从数据库读取调度表） |
 
-典型多容器部署下，gunicorn 容器执行一次 `register_periodic_tasks`；celery / celery-beat 共用同一数据库，无需重复执行。
+典型多容器部署下，API 启动只等待 migrations。运行时维护任务在独立
+一次性容器中执行，celery-beat 等定时任务注册完成后再启动。
 
 ## 设计原则
 

--- a/backend/core/management/commands/init_backend.py
+++ b/backend/core/management/commands/init_backend.py
@@ -40,6 +40,15 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
+            "--phase",
+            choices=("all", "schema", "runtime"),
+            default="all",
+            help=(
+                "Initialization phase to run. schema runs migrations only; "
+                "runtime runs database-backed runtime setup only."
+            ),
+        )
+        parser.add_argument(
             "--skip-collectstatic",
             action="store_true",
             help="Skip collectstatic even if BACKEND_INIT_COLLECTSTATIC=true.",
@@ -76,9 +85,14 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         verbosity = options.get("verbosity", 1)
+        phase = options["phase"]
 
-        with self._timed_step("Running Django migrations"):
-            call_command("migrate", interactive=False, verbosity=verbosity)
+        if phase in {"all", "schema"}:
+            with self._timed_step("Running Django migrations"):
+                call_command("migrate", interactive=False, verbosity=verbosity)
+
+        if phase == "schema":
+            return
 
         should_bootstrap_llm_ops = _env_enabled(
             "BACKEND_INIT_BOOTSTRAP_LLM_OPS",

--- a/backend/tests/test_init_backend_command.py
+++ b/backend/tests/test_init_backend_command.py
@@ -7,6 +7,7 @@ from core.management.commands.init_backend import Command
 def _run_command(**options):
     command = Command()
     defaults = {
+        "phase": "all",
         "skip_collectstatic": False,
         "skip_llm_ops_bootstrap": False,
         "verbosity": 1,
@@ -26,6 +27,36 @@ def test_init_backend_bootstraps_llm_ops_before_periodic_tasks():
 
     assert call_command.call_args_list == [
         call("migrate", interactive=False, verbosity=1),
+        call("bootstrap_llm_ops_catalog", verbosity=1),
+    ]
+    discover_and_register.assert_called_once_with()
+
+
+def test_init_backend_schema_phase_only_runs_migrations():
+    with patch(
+        "core.management.commands.init_backend.call_command"
+    ) as call_command:
+        with patch(
+            "core.management.commands.init_backend.discover_and_register"
+        ) as discover_and_register:
+            _run_command(phase="schema")
+
+    assert call_command.call_args_list == [
+        call("migrate", interactive=False, verbosity=1),
+    ]
+    discover_and_register.assert_not_called()
+
+
+def test_init_backend_runtime_phase_skips_migrations():
+    with patch(
+        "core.management.commands.init_backend.call_command"
+    ) as call_command:
+        with patch(
+            "core.management.commands.init_backend.discover_and_register"
+        ) as discover_and_register:
+            _run_command(phase="runtime", skip_collectstatic=True)
+
+    assert call_command.call_args_list == [
         call("bootstrap_llm_ops_catalog", verbosity=1),
     ]
     discover_and_register.assert_called_once_with()

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -26,7 +26,38 @@ services:
     depends_on:
       postgresql:
         condition: service_healthy
-    command: init
+    command: init-schema
+
+  backend-runtime-init:
+    image: devmind-backend:dev
+    container_name: backend-runtime-init-dev
+    restart: "no"
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: backend
+      args:
+        USE_MIRROR: ${USE_MIRROR:-true}
+        DEV_MODE: "1"
+    env_file:
+      - ./.env.dev
+    environment:
+      BACKEND_INIT_COLLECTSTATIC: "false"
+    volumes:
+      - ./data.dev/django/staticfiles:/opt/backend/core/staticfiles
+      - ./data.dev/logs/api:/var/log/gunicorn
+      - ./backend:/opt/backend
+      - ./cache.dev:/opt/cache
+      - ./docker/nginx/certs:/opt/backend/docker/nginx/certs
+      - ./data.dev/storage:/opt/storage
+    networks:
+      - backend_network
+    depends_on:
+      backend-init:
+        condition: service_completed_successfully
+      postgresql:
+        condition: service_healthy
+    command: init-runtime
 
   backend-api:
     image: devmind-backend:dev
@@ -101,8 +132,8 @@ services:
     networks:
       - backend_network
     depends_on:
-      backend-api:
-        condition: service_started
+      backend-runtime-init:
+        condition: service_completed_successfully
       postgresql:
         condition: service_healthy
       redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,28 @@ services:
     depends_on:
       postgresql:
         condition: service_healthy
-    command: init
+    command: init-schema
+
+  backend-runtime-init:
+    image: registry.cn-beijing.aliyuncs.com/hypermotion_dockers/devmind-backend:${APP_VERSION:?APP_VERSION is required}
+    container_name: backend-runtime-init
+    restart: "no"
+    env_file:
+      - ./.env
+    volumes:
+      - ./data/django/staticfiles:/opt/backend/core/staticfiles
+      - ./data/logs/api:/var/log/gunicorn
+      - ./data/storage:/opt/storage
+      - ./cache:/opt/cache
+      - ./docker/nginx/certs:/opt/backend/docker/nginx/certs
+    networks:
+      - backend_network
+    depends_on:
+      backend-init:
+        condition: service_completed_successfully
+      postgresql:
+        condition: service_healthy
+    command: init-runtime
 
   backend-api:
     image: registry.cn-beijing.aliyuncs.com/hypermotion_dockers/devmind-backend:${APP_VERSION:?APP_VERSION is required}
@@ -86,8 +107,8 @@ services:
     networks:
       - backend_network
     depends_on:
-      backend-api:
-        condition: service_started
+      backend-runtime-init:
+        condition: service_completed_successfully
       postgresql:
         condition: service_healthy
       redis:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -130,6 +130,16 @@ run_startup_maintenance() {
     python manage.py init_backend
 }
 
+run_schema_initialization() {
+    log "Running backend schema initialization..."
+    python manage.py init_backend --phase schema
+}
+
+run_runtime_initialization() {
+    log "Running backend runtime initialization..."
+    python manage.py init_backend --phase runtime
+}
+
 # --- Process Starters ---
 start_gunicorn() {
     log "Starting Gunicorn..."
@@ -199,6 +209,14 @@ case "$1" in
     init)
         wait_for_db
         run_startup_maintenance
+        ;;
+    init-schema)
+        wait_for_db
+        run_schema_initialization
+        ;;
+    init-runtime)
+        wait_for_db
+        run_runtime_initialization
         ;;
     create-superuser)
         wait_for_db


### PR DESCRIPTION
## Summary
- Split backend initialization into schema and runtime phases
- Let backend-api wait only for migrations before starting
- Add a backend-runtime-init one-shot container for LLM bootstrap, periodic task registration, and optional collectstatic
- Keep celery-beat gated on runtime initialization so database schedules exist before beat starts

## Test plan
- [x] bash -n docker/entrypoint.sh
- [x] git diff --check
- [x] python3 -m py_compile backend/core/management/commands/init_backend.py backend/tests/test_init_backend_command.py
- [ ] PYTHONPATH=backend python3 -m pytest backend/tests/test_init_backend_command.py (blocked locally: django is not installed)