### PR TITLE
Upgrade Gunicorn to avoid pkg_resources runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,11 +28,10 @@ dependencies = [
     "flower==2.0.1",
     "redis",
     "sentry-sdk>=1.40.0",  # Error tracking and performance monitoring
-    "setuptools>=61.0",  # Runtime dependency for Gunicorn 20 pkg_resources
     "channels>=4.1,<4.2",
     "daphne>=4.1,<4.2",
     "channels_redis>=4.2,<4.3",
-    "gunicorn==20.1.0",
+    "gunicorn==21.2.0",
     "requests>=2.31.0",
     "httpx>=0.27.0",
     "cryptography>=44.0.0",


### PR DESCRIPTION
## Summary
- Upgrade Gunicorn from 20.1.0 to 21.2.0
- Remove the explicit `setuptools` runtime dependency added only for Gunicorn 20's `pkg_resources` import

## Test plan
- [x] `git diff --check`
- [x] Verified `gunicorn==21.2.0` imports `gunicorn.app.wsgiapp` when `pkg_resources` is unavailable in a temporary venv

## Notes
- No linked GitHub issue was found for auto-close.

Made with [Orca](https://github.com/stablyai/orca) 🐋
