### PR TITLE
Complete LLMOps console i18n coverage

### DIFF
--- a/frontend/src/components/llm-ops/AgioneListingStatusBoard.vue
+++ b/frontend/src/components/llm-ops/AgioneListingStatusBoard.vue
@@ -37,15 +37,19 @@
     <div class="panel overflow-hidden p-0">
       <div class="listing-board-toolbar">
         <div class="listing-board-heading">
-          <h3 class="panel-title">模型挂售列表</h3>
-          <p class="listing-board-subtitle">仅展示当前平台流程内模型。</p>
+          <h3 class="panel-title">
+            {{ t('llmOps.listingBoard.title') }}
+          </h3>
+          <p class="listing-board-subtitle">
+            {{ t('llmOps.listingBoard.subtitle') }}
+          </p>
         </div>
         <div class="listing-board-controls">
           <input
             v-model="searchQuery"
             type="text"
             class="listing-search-input"
-            placeholder="搜索模型 / code"
+            :placeholder="t('llmOps.listingBoard.searchPlaceholder')"
           />
           <div class="status-filter-group">
             <button
@@ -64,7 +68,7 @@
             </button>
           </div>
           <label class="pagination-size-field">
-            <span>每页</span>
+            <span>{{ t('llmOps.listingBoard.pagination.pageSize') }}</span>
             <select v-model.number="pageSize" class="pagination-select">
               <option v-for="size in pageSizeOptions" :key="size" :value="size">
                 {{ size }}
@@ -77,7 +81,11 @@
           </span>
           <template v-if="selectedRows.length">
             <span class="listing-selected-count">
-              已选 {{ selectedRows.length }}
+              {{
+                t('llmOps.listingBoard.selectedCount', {
+                  count: selectedRows.length
+                })
+              }}
             </span>
             <button
               type="button"
@@ -95,7 +103,7 @@
               :disabled="!canBatchOffline || savingListings"
               @click="handleBatchAction('offline')"
             >
-              批量下架
+              {{ t('llmOps.listingBoard.batch.offline') }}
             </button>
             <button
               type="button"
@@ -104,7 +112,7 @@
               :disabled="savingListings"
               @click="handleBatchAction('price')"
             >
-              批量改价
+              {{ t('llmOps.listingBoard.batch.price') }}
             </button>
           </template>
           <button
@@ -112,7 +120,7 @@
             class="add-listing-button btn-action-create"
             @click="openWorkspace(null, 'create')"
           >
-            新建上架
+            {{ t('llmOps.listingBoard.createListing') }}
           </button>
         </div>
       </div>
@@ -142,15 +150,33 @@
                   @change="toggleAllVisible"
                 />
               </th>
-              <th class="table-head">挂售平台</th>
-              <th class="table-head min-w-[200px]">模型</th>
-              <th class="table-head">供货链路</th>
-              <th class="table-head">成本</th>
-              <th class="table-head">售价</th>
-              <th class="table-head">积分</th>
-              <th class="table-head">利润率</th>
-              <th class="table-head">状态</th>
-              <th class="table-head">操作</th>
+              <th class="table-head">
+                {{ t('llmOps.listingBoard.table.platform') }}
+              </th>
+              <th class="table-head min-w-[200px]">
+                {{ t('llmOps.listingBoard.table.model') }}
+              </th>
+              <th class="table-head">
+                {{ t('llmOps.listingBoard.table.supplyChain') }}
+              </th>
+              <th class="table-head">
+                {{ t('llmOps.listingBoard.table.cost') }}
+              </th>
+              <th class="table-head">
+                {{ t('llmOps.listingBoard.table.retail') }}
+              </th>
+              <th class="table-head">
+                {{ t('llmOps.listingBoard.table.points') }}
+              </th>
+              <th class="table-head">
+                {{ t('llmOps.listingBoard.table.margin') }}
+              </th>
+              <th class="table-head">
+                {{ t('llmOps.listingBoard.table.status') }}
+              </th>
+              <th class="table-head">
+                {{ t('llmOps.listingBoard.table.actions') }}
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -272,8 +298,13 @@
       </div>
       <div v-if="filteredListingRows.length" class="pagination-bar">
         <p class="pagination-summary">
-          第 {{ currentPage }} / {{ totalPages }} 页 · 共
-          {{ filteredListingRows.length }} 条
+          {{
+            t('llmOps.listingBoard.pagination.summary', {
+              current: currentPage,
+              total: totalPages,
+              count: filteredListingRows.length
+            })
+          }}
         </p>
         <div class="pagination-actions">
           <button
@@ -282,7 +313,7 @@
             :disabled="currentPage <= 1"
             @click="goToPreviousPage"
           >
-            上一页
+            {{ t('llmOps.listingBoard.pagination.previous') }}
           </button>
           <button
             type="button"
@@ -290,7 +321,7 @@
             :disabled="currentPage >= totalPages"
             @click="goToNextPage"
           >
-            下一页
+            {{ t('llmOps.listingBoard.pagination.next') }}
           </button>
         </div>
       </div>
@@ -300,6 +331,8 @@
 
 <script setup>
 import { computed, onMounted, onUnmounted, ref, toRef, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
 import { llmOpsApi } from '@/api/llmOps'
 import { useToast } from '@/composables/useToast'
 import { useAgioneListingRows } from '@/composables/useAgioneListingRows'
@@ -357,6 +390,7 @@ const emit = defineEmits([
   'open-workspace',
   'listings-updated'
 ])
+const { t } = useI18n()
 const { showSuccess, showError } = useToast()
 
 const listingStatusFilter = ref('all')
@@ -367,12 +401,12 @@ const savingListings = ref(false)
 const selectedModelIds = ref(new Set())
 const pageSizeOptions = [10, 20, 50]
 
-const listingStatusOptions = [
-  { label: '待处理', value: 'actionable' },
-  { label: '全部', value: 'all' },
-  { label: '已上架', value: 'listed' },
-  { label: '未上架', value: 'unlisted' }
-]
+const listingStatusOptions = computed(() => [
+  { label: t('llmOps.listingBoard.filters.actionable'), value: 'actionable' },
+  { label: t('llmOps.listingBoard.filters.all'), value: 'all' },
+  { label: t('llmOps.listingBoard.filters.listed'), value: 'listed' },
+  { label: t('llmOps.listingBoard.filters.unlisted'), value: 'unlisted' }
+])
 
 const unusedModelId = ref('')
 const unusedChannelId = ref('')
@@ -393,7 +427,9 @@ const rows = useAgioneListingRows({
   pointConversionRef: toRef(props, 'pointConversion')
 })
 
-const platformLabel = computed(() => props.agionePlatform?.name || '挂售平台')
+const platformLabel = computed(
+  () => props.agionePlatform?.name || t('llmOps.listingBoard.platformFallback')
+)
 
 const visibleListingRows = computed(() =>
   rows.listingRows.value.filter((row) => !isHiddenRow(row))
@@ -477,11 +513,11 @@ const batchConfirmAction = computed(() => {
 const batchConfirmLabel = computed(() => {
   return (
     {
-      submit: '批量确认提交',
-      confirm_publish: '批量确认上架',
-      confirm_update: '批量确认更新',
-      confirm_offline: '批量确认下架'
-    }[batchConfirmAction.value] || '批量确认'
+      submit: t('llmOps.listingBoard.batch.confirmSubmit'),
+      confirm_publish: t('llmOps.listingBoard.batch.confirmPublish'),
+      confirm_update: t('llmOps.listingBoard.batch.confirmUpdate'),
+      confirm_offline: t('llmOps.listingBoard.batch.confirmOffline')
+    }[batchConfirmAction.value] || t('llmOps.listingBoard.batch.confirm')
   )
 })
 
@@ -523,20 +559,22 @@ function actionTone(kind) {
 function rowActionVisibleLabel(action) {
   return (
     {
-      abandon_update: '放弃',
-      confirm_offline: '确认下架',
-      confirm_publish: '确认上架',
-      confirm_update: '确认更新',
-      delete: '删除',
-      direct_offline: '直接下架',
-      edit: '编辑',
-      mark_offline_exception: '标记异常',
-      reject_offline: '驳回',
-      republish: '重新发布',
-      request_offline: '申请下架',
-      start_edit: '编辑',
-      submit: '提交',
-      withdraw: '撤回'
+      abandon_update: t('llmOps.listingBoard.rowActions.abandonUpdate'),
+      confirm_offline: t('llmOps.listingBoard.rowActions.confirmOffline'),
+      confirm_publish: t('llmOps.listingBoard.rowActions.confirmPublish'),
+      confirm_update: t('llmOps.listingBoard.rowActions.confirmUpdate'),
+      delete: t('llmOps.listingBoard.rowActions.delete'),
+      direct_offline: t('llmOps.listingBoard.rowActions.directOffline'),
+      edit: t('llmOps.listingBoard.rowActions.edit'),
+      mark_offline_exception: t(
+        'llmOps.listingBoard.rowActions.markOfflineException'
+      ),
+      reject_offline: t('llmOps.listingBoard.rowActions.rejectOffline'),
+      republish: t('llmOps.listingBoard.rowActions.republish'),
+      request_offline: t('llmOps.listingBoard.rowActions.requestOffline'),
+      start_edit: t('llmOps.listingBoard.rowActions.edit'),
+      submit: t('llmOps.listingBoard.rowActions.submit'),
+      withdraw: t('llmOps.listingBoard.rowActions.withdraw')
     }[action.kind] || action.label
   )
 }
@@ -572,38 +610,43 @@ const listingKpis = computed(() => {
     : null
   return [
     {
-      label: '可挂售模型',
+      label: t('llmOps.listingBoard.kpis.availableModels.label'),
       value: visibleRows.length,
-      hint: `${unlistedCount(visibleRows, listedRows)} 个未上架`,
-      delta: '本周期',
+      hint: t('llmOps.listingBoard.kpis.availableModels.hint', {
+        count: unlistedCount(visibleRows, listedRows)
+      }),
+      delta: t('llmOps.listingBoard.kpis.availableModels.delta'),
       deltaTone: 'text-slate-400'
     },
     {
-      label: '挂售平台',
+      label: t('llmOps.listingBoard.kpis.platforms.label'),
       value: props.platformCount,
-      hint: '可见挂售平台汇总',
-      delta: '稳定',
+      hint: t('llmOps.listingBoard.kpis.platforms.hint'),
+      delta: t('llmOps.listingBoard.kpis.platforms.delta'),
       deltaTone: 'text-slate-400'
     },
     {
-      label: '已上架',
+      label: t('llmOps.listingBoard.kpis.listed.label'),
       value: listedRows.length,
-      hint: '外部平台当前在线',
-      delta: listedRows.length > 0 ? '+ 上架中' : '待上架',
+      hint: t('llmOps.listingBoard.kpis.listed.hint'),
+      delta:
+        listedRows.length > 0
+          ? t('llmOps.listingBoard.kpis.listed.activeDelta')
+          : t('llmOps.listingBoard.kpis.listed.pendingDelta'),
       deltaTone: listedRows.length > 0 ? 'text-emerald-600' : 'text-amber-600'
     },
     {
-      label: '未上架',
+      label: t('llmOps.listingBoard.kpis.unlisted.label'),
       value: visibleRows.length - listedRows.length,
-      hint: '可在工作台一键处理',
-      delta: '需处理',
+      hint: t('llmOps.listingBoard.kpis.unlisted.hint'),
+      delta: t('llmOps.listingBoard.kpis.unlisted.delta'),
       deltaTone: 'text-amber-600'
     },
     {
-      label: '整体平均利润率',
+      label: t('llmOps.listingBoard.kpis.averageMargin.label'),
       value: avgMargin !== null ? `${avgMargin}%` : '—',
-      hint: '按 Input / Output / Cached 统一估算',
-      delta: '参考',
+      hint: t('llmOps.listingBoard.kpis.averageMargin.hint'),
+      delta: t('llmOps.listingBoard.kpis.averageMargin.delta'),
       deltaTone: 'text-slate-400'
     }
   ]
@@ -615,10 +658,12 @@ function unlistedCount(visibleRows, listedRows) {
 
 const listingEmptyText = computed(() => {
   if (listingStatusFilter.value === 'actionable')
-    return '暂无需要处理的挂售模型。'
-  if (listingStatusFilter.value === 'listed') return '当前没有已上架的模型。'
-  if (listingStatusFilter.value === 'unlisted') return '当前没有可上架的模型。'
-  return '没有符合筛选条件的模型。'
+    return t('llmOps.listingBoard.empty.actionable')
+  if (listingStatusFilter.value === 'listed')
+    return t('llmOps.listingBoard.empty.listed')
+  if (listingStatusFilter.value === 'unlisted')
+    return t('llmOps.listingBoard.empty.unlisted')
+  return t('llmOps.listingBoard.empty.default')
 })
 
 function isHiddenRow(row) {
@@ -650,9 +695,11 @@ function isActionableRow(row) {
 function activeListingChannelLabel(row) {
   const activeListings = row.active_listings || []
   if (activeListings.length > 1) {
-    return `${activeListings.length} 条上架链路`
+    return t('llmOps.listingBoard.supply.activeLinks', {
+      count: activeListings.length
+    })
   }
-  return row.lowest_option?.channel_name || '暂无供应'
+  return row.lowest_option?.channel_name || t('llmOps.listingBoard.supply.none')
 }
 
 function listingPriceMetrics(row) {
@@ -728,17 +775,19 @@ function listingUnifiedMarginRate(row) {
 
 function statusPillLabel(row) {
   const labels = {
-    draft: '草稿',
-    pending_publish: '待发布',
-    online: '已上架',
-    update_draft: '更新草稿',
-    pending_update: '待更新',
-    pending_offline: '待下架',
-    offline_exception: '下架异常',
-    offline: '已下架',
-    deleted: '已失效'
+    draft: t('llmOps.listingBoard.workflowStatus.draft'),
+    pending_publish: t('llmOps.listingBoard.workflowStatus.pendingPublish'),
+    online: t('llmOps.listingBoard.workflowStatus.online'),
+    update_draft: t('llmOps.listingBoard.workflowStatus.updateDraft'),
+    pending_update: t('llmOps.listingBoard.workflowStatus.pendingUpdate'),
+    pending_offline: t('llmOps.listingBoard.workflowStatus.pendingOffline'),
+    offline_exception: t('llmOps.listingBoard.workflowStatus.offlineException'),
+    offline: t('llmOps.listingBoard.workflowStatus.offline'),
+    deleted: t('llmOps.listingBoard.workflowStatus.deleted')
   }
-  return labels[row.workflow_status] || '未上架'
+  return (
+    labels[row.workflow_status] || t('llmOps.listingBoard.filters.unlisted')
+  )
 }
 
 function statusPillTone(row) {
@@ -761,45 +810,131 @@ function rowStateActions(row) {
   const status = row.workflow_status || 'draft'
   const actions = {
     draft: [
-      { label: '继续编辑', kind: 'edit', tone: 'default' },
-      { label: '确认提交', kind: 'submit', tone: 'primary' },
-      { label: '删除数据', kind: 'delete', tone: 'danger' }
+      {
+        label: t('llmOps.listingBoard.rowActions.continueEdit'),
+        kind: 'edit',
+        tone: 'default'
+      },
+      {
+        label: t('llmOps.listingBoard.rowActions.confirmSubmit'),
+        kind: 'submit',
+        tone: 'primary'
+      },
+      {
+        label: t('llmOps.listingBoard.rowActions.deleteData'),
+        kind: 'delete',
+        tone: 'danger'
+      }
     ],
     pending_publish: [
-      { label: '撤回申请', kind: 'withdraw', tone: 'default' },
-      { label: '确认上架', kind: 'confirm_publish', tone: 'success' }
+      {
+        label: t('llmOps.listingBoard.rowActions.withdrawRequest'),
+        kind: 'withdraw',
+        tone: 'default'
+      },
+      {
+        label: t('llmOps.listingBoard.rowActions.confirmPublish'),
+        kind: 'confirm_publish',
+        tone: 'success'
+      }
     ],
     online: [
-      { label: '发起编辑', kind: 'start_edit', tone: 'default' },
-      { label: '发起下架', kind: 'request_offline', tone: 'warn' },
-      { label: '直接下架', kind: 'direct_offline', tone: 'danger' }
+      {
+        label: t('llmOps.listingBoard.rowActions.startEdit'),
+        kind: 'start_edit',
+        tone: 'default'
+      },
+      {
+        label: t('llmOps.listingBoard.rowActions.requestOffline'),
+        kind: 'request_offline',
+        tone: 'warn'
+      },
+      {
+        label: t('llmOps.listingBoard.rowActions.directOffline'),
+        kind: 'direct_offline',
+        tone: 'danger'
+      }
     ],
     update_draft: [
-      { label: '继续编辑', kind: 'edit', tone: 'default' },
-      { label: '确认提交', kind: 'submit', tone: 'primary' },
-      { label: '放弃修改', kind: 'abandon_update', tone: 'warn' }
+      {
+        label: t('llmOps.listingBoard.rowActions.continueEdit'),
+        kind: 'edit',
+        tone: 'default'
+      },
+      {
+        label: t('llmOps.listingBoard.rowActions.confirmSubmit'),
+        kind: 'submit',
+        tone: 'primary'
+      },
+      {
+        label: t('llmOps.listingBoard.rowActions.abandonChange'),
+        kind: 'abandon_update',
+        tone: 'warn'
+      }
     ],
     pending_update: [
-      { label: '撤回修改', kind: 'withdraw', tone: 'default' },
-      { label: '确认更新', kind: 'confirm_update', tone: 'success' }
+      {
+        label: t('llmOps.listingBoard.rowActions.withdrawChange'),
+        kind: 'withdraw',
+        tone: 'default'
+      },
+      {
+        label: t('llmOps.listingBoard.rowActions.confirmUpdate'),
+        kind: 'confirm_update',
+        tone: 'success'
+      }
     ],
     pending_offline: [
-      { label: '撤回下架', kind: 'withdraw', tone: 'default' },
-      { label: '确认下架', kind: 'confirm_offline', tone: 'danger' },
-      { label: '驳回下架', kind: 'reject_offline', tone: 'default' },
-      { label: '标记异常', kind: 'mark_offline_exception', tone: 'danger' }
+      {
+        label: t('llmOps.listingBoard.rowActions.withdrawOffline'),
+        kind: 'withdraw',
+        tone: 'default'
+      },
+      {
+        label: t('llmOps.listingBoard.rowActions.confirmOffline'),
+        kind: 'confirm_offline',
+        tone: 'danger'
+      },
+      {
+        label: t('llmOps.listingBoard.rowActions.rejectOffline'),
+        kind: 'reject_offline',
+        tone: 'default'
+      },
+      {
+        label: t('llmOps.listingBoard.rowActions.markOfflineException'),
+        kind: 'mark_offline_exception',
+        tone: 'danger'
+      }
     ],
     offline_exception: [
-      { label: '确认下架', kind: 'confirm_offline', tone: 'danger' }
+      {
+        label: t('llmOps.listingBoard.rowActions.confirmOffline'),
+        kind: 'confirm_offline',
+        tone: 'danger'
+      }
     ],
     offline: [
-      { label: '重新发布', kind: 'republish', tone: 'primary' },
-      { label: '删除数据', kind: 'delete', tone: 'danger' }
+      {
+        label: t('llmOps.listingBoard.rowActions.republish'),
+        kind: 'republish',
+        tone: 'primary'
+      },
+      {
+        label: t('llmOps.listingBoard.rowActions.deleteData'),
+        kind: 'delete',
+        tone: 'danger'
+      }
     ],
     deleted: []
   }
   return (
-    actions[status] || [{ label: '去挂售', kind: 'create', tone: 'primary' }]
+    actions[status] || [
+      {
+        label: t('llmOps.listingBoard.rowActions.goListing'),
+        kind: 'create',
+        tone: 'primary'
+      }
+    ]
   )
 }
 
@@ -980,10 +1115,17 @@ async function handleBatchAction(kind) {
   const selectedKeys = targetRows.map((row) => rowSelectionKey(row))
   const confirmMessage =
     kind === 'offline'
-      ? `确认批量发起下架 ${modelIds.length} 个模型？`
+      ? t('llmOps.listingBoard.confirm.batchOffline', {
+          count: modelIds.length
+        })
       : kind === 'confirm'
-        ? `${batchConfirmLabel.value} ${modelIds.length} 个模型？`
-        : `确认对 ${modelIds.length} 个模型进入批量改价工作台？`
+        ? t('llmOps.listingBoard.confirm.batchConfirm', {
+            action: batchConfirmLabel.value,
+            count: modelIds.length
+          })
+        : t('llmOps.listingBoard.confirm.batchPrice', {
+            count: modelIds.length
+          })
   if (!confirm(confirmMessage)) return
   if (kind === 'price') {
     emit('open-workspace', { modelId: null, kind: 'batch-price', modelIds })
@@ -996,13 +1138,17 @@ async function handleBatchAction(kind) {
         actionPayloadForRows(targetRows, 'request_offline')
       )
       emitUpdatedListings(response)
-      showSuccess('已批量发起下架')
+      showSuccess(t('llmOps.listingBoard.messages.batchOfflineRequested'))
     } else if (kind === 'confirm') {
       const response = await llmOpsApi.bulkTransitionResaleListings(
         actionPayloadForRows(targetRows, batchConfirmAction.value)
       )
       emitUpdatedListings(response)
-      showSuccess(batchConfirmLabel.value.replace('批量', '已批量'))
+      showSuccess(
+        t('llmOps.listingBoard.messages.batchConfirmed', {
+          action: batchConfirmLabel.value
+        })
+      )
     }
     setSelectedModelIds(
       Array.from(selectedModelIds.value).filter(
@@ -1028,38 +1174,42 @@ function emitUpdatedListings(response) {
 }
 
 function actionErrorLabel(kind) {
-  if (kind === 'direct_offline') return '直接下架失败'
-  if (isWorkflowTransition(kind)) return '状态流转失败'
-  return '操作失败'
+  if (kind === 'direct_offline')
+    return t('llmOps.listingBoard.errors.directOfflineFailed')
+  if (isWorkflowTransition(kind))
+    return t('llmOps.listingBoard.errors.transitionFailed')
+  return t('llmOps.listingBoard.errors.operationFailed')
 }
 
 function workflowConfirmText(kind) {
   const messages = {
-    request_offline: '确认发起下架申请？外部平台仍保持已上架，等待确认下架。',
-    confirm_offline: '确认外部平台已完成下架？该模型将进入已下架状态。',
-    direct_offline: '确认直接下架？该操作表示外部平台已同步下线。',
-    delete: '确认删除该挂售数据？删除后将从常规业务列表隐藏。'
+    request_offline: t('llmOps.listingBoard.confirm.requestOffline'),
+    confirm_offline: t('llmOps.listingBoard.confirm.confirmOffline'),
+    direct_offline: t('llmOps.listingBoard.confirm.directOffline'),
+    delete: t('llmOps.listingBoard.confirm.delete')
   }
-  return messages[kind] || '确认执行该状态操作？'
+  return messages[kind] || t('llmOps.listingBoard.confirm.default')
 }
 
 function workflowSuccessText(kind) {
   const messages = {
-    submit: '已提交',
-    withdraw: '已撤回',
-    confirm_publish: '已确认上架',
-    start_edit: '已进入更新草稿',
-    abandon_update: '已放弃修改',
-    confirm_update: '已确认更新',
-    request_offline: '已发起下架',
-    confirm_offline: '已确认下架',
-    direct_offline: '已直接下架',
-    reject_offline: '已驳回下架',
-    mark_offline_exception: '已标记异常',
-    republish: '已重新提交发布',
-    delete: '已删除'
+    submit: t('llmOps.listingBoard.messages.submitted'),
+    withdraw: t('llmOps.listingBoard.messages.withdrawn'),
+    confirm_publish: t('llmOps.listingBoard.messages.publishConfirmed'),
+    start_edit: t('llmOps.listingBoard.messages.updateDraftStarted'),
+    abandon_update: t('llmOps.listingBoard.messages.updateAbandoned'),
+    confirm_update: t('llmOps.listingBoard.messages.updateConfirmed'),
+    request_offline: t('llmOps.listingBoard.messages.offlineRequested'),
+    confirm_offline: t('llmOps.listingBoard.messages.offlineConfirmed'),
+    direct_offline: t('llmOps.listingBoard.messages.directOfflineDone'),
+    reject_offline: t('llmOps.listingBoard.messages.offlineRejected'),
+    mark_offline_exception: t(
+      'llmOps.listingBoard.messages.offlineExceptionMarked'
+    ),
+    republish: t('llmOps.listingBoard.messages.republishSubmitted'),
+    delete: t('llmOps.listingBoard.messages.deleted')
   }
-  return messages[kind] || '状态已更新'
+  return messages[kind] || t('llmOps.listingBoard.messages.statusUpdated')
 }
 </script>
 

--- a/frontend/src/components/llm-ops/AuditLogPanel.vue
+++ b/frontend/src/components/llm-ops/AuditLogPanel.vue
@@ -3,7 +3,9 @@
     <div class="panel audit-filter-panel">
       <div class="audit-filter-grid">
         <label class="form-field audit-filter-field">
-          <span class="field-label">大类</span>
+          <span class="field-label">
+            {{ t('llmOps.auditLog.filters.category') }}
+          </span>
           <CompactSelect
             v-model="filters.target_type"
             :options="businessCategoryOptions"
@@ -11,7 +13,9 @@
           />
         </label>
         <label class="form-field audit-filter-field">
-          <span class="field-label">操作动作</span>
+          <span class="field-label">
+            {{ t('llmOps.auditLog.filters.action') }}
+          </span>
           <CompactSelect
             v-model="filters.action"
             :options="actionOptions"
@@ -19,23 +23,27 @@
           />
         </label>
         <label class="form-field audit-filter-field">
-          <span class="field-label">实例名称</span>
+          <span class="field-label">
+            {{ t('llmOps.auditLog.filters.target') }}
+          </span>
           <input
             id="audit-target"
             v-model.trim="filters.target"
             class="audit-filter-input"
             name="target"
-            placeholder="如 DeepSeek R1"
+            :placeholder="t('llmOps.auditLog.filters.targetPlaceholder')"
           />
         </label>
         <label class="form-field audit-filter-field">
-          <span class="field-label">操作人</span>
+          <span class="field-label">
+            {{ t('llmOps.auditLog.filters.actor') }}
+          </span>
           <input
             id="audit-actor"
             v-model.trim="filters.actor"
             class="audit-filter-input"
             name="actor"
-            placeholder="如 ops"
+            :placeholder="t('llmOps.auditLog.filters.actorPlaceholder')"
           />
         </label>
       </div>
@@ -47,7 +55,7 @@
           :disabled="loading"
           @click="applyFilters"
         >
-          查询
+          {{ t('llmOps.auditLog.actions.search') }}
         </button>
         <button
           type="button"
@@ -55,9 +63,11 @@
           :disabled="loading"
           @click="resetFilters"
         >
-          重置
+          {{ t('llmOps.auditLog.actions.reset') }}
         </button>
-        <span class="audit-count"> {{ totalCount }} 条记录 </span>
+        <span class="audit-count">
+          {{ t('llmOps.auditLog.recordCount', { count: totalCount }) }}
+        </span>
       </div>
     </div>
 
@@ -78,12 +88,20 @@
           </colgroup>
           <thead>
             <tr>
-              <th class="table-head">大类</th>
-              <th class="table-head">平台</th>
-              <th class="table-head">实例</th>
-              <th class="table-head">操作人</th>
-              <th class="table-head">操作时间</th>
-              <th class="table-head">变更内容</th>
+              <th class="table-head">
+                {{ t('llmOps.auditLog.table.category') }}
+              </th>
+              <th class="table-head">
+                {{ t('llmOps.auditLog.table.platform') }}
+              </th>
+              <th class="table-head">
+                {{ t('llmOps.auditLog.table.instance') }}
+              </th>
+              <th class="table-head">{{ t('llmOps.auditLog.table.actor') }}</th>
+              <th class="table-head">{{ t('llmOps.auditLog.table.time') }}</th>
+              <th class="table-head">
+                {{ t('llmOps.auditLog.table.changes') }}
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -160,11 +178,17 @@
                       v-if="extraChangeCount(row)"
                       class="audit-more-change"
                     >
-                      +{{ extraChangeCount(row) }} 项
+                      {{
+                        t('llmOps.auditLog.moreChanges', {
+                          count: extraChangeCount(row)
+                        })
+                      }}
                     </span>
                   </div>
                   <span v-else class="audit-muted">
-                    {{ row.summary || '未记录字段变更' }}
+                    {{
+                      row.summary || t('llmOps.auditLog.empty.noFieldChanges')
+                    }}
                   </span>
                 </td>
               </tr>
@@ -172,7 +196,7 @@
                 <td class="detail-cell" colspan="6">
                   <div class="audit-detail-grid">
                     <div class="audit-detail-block">
-                      <h4>状态变更</h4>
+                      <h4>{{ t('llmOps.auditLog.detail.statusChanges') }}</h4>
                       <div
                         v-if="statusChangeItems(row).length"
                         class="audit-change-list"
@@ -192,10 +216,12 @@
                           </strong>
                         </div>
                       </div>
-                      <p v-else class="audit-muted">未记录状态变更。</p>
+                      <p v-else class="audit-muted">
+                        {{ t('llmOps.auditLog.empty.noStatusChanges') }}
+                      </p>
                     </div>
                     <div class="audit-detail-block">
-                      <h4>内容变更</h4>
+                      <h4>{{ t('llmOps.auditLog.detail.contentChanges') }}</h4>
                       <div
                         v-if="contentChangeItems(row).length"
                         class="audit-change-list"
@@ -211,7 +237,9 @@
                           <strong>{{ item.after }}</strong>
                         </div>
                       </div>
-                      <p v-else class="audit-muted">未记录内容字段差异。</p>
+                      <p v-else class="audit-muted">
+                        {{ t('llmOps.auditLog.empty.noContentChanges') }}
+                      </p>
                     </div>
                   </div>
                 </td>
@@ -220,15 +248,19 @@
             <tr v-if="!loading && !rows.length">
               <td class="table-cell" colspan="6">
                 <div class="empty-state">
-                  <p class="font-medium text-slate-700">暂无操作记录</p>
+                  <p class="font-medium text-slate-700">
+                    {{ t('llmOps.auditLog.empty.title') }}
+                  </p>
                   <p class="mt-1 text-sm text-slate-500">
-                    调整筛选条件，或完成一次渠道、价格、上架、审批操作后再查询。
+                    {{ t('llmOps.auditLog.empty.description') }}
                   </p>
                 </div>
               </td>
             </tr>
             <tr v-if="loading">
-              <td class="table-cell" colspan="6">正在加载操作记录...</td>
+              <td class="table-cell" colspan="6">
+                {{ t('llmOps.auditLog.loading') }}
+              </td>
             </tr>
           </tbody>
         </table>
@@ -240,7 +272,7 @@
         </div>
         <div class="audit-footer-controls">
           <label class="audit-footer-page-size">
-            <span>每页</span>
+            <span>{{ t('llmOps.auditLog.pagination.pageSize') }}</span>
             <CompactSelect
               v-model="filters.page_size"
               :options="pageSizeOptions"
@@ -254,7 +286,7 @@
               :disabled="loading || page <= 1"
               @click="goToPage(page - 1)"
             >
-              上一页
+              {{ t('llmOps.auditLog.pagination.previous') }}
             </button>
             <span class="audit-page-label">{{ page }} / {{ totalPages }}</span>
             <button
@@ -263,7 +295,7 @@
               :disabled="loading || page >= totalPages"
               @click="goToPage(page + 1)"
             >
-              下一页
+              {{ t('llmOps.auditLog.pagination.next') }}
             </button>
           </div>
         </div>
@@ -274,6 +306,8 @@
 
 <script setup>
 import { computed, onMounted, reactive, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
 import { llmOpsApi } from '@/api/llmOps'
 import CompactSelect from '@/components/llm-ops/CompactSelect.vue'
 
@@ -283,27 +317,40 @@ const props = defineProps({
     default: () => []
   }
 })
+const { t } = useI18n()
 
-const actionOptions = [
-  { label: '全部动作', value: '' },
-  { label: '创建', value: 'create' },
-  { label: '更新', value: 'update' },
-  { label: '删除', value: 'delete' },
-  { label: '采集', value: 'collect' },
-  { label: '导入', value: 'import' },
-  { label: '批量提交', value: 'bulk_upsert' },
-  { label: '保存草稿', value: 'bulk_draft' },
-  { label: '批量替换', value: 'bulk_replace' },
-  { label: '审批流转', value: 'transition' },
-  { label: '下架', value: 'offline' },
-  { label: '恢复', value: 'restore' },
-  { label: '同步', value: 'sync' }
-]
-
-const businessCategoryOptions = [
-  { label: '全部大类', value: '' },
+const actionOptions = computed(() => [
+  { label: t('llmOps.auditLog.actionOptions.all'), value: '' },
+  { label: t('llmOps.auditLog.actionOptions.create'), value: 'create' },
+  { label: t('llmOps.auditLog.actionOptions.update'), value: 'update' },
+  { label: t('llmOps.auditLog.actionOptions.delete'), value: 'delete' },
+  { label: t('llmOps.auditLog.actionOptions.collect'), value: 'collect' },
+  { label: t('llmOps.auditLog.actionOptions.import'), value: 'import' },
   {
-    label: '模型挂售',
+    label: t('llmOps.auditLog.actionOptions.bulkUpsert'),
+    value: 'bulk_upsert'
+  },
+  {
+    label: t('llmOps.auditLog.actionOptions.bulkDraft'),
+    value: 'bulk_draft'
+  },
+  {
+    label: t('llmOps.auditLog.actionOptions.bulkReplace'),
+    value: 'bulk_replace'
+  },
+  {
+    label: t('llmOps.auditLog.actionOptions.transition'),
+    value: 'transition'
+  },
+  { label: t('llmOps.auditLog.actionOptions.offline'), value: 'offline' },
+  { label: t('llmOps.auditLog.actionOptions.restore'), value: 'restore' },
+  { label: t('llmOps.auditLog.actionOptions.sync'), value: 'sync' }
+])
+
+const businessCategoryOptions = computed(() => [
+  { label: t('llmOps.auditLog.businessCategories.all'), value: '' },
+  {
+    label: t('llmOps.auditLog.businessCategories.listing'),
     value: [
       'llm_ops.ResaleListing',
       'llm_ops.ResaleListingExclusion',
@@ -311,7 +358,7 @@ const businessCategoryOptions = [
     ].join(',')
   },
   {
-    label: '渠道配置',
+    label: t('llmOps.auditLog.businessCategories.channelConfig'),
     value: [
       'llm_ops.ProcurementChannel',
       'llm_ops.ChannelModelPrice',
@@ -319,23 +366,33 @@ const businessCategoryOptions = [
     ].join(',')
   },
   {
-    label: '元模型',
+    label: t('llmOps.auditLog.businessCategories.metaModel'),
     value: [
       'llm_ops.LLMProvider',
       'llm_ops.LLMModel',
       'llm_ops.MetaModel'
     ].join(',')
   },
-  { label: '模型价格', value: 'llm_ops.ModelPriceItem' },
-  { label: '价格源配置', value: 'llm_ops.PriceCollectionSource' },
-  { label: '用量对账', value: 'llm_ops.UsageReconciliationRecord' }
-]
+  {
+    label: t('llmOps.auditLog.businessCategories.modelPrice'),
+    value: 'llm_ops.ModelPriceItem'
+  },
+  {
+    label: t('llmOps.auditLog.businessCategories.priceSource'),
+    value: 'llm_ops.PriceCollectionSource'
+  },
+  {
+    label: t('llmOps.auditLog.businessCategories.reconciliation'),
+    value: 'llm_ops.UsageReconciliationRecord'
+  }
+])
 
-const pageSizeOptions = [
-  { label: '20 条/页', value: '20' },
-  { label: '50 条/页', value: '50' },
-  { label: '100 条/页', value: '100' }
-]
+const pageSizeOptions = computed(() =>
+  ['20', '50', '100'].map((size) => ({
+    label: t('llmOps.auditLog.pagination.pageSizeOption', { size }),
+    value: size
+  }))
+)
 
 const statusFieldKeys = new Set([
   'comparison_status',
@@ -349,34 +406,34 @@ const statusFieldKeys = new Set([
   'workflow_status'
 ])
 
-const auditBusinessCategoryLabels = {
-  'llm_ops.ChannelModelPrice': '渠道配置',
-  'llm_ops.ChannelPriceItem': '渠道配置',
-  'llm_ops.LLMModel': '元模型',
-  'llm_ops.LLMProvider': '元模型',
-  'llm_ops.MetaModel': '元模型',
-  'llm_ops.ModelPriceItem': '模型价格',
-  'llm_ops.PriceCollectionSource': '价格源配置',
-  'llm_ops.ProcurementChannel': '渠道配置',
-  'llm_ops.ResaleListing': '模型挂售',
-  'llm_ops.ResaleListingExclusion': '模型挂售',
-  'llm_ops.ResalePlatform': '模型挂售',
-  'llm_ops.UsageReconciliationRecord': '用量对账'
+const auditBusinessCategoryKeys = {
+  'llm_ops.ChannelModelPrice': 'channelConfig',
+  'llm_ops.ChannelPriceItem': 'channelConfig',
+  'llm_ops.LLMModel': 'metaModel',
+  'llm_ops.LLMProvider': 'metaModel',
+  'llm_ops.MetaModel': 'metaModel',
+  'llm_ops.ModelPriceItem': 'modelPrice',
+  'llm_ops.PriceCollectionSource': 'priceSource',
+  'llm_ops.ProcurementChannel': 'channelConfig',
+  'llm_ops.ResaleListing': 'listing',
+  'llm_ops.ResaleListingExclusion': 'listing',
+  'llm_ops.ResalePlatform': 'listing',
+  'llm_ops.UsageReconciliationRecord': 'reconciliation'
 }
 
-const targetTypeLabels = {
-  'llm_ops.ChannelModelPrice': '渠道模型配置',
-  'llm_ops.ChannelPriceItem': '渠道价格项',
-  'llm_ops.LLMModel': '模型',
-  'llm_ops.LLMProvider': '元模型厂商',
-  'llm_ops.MetaModel': '元模型',
-  'llm_ops.ModelPriceItem': '模型价格',
-  'llm_ops.PriceCollectionSource': '价格源',
-  'llm_ops.ProcurementChannel': '渠道',
-  'llm_ops.ResaleListing': '模型挂售',
-  'llm_ops.ResaleListingExclusion': '挂售排除',
-  'llm_ops.ResalePlatform': '挂售平台',
-  'llm_ops.UsageReconciliationRecord': '对账记录'
+const targetTypeKeys = {
+  'llm_ops.ChannelModelPrice': 'channelModelPrice',
+  'llm_ops.ChannelPriceItem': 'channelPriceItem',
+  'llm_ops.LLMModel': 'model',
+  'llm_ops.LLMProvider': 'provider',
+  'llm_ops.MetaModel': 'metaModel',
+  'llm_ops.ModelPriceItem': 'modelPrice',
+  'llm_ops.PriceCollectionSource': 'priceSource',
+  'llm_ops.ProcurementChannel': 'channel',
+  'llm_ops.ResaleListing': 'listing',
+  'llm_ops.ResaleListingExclusion': 'listingExclusion',
+  'llm_ops.ResalePlatform': 'resalePlatform',
+  'llm_ops.UsageReconciliationRecord': 'reconciliationRecord'
 }
 
 const auditBusinessCategoryTones = {
@@ -394,114 +451,114 @@ const auditBusinessCategoryTones = {
   'llm_ops.UsageReconciliationRecord': 'tone-danger'
 }
 
-const fieldLabels = {
-  aliases: '别名',
-  api_endpoint: 'API Endpoint',
-  base_price_item_id: '基准价格项',
-  billing_unit: '计费单位',
-  capabilities: '能力',
-  channel_id: '渠道',
-  code: '编码',
-  comparison_status: '价格对比状态',
-  context_window: '上下文窗口',
-  currency: '币种',
-  custom_audio_input_price_per_second: '自定义音频输入价',
-  custom_audio_output_price_per_second: '自定义音频输出价',
-  custom_input_price_per_million: '自定义输入价',
-  custom_output_price_per_million: '自定义输出价',
-  custom_video_input_price_per_second: '自定义视频输入价',
-  custom_video_output_price_per_second: '自定义视频输出价',
-  custom_video_resolution_prices: '自定义视频分辨率价格',
-  delta_amount: '价差金额',
-  delta_percent: '价差比例',
-  dimension: '计费维度',
-  endpoint_url: '端点 URL',
-  family: '模型族',
-  fee_rate: '费率',
-  is_active: '启用状态',
-  is_current: '当前版本',
-  is_enabled: '采集状态',
-  is_listed: '渠道上架状态',
-  latency_ms: '延迟',
-  max_output_tokens: '最大输出 Token',
-  meta_model_id: '元模型',
-  metadata: '扩展信息',
-  modality: '模态',
-  model_id: '模型',
-  name: '名称',
-  notes: '备注',
-  platform_id: '平台',
-  point_name: '点数名称',
-  point_rounding_mode: '点数取整',
-  points_per_currency_unit: '点数换算',
-  price_fingerprint: '价格指纹',
-  price_source_id: '价格来源',
-  price_source_type: '价格来源类型',
-  provider_id: '厂商',
-  publish_status: '发布状态',
-  reason: '原因',
-  retail_audio_input_price_per_second: '零售音频输入价',
-  retail_audio_output_price_per_second: '零售音频输出价',
-  retail_cache_input_price_per_million: '零售缓存输入价',
-  retail_image_output_price_per_image: '零售图片输出价',
-  retail_input_price_per_million: '零售输入价',
-  retail_output_price_per_million: '零售输出价',
-  retail_video_input_price_per_second: '零售视频输入价',
-  retail_video_output_price_per_second: '零售视频输出价',
-  retail_video_resolution_prices: '零售视频分辨率价格',
-  rpm_limit: 'RPM 限制',
-  service_fee_rate: '服务费率',
-  settlement_ratio: '结算比例',
-  source_category: '价格源分类',
-  source_id: '价格源',
-  source_type: '价格源类型',
-  source_url: '来源 URL',
-  spec: '规格',
-  status: '状态',
-  tier_end: '阶梯结束',
-  tier_start: '阶梯起始',
-  tier_type: '阶梯类型',
-  tpm_limit: 'TPM 限制',
-  unit_price: '单价',
-  updates_model_prices: '更新模型价格',
-  website: '官网',
-  workflow_status: '流程状态'
+const fieldLabelKeys = {
+  aliases: 'aliases',
+  api_endpoint: 'apiEndpoint',
+  base_price_item_id: 'basePriceItem',
+  billing_unit: 'billingUnit',
+  capabilities: 'capabilities',
+  channel_id: 'channel',
+  code: 'code',
+  comparison_status: 'comparisonStatus',
+  context_window: 'contextWindow',
+  currency: 'currency',
+  custom_audio_input_price_per_second: 'customAudioInput',
+  custom_audio_output_price_per_second: 'customAudioOutput',
+  custom_input_price_per_million: 'customInput',
+  custom_output_price_per_million: 'customOutput',
+  custom_video_input_price_per_second: 'customVideoInput',
+  custom_video_output_price_per_second: 'customVideoOutput',
+  custom_video_resolution_prices: 'customVideoResolution',
+  delta_amount: 'deltaAmount',
+  delta_percent: 'deltaPercent',
+  dimension: 'dimension',
+  endpoint_url: 'endpointUrl',
+  family: 'family',
+  fee_rate: 'feeRate',
+  is_active: 'isActive',
+  is_current: 'isCurrent',
+  is_enabled: 'isEnabled',
+  is_listed: 'isListed',
+  latency_ms: 'latency',
+  max_output_tokens: 'maxOutputTokens',
+  meta_model_id: 'metaModel',
+  metadata: 'metadata',
+  modality: 'modality',
+  model_id: 'model',
+  name: 'name',
+  notes: 'notes',
+  platform_id: 'platform',
+  point_name: 'pointName',
+  point_rounding_mode: 'pointRoundingMode',
+  points_per_currency_unit: 'pointsPerCurrencyUnit',
+  price_fingerprint: 'priceFingerprint',
+  price_source_id: 'priceSource',
+  price_source_type: 'priceSourceType',
+  provider_id: 'provider',
+  publish_status: 'publishStatus',
+  reason: 'reason',
+  retail_audio_input_price_per_second: 'retailAudioInput',
+  retail_audio_output_price_per_second: 'retailAudioOutput',
+  retail_cache_input_price_per_million: 'retailCacheInput',
+  retail_image_output_price_per_image: 'retailImageOutput',
+  retail_input_price_per_million: 'retailInput',
+  retail_output_price_per_million: 'retailOutput',
+  retail_video_input_price_per_second: 'retailVideoInput',
+  retail_video_output_price_per_second: 'retailVideoOutput',
+  retail_video_resolution_prices: 'retailVideoResolution',
+  rpm_limit: 'rpmLimit',
+  service_fee_rate: 'serviceFeeRate',
+  settlement_ratio: 'settlementRatio',
+  source_category: 'sourceCategory',
+  source_id: 'priceSource',
+  source_type: 'sourceType',
+  source_url: 'sourceUrl',
+  spec: 'spec',
+  status: 'status',
+  tier_end: 'tierEnd',
+  tier_start: 'tierStart',
+  tier_type: 'tierType',
+  tpm_limit: 'tpmLimit',
+  unit_price: 'unitPrice',
+  updates_model_prices: 'updatesModelPrices',
+  website: 'website',
+  workflow_status: 'workflowStatus'
 }
 
-const valueLabelsByField = {
+const valueLabelKeysByField = {
   comparison_status: {
-    above_official: '高于上游价',
-    below_official: '低于上游价',
-    same_as_official: '等于上游价',
-    unknown: '待判断'
+    above_official: 'aboveOfficial',
+    below_official: 'belowOfficial',
+    same_as_official: 'sameAsOfficial',
+    unknown: 'unknown'
   },
   publish_status: {
-    deleted: '已删除',
-    none: '未发布',
-    offline: '已下架',
-    online: '已发布'
+    deleted: 'deleted',
+    none: 'none',
+    offline: 'offline',
+    online: 'online'
   },
   status: {
-    active: '启用',
-    draft: '草稿',
-    failed: '失败',
-    inactive: '停用',
-    matched: '已匹配',
-    mismatch: '不一致',
-    pending: '待处理',
-    retired: '停用',
-    unmatched: '未匹配'
+    active: 'active',
+    draft: 'draft',
+    failed: 'failed',
+    inactive: 'inactive',
+    matched: 'matched',
+    mismatch: 'mismatch',
+    pending: 'pending',
+    retired: 'retired',
+    unmatched: 'unmatched'
   },
   workflow_status: {
-    deleted: '已失效',
-    draft: '草稿',
-    offline: '已下架',
-    offline_exception: '下架异常',
-    online: '已上架',
-    pending_offline: '待下架',
-    pending_publish: '待发布',
-    pending_update: '待更新',
-    update_draft: '更新草稿'
+    deleted: 'deleted',
+    draft: 'draft',
+    offline: 'offline',
+    offline_exception: 'offlineException',
+    online: 'online',
+    pending_offline: 'pendingOffline',
+    pending_publish: 'pendingPublish',
+    pending_update: 'pendingUpdate',
+    update_draft: 'updateDraft'
   }
 }
 
@@ -527,10 +584,14 @@ const totalPages = computed(() =>
 )
 
 const pageRangeLabel = computed(() => {
-  if (!totalCount.value) return '0 条记录'
+  if (!totalCount.value) return t('llmOps.auditLog.pagination.emptyRange')
   const start = (page.value - 1) * pageSizeNumber.value + 1
   const end = Math.min(page.value * pageSizeNumber.value, totalCount.value)
-  return `${start}-${end} / ${totalCount.value} 条记录`
+  return t('llmOps.auditLog.pagination.range', {
+    count: totalCount.value,
+    end,
+    start
+  })
 })
 
 watch(
@@ -584,7 +645,7 @@ async function loadAuditLogs() {
       error?.response?.data?.detail ||
       error?.response?.data?.message ||
       error?.message ||
-      '操作记录加载失败'
+      t('llmOps.auditLog.errors.loadFailed')
   } finally {
     loading.value = false
   }
@@ -612,7 +673,8 @@ function actorLabel(row) {
 }
 
 function targetTypeLabel(value) {
-  return targetTypeLabels[value] || value || '-'
+  const key = targetTypeKeys[value]
+  return key ? t(`llmOps.auditLog.targetTypes.${key}`) : value || '-'
 }
 
 function platformLabel(row) {
@@ -628,7 +690,7 @@ function instanceLabel(row) {
 function channelModelLabel(row) {
   const channel = channelName(row)
   if (!channel || channel === '-') return ''
-  return `渠道：${channel}`
+  return t('llmOps.auditLog.channelPrefix', { name: channel })
 }
 
 function channelName(row) {
@@ -636,7 +698,7 @@ function channelName(row) {
   if (!channelId) return '-'
   return (
     props.channels.find((channel) => String(channel.id) === String(channelId))
-      ?.name || `渠道 #${channelId}`
+      ?.name || t('llmOps.auditLog.channelFallback', { id: channelId })
   )
 }
 
@@ -672,11 +734,10 @@ function splitTargetRepr(value) {
 }
 
 function auditBusinessCategoryLabel(targetType) {
-  return (
-    auditBusinessCategoryLabels[targetType] ||
-    targetTypeLabel(targetType) ||
-    '-'
-  )
+  const key = auditBusinessCategoryKeys[targetType]
+  return key
+    ? t(`llmOps.auditLog.businessCategories.${key}`)
+    : targetTypeLabel(targetType) || '-'
 }
 
 function auditBusinessCategoryTone(targetType) {
@@ -721,37 +782,73 @@ function changeItems(row) {
 }
 
 function fieldLabel(key) {
-  return fieldLabels[key] || key
+  const labelKey = fieldLabelKeys[key]
+  return labelKey ? t(`llmOps.auditLog.fields.${labelKey}`) : key
 }
 
 function formatChangeValue(key, value) {
-  if (Object.prototype.hasOwnProperty.call(valueLabelsByField, key)) {
+  if (Object.prototype.hasOwnProperty.call(valueLabelKeysByField, key)) {
     const normalized = compactValue(value)
-    return valueLabelsByField[key][normalized] || normalized
+    const labelKey = valueLabelKeysByField[key][normalized]
+    return labelKey
+      ? t(`llmOps.auditLog.values.${key}.${labelKey}`)
+      : normalized
   }
   return compactValue(value)
 }
 
 function compactValue(value) {
   if (value === null || value === undefined || value === '') return '-'
-  if (typeof value === 'boolean') return value ? '是' : '否'
+  if (typeof value === 'boolean') {
+    return value
+      ? t('llmOps.auditLog.values.boolean.yes')
+      : t('llmOps.auditLog.values.boolean.no')
+  }
   if (typeof value === 'object') return JSON.stringify(value)
   return String(value)
 }
 
 function statusValueClass(value) {
-  if (['停用', '已删除', '已失效', '已下架', '否'].includes(value)) {
+  const mutedValues = [
+    t('llmOps.auditLog.values.boolean.no'),
+    t('llmOps.auditLog.values.publish_status.deleted'),
+    t('llmOps.auditLog.values.publish_status.offline'),
+    t('llmOps.auditLog.values.status.inactive'),
+    t('llmOps.auditLog.values.status.retired'),
+    t('llmOps.auditLog.values.workflow_status.deleted'),
+    t('llmOps.auditLog.values.workflow_status.offline')
+  ]
+  const dangerValues = [
+    t('llmOps.auditLog.values.status.failed'),
+    t('llmOps.auditLog.values.status.mismatch'),
+    t('llmOps.auditLog.values.workflow_status.offlineException')
+  ]
+  const warnValues = [
+    t('llmOps.auditLog.values.status.draft'),
+    t('llmOps.auditLog.values.status.pending'),
+    t('llmOps.auditLog.values.workflow_status.draft'),
+    t('llmOps.auditLog.values.workflow_status.pendingOffline'),
+    t('llmOps.auditLog.values.workflow_status.pendingPublish'),
+    t('llmOps.auditLog.values.workflow_status.pendingUpdate'),
+    t('llmOps.auditLog.values.workflow_status.updateDraft')
+  ]
+  const successValues = [
+    t('llmOps.auditLog.values.boolean.yes'),
+    t('llmOps.auditLog.values.publish_status.online'),
+    t('llmOps.auditLog.values.status.active'),
+    t('llmOps.auditLog.values.status.matched'),
+    t('llmOps.auditLog.values.workflow_status.online')
+  ]
+  if (mutedValues.includes(value)) {
     return 'audit-status-value tone-muted'
   }
-  if (['失败', '不一致', '下架异常'].includes(value)) {
+  if (dangerValues.includes(value)) {
     return 'audit-status-value tone-danger'
   }
-  if (
-    ['待发布', '待更新', '待下架', '待处理', '草稿', '更新草稿'].includes(value)
-  ) {
+  if (warnValues.includes(value)) {
     return 'audit-status-value tone-warn'
   }
-  if (['启用', '已上架', '已发布', '已匹配', '是'].includes(value)) {
+  if (successValues.includes(value)) {
     return 'audit-status-value tone-success'
   }
   return 'audit-status-value tone-info'

--- a/frontend/src/components/llm-ops/ChannelManagement.vue
+++ b/frontend/src/components/llm-ops/ChannelManagement.vue
@@ -3,9 +3,11 @@
     <div class="panel overflow-hidden p-0">
       <div class="table-toolbar">
         <div>
-          <h3 class="panel-title">转发渠道配置</h3>
+          <h3 class="panel-title">
+            {{ t('llmOps.channelManagement.title') }}
+          </h3>
           <p class="mt-1 text-xs text-slate-500">
-            维护渠道基础信息，并进入模型管理配置渠道上游、成本规则和转发能力。
+            {{ t('llmOps.channelManagement.description') }}
           </p>
         </div>
         <div class="flex flex-col gap-2 sm:flex-row sm:items-center">
@@ -17,7 +19,7 @@
           <input
             v-model="searchKeyword"
             class="control-field sm:w-64"
-            placeholder="搜索渠道名称、标识或地址"
+            :placeholder="t('llmOps.channelManagement.searchPlaceholder')"
           />
           <button
             class="btn-primary toolbar-button btn-action-create"
@@ -37,7 +39,7 @@
               <path d="M12 5v14" />
               <path d="M5 12h14" />
             </svg>
-            新建渠道
+            {{ t('llmOps.channelManagement.createChannel') }}
           </button>
         </div>
       </div>
@@ -52,11 +54,21 @@
           </colgroup>
           <thead>
             <tr>
-              <th class="table-head">渠道</th>
-              <th class="table-head">默认配置</th>
-              <th class="table-head">模型管理</th>
-              <th class="table-head">状态</th>
-              <th class="table-head">操作</th>
+              <th class="table-head">
+                {{ t('llmOps.channelManagement.table.channel') }}
+              </th>
+              <th class="table-head">
+                {{ t('llmOps.channelManagement.table.defaultConfig') }}
+              </th>
+              <th class="table-head">
+                {{ t('llmOps.channelManagement.table.modelManagement') }}
+              </th>
+              <th class="table-head">
+                {{ t('llmOps.channelManagement.table.status') }}
+              </th>
+              <th class="table-head">
+                {{ t('llmOps.channelManagement.table.actions') }}
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -81,15 +93,25 @@
                     target="_blank"
                     :title="channel.api_endpoint"
                   >
-                    已配置 API
+                    {{ t('llmOps.channelManagement.apiConfigured') }}
                   </a>
-                  <span v-else class="config-status-muted"> API 未配置 </span>
+                  <span v-else class="config-status-muted">
+                    {{ t('llmOps.channelManagement.apiNotConfigured') }}
+                  </span>
                   <div class="channel-config-chips">
                     <span class="config-chip">
-                      币种 {{ channel.currency || 'USD' }}
+                      {{
+                        t('llmOps.channelManagement.currency', {
+                          currency: channel.currency || 'USD'
+                        })
+                      }}
                     </span>
                     <span class="config-chip">
-                      折扣 {{ ratioLabel(channel.settlement_ratio) }}
+                      {{
+                        t('llmOps.channelManagement.discount', {
+                          ratio: ratioLabel(channel.settlement_ratio)
+                        })
+                      }}
                     </span>
                   </div>
                 </div>
@@ -98,36 +120,40 @@
                 <div class="channel-model-metrics">
                   <span class="model-metric-pill">
                     <strong>{{ channel.model_count }}</strong>
-                    <span>启用</span>
+                    <span>{{ t('llmOps.channelManagement.enabled') }}</span>
                   </span>
                   <span class="model-metric-pill">
                     <strong>{{ channel.configured_model_count }}</strong>
-                    <span>配置</span>
+                    <span>{{ t('llmOps.channelManagement.configured') }}</span>
                   </span>
                 </div>
               </td>
               <td class="table-cell">
                 <span :class="channel.is_active ? 'badge-ok' : 'badge-muted'">
-                  {{ channel.is_active ? '启用' : '停用' }}
+                  {{
+                    channel.is_active
+                      ? t('llmOps.channelManagement.status.active')
+                      : t('llmOps.channelManagement.status.inactive')
+                  }}
                 </span>
               </td>
               <td class="table-cell">
                 <div class="inline-flex items-center justify-center gap-2">
                   <OperationIconButton
                     icon="config"
-                    label="管理模型"
+                    :label="t('llmOps.channelManagement.actions.manageModels')"
                     tone="primary"
                     @click="selectedChannelForModels = channel"
                   />
                   <OperationIconButton
                     icon="edit"
-                    label="编辑"
+                    :label="t('llmOps.channelManagement.actions.edit')"
                     @click="openChannelModal(channel)"
                   />
                   <OperationIconButton
                     :disabled="deletingChannelId === channel.id"
                     icon="delete"
-                    label="删除"
+                    :label="t('llmOps.channelManagement.actions.delete')"
                     tone="danger"
                     @click="openDeleteConfirm(channel)"
                   />
@@ -136,7 +162,7 @@
             </tr>
             <tr v-if="!filteredChannelRows.length">
               <td class="table-cell text-slate-500" colspan="5">
-                暂无符合条件的渠道配置。
+                {{ t('llmOps.channelManagement.empty') }}
               </td>
             </tr>
           </tbody>
@@ -170,10 +196,11 @@
     >
       <div class="w-full max-w-md rounded-lg bg-white shadow-xl">
         <div class="border-b border-slate-200 px-5 py-4">
-          <h3 class="text-base font-semibold text-slate-900">删除转发渠道</h3>
+          <h3 class="text-base font-semibold text-slate-900">
+            {{ t('llmOps.channelManagement.deleteDialog.title') }}
+          </h3>
           <p class="mt-1 text-sm text-slate-500">
-            删除后，该渠道下的模型配置、采购价格项和对账记录会一并删除；
-            已上架记录会保留，但不再关联该渠道。
+            {{ t('llmOps.channelManagement.deleteDialog.description') }}
           </p>
         </div>
         <div class="space-y-3 px-5 py-4">
@@ -186,7 +213,7 @@
             </p>
           </div>
           <p class="text-sm text-slate-500">
-            请确认不再需要这个渠道及其模型关系后再删除。
+            {{ t('llmOps.channelManagement.deleteDialog.confirmation') }}
           </p>
         </div>
         <div
@@ -198,7 +225,7 @@
             :disabled="Boolean(deletingChannelId)"
             @click="closeDeleteConfirm"
           >
-            取消
+            {{ t('llmOps.channelManagement.actions.cancel') }}
           </button>
           <button
             class="btn-danger btn-action-danger"
@@ -206,7 +233,11 @@
             :disabled="Boolean(deletingChannelId)"
             @click="deleteChannel"
           >
-            {{ deletingChannelId ? '删除中' : '确认删除' }}
+            {{
+              deletingChannelId
+                ? t('llmOps.channelManagement.deleteDialog.deleting')
+                : t('llmOps.channelManagement.deleteDialog.confirmDelete')
+            }}
           </button>
         </div>
       </div>
@@ -216,6 +247,8 @@
 
 <script setup>
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
 import { llmOpsApi } from '@/api/llmOps'
 import { useToast } from '@/composables/useToast'
 import ChannelModelDrawer from '@/components/llm-ops/ChannelModelDrawer.vue'
@@ -259,6 +292,7 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['refresh'])
+const { t } = useI18n()
 const { showSuccess, showError } = useToast()
 
 const showChannelModal = ref(false)
@@ -269,11 +303,14 @@ const searchKeyword = ref('')
 const statusFilter = ref('all')
 const deletingChannelId = ref(null)
 
-const statusFilterOptions = [
-  { label: '全部状态', value: 'all' },
-  { label: '仅启用', value: 'active' },
-  { label: '仅停用', value: 'inactive' }
-]
+const statusFilterOptions = computed(() => [
+  { label: t('llmOps.channelManagement.filters.allStatus'), value: 'all' },
+  { label: t('llmOps.channelManagement.filters.activeOnly'), value: 'active' },
+  {
+    label: t('llmOps.channelManagement.filters.inactiveOnly'),
+    value: 'inactive'
+  }
+])
 
 const channelRows = computed(() =>
   props.channels.map((channel) => ({
@@ -332,14 +369,20 @@ async function deleteChannel() {
   deletingChannelId.value = deleteTarget.value.id
   try {
     await llmOpsApi.deleteChannel(deleteTarget.value.id)
-    showSuccess(`${deleteTarget.value.name} 已删除`)
+    showSuccess(
+      t('llmOps.channelManagement.messages.deleted', {
+        name: deleteTarget.value.name
+      })
+    )
     if (selectedChannelForModels.value?.id === deleteTarget.value.id) {
       selectedChannelForModels.value = null
     }
     deleteTarget.value = null
     emit('refresh')
   } catch (error) {
-    showError(errorMessage(error, '删除渠道失败'))
+    showError(
+      errorMessage(error, t('llmOps.channelManagement.messages.deleteFailed'))
+    )
   } finally {
     deletingChannelId.value = null
   }

--- a/frontend/src/components/llm-ops/ManualPriceEntryModal.vue
+++ b/frontend/src/components/llm-ops/ManualPriceEntryModal.vue
@@ -12,10 +12,10 @@
         <div class="min-w-0">
           <p class="eyebrow">Manual Price Entry</p>
           <h3 class="mt-2 text-lg font-semibold text-slate-900">
-            录入模型价格
+            {{ t('llmOps.manualPriceEntry.title') }}
           </h3>
           <p class="mt-1 text-sm text-slate-500">
-            为当前价格源维护一条模型价格。优先选择已有原厂模型，确实不存在时可新增自定义模型。
+            {{ t('llmOps.manualPriceEntry.description') }}
           </p>
         </div>
         <button
@@ -24,7 +24,7 @@
           :disabled="saving"
           @click="close"
         >
-          关闭
+          {{ t('llmOps.manualPriceEntry.actions.close') }}
         </button>
       </div>
 
@@ -35,7 +35,12 @@
               {{ source?.name || '-' }}
             </p>
             <p class="mt-1 truncate text-xs text-slate-500">
-              {{ sourceRelationLabel }} · 默认币种 {{ form.currency }}
+              {{
+                t('llmOps.manualPriceEntry.sourceContext', {
+                  relation: sourceRelationLabel,
+                  currency: form.currency
+                })
+              }}
             </p>
           </div>
           <span :class="['source-badge', sourceCategoryTone]">
@@ -45,8 +50,8 @@
 
         <section class="form-section">
           <div class="section-heading">
-            <h4>选择模型</h4>
-            <p>渠道和挂售后续会基于这个模型和价格源计算成本。</p>
+            <h4>{{ t('llmOps.manualPriceEntry.sections.model') }}</h4>
+            <p>{{ t('llmOps.manualPriceEntry.sections.modelHint') }}</p>
           </div>
 
           <div class="mode-tabs">
@@ -56,7 +61,7 @@
               type="button"
               @click="modelMode = 'existing'"
             >
-              选择已有模型
+              {{ t('llmOps.manualPriceEntry.modelMode.existing') }}
             </button>
             <button
               class="mode-tab"
@@ -64,7 +69,7 @@
               type="button"
               @click="modelMode = 'custom'"
             >
-              新建自定义模型
+              {{ t('llmOps.manualPriceEntry.modelMode.custom') }}
             </button>
           </div>
 
@@ -73,55 +78,73 @@
             class="grid gap-4 md:grid-cols-2"
           >
             <label class="field-group md:col-span-2">
-              <span class="field-label">模型</span>
+              <span class="field-label">
+                {{ t('llmOps.manualPriceEntry.fields.model') }}
+              </span>
               <CompactSelect
                 v-model="form.model_id"
                 :options="modelOptions"
                 searchable
-                search-placeholder="搜索模型名称、编码或厂商"
+                :search-placeholder="
+                  t('llmOps.manualPriceEntry.placeholders.searchModel')
+                "
               />
               <span class="field-help">
-                只从当前系统已有模型中选择，选择后会自动带入模型厂商和类型。
+                {{ t('llmOps.manualPriceEntry.help.existingModel') }}
               </span>
             </label>
             <div class="readonly-field">
-              <span>模型厂商</span>
+              <span>{{ t('llmOps.manualPriceEntry.fields.provider') }}</span>
               <strong>{{ selectedModel?.provider_name || '-' }}</strong>
             </div>
             <div class="readonly-field">
-              <span>模型类型</span>
+              <span>{{ t('llmOps.manualPriceEntry.fields.modality') }}</span>
               <strong>{{ modalityLabel(selectedModel?.modality) }}</strong>
             </div>
           </div>
 
           <div v-else class="grid gap-4 md:grid-cols-2">
             <label class="field-group">
-              <span class="field-label">模型名称</span>
+              <span class="field-label">
+                {{ t('llmOps.manualPriceEntry.fields.modelName') }}
+              </span>
               <input
                 v-model="form.custom_model_name"
                 class="field"
-                placeholder="例如 DeepSeek V3"
+                :placeholder="
+                  t('llmOps.manualPriceEntry.placeholders.modelName')
+                "
               />
             </label>
             <label class="field-group">
-              <span class="field-label">模型编码</span>
+              <span class="field-label">
+                {{ t('llmOps.manualPriceEntry.fields.modelCode') }}
+              </span>
               <input
                 v-model="form.custom_model_code"
                 class="field"
-                placeholder="例如 deepseek-v3"
+                :placeholder="
+                  t('llmOps.manualPriceEntry.placeholders.modelCode')
+                "
               />
             </label>
             <label class="field-group">
-              <span class="field-label">模型厂商</span>
+              <span class="field-label">
+                {{ t('llmOps.manualPriceEntry.fields.provider') }}
+              </span>
               <CompactSelect
                 v-model="form.provider"
                 :options="providerOptions"
                 searchable
-                search-placeholder="搜索模型厂商"
+                :search-placeholder="
+                  t('llmOps.manualPriceEntry.placeholders.searchProvider')
+                "
               />
             </label>
             <label class="field-group">
-              <span class="field-label">模型类型</span>
+              <span class="field-label">
+                {{ t('llmOps.manualPriceEntry.fields.modality') }}
+              </span>
               <CompactSelect
                 v-model="form.modality"
                 :options="modalityOptions"
@@ -132,24 +155,30 @@
 
         <section class="form-section">
           <div class="section-heading">
-            <h4>价格明细</h4>
-            <p>按模型支持的计费维度填写；未填写的维度不会生成价格项。</p>
+            <h4>{{ t('llmOps.manualPriceEntry.sections.price') }}</h4>
+            <p>{{ t('llmOps.manualPriceEntry.sections.priceHint') }}</p>
           </div>
 
           <div class="grid gap-4 md:grid-cols-2">
             <label class="field-group compact-field">
-              <span class="field-label">币种</span>
+              <span class="field-label">
+                {{ t('llmOps.manualPriceEntry.fields.currency') }}
+              </span>
               <CompactSelect
                 v-model="form.currency"
                 :options="currencyOptions"
               />
             </label>
             <label class="field-group">
-              <span class="field-label">来源地址</span>
+              <span class="field-label">
+                {{ t('llmOps.manualPriceEntry.fields.sourceUrl') }}
+              </span>
               <input
                 v-model="form.source_url"
                 class="field"
-                placeholder="可选，价格页或报价单链接"
+                :placeholder="
+                  t('llmOps.manualPriceEntry.placeholders.sourceUrl')
+                "
                 type="url"
               />
             </label>
@@ -189,7 +218,7 @@
             :disabled="saving"
             @click="close"
           >
-            取消
+            {{ t('llmOps.manualPriceEntry.actions.cancel') }}
           </button>
           <button
             class="btn-primary btn-action-save"
@@ -197,7 +226,11 @@
             :disabled="saving"
           >
             <span class="save-icon" aria-hidden="true" />
-            {{ saving ? '保存中' : '保存价格' }}
+            {{
+              saving
+                ? t('llmOps.manualPriceEntry.actions.saving')
+                : t('llmOps.manualPriceEntry.actions.save')
+            }}
           </button>
         </div>
       </div>
@@ -207,6 +240,7 @@
 
 <script setup>
 import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { llmOpsApi } from '@/api/llmOps'
 import { useToast } from '@/composables/useToast'
 import CompactSelect from '@/components/llm-ops/CompactSelect.vue'
@@ -232,76 +266,83 @@ const props = defineProps({
 
 const emit = defineEmits(['close', 'saved'])
 const { showSuccess, showError } = useToast()
+const { t } = useI18n()
 
 const saving = ref(false)
 const modelMode = ref('existing')
 const form = ref(defaults())
 
-const priceFields = [
+const priceFields = computed(() => [
   {
     key: 'input_price_per_million',
-    label: '文本输入 / 百万 token',
-    help: 'Prompt 或输入 token 单价',
+    label: t('llmOps.manualPriceEntry.priceFields.textInput.label'),
+    help: t('llmOps.manualPriceEntry.priceFields.textInput.help'),
     modalities: ['text', 'multimodal']
   },
   {
     key: 'output_price_per_million',
-    label: '文本输出 / 百万 token',
-    help: 'Completion 或输出 token 单价',
+    label: t('llmOps.manualPriceEntry.priceFields.textOutput.label'),
+    help: t('llmOps.manualPriceEntry.priceFields.textOutput.help'),
     modalities: ['text', 'multimodal']
   },
   {
     key: 'cache_input_price_per_million',
-    label: '缓存输入 / 百万 token',
-    help: '可选，命中缓存后的输入价格',
+    label: t('llmOps.manualPriceEntry.priceFields.cacheInput.label'),
+    help: t('llmOps.manualPriceEntry.priceFields.cacheInput.help'),
     modalities: ['text', 'multimodal']
   },
   {
     key: 'image_output_price_per_image',
-    label: '图片输出 / 张',
-    help: '图片生成模型按张计价',
+    label: t('llmOps.manualPriceEntry.priceFields.imageOutput.label'),
+    help: t('llmOps.manualPriceEntry.priceFields.imageOutput.help'),
     modalities: ['multimodal']
   },
   {
     key: 'audio_input_price_per_second',
-    label: '音频输入 / 秒',
-    help: '语音识别或音频理解输入',
+    label: t('llmOps.manualPriceEntry.priceFields.audioInput.label'),
+    help: t('llmOps.manualPriceEntry.priceFields.audioInput.help'),
     modalities: ['audio']
   },
   {
     key: 'audio_output_price_per_second',
-    label: '音频输出 / 秒',
-    help: '语音合成或音频生成输出',
+    label: t('llmOps.manualPriceEntry.priceFields.audioOutput.label'),
+    help: t('llmOps.manualPriceEntry.priceFields.audioOutput.help'),
     modalities: ['audio']
   },
   {
     key: 'video_input_price_per_second',
-    label: '视频输入 / 秒',
-    help: '视频理解输入',
+    label: t('llmOps.manualPriceEntry.priceFields.videoInput.label'),
+    help: t('llmOps.manualPriceEntry.priceFields.videoInput.help'),
     modalities: ['video']
   },
   {
     key: 'video_output_price_per_second',
-    label: '视频输出 / 秒',
-    help: '视频生成输出',
+    label: t('llmOps.manualPriceEntry.priceFields.videoOutput.label'),
+    help: t('llmOps.manualPriceEntry.priceFields.videoOutput.help'),
     modalities: ['video']
   }
-]
+])
 
-const modalityOptions = [
-  { label: '文本', value: 'text' },
-  { label: '多模态', value: 'multimodal' },
-  { label: '音频', value: 'audio' },
-  { label: '视频', value: 'video' }
-]
+const modalityOptions = computed(() => [
+  { label: t('llmOps.manualPriceEntry.modalities.text'), value: 'text' },
+  {
+    label: t('llmOps.manualPriceEntry.modalities.multimodal'),
+    value: 'multimodal'
+  },
+  { label: t('llmOps.manualPriceEntry.modalities.audio'), value: 'audio' },
+  { label: t('llmOps.manualPriceEntry.modalities.video'), value: 'video' }
+])
 
-const currencyOptions = [
-  { label: '人民币 CNY', value: 'CNY' },
-  { label: '美元 USD', value: 'USD' }
-]
+const currencyOptions = computed(() => [
+  { label: t('llmOps.manualPriceEntry.currencies.cny'), value: 'CNY' },
+  { label: t('llmOps.manualPriceEntry.currencies.usd'), value: 'USD' }
+])
 
 const providerOptions = computed(() => [
-  { label: '选择模型厂商', value: '' },
+  {
+    label: t('llmOps.manualPriceEntry.placeholders.selectProvider'),
+    value: ''
+  },
   ...props.providers
     .slice()
     .sort((left, right) => left.name.localeCompare(right.name))
@@ -326,7 +367,7 @@ const currentPriceModality = computed(() => {
 })
 
 const activePriceFields = computed(() =>
-  priceFields.filter((field) =>
+  priceFields.value.filter((field) =>
     field.modalities.includes(currentPriceModality.value)
   )
 )
@@ -339,16 +380,16 @@ const selectedProvider = computed(() =>
 
 const sourceCategoryLabel = computed(() => {
   const labels = {
-    official_provider: '原厂',
-    supplier: '供货商',
-    manual: '人工',
-    unknown: '其他'
+    official_provider: t('llmOps.manualPriceEntry.categories.officialProvider'),
+    supplier: t('llmOps.manualPriceEntry.categories.supplier'),
+    manual: t('llmOps.manualPriceEntry.categories.manual'),
+    unknown: t('llmOps.manualPriceEntry.categories.unknown')
   }
   const category =
     props.source?.business_source_category ||
     props.source?.source_category ||
     'unknown'
-  return labels[category] || '其他'
+  return labels[category] || labels.unknown
 })
 
 const sourceCategoryTone = computed(() => {
@@ -365,23 +406,36 @@ const sourceCategoryTone = computed(() => {
 })
 
 const sourceRelationLabel = computed(() => {
-  if (props.source?.provider_name)
-    return `模型厂商 ${props.source.provider_name}`
-  if (props.source?.channel_name) return `转发渠道 ${props.source.channel_name}`
-  return '未绑定模型厂商'
+  if (props.source?.provider_name) {
+    return t('llmOps.manualPriceEntry.relation.provider', {
+      name: props.source.provider_name
+    })
+  }
+  if (props.source?.channel_name) {
+    return t('llmOps.manualPriceEntry.relation.channel', {
+      name: props.source.channel_name
+    })
+  }
+  return t('llmOps.manualPriceEntry.relation.unbound')
 })
 
 const validationMessage = computed(() => {
-  if (!props.source?.id) return '缺少价格源。'
+  if (!props.source?.id) return t('llmOps.manualPriceEntry.validation.noSource')
   if (modelMode.value === 'existing' && !selectedModel.value) {
-    return '请选择一个已有模型。'
+    return t('llmOps.manualPriceEntry.validation.selectExistingModel')
   }
   if (modelMode.value === 'custom') {
-    if (!form.value.custom_model_name.trim()) return '请填写自定义模型名称。'
-    if (!form.value.custom_model_code.trim()) return '请填写自定义模型编码。'
-    if (!selectedProvider.value) return '请选择自定义模型的模型厂商。'
+    if (!form.value.custom_model_name.trim()) {
+      return t('llmOps.manualPriceEntry.validation.customModelName')
+    }
+    if (!form.value.custom_model_code.trim()) {
+      return t('llmOps.manualPriceEntry.validation.customModelCode')
+    }
+    if (!selectedProvider.value) {
+      return t('llmOps.manualPriceEntry.validation.customModelProvider')
+    }
   }
-  if (!hasAnyPrice()) return '至少填写一个价格维度。'
+  if (!hasAnyPrice()) return t('llmOps.manualPriceEntry.validation.price')
   return ''
 })
 
@@ -451,10 +505,10 @@ async function submit() {
       updates_model_prices: Boolean(props.source.updates_model_prices),
       rows: [row]
     })
-    showSuccess('模型价格已保存')
+    showSuccess(t('llmOps.manualPriceEntry.messages.saved'))
     emit('saved')
   } catch (error) {
-    showError(errorMessage(error, '保存模型价格失败'))
+    showError(errorMessage(error, t('llmOps.manualPriceEntry.errors.save')))
   } finally {
     saving.value = false
   }
@@ -500,7 +554,7 @@ function hasAnyPrice() {
 
 function clearInactivePrices() {
   const activeKeys = new Set(activePriceFields.value.map((field) => field.key))
-  priceFields.forEach((field) => {
+  priceFields.value.forEach((field) => {
     if (!activeKeys.has(field.key)) {
       form.value[field.key] = ''
     }
@@ -526,9 +580,17 @@ function buildModelOptions() {
     return sortedModels.map(modelOption)
   }
   return [
-    { label: '当前价格源关联厂商', value: '__group_preferred', type: 'group' },
+    {
+      label: t('llmOps.manualPriceEntry.groups.currentProvider'),
+      value: '__group_preferred',
+      type: 'group'
+    },
     ...preferred.map(modelOption),
-    { label: '其他模型', value: '__group_others', type: 'group' },
+    {
+      label: t('llmOps.manualPriceEntry.groups.otherModels'),
+      value: '__group_others',
+      type: 'group'
+    },
     ...others.map(modelOption)
   ]
 }
@@ -537,7 +599,10 @@ function modelOption(model) {
   return {
     label: model.name || model.code,
     value: model.id,
-    description: `${model.provider_name || '未知厂商'} · ${model.code}`,
+    description: `${
+      model.provider_name ||
+      t('llmOps.manualPriceEntry.fallback.unknownProvider')
+    } · ${model.code}`,
     badge: modalityLabel(model.modality),
     searchText: [model.name, model.code, model.provider_name].join(' ')
   }
@@ -552,12 +617,12 @@ function normalizePrice(value) {
 
 function modalityLabel(value) {
   const labels = {
-    text: '文本',
-    multimodal: '多模态',
-    audio: '音频',
-    video: '视频'
+    text: t('llmOps.manualPriceEntry.modalities.text'),
+    multimodal: t('llmOps.manualPriceEntry.modalities.multimodal'),
+    audio: t('llmOps.manualPriceEntry.modalities.audio'),
+    video: t('llmOps.manualPriceEntry.modalities.video')
   }
-  return labels[value] || value || '文本'
+  return labels[value] || value || labels.text
 }
 
 function errorMessage(error, fallback) {

--- a/frontend/src/components/llm-ops/ManualPriceImportModal.vue
+++ b/frontend/src/components/llm-ops/ManualPriceImportModal.vue
@@ -9,10 +9,10 @@
         <div>
           <p class="eyebrow">Manual Price Source</p>
           <h3 class="mt-1 text-lg font-semibold text-slate-900">
-            导入人工价格表
+            {{ t('llmOps.manualPriceImport.title') }}
           </h3>
           <p class="mt-1 text-xs leading-5 text-slate-500">
-            适合无法自动采集的模型价格源，可从 Excel 复制整张表后粘贴。
+            {{ t('llmOps.manualPriceImport.description') }}
           </p>
         </div>
         <button
@@ -20,34 +20,46 @@
           type="button"
           @click="close"
         >
-          关闭
+          {{ t('llmOps.manualPriceImport.actions.close') }}
         </button>
       </div>
 
       <div class="modal-body space-y-4">
         <div class="grid gap-3 md:grid-cols-2">
           <label class="form-field">
-            <span class="field-label">模型厂商</span>
+            <span class="field-label">
+              {{ t('llmOps.manualPriceImport.fields.provider') }}
+            </span>
             <CompactSelect v-model="form.provider" :options="providerOptions" />
           </label>
           <label class="form-field">
-            <span class="field-label">默认币种</span>
+            <span class="field-label">
+              {{ t('llmOps.manualPriceImport.fields.currency') }}
+            </span>
             <CompactSelect v-model="form.currency" :options="currencyOptions" />
           </label>
           <label class="form-field">
-            <span class="field-label">模型价格源名称</span>
+            <span class="field-label">
+              {{ t('llmOps.manualPriceImport.fields.sourceName') }}
+            </span>
             <input
               v-model="form.source_name"
               class="field"
-              placeholder="例如 OpenAI 2026-06 手动价格表"
+              :placeholder="
+                t('llmOps.manualPriceImport.placeholders.sourceName')
+              "
             />
           </label>
           <label class="form-field">
-            <span class="field-label">模型价格源地址</span>
+            <span class="field-label">
+              {{ t('llmOps.manualPriceImport.fields.sourceUrl') }}
+            </span>
             <input
               v-model="form.source_url"
               class="field"
-              placeholder="可选，官网或内部表格链接"
+              :placeholder="
+                t('llmOps.manualPriceImport.placeholders.sourceUrl')
+              "
             />
           </label>
         </div>
@@ -59,15 +71,16 @@
             type="checkbox"
           />
           <span>
-            导入后同步更新模型价格源价格。关闭后只生成模型价格源和标准价格项，
-            不覆盖模型主数据价格。
+            {{ t('llmOps.manualPriceImport.updateModelPrices') }}
           </span>
         </label>
 
         <div class="rounded-lg border border-slate-200 bg-slate-50 p-3">
           <div class="flex flex-col gap-3 xl:flex-row xl:items-start">
             <div class="min-w-0 flex-1">
-              <label class="field-label">Excel / CSV 内容</label>
+              <label class="field-label">
+                {{ t('llmOps.manualPriceImport.fields.tableContent') }}
+              </label>
               <textarea
                 v-model="rawTable"
                 class="table-input"
@@ -76,7 +89,9 @@
               />
             </div>
             <div class="example-box">
-              <p class="text-xs font-semibold text-slate-700">支持字段</p>
+              <p class="text-xs font-semibold text-slate-700">
+                {{ t('llmOps.manualPriceImport.supportedFieldsTitle') }}
+              </p>
               <p class="mt-2 text-xs leading-5 text-slate-500">
                 model_code、model_name、modality、currency、source_url、
                 input_price_per_million、output_price_per_million、
@@ -91,14 +106,24 @@
         <div class="preview-panel">
           <div class="flex flex-wrap items-center justify-between gap-2">
             <div>
-              <p class="text-sm font-semibold text-slate-900">解析预览</p>
+              <p class="text-sm font-semibold text-slate-900">
+                {{ t('llmOps.manualPriceImport.preview.title') }}
+              </p>
               <p class="mt-1 text-xs text-slate-500">
-                有效 {{ parsedRows.length }} 行，错误
-                {{ parseErrors.length }} 条
+                {{
+                  t('llmOps.manualPriceImport.preview.summary', {
+                    valid: parsedRows.length,
+                    errors: parseErrors.length
+                  })
+                }}
               </p>
             </div>
             <span :class="parseErrors.length ? 'badge-warn' : 'badge-ok'">
-              {{ parseErrors.length ? '需要修正' : '可导入' }}
+              {{
+                parseErrors.length
+                  ? t('llmOps.manualPriceImport.preview.needsFix')
+                  : t('llmOps.manualPriceImport.preview.ready')
+              }}
             </span>
           </div>
 
@@ -116,14 +141,24 @@
             <table class="preview-table">
               <thead>
                 <tr>
-                  <th>模型</th>
-                  <th>类型</th>
-                  <th>币种</th>
-                  <th class="text-right">输入</th>
-                  <th class="text-right">输出</th>
-                  <th class="text-right">图片</th>
-                  <th class="text-right">音频</th>
-                  <th class="text-right">视频</th>
+                  <th>{{ t('llmOps.manualPriceImport.table.model') }}</th>
+                  <th>{{ t('llmOps.manualPriceImport.table.type') }}</th>
+                  <th>{{ t('llmOps.manualPriceImport.table.currency') }}</th>
+                  <th class="text-right">
+                    {{ t('llmOps.manualPriceImport.table.input') }}
+                  </th>
+                  <th class="text-right">
+                    {{ t('llmOps.manualPriceImport.table.output') }}
+                  </th>
+                  <th class="text-right">
+                    {{ t('llmOps.manualPriceImport.table.image') }}
+                  </th>
+                  <th class="text-right">
+                    {{ t('llmOps.manualPriceImport.table.audio') }}
+                  </th>
+                  <th class="text-right">
+                    {{ t('llmOps.manualPriceImport.table.video') }}
+                  </th>
                 </tr>
               </thead>
               <tbody>
@@ -166,7 +201,7 @@
                 </tr>
                 <tr v-if="!parsedRows.length">
                   <td class="py-6 text-center text-slate-400" colspan="8">
-                    粘贴带表头的价格表后会显示预览。
+                    {{ t('llmOps.manualPriceImport.emptyPreview') }}
                   </td>
                 </tr>
               </tbody>
@@ -182,7 +217,7 @@
             type="button"
             @click="close"
           >
-            取消
+            {{ t('llmOps.manualPriceImport.actions.cancel') }}
           </button>
           <button
             class="btn-primary btn-action-import"
@@ -191,7 +226,11 @@
             @click="submit"
           >
             <span class="icon-mark" :class="saving ? 'animate-spin' : ''" />
-            {{ saving ? '导入中' : '确认导入' }}
+            {{
+              saving
+                ? t('llmOps.manualPriceImport.actions.importing')
+                : t('llmOps.manualPriceImport.actions.confirmImport')
+            }}
           </button>
         </div>
       </div>
@@ -201,6 +240,7 @@
 
 <script setup>
 import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { llmOpsApi } from '@/api/llmOps'
 import CompactSelect from '@/components/llm-ops/CompactSelect.vue'
 
@@ -216,6 +256,7 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['close', 'imported'])
+const { t } = useI18n()
 
 const rawTable = ref('')
 const saving = ref(false)
@@ -227,7 +268,10 @@ const currencyOptions = [
 ]
 
 const providerOptions = computed(() => [
-  { label: '选择模型归属方', value: '' },
+  {
+    label: t('llmOps.manualPriceImport.placeholders.selectProvider'),
+    value: ''
+  },
   ...props.providers
     .slice()
     .sort((left, right) => left.name.localeCompare(right.name))
@@ -292,13 +336,16 @@ function parseTable(value) {
   if (!text) return { rows: [], errors: [] }
   const lines = text.split(/\r?\n/).filter((line) => line.trim())
   if (lines.length < 2) {
-    return { rows: [], errors: ['至少需要表头和一行数据。'] }
+    return {
+      rows: [],
+      errors: [t('llmOps.manualPriceImport.parseErrors.needHeaderAndRow')]
+    }
   }
   const delimiter = lines[0].includes('\t') ? '\t' : ','
   const headers = splitLine(lines[0], delimiter).map(normalizeHeader)
   const errors = []
   if (!headers.includes('model_code')) {
-    errors.push('缺少必填表头：model_code。')
+    errors.push(t('llmOps.manualPriceImport.parseErrors.missingModelCode'))
   }
   const rows = lines.slice(1).map((line, index) => {
     const cells = splitLine(line, delimiter)
@@ -340,18 +387,18 @@ function normalizeHeader(header) {
   const aliases = {
     code: 'model_code',
     model: 'model_code',
-    模型编码: 'model_code',
-    模型名称: 'model_name',
-    类型: 'modality',
-    币种: 'currency',
-    输入价格: 'input_price_per_million',
-    输出价格: 'output_price_per_million',
-    图片输出: 'image_output_price_per_image',
-    音频输入: 'audio_input_price_per_second',
-    音频输出: 'audio_output_price_per_second',
-    视频输入: 'video_input_price_per_second',
-    视频输出: 'video_output_price_per_second',
-    来源地址: 'source_url'
+    '\u6a21\u578b\u7f16\u7801': 'model_code',
+    '\u6a21\u578b\u540d\u79f0': 'model_name',
+    '\u7c7b\u578b': 'modality',
+    '\u5e01\u79cd': 'currency',
+    '\u8f93\u5165\u4ef7\u683c': 'input_price_per_million',
+    '\u8f93\u51fa\u4ef7\u683c': 'output_price_per_million',
+    '\u56fe\u7247\u8f93\u51fa': 'image_output_price_per_image',
+    '\u97f3\u9891\u8f93\u5165': 'audio_input_price_per_second',
+    '\u97f3\u9891\u8f93\u51fa': 'audio_output_price_per_second',
+    '\u89c6\u9891\u8f93\u5165': 'video_input_price_per_second',
+    '\u89c6\u9891\u8f93\u51fa': 'video_output_price_per_second',
+    '\u6765\u6e90\u5730\u5740': 'source_url'
   }
   const normalized = String(header || '').trim()
   return aliases[normalized] || normalized
@@ -359,7 +406,11 @@ function normalizeHeader(header) {
 
 function normalizeRow(row, lineNumber, errors) {
   if (!row.model_code) {
-    errors.push(`第 ${lineNumber} 行缺少 model_code。`)
+    errors.push(
+      t('llmOps.manualPriceImport.parseErrors.rowMissingModelCode', {
+        line: lineNumber
+      })
+    )
     return null
   }
   const next = {
@@ -385,18 +436,31 @@ function normalizeRow(row, lineNumber, errors) {
     }
     const value = Number(next[field])
     if (!Number.isFinite(value) || value < 0) {
-      errors.push(`第 ${lineNumber} 行 ${field} 不是有效的非负数字。`)
+      errors.push(
+        t('llmOps.manualPriceImport.parseErrors.invalidNumber', {
+          line: lineNumber,
+          field
+        })
+      )
       return
     }
     next[field] = String(value)
     hasPrice = true
   })
   if (!hasPrice) {
-    errors.push(`第 ${lineNumber} 行至少需要一个价格字段。`)
+    errors.push(
+      t('llmOps.manualPriceImport.parseErrors.noPrice', {
+        line: lineNumber
+      })
+    )
     return null
   }
   if (next.currency && !['USD', 'CNY'].includes(next.currency)) {
-    errors.push(`第 ${lineNumber} 行币种只支持 USD 或 CNY。`)
+    errors.push(
+      t('llmOps.manualPriceImport.parseErrors.unsupportedCurrency', {
+        line: lineNumber
+      })
+    )
     return null
   }
   return next
@@ -407,14 +471,14 @@ function normalizeModality(value) {
     .trim()
     .toLowerCase()
   const labels = {
-    文本: 'text',
+    '\u6587\u672c': 'text',
     text: 'text',
-    图片: 'multimodal',
-    多模态: 'multimodal',
+    '\u56fe\u7247': 'multimodal',
+    '\u591a\u6a21\u6001': 'multimodal',
     multimodal: 'multimodal',
-    音频: 'audio',
+    '\u97f3\u9891': 'audio',
     audio: 'audio',
-    视频: 'video',
+    '\u89c6\u9891': 'video',
     video: 'video'
   }
   return labels[text] || 'text'
@@ -444,12 +508,12 @@ function compactPair(input, output) {
 
 function modalityLabel(value) {
   const labels = {
-    text: '文本',
-    multimodal: '多模态',
-    audio: '音频',
-    video: '视频'
+    text: t('llmOps.manualPriceImport.modalities.text'),
+    multimodal: t('llmOps.manualPriceImport.modalities.multimodal'),
+    audio: t('llmOps.manualPriceImport.modalities.audio'),
+    video: t('llmOps.manualPriceImport.modalities.video')
   }
-  return labels[value] || value || '文本'
+  return labels[value] || value || labels.text
 }
 </script>
 

--- a/frontend/src/components/llm-ops/PriceSourceModal.vue
+++ b/frontend/src/components/llm-ops/PriceSourceModal.vue
@@ -17,13 +17,17 @@
               Price Source
             </p>
             <h3 class="mt-2 text-lg font-semibold text-slate-900">
-              {{ isEditing ? '编辑模型价格源' : '新建模型价格源' }}
+              {{
+                isEditing
+                  ? t('llmOps.priceSourceModal.title.edit')
+                  : t('llmOps.priceSourceModal.title.create')
+              }}
             </h3>
             <p class="mt-1 text-sm text-slate-500">
               {{
                 isEditing
-                  ? '维护价格源名称、口径、价格地址和启停状态。'
-                  : '新建原厂、供货商或人工维护价格源，用于后续录价和采集模型价格。'
+                  ? t('llmOps.priceSourceModal.description.edit')
+                  : t('llmOps.priceSourceModal.description.create')
               }}
             </p>
           </div>
@@ -33,7 +37,7 @@
             :disabled="saving"
             @click="close"
           >
-            关闭
+            {{ t('llmOps.priceSourceModal.actions.close') }}
           </button>
         </div>
       </div>
@@ -43,48 +47,60 @@
       >
         <section class="form-section">
           <div class="section-heading">
-            <h4>基础信息</h4>
-            <p>只保留运营侧需要维护的字段。</p>
+            <h4>{{ t('llmOps.priceSourceModal.sections.basic') }}</h4>
+            <p>{{ t('llmOps.priceSourceModal.sections.basicHint') }}</p>
           </div>
           <div class="source-meta-strip">
             <div class="source-meta-item">
-              <span>系统标识</span>
+              <span>{{ t('llmOps.priceSourceModal.fields.slug') }}</span>
               <strong>{{ internalSlugLabel }}</strong>
             </div>
             <div class="source-meta-item">
-              <span>来源方式</span>
+              <span>{{ t('llmOps.priceSourceModal.fields.sourceType') }}</span>
               <strong>{{ sourceTypeLabel }}</strong>
             </div>
           </div>
           <div class="grid gap-4 md:grid-cols-2">
             <label class="field-group">
-              <span class="field-label">价格源名称</span>
+              <span class="field-label">
+                {{ t('llmOps.priceSourceModal.fields.name') }}
+              </span>
               <input
                 v-model="form.name"
                 class="field"
-                placeholder="例如：云测 / 阿里云百炼华东专线"
+                :placeholder="t('llmOps.priceSourceModal.placeholders.name')"
                 required
               />
               <span v-if="!isEditing" class="field-help">
-                创建后系统标识将自动生成：{{ internalSlugLabel }}
+                {{
+                  t('llmOps.priceSourceModal.help.autoSlug', {
+                    slug: internalSlugLabel
+                  })
+                }}
               </span>
             </label>
             <label class="field-group">
-              <span class="field-label">价格口径</span>
+              <span class="field-label">
+                {{ t('llmOps.priceSourceModal.fields.category') }}
+              </span>
               <CompactSelect
                 v-model="form.source_category"
                 :options="sourceCategoryOptions"
               />
             </label>
             <label class="field-group">
-              <span class="field-label">默认币种</span>
+              <span class="field-label">
+                {{ t('llmOps.priceSourceModal.fields.currency') }}
+              </span>
               <CompactSelect
                 v-model="form.currency"
                 :options="currencyOptions"
               />
             </label>
             <label class="field-group md:col-span-2">
-              <span class="field-label">价格地址</span>
+              <span class="field-label">
+                {{ t('llmOps.priceSourceModal.fields.endpointUrl') }}
+              </span>
               <input
                 v-model="form.endpoint_url"
                 class="field"
@@ -92,7 +108,7 @@
                 type="url"
               />
               <span class="field-help">
-                官方价格页、供货商价格接口或人工价格来源地址。
+                {{ t('llmOps.priceSourceModal.help.endpointUrl') }}
               </span>
             </label>
           </div>
@@ -100,13 +116,13 @@
 
         <section class="form-section">
           <div class="section-heading">
-            <h4>补充说明</h4>
-            <p>可选，用于记录区域、合同价或特殊说明。</p>
+            <h4>{{ t('llmOps.priceSourceModal.sections.notes') }}</h4>
+            <p>{{ t('llmOps.priceSourceModal.sections.notesHint') }}</p>
           </div>
           <textarea
             v-model="form.notes"
             class="field min-h-20 resize-none"
-            placeholder="例如：华东专线、合同价、只覆盖 qwen-plus"
+            :placeholder="t('llmOps.priceSourceModal.placeholders.notes')"
           />
         </section>
       </div>
@@ -121,7 +137,11 @@
             <span class="status-switch-dot" />
           </span>
           <span class="text-sm text-slate-700">
-            {{ form.is_enabled ? '价格源已启用' : '价格源已停用' }}
+            {{
+              form.is_enabled
+                ? t('llmOps.priceSourceModal.status.enabled')
+                : t('llmOps.priceSourceModal.status.disabled')
+            }}
           </span>
         </label>
         <div class="modal-footer-actions">
@@ -131,7 +151,7 @@
             :disabled="saving"
             @click="close"
           >
-            取消
+            {{ t('llmOps.priceSourceModal.actions.cancel') }}
           </button>
           <button
             class="btn-primary btn-action-save"
@@ -139,7 +159,13 @@
             :disabled="saving"
           >
             <span class="icon-mark" />
-            {{ saving ? '保存中' : isEditing ? '保存修改' : '创建价格源' }}
+            {{
+              saving
+                ? t('llmOps.priceSourceModal.actions.saving')
+                : isEditing
+                  ? t('llmOps.priceSourceModal.actions.saveChanges')
+                  : t('llmOps.priceSourceModal.actions.create')
+            }}
           </button>
         </div>
       </div>
@@ -149,6 +175,7 @@
 
 <script setup>
 import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { llmOpsApi } from '@/api/llmOps'
 import { useToast } from '@/composables/useToast'
 import CompactSelect from '@/components/llm-ops/CompactSelect.vue'
@@ -166,6 +193,7 @@ const props = defineProps({
 
 const emit = defineEmits(['close', 'saved'])
 const { showSuccess, showError } = useToast()
+const { t } = useI18n()
 
 const saving = ref(false)
 const form = ref(defaults())
@@ -178,22 +206,34 @@ const sourceTypeLabel = computed(() => {
   const labels = {
     agione: 'Agione',
     yunce: 'Yunce',
-    custom: '自定义'
+    custom: t('llmOps.priceSourceModal.sourceTypes.custom')
   }
   return labels[type] || type || '-'
 })
 
-const sourceCategoryOptions = [
-  { label: '原厂价格源', value: 'official_provider' },
-  { label: '供货商价格源', value: 'supplier' },
-  { label: '人工维护', value: 'manual' },
-  { label: '其他', value: 'unknown' }
-]
+const sourceCategoryOptions = computed(() => [
+  {
+    label: t('llmOps.priceSourceModal.categories.officialProvider'),
+    value: 'official_provider'
+  },
+  {
+    label: t('llmOps.priceSourceModal.categories.supplier'),
+    value: 'supplier'
+  },
+  {
+    label: t('llmOps.priceSourceModal.categories.manual'),
+    value: 'manual'
+  },
+  {
+    label: t('llmOps.priceSourceModal.categories.unknown'),
+    value: 'unknown'
+  }
+])
 
-const currencyOptions = [
-  { label: '人民币 CNY', value: 'CNY' },
-  { label: '美元 USD', value: 'USD' }
-]
+const currencyOptions = computed(() => [
+  { label: t('llmOps.priceSourceModal.currencies.cny'), value: 'CNY' },
+  { label: t('llmOps.priceSourceModal.currencies.usd'), value: 'USD' }
+])
 
 watch(
   () => props.source,
@@ -246,14 +286,14 @@ async function save() {
     }
     if (isEditing.value) {
       await llmOpsApi.updateCollectionSource(props.source.id, payload)
-      showSuccess('模型价格源已更新')
+      showSuccess(t('llmOps.priceSourceModal.messages.updated'))
     } else {
       await llmOpsApi.createCollectionSource(payload)
-      showSuccess('模型价格源已创建')
+      showSuccess(t('llmOps.priceSourceModal.messages.created'))
     }
     emit('saved')
   } catch (error) {
-    showError(errorMessage(error, '保存模型价格源失败'))
+    showError(errorMessage(error, t('llmOps.priceSourceModal.errors.save')))
   } finally {
     saving.value = false
   }

--- a/frontend/src/components/llm-ops/ProviderManagement.vue
+++ b/frontend/src/components/llm-ops/ProviderManagement.vue
@@ -19,10 +19,9 @@
     <div class="panel overflow-hidden p-0">
       <div class="table-toolbar">
         <div>
-          <h3 class="panel-title">供货商价格列表</h3>
-          <p class="mt-1 text-xs text-slate-500">
-            先看供货商与价格源列表，再进入抽屉查看该供货商下的元模型价格。
-          </p>
+          <h3 class="panel-title">
+            {{ t('llmOps.providerManagement.title') }}
+          </h3>
         </div>
         <div class="provider-toolbar-actions">
           <button
@@ -30,7 +29,7 @@
             type="button"
             @click="showManualImportModal = true"
           >
-            批量导入
+            {{ t('llmOps.providerManagement.actions.bulkImport') }}
           </button>
           <button
             class="btn-primary source-primary-button btn-action-create"
@@ -50,7 +49,7 @@
               <path d="M12 5v14" />
               <path d="M5 12h14" />
             </svg>
-            新建价格源
+            {{ t('llmOps.providerManagement.actions.createSource') }}
           </button>
         </div>
       </div>
@@ -60,19 +59,27 @@
           <input
             v-model="sourceSearch"
             class="field-input"
-            placeholder="搜索供货商、价格源、厂商或地址"
+            :placeholder="
+              t('llmOps.providerManagement.filters.searchPlaceholder')
+            "
           />
           <select v-model="sourceCategoryFilter" class="field-input">
-            <option value="all">全部类型</option>
-            <option value="official_provider">原厂</option>
-            <option value="supplier">供货商</option>
-            <option value="manual">人工</option>
-            <option value="unknown">其他</option>
+            <option
+              v-for="option in sourceCategoryFilterOptions"
+              :key="option.value"
+              :value="option.value"
+            >
+              {{ option.label }}
+            </option>
           </select>
           <select v-model="sourceStatusFilter" class="field-input">
-            <option value="all">全部状态</option>
-            <option value="active">仅启用</option>
-            <option value="inactive">仅停用</option>
+            <option
+              v-for="option in sourceStatusFilterOptions"
+              :key="option.value"
+              :value="option.value"
+            >
+              {{ option.label }}
+            </option>
           </select>
         </div>
       </div>
@@ -88,11 +95,21 @@
           </colgroup>
           <thead>
             <tr>
-              <th class="table-head">供货商 / 价格源</th>
-              <th class="table-head">类型</th>
-              <th class="table-head">关联元模型</th>
-              <th class="table-head">状态</th>
-              <th class="table-head">操作</th>
+              <th class="table-head">
+                {{ t('llmOps.providerManagement.table.source') }}
+              </th>
+              <th class="table-head">
+                {{ t('llmOps.providerManagement.table.type') }}
+              </th>
+              <th class="table-head">
+                {{ t('llmOps.providerManagement.table.metaModels') }}
+              </th>
+              <th class="table-head">
+                {{ t('llmOps.providerManagement.table.status') }}
+              </th>
+              <th class="table-head">
+                {{ t('llmOps.providerManagement.table.actions') }}
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -118,7 +135,11 @@
 
               <td class="table-cell">
                 <p class="font-medium text-slate-900">
-                  {{ source.covered_model_count }} 个元模型
+                  {{
+                    t('llmOps.providerManagement.modelsCount', {
+                      count: source.covered_model_count
+                    })
+                  }}
                 </p>
               </td>
 
@@ -135,19 +156,21 @@
                 <div class="provider-actions">
                   <OperationIconButton
                     icon="view"
-                    label="查看元模型"
+                    :label="t('llmOps.providerManagement.actions.viewModels')"
                     @click.stop="selectedSource = source"
                   />
                   <OperationIconButton
                     v-if="source.can_manual_entry"
                     icon="manual"
-                    label="手工录价"
+                    :label="
+                      t('llmOps.providerManagement.actions.manualPricing')
+                    "
                     tone="success"
                     @click.stop="priceEntrySource = source"
                   />
                   <OperationIconButton
                     icon="edit"
-                    label="编辑"
+                    :label="t('llmOps.providerManagement.actions.edit')"
                     @click.stop="editingSource = source"
                   />
                   <OperationIconButton
@@ -158,7 +181,7 @@
                     icon="collect"
                     :label="
                       collectingSourceId === source.id
-                        ? '提交中'
+                        ? t('llmOps.providerManagement.actions.submitting')
                         : source.collect_action_label
                     "
                     tone="primary"
@@ -167,7 +190,11 @@
                   <OperationIconButton
                     :disabled="deletingSourceId === source.id"
                     icon="delete"
-                    :label="deletingSourceId === source.id ? '删除中' : '删除'"
+                    :label="
+                      deletingSourceId === source.id
+                        ? t('llmOps.providerManagement.actions.deleting')
+                        : t('llmOps.providerManagement.actions.delete')
+                    "
                     tone="danger"
                     @click.stop="deleteSource(source)"
                   />
@@ -176,7 +203,7 @@
             </tr>
             <tr v-if="!filteredSourceRows.length">
               <td class="table-cell text-slate-500" colspan="5">
-                暂无匹配的供货商价格源。
+                {{ t('llmOps.providerManagement.empty') }}
               </td>
             </tr>
           </tbody>
@@ -220,6 +247,7 @@
 
 <script setup>
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { llmOpsApi } from '@/api/llmOps'
 import { useToast } from '@/composables/useToast'
 import ManualPriceImportModal from '@/components/llm-ops/ManualPriceImportModal.vue'
@@ -261,6 +289,7 @@ const props = defineProps({
 
 const emit = defineEmits(['refresh'])
 const { showSuccess, showError } = useToast()
+const { t } = useI18n()
 
 const selectedSource = ref(null)
 const editingSource = ref(null)
@@ -272,6 +301,44 @@ const deletingSourceId = ref(null)
 const sourceSearch = ref('')
 const sourceCategoryFilter = ref('all')
 const sourceStatusFilter = ref('all')
+
+const sourceCategoryFilterOptions = computed(() => [
+  {
+    value: 'all',
+    label: t('llmOps.providerManagement.filters.allTypes')
+  },
+  {
+    value: 'official_provider',
+    label: t('llmOps.providerManagement.category.officialProvider')
+  },
+  {
+    value: 'supplier',
+    label: t('llmOps.providerManagement.category.supplier')
+  },
+  {
+    value: 'manual',
+    label: t('llmOps.providerManagement.category.manual')
+  },
+  {
+    value: 'unknown',
+    label: t('llmOps.providerManagement.category.unknown')
+  }
+])
+
+const sourceStatusFilterOptions = computed(() => [
+  {
+    value: 'all',
+    label: t('llmOps.providerManagement.filters.allStatuses')
+  },
+  {
+    value: 'active',
+    label: t('llmOps.providerManagement.filters.activeOnly')
+  },
+  {
+    value: 'inactive',
+    label: t('llmOps.providerManagement.filters.inactiveOnly')
+  }
+])
 
 const sourceRows = computed(() =>
   props.sources
@@ -302,24 +369,27 @@ const sourceMetrics = computed(() => {
 
   return [
     {
-      label: '价格源',
+      label: t('llmOps.providerManagement.metrics.sources.label'),
       value: sourceRows.value.length,
-      hint: '供货商与原厂价格目录'
+      hint: t('llmOps.providerManagement.metrics.sources.hint')
     },
     {
-      label: '覆盖元模型',
+      label: t('llmOps.providerManagement.metrics.metaModels.label'),
       value: coveredMetaModelIds.size,
-      hint: '至少绑定一条当前价格'
+      hint: t('llmOps.providerManagement.metrics.metaModels.hint')
     },
     {
-      label: '原厂源',
+      label: t('llmOps.providerManagement.metrics.official.label'),
       value: official,
-      hint: '由元模型厂商直接发布'
+      hint: t('llmOps.providerManagement.metrics.official.hint')
     },
     {
-      label: '供货商 / 人工',
+      label: t('llmOps.providerManagement.metrics.supplierManual.label'),
       value: supplier + manual,
-      hint: `供货商 ${supplier} · 人工 ${manual}`
+      hint: t('llmOps.providerManagement.metrics.supplierManual.hint', {
+        supplier,
+        manual
+      })
     }
   ]
 })
@@ -458,11 +528,18 @@ async function collectSource(source) {
     const response = await llmOpsApi.collectCollectionSource(source.id)
     const taskId = response?.data?.task_id
     showSuccess(
-      `${source.name} 同步任务已提交` + `${taskId ? `（${taskId}）` : ''}`
+      t('llmOps.providerManagement.messages.syncSubmitted', {
+        name: source.name,
+        taskId: taskId
+          ? t('llmOps.providerManagement.messages.taskId', { taskId })
+          : ''
+      })
     )
     emit('refresh')
   } catch (error) {
-    showError(errorMessage(error, '提交价格同步任务失败'))
+    showError(
+      errorMessage(error, t('llmOps.providerManagement.errors.syncFailed'))
+    )
   } finally {
     collectingSourceId.value = null
   }
@@ -471,8 +548,9 @@ async function collectSource(source) {
 async function deleteSource(source) {
   if (!source?.id) return
   const confirmed = window.confirm(
-    `确认删除模型价格源「${source.name}」吗？\n\n` +
-      '删除后会移除该价格源及其采集记录，关联模型或渠道会失去这个价格来源。'
+    t('llmOps.providerManagement.confirm.deleteSource', {
+      name: source.name
+    })
   )
   if (!confirmed) return
 
@@ -482,10 +560,12 @@ async function deleteSource(source) {
     if (selectedSource.value?.id === source.id) {
       selectedSource.value = null
     }
-    showSuccess('模型价格源已删除')
+    showSuccess(t('llmOps.providerManagement.messages.deleted'))
     emit('refresh')
   } catch (error) {
-    showError(errorMessage(error, '删除模型价格源失败'))
+    showError(
+      errorMessage(error, t('llmOps.providerManagement.errors.deleteFailed'))
+    )
   } finally {
     deletingSourceId.value = null
   }
@@ -500,19 +580,19 @@ function businessSourceCategory(source) {
 function sourceCategory(category) {
   const labels = {
     official_provider: {
-      label: '原厂',
+      label: t('llmOps.providerManagement.category.officialProvider'),
       tone: 'official'
     },
     supplier: {
-      label: '供货商',
+      label: t('llmOps.providerManagement.category.supplier'),
       tone: 'supplier'
     },
     manual: {
-      label: '人工',
+      label: t('llmOps.providerManagement.category.manual'),
       tone: 'manual'
     },
     unknown: {
-      label: '其他',
+      label: t('llmOps.providerManagement.category.unknown'),
       tone: 'unknown'
     }
   }
@@ -533,18 +613,18 @@ function sourceRelation(source) {
   if (source.provider_name) {
     return {
       name: source.provider_name,
-      hint: '元模型厂商'
+      hint: t('llmOps.providerManagement.relation.metaProvider')
     }
   }
   if (source.channel_name) {
     return {
       name: source.channel_name,
-      hint: '转发渠道'
+      hint: t('llmOps.providerManagement.relation.forwardingChannel')
     }
   }
   return {
-    name: '未绑定来源',
-    hint: '待补充归属'
+    name: t('llmOps.providerManagement.relation.unbound'),
+    hint: t('llmOps.providerManagement.relation.needsOwner')
   }
 }
 
@@ -552,17 +632,27 @@ function sourceModeLabel(source) {
   const type = source?.source_type || ''
   const category = source?.source_category || ''
 
-  if (isModelsDevSource(source)) return '聚合同步'
-  if (category === 'official_provider') return '自动采集'
-  if (category === 'manual') return '手动维护'
-  if (category === 'supplier') return '供货商维护'
+  if (isModelsDevSource(source)) {
+    return t('llmOps.providerManagement.sourceMode.aggregateSync')
+  }
+  if (category === 'official_provider') {
+    return t('llmOps.providerManagement.sourceMode.autoCollect')
+  }
+  if (category === 'manual') {
+    return t('llmOps.providerManagement.sourceMode.manualMaintenance')
+  }
+  if (category === 'supplier') {
+    return t('llmOps.providerManagement.sourceMode.supplierMaintenance')
+  }
 
   const labels = {
     agione: 'Agione',
-    yunce: '专用采集',
-    custom: '自定义'
+    yunce: t('llmOps.providerManagement.sourceMode.dedicatedCollect'),
+    custom: t('llmOps.providerManagement.sourceMode.custom')
   }
-  return labels[type] || type || '待适配'
+  return (
+    labels[type] || type || t('llmOps.providerManagement.sourceMode.pending')
+  )
 }
 
 function sourceConfigSummary(source, relation = sourceRelation(source)) {
@@ -574,43 +664,43 @@ function sourceConfigSummary(source, relation = sourceRelation(source)) {
 function sourceStatus(source, latestRun) {
   if (!source.is_enabled) {
     return {
-      label: '停用',
+      label: t('llmOps.providerManagement.sourceStatus.inactive.label'),
       tone: 'muted',
-      hint: '不会参与采集'
+      hint: t('llmOps.providerManagement.sourceStatus.inactive.hint')
     }
   }
   if (canManualEntrySource(source)) {
     return {
-      label: '手动维护',
+      label: t('llmOps.providerManagement.sourceStatus.manual.label'),
       tone: 'info',
-      hint: '通过录入或 Excel 导入更新'
+      hint: t('llmOps.providerManagement.sourceStatus.manual.hint')
     }
   }
   if (!canCollectSource(source)) {
     return {
-      label: '待适配',
+      label: t('llmOps.providerManagement.sourceStatus.pending.label'),
       tone: 'warn',
       hint: collectModeLabel(source)
     }
   }
   if (latestRun?.status === 'failed') {
     return {
-      label: '采集失败',
+      label: t('llmOps.providerManagement.sourceStatus.failed.label'),
       tone: 'danger',
-      hint: '需要检查价格地址或采集器'
+      hint: t('llmOps.providerManagement.sourceStatus.failed.hint')
     }
   }
   if (['running', 'pending', 'processing'].includes(latestRun?.status)) {
     return {
-      label: '同步中',
+      label: t('llmOps.providerManagement.sourceStatus.syncing.label'),
       tone: 'info',
-      hint: '请稍后刷新'
+      hint: t('llmOps.providerManagement.sourceStatus.syncing.hint')
     }
   }
   return {
-    label: '启用',
+    label: t('llmOps.providerManagement.sourceStatus.active.label'),
     tone: 'ok',
-    hint: '可参与采集和计算'
+    hint: t('llmOps.providerManagement.sourceStatus.active.hint')
   }
 }
 
@@ -625,8 +715,10 @@ function canManualEntrySource(source) {
 }
 
 function collectActionLabel(source) {
-  if (canCollectSource(source)) return '同步价格'
-  return '暂不支持'
+  if (canCollectSource(source)) {
+    return t('llmOps.providerManagement.actions.syncPrice')
+  }
+  return t('llmOps.providerManagement.actions.notSupported')
 }
 
 function collectModeLabel(source) {
@@ -634,15 +726,15 @@ function collectModeLabel(source) {
     if (isModelsDevSource(source)) {
       return 'models.dev'
     }
-    return '自动采集'
+    return t('llmOps.providerManagement.collectMode.autoCollect')
   }
   if (canManualEntrySource(source)) {
-    return '手工维护'
+    return t('llmOps.providerManagement.collectMode.manualMaintenance')
   }
   if (source.source_type === 'yunce') {
-    return '专用采集器'
+    return t('llmOps.providerManagement.collectMode.dedicatedCollector')
   }
-  return '未适配'
+  return t('llmOps.providerManagement.collectMode.pending')
 }
 
 function isModelsDevSource(source) {

--- a/frontend/src/components/llm-ops/ResalePublishingDrawer.vue
+++ b/frontend/src/components/llm-ops/ResalePublishingDrawer.vue
@@ -40,7 +40,9 @@
                       clip-rule="evenodd"
                     />
                   </svg>
-                  <span class="sr-only">返回</span>
+                  <span class="sr-only">
+                    {{ t('llmOps.publishingDrawer.back') }}
+                  </span>
                 </button>
                 <div class="min-w-0 flex-1">
                   <p
@@ -51,7 +53,7 @@
                   <h2
                     class="mt-0.5 truncate text-base font-bold text-slate-900"
                   >
-                    模型沉浸式上架工作台
+                    {{ t('llmOps.publishingDrawer.title') }}
                   </h2>
                 </div>
               </div>
@@ -62,7 +64,7 @@
                   :disabled="!canDraft || saving"
                   @click="handleSaveDraft"
                 >
-                  保存草稿
+                  {{ t('llmOps.publishingDrawer.saveDraft') }}
                 </button>
                 <button
                   type="button"
@@ -70,7 +72,11 @@
                   :disabled="!canPublish || saving"
                   @click="handlePublish"
                 >
-                  {{ saving ? '提交中…' : '提交上架' }}
+                  {{
+                    saving
+                      ? t('llmOps.publishingDrawer.submitting')
+                      : t('llmOps.publishingDrawer.submit')
+                  }}
                 </button>
               </div>
             </header>
@@ -105,6 +111,8 @@
 
 <script setup>
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
 import ResalePublishingWorkspace from '@/components/llm-ops/ResalePublishingWorkspace.vue'
 import { useToast } from '@/composables/useToast'
 
@@ -172,6 +180,7 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['update:open', 'saved', 'draft'])
+const { t } = useI18n()
 const { showError } = useToast()
 
 const workspaceRef = ref(null)
@@ -218,7 +227,7 @@ async function handleSaveDraft() {
     emit('draft', latestPayload.value)
     tryClose()
   } catch (error) {
-    showError(error?.message || '保存失败')
+    showError(error?.message || t('llmOps.publishingDrawer.saveFailed'))
   } finally {
     saving.value = false
   }
@@ -231,7 +240,7 @@ async function handlePublish() {
     emit('saved', latestPayload.value)
     tryClose()
   } catch (error) {
-    showError(error?.message || '提交失败')
+    showError(error?.message || t('llmOps.publishingDrawer.submitFailed'))
   } finally {
     saving.value = false
   }

--- a/frontend/src/components/llm-ops/ResalePublishingWorkspace.vue
+++ b/frontend/src/components/llm-ops/ResalePublishingWorkspace.vue
@@ -8,7 +8,7 @@
     <section class="workspace-section workspace-toolbar">
       <div class="workspace-filter-grid">
         <label class="filter-field">
-          <span>发布平台</span>
+          <span>{{ t('llmOps.publishingWorkspace.filters.platform') }}</span>
           <CompactSelect
             v-model="form.platformId"
             :options="platformSelectOptions"
@@ -18,7 +18,7 @@
           />
         </label>
         <label class="filter-field">
-          <span>元厂商</span>
+          <span>{{ t('llmOps.publishingWorkspace.filters.vendor') }}</span>
           <CompactSelect
             v-model="form.metaVendorId"
             :options="metaVendorSelectOptions"
@@ -30,7 +30,7 @@
           />
         </label>
         <label class="filter-field">
-          <span>元模型</span>
+          <span>{{ t('llmOps.publishingWorkspace.filters.metaModel') }}</span>
           <CompactSelect
             v-model="form.modelId"
             :options="baseModelSelectOptions"
@@ -42,7 +42,7 @@
           />
         </label>
         <label class="filter-field">
-          <span>供货渠道</span>
+          <span>{{ t('llmOps.publishingWorkspace.filters.supplier') }}</span>
           <CompactSelect
             v-model="form.supplierId"
             :disabled="!form.modelId"
@@ -55,13 +55,17 @@
       </div>
       <div class="pricing-context">
         <div class="pricing-segment">
-          <span class="pricing-segment-label">当前平台币种</span>
+          <span class="pricing-segment-label">
+            {{ t('llmOps.publishingWorkspace.context.platformCurrency') }}
+          </span>
           <strong class="pricing-segment-value">
             {{ platformCurrencyLabel }}
           </strong>
         </div>
         <div class="pricing-segment">
-          <span class="pricing-segment-label">汇率</span>
+          <span class="pricing-segment-label">
+            {{ t('llmOps.publishingWorkspace.context.exchangeRate') }}
+          </span>
           <strong class="pricing-segment-value">
             1 USD =
             {{ formatReadonlyNumber(globalPricing.exchangeRate, 4) }}
@@ -69,7 +73,13 @@
           </strong>
         </div>
         <div class="pricing-segment">
-          <span class="pricing-segment-label">{{ pointUnitLabel }}换算</span>
+          <span class="pricing-segment-label">
+            {{
+              t('llmOps.publishingWorkspace.context.pointConversion', {
+                point: pointUnitLabel
+              })
+            }}
+          </span>
           <strong class="pricing-segment-value">
             1 {{ platformCurrencyLabel }} =
             {{ formatReadonlyNumber(globalPricing.creditRatio, 2) }}
@@ -85,41 +95,59 @@
       >
         <h3 class="flex items-center gap-2 text-sm font-bold text-slate-900">
           <span class="inline-block h-2 w-2 rounded-full bg-agione-500" />
-          供应链路甄选
+          {{ t('llmOps.publishingWorkspace.supply.title') }}
         </h3>
         <div class="flex items-center gap-3 text-xs">
           <span
             v-if="!isSupplyChainExpanded"
             class="rounded bg-agione-50 px-2 py-1 font-semibold text-agione-700"
           >
-            已选 {{ selectedChainRows.length }} 条链路
+            {{
+              t('llmOps.publishingWorkspace.supply.selectedCount', {
+                count: selectedChainRows.length
+              })
+            }}
           </span>
-          <span v-else class="text-slate-500"
-            >共 {{ chainRows.length }} 条可用链路</span
-          >
+          <span v-else class="text-slate-500">
+            {{
+              t('llmOps.publishingWorkspace.supply.availableCount', {
+                count: chainRows.length
+              })
+            }}
+          </span>
           <button
             type="button"
             class="btn-secondary btn-action-view !px-2.5 !py-1.5 !text-xs"
             @click="isSupplyChainExpanded = !isSupplyChainExpanded"
           >
-            {{ isSupplyChainExpanded ? '收起' : '展开' }}
+            {{
+              isSupplyChainExpanded
+                ? t('llmOps.publishingWorkspace.supply.collapse')
+                : t('llmOps.publishingWorkspace.supply.expand')
+            }}
           </button>
         </div>
       </header>
 
       <div v-show="isSupplyChainExpanded">
         <div class="supply-grid supply-grid-header">
-          <div>商务及物理链路</div>
-          <div>成本</div>
-          <div>售价</div>
-          <div>最终 {{ pointUnitLabel }}</div>
+          <div>{{ t('llmOps.publishingWorkspace.supply.chain') }}</div>
+          <div>{{ t('llmOps.publishingWorkspace.pricing.cost') }}</div>
+          <div>{{ t('llmOps.publishingWorkspace.pricing.price') }}</div>
+          <div>
+            {{
+              t('llmOps.publishingWorkspace.pricing.finalPoint', {
+                point: pointUnitLabel
+              })
+            }}
+          </div>
         </div>
 
         <div
           v-if="!chainRows.length"
           class="bg-white p-8 text-center text-sm text-slate-500"
         >
-          当前元模型暂无可用供应链路
+          {{ t('llmOps.publishingWorkspace.supply.empty') }}
         </div>
 
         <div
@@ -132,7 +160,11 @@
             class="flex items-center gap-2 border-b border-slate-200 bg-slate-50 px-4 py-2 text-[13px] font-bold text-slate-700"
           >
             <span class="inline-block h-1.5 w-1.5 rounded-full bg-agione-500" />
-            供货渠道：{{ group.supplierName }}
+            {{
+              t('llmOps.publishingWorkspace.supply.supplierPrefix', {
+                name: group.supplierName
+              })
+            }}
           </div>
           <div
             v-for="srcGroup in group.sources"
@@ -143,7 +175,11 @@
               class="flex items-center gap-2 bg-slate-50/60 px-4 py-1.5 pl-10 text-[12px] font-medium text-slate-500"
             >
               <span class="inline-block h-1 w-1 rounded-full bg-slate-400" />
-              供应源：{{ srcGroup.source }}
+              {{
+                t('llmOps.publishingWorkspace.supply.sourcePrefix', {
+                  name: srcGroup.source
+                })
+              }}
             </div>
             <div
               v-for="row in srcGroup.models"
@@ -171,7 +207,7 @@
                   v-if="row.isLowest"
                   class="rounded-full border border-emerald-100 bg-emerald-50 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-700"
                 >
-                  最低
+                  {{ t('llmOps.publishingWorkspace.supply.lowest') }}
                 </span>
               </label>
 
@@ -191,7 +227,9 @@
               </div>
 
               <div class="supply-metric-column">
-                <span class="text-slate-500 lg:hidden">售价</span>
+                <span class="text-slate-500 lg:hidden">
+                  {{ t('llmOps.publishingWorkspace.pricing.price') }}
+                </span>
                 <template v-if="row.selected">
                   <div
                     v-for="dim in priceDimensions(row)"
@@ -244,7 +282,7 @@
       <aside class="workspace-section performance-sidebar overflow-hidden p-0">
         <header class="performance-sidebar-header">
           <span class="performance-sidebar-dot" />
-          <h3>链路性能全景对标</h3>
+          <h3>{{ t('llmOps.publishingWorkspace.performance.title') }}</h3>
         </header>
         <div class="performance-sidebar-body">
           <section
@@ -276,7 +314,7 @@
                 </div>
               </div>
               <p v-if="!perfCompareRows.length" class="perf-empty">
-                暂无对比数据
+                {{ t('llmOps.publishingWorkspace.performance.empty') }}
               </p>
             </div>
           </section>
@@ -284,7 +322,7 @@
         <button
           type="button"
           class="performance-sidebar-resize"
-          aria-label="调整链路性能全景对标宽度"
+          :aria-label="t('llmOps.publishingWorkspace.performance.resize')"
           @pointerdown="startSidebarResize"
         />
       </aside>
@@ -319,15 +357,15 @@
             <span
               v-if="row.isLowest"
               class="rounded-full border border-emerald-100 bg-emerald-50 px-2 py-0.5 text-[10px] font-semibold text-emerald-700"
-              >最低采购链路</span
-            >
+              >{{ t('llmOps.publishingWorkspace.supply.lowestProcurement') }}
+            </span>
           </header>
           <div class="space-y-6 p-5">
             <div class="unified-margin-row">
               <div>
                 <div class="flex flex-wrap items-center gap-2">
                   <p class="text-[11px] font-semibold text-slate-500">
-                    统一利润期望
+                    {{ t('llmOps.publishingWorkspace.margin.title') }}
                   </p>
                   <span
                     v-if="selectedPlatformAutoApproveLimit !== null"
@@ -342,14 +380,14 @@
                   </span>
                 </div>
                 <p class="mt-0.5 text-[11px] text-slate-400">
-                  Input / Output / Cache 按同一利润率推导各自售价。
+                  {{ t('llmOps.publishingWorkspace.margin.description') }}
                 </p>
               </div>
               <div class="unified-margin-input">
                 <input
                   :value="row.margin"
                   type="number"
-                  aria-label="统一利润率"
+                  :aria-label="t('llmOps.publishingWorkspace.margin.input')"
                   name="unified_margin_rate"
                   step="0.1"
                   min="0"
@@ -362,8 +400,12 @@
 
             <div class="pricing-matrix">
               <div class="pricing-matrix-head pricing-matrix-label" />
-              <div class="pricing-matrix-head">成本</div>
-              <div class="pricing-matrix-head">售价</div>
+              <div class="pricing-matrix-head">
+                {{ t('llmOps.publishingWorkspace.pricing.cost') }}
+              </div>
+              <div class="pricing-matrix-head">
+                {{ t('llmOps.publishingWorkspace.pricing.price') }}
+              </div>
               <div class="pricing-matrix-head">{{ pointUnitLabel }}</div>
               <template
                 v-for="dimension in priceDimensions(row)"
@@ -373,7 +415,9 @@
                   {{ dimension.label }}
                 </div>
                 <div class="pricing-matrix-card cost-formula-cell">
-                  <p class="pricing-card-caption">成本价</p>
+                  <p class="pricing-card-caption">
+                    {{ t('llmOps.publishingWorkspace.pricing.costPrice') }}
+                  </p>
                   <p class="font-mono text-[13px] font-bold text-slate-900">
                     {{ currencySymbol }}{{ dimension.costText }}
                   </p>
@@ -387,7 +431,7 @@
                 <div class="pricing-matrix-card terminal-price-card">
                   <div class="terminal-price-main">
                     <p class="pricing-card-caption text-emerald-600">
-                      终端售卖价
+                      {{ t('llmOps.publishingWorkspace.pricing.retailPrice') }}
                     </p>
                     <div class="terminal-price-control">
                       <span>{{ currencySymbol }}</span>
@@ -412,11 +456,14 @@
                       "
                       :title="referencePriceTitle(dimension)"
                     >
-                      下限 {{ currencySymbol
-                      }}{{ dimension.referencePriceText }}
+                      {{
+                        t('llmOps.publishingWorkspace.pricing.floor', {
+                          value: currencySymbol + dimension.referencePriceText
+                        })
+                      }}
                     </p>
                     <p>
-                      均价
+                      {{ t('llmOps.publishingWorkspace.pricing.average') }}
                       <strong>{{
                         marketAverageText(dimension.marketAverage)
                       }}</strong>
@@ -455,7 +502,13 @@
                   </div>
                 </div>
                 <div class="pricing-matrix-card final-credit-card">
-                  <p class="pricing-card-caption">最终 {{ pointUnitLabel }}</p>
+                  <p class="pricing-card-caption">
+                    {{
+                      t('llmOps.publishingWorkspace.pricing.finalPoint', {
+                        point: pointUnitLabel
+                      })
+                    }}
+                  </p>
                   <p class="font-mono text-[13px] font-bold text-agione-700">
                     {{ formatCredit(dimension.priceRaw) }}
                   </p>
@@ -470,7 +523,11 @@
                 :refs="marketMarginRefsFor(row)"
                 :lower-tooltip="marginPolicyTooltip('min')"
                 :upper-tooltip="marginPolicyTooltip('max')"
-                :label="`统一利润率 ${formatPercent(row.margin)}`"
+                :label="
+                  t('llmOps.publishingWorkspace.margin.axisLabel', {
+                    value: formatPercent(row.margin)
+                  })
+                "
                 value-prefix=""
                 value-suffix="%"
                 :digits="1"
@@ -486,13 +543,15 @@
       v-else-if="form.modelId"
       class="rounded-lg border border-dashed border-slate-200 bg-slate-50 p-8 text-center text-sm text-slate-500"
     >
-      请在链路甄选面板中勾选至少一条供应链路，继续定价。
+      {{ t('llmOps.publishingWorkspace.supply.selectRequired') }}
     </div>
   </div>
 </template>
 
 <script setup>
 import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
 import BulletChart from '@/components/llm-ops/BulletChart.vue'
 import CompactSelect from '@/components/llm-ops/CompactSelect.vue'
 import {
@@ -563,6 +622,7 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['change'])
+const { t } = useI18n()
 
 const form = ref({
   platformId: '',
@@ -694,7 +754,10 @@ const selectedMetaModelProcurements = computed(() => {
 const platformSelectOptions = computed(() =>
   (props.platforms || []).map((item) => ({
     value: String(item.id),
-    label: item.name || item.code || `平台 ${item.id}`
+    label:
+      item.name ||
+      item.code ||
+      t('llmOps.publishingWorkspace.fallback.platform', { id: item.id })
   }))
 )
 
@@ -708,7 +771,10 @@ const metaVendorOptions = computed(() => {
     if (map.has(key)) return
     map.set(key, {
       id,
-      name: model.effective_vendor_name || model.vendor_name || '未归类',
+      name:
+        model.effective_vendor_name ||
+        model.vendor_name ||
+        t('llmOps.publishingWorkspace.fallback.uncategorized'),
       code: model.effective_vendor_code || ''
     })
   })
@@ -718,7 +784,7 @@ const metaVendorOptions = computed(() => {
 })
 
 const metaVendorSelectOptions = computed(() => [
-  { value: '', label: '全部' },
+  { value: '', label: t('llmOps.publishingWorkspace.filters.all') },
   ...metaVendorOptions.value.map((item) => ({
     value: String(item.id),
     label: item.name,
@@ -745,7 +811,10 @@ const baseModelOptions = computed(() => {
 })
 
 const baseModelSelectOptions = computed(() => [
-  { value: '', label: '选择元模型' },
+  {
+    value: '',
+    label: t('llmOps.publishingWorkspace.filters.selectMetaModel')
+  },
   ...baseModelOptions.value.map((item) => ({
     value: String(item.id),
     label: item.name,
@@ -776,10 +845,19 @@ const supplierOptions = computed(() => {
 
 const supplierSelectOptions = computed(() => {
   if (!form.value.modelId) {
-    return [{ value: '', label: '先选择元模型', disabled: true }]
+    return [
+      {
+        value: '',
+        label: t('llmOps.publishingWorkspace.filters.selectMetaModelFirst'),
+        disabled: true
+      }
+    ]
   }
   return [
-    { value: '', label: '全部支持渠道' },
+    {
+      value: '',
+      label: t('llmOps.publishingWorkspace.filters.allSupportedChannels')
+    },
     ...supplierOptions.value.map((item) => ({
       value: String(item.id),
       label: item.name
@@ -792,7 +870,9 @@ const supportedSupplierIds = computed(
 )
 
 const pointUnitLabel = computed(
-  () => props.pointConversion?.point_name || '积分'
+  () =>
+    props.pointConversion?.point_name ||
+    t('llmOps.publishingWorkspace.fallback.points')
 )
 
 const selectedPlatform = computed(() => {
@@ -805,7 +885,9 @@ const selectedPlatform = computed(() => {
 })
 
 const selectedPlatformLabel = computed(
-  () => selectedPlatform.value?.name || '当前平台'
+  () =>
+    selectedPlatform.value?.name ||
+    t('llmOps.publishingWorkspace.fallback.currentPlatform')
 )
 
 const platformCurrencyLabel = computed(() =>
@@ -1045,7 +1127,9 @@ const chainRows = computed(() => {
         metaVendorId: metaVendor.id,
         metaVendorName: metaVendor.name || metaVendor.code,
         metaVendorCode: metaVendor.code,
-        provider: metaVendor.name || '未归类',
+        provider:
+          metaVendor.name ||
+          t('llmOps.publishingWorkspace.fallback.uncategorized'),
         modelId: procurement.model_id,
         skuModelName:
           skuModel?.name || procurement.model_name || procurement.model_code,
@@ -1408,14 +1492,12 @@ function referencePriceText(value) {
 }
 
 function referencePriceTitle(dimension) {
-  return [
-    '最低参考定价 = 成本价 × (1 + 服务费率 + 平台抽佣比例)',
-    `当前服务费率 ${formatRatioPercent(selectedPlatformServiceFeeRate.value)}`,
-    `当前平台抽佣比例 ${formatRatioPercent(selectedPlatformFeeRate.value)}`,
-    `参考价 ${currencySymbol.value}${referencePriceText(
-      dimension.referencePriceRaw
-    )}`
-  ].join('；')
+  return t('llmOps.publishingWorkspace.pricing.referenceTitle', {
+    serviceFee: formatRatioPercent(selectedPlatformServiceFeeRate.value),
+    commission: formatRatioPercent(selectedPlatformFeeRate.value),
+    reference:
+      currencySymbol.value + referencePriceText(dimension.referencePriceRaw)
+  })
 }
 
 function isBelowReferencePrice(price, referencePrice) {
@@ -1429,28 +1511,34 @@ function isBelowReferencePrice(price, referencePrice) {
 
 function autoApproveStatus(margin) {
   if (selectedPlatformAutoApproveLimit.value === null) {
-    return { ok: true, label: '未配置免审利润率' }
+    return {
+      ok: true,
+      label: t('llmOps.publishingWorkspace.margin.noAutoApprove')
+    }
   }
   const isAllowed = isMarginAutoApprovable(
     margin,
     selectedPlatformAutoApproveLimit.value
   )
   if (isAllowed === null) {
-    return { ok: true, label: '免审阈值未生效' }
+    return {
+      ok: true,
+      label: t('llmOps.publishingWorkspace.margin.autoApproveInactive')
+    }
   }
   if (isAllowed) {
     return {
       ok: true,
-      label: `免审范围内（<= ${formatPercent(
-        selectedPlatformAutoApproveLimit.value
-      )}）`
+      label: t('llmOps.publishingWorkspace.margin.withinAutoApprove', {
+        value: formatPercent(selectedPlatformAutoApproveLimit.value)
+      })
     }
   }
   return {
     ok: false,
-    label: `超出免审上限（> ${formatPercent(
-      selectedPlatformAutoApproveLimit.value
-    )}）`
+    label: t('llmOps.publishingWorkspace.margin.aboveAutoApprove', {
+      value: formatPercent(selectedPlatformAutoApproveLimit.value)
+    })
   }
 }
 
@@ -1478,7 +1566,9 @@ function costFormulaText(row, key) {
 }
 
 function costFormulaTitle(row, key) {
-  return `成本价 = 供应商成本价 × 折扣；${costFormulaText(row, key)}`
+  return t('llmOps.publishingWorkspace.pricing.costFormulaTitle', {
+    formula: costFormulaText(row, key)
+  })
 }
 
 function marketAverageText(avg) {
@@ -1490,12 +1580,22 @@ function marketAverageText(avg) {
 function priceDiffText(price, avg) {
   const p = Number(price)
   const a = Number(avg)
-  if (!Number.isFinite(p) || !Number.isFinite(a) || a <= 0) return '暂无对账'
+  if (!Number.isFinite(p) || !Number.isFinite(a) || a <= 0) {
+    return t('llmOps.publishingWorkspace.pricing.noBenchmark')
+  }
   const diff = p - a
   const pct = Math.abs((diff / a) * 100).toFixed(1)
-  if (diff < -0.00001) return `↓ 低 ${pct}%`
-  if (diff > 0.00001) return `↑ 高 ${pct}%`
-  return '- 持平'
+  if (diff < -0.00001) {
+    return t('llmOps.publishingWorkspace.pricing.lowerThanAverage', {
+      pct
+    })
+  }
+  if (diff > 0.00001) {
+    return t('llmOps.publishingWorkspace.pricing.higherThanAverage', {
+      pct
+    })
+  }
+  return t('llmOps.publishingWorkspace.pricing.sameAsAverage')
 }
 
 function priceDiffAmountText(price, avg) {
@@ -1615,7 +1715,7 @@ function marketMarginRefsFor(row) {
     margins.reduce((total, value) => total + value, 0) / margins.length
   return [
     {
-      source: '市场均价',
+      source: t('llmOps.publishingWorkspace.pricing.marketAverage'),
       price: Number(average.toFixed(2))
     }
   ]
@@ -1646,26 +1746,31 @@ function marginPolicyTooltip(type) {
   const floor = referenceMarginFloor()
   const approveLimit = Number(selectedPlatformAutoApproveLimit.value)
   return {
-    title: isMin ? '最低利润率下限' : '免审利润率上限',
+    title: isMin
+      ? t('llmOps.publishingWorkspace.margin.minTitle')
+      : t('llmOps.publishingWorkspace.margin.autoApproveTitle'),
     source: isMin
-      ? '成本价 × (1 + 服务费率 + 平台抽佣比例)'
-      : '平台配置的自动免审阈值，仅影响审批判断',
+      ? t('llmOps.publishingWorkspace.margin.minSource')
+      : t('llmOps.publishingWorkspace.margin.autoApproveSource'),
     rows: isMin
       ? [
           {
-            label: '平台下限',
+            label: t('llmOps.publishingWorkspace.margin.platformFloor'),
             value: formatPercent(floor),
-            source: `服务费 ${formatRatioPercent(
-              selectedPlatformServiceFeeRate.value
-            )} + 抽佣 ${formatRatioPercent(selectedPlatformFeeRate.value)}`
+            source: t('llmOps.publishingWorkspace.margin.feeBreakdown', {
+              serviceFee: formatRatioPercent(
+                selectedPlatformServiceFeeRate.value
+              ),
+              commission: formatRatioPercent(selectedPlatformFeeRate.value)
+            })
           }
         ]
       : [
           {
-            label: '免审上限',
+            label: t('llmOps.publishingWorkspace.margin.autoApproveLimit'),
             value: Number.isFinite(approveLimit)
               ? formatPercent(approveLimit)
-              : '未配置',
+              : t('llmOps.publishingWorkspace.fallback.notConfigured'),
             source: selectedPlatformLabel.value
           }
         ]
@@ -1685,7 +1790,9 @@ const perfCompareRows = computed(() =>
 function performanceRowName(row) {
   const channelName = row.channelName || row.supplierName || row.source
   const modelName = row.skuModelName || row.modelName
-  if (!channelName) return modelName || '供货链路'
+  if (!channelName) {
+    return modelName || t('llmOps.publishingWorkspace.supply.chainFallback')
+  }
   if (!modelName || modelName === row.modelName) return channelName
   return `${channelName} · ${modelName}`
 }
@@ -1697,21 +1804,21 @@ const perfMetrics = computed(() => {
   return [
     {
       key: 'rpm',
-      label: '并发请求速率 (RPM)',
+      label: t('llmOps.publishingWorkspace.performance.rpm'),
       max: rpmMax,
       format: (v) => formatPerformanceValue(v, 'K', 1000),
       barClass: () => 'bg-violet-500'
     },
     {
       key: 'tpm',
-      label: 'Token 吞吐量 (TPM)',
+      label: t('llmOps.publishingWorkspace.performance.tpm'),
       max: tpmMax,
       format: (v) => formatPerformanceValue(v, 'M', 1000000),
       barClass: () => 'bg-emerald-500'
     },
     {
       key: 'latency',
-      label: '首字延迟 (Latency · 越低越好)',
+      label: t('llmOps.publishingWorkspace.performance.latency'),
       max: latMax,
       format: (v) => (Number.isFinite(v) ? `${v}ms` : '-'),
       barClass: () => 'bg-amber-500'

--- a/frontend/src/components/llm-ops/SourcePriceDrawer.vue
+++ b/frontend/src/components/llm-ops/SourcePriceDrawer.vue
@@ -31,14 +31,18 @@
               :disabled="deleting"
               @click="$emit('delete', source)"
             >
-              {{ deleting ? '删除中' : '删除' }}
+              {{
+                deleting
+                  ? t('llmOps.sourcePriceDrawer.actions.deleting')
+                  : t('llmOps.sourcePriceDrawer.actions.delete')
+              }}
             </button>
             <button
               type="button"
               class="btn-secondary btn-action-cancel"
               @click="$emit('close')"
             >
-              关闭
+              {{ t('llmOps.sourcePriceDrawer.actions.close') }}
             </button>
           </div>
         </div>
@@ -47,34 +51,40 @@
       <div class="space-y-5 px-5 py-5">
         <div class="grid gap-3 md:grid-cols-4">
           <div class="summary-card">
-            <p>覆盖元模型</p>
+            <p>{{ t('llmOps.sourcePriceDrawer.summary.metaModels') }}</p>
             <strong>{{ modelRows.length }}</strong>
           </div>
           <div class="summary-card">
-            <p>当前价格项</p>
+            <p>{{ t('llmOps.sourcePriceDrawer.summary.currentItems') }}</p>
             <strong>{{ sourceItemRows.length }}</strong>
           </div>
           <div class="summary-card">
-            <p>默认币种</p>
+            <p>{{ t('llmOps.sourcePriceDrawer.summary.currency') }}</p>
             <strong>{{ source.currency || '-' }}</strong>
           </div>
           <div class="summary-card">
-            <p>状态</p>
-            <strong>{{ source.is_enabled ? '启用' : '停用' }}</strong>
+            <p>{{ t('llmOps.sourcePriceDrawer.summary.status') }}</p>
+            <strong>
+              {{
+                source.is_enabled
+                  ? t('llmOps.sourcePriceDrawer.status.enabled')
+                  : t('llmOps.sourcePriceDrawer.status.disabled')
+              }}
+            </strong>
           </div>
         </div>
 
         <div class="source-info-grid">
           <div>
-            <span>来源归属</span>
+            <span>{{ t('llmOps.sourcePriceDrawer.info.owner') }}</span>
             <strong>{{ relationName }}</strong>
           </div>
           <div>
-            <span>更新方式</span>
+            <span>{{ t('llmOps.sourcePriceDrawer.info.updateMode') }}</span>
             <strong>{{ sourceConfigSummary }}</strong>
           </div>
           <div>
-            <span>价格地址</span>
+            <span>{{ t('llmOps.sourcePriceDrawer.info.priceUrl') }}</span>
             <a
               v-if="source.endpoint_url"
               class="source-link"
@@ -92,15 +102,14 @@
         <div class="panel overflow-hidden p-0">
           <div class="table-toolbar">
             <div>
-              <h3 class="panel-title">供货商下的元模型价格</h3>
-              <p class="mt-1 text-xs text-slate-500">
-                按元模型直接展示 Input、Output、Cache 三项核心价格。
-              </p>
+              <h3 class="panel-title">
+                {{ t('llmOps.sourcePriceDrawer.title') }}
+              </h3>
             </div>
             <input
               v-model="search"
               class="field-input w-full md:w-72"
-              placeholder="搜索元模型、厂商或 code"
+              :placeholder="t('llmOps.sourcePriceDrawer.searchPlaceholder')"
             />
           </div>
           <div class="overflow-x-auto">
@@ -112,9 +121,13 @@
               </colgroup>
               <thead>
                 <tr>
-                  <th class="table-head">元模型</th>
+                  <th class="table-head">
+                    {{ t('llmOps.sourcePriceDrawer.table.metaModel') }}
+                  </th>
                   <th class="table-head">{{ priceHeaderLabel }}</th>
-                  <th class="table-head">最近更新</th>
+                  <th class="table-head">
+                    {{ t('llmOps.sourcePriceDrawer.table.updatedAt') }}
+                  </th>
                 </tr>
               </thead>
               <tbody>
@@ -146,7 +159,7 @@
                         </div>
                       </div>
                       <span v-else class="text-xs text-slate-400">
-                        暂无价格
+                        {{ t('llmOps.sourcePriceDrawer.empty.noPrice') }}
                       </span>
                     </td>
                     <td class="table-cell">
@@ -156,7 +169,7 @@
                 </template>
                 <tr v-if="!filteredModelRows.length">
                   <td class="table-cell text-slate-500" colspan="3">
-                    当前价格源还没有模型价格记录。
+                    {{ t('llmOps.sourcePriceDrawer.empty.noRows') }}
                   </td>
                 </tr>
               </tbody>
@@ -170,6 +183,7 @@
 
 <script setup>
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 defineEmits(['close', 'delete', 'refresh'])
 
@@ -192,6 +206,7 @@ const props = defineProps({
   }
 })
 
+const { t, locale } = useI18n()
 const search = ref('')
 
 const tokenPriceDimensions = [
@@ -263,7 +278,7 @@ const filteredModelRows = computed(() => {
 const relationName = computed(() => {
   if (props.source?.provider_name) return props.source.provider_name
   if (props.source?.channel_name) return props.source.channel_name
-  return '未绑定'
+  return t('llmOps.sourcePriceDrawer.fallback.unbound')
 })
 
 const sourceConfigSummary = computed(() =>
@@ -287,7 +302,9 @@ const sourceAddressLabel = computed(() => {
   }
 })
 
-const priceHeaderLabel = computed(() => '价格（原始币种 / 1M tokens）')
+const priceHeaderLabel = computed(() =>
+  t('llmOps.sourcePriceDrawer.table.price')
+)
 
 function buildRawItemRow(item) {
   const model = modelMap.value.get(String(item.model)) || {}
@@ -298,14 +315,16 @@ function buildRawItemRow(item) {
     meta_model_id: item.meta_model || model.meta_model || '',
     raw: item,
     meta_model_name:
-      item.meta_model_name || model.meta_model_name || '未知元模型',
+      item.meta_model_name ||
+      model.meta_model_name ||
+      t('llmOps.sourcePriceDrawer.fallback.unknownMetaModel'),
     meta_model_code: item.meta_model_code || model.meta_model_code || '-',
     provider_name:
       item.meta_model_vendor_name ||
       model.meta_model_vendor_name ||
       item.provider_name ||
       model.provider_name ||
-      '未绑定厂商',
+      t('llmOps.sourcePriceDrawer.fallback.unboundProvider'),
     sku_name: item.model_name || model.name || '',
     sku_code: item.model_code || model.code || '',
     modality_label: modalityLabel(model.modality),
@@ -355,10 +374,15 @@ function buildModelRow(key, rows) {
 function buildFallbackModelRow(model, key) {
   return {
     key,
-    meta_model_name: model.meta_model_name || model.name || '未知元模型',
+    meta_model_name:
+      model.meta_model_name ||
+      model.name ||
+      t('llmOps.sourcePriceDrawer.fallback.unknownMetaModel'),
     meta_model_code: model.meta_model_code || model.code || '-',
     provider_name:
-      model.meta_model_vendor_name || model.provider_name || '未绑定厂商',
+      model.meta_model_vendor_name ||
+      model.provider_name ||
+      t('llmOps.sourcePriceDrawer.fallback.unboundProvider'),
     modality_label: modalityLabel(model.modality),
     token_price_rows: tokenPriceRowsFromModel(model),
     price_count: 0,
@@ -461,45 +485,47 @@ function hasValue(value) {
 
 function dimensionLabel(dimension) {
   const labels = {
-    text_input: '文本输入',
-    text_output: '文本输出',
-    cache_input: '缓存输入',
-    image_input: '图片输入',
-    image_output: '图片输出',
-    audio_input: '音频输入',
-    audio_output: '音频输出',
-    video_input: '视频输入',
-    video_output: '视频输出'
+    text_input: t('llmOps.sourcePriceDrawer.dimensions.textInput'),
+    text_output: t('llmOps.sourcePriceDrawer.dimensions.textOutput'),
+    cache_input: t('llmOps.sourcePriceDrawer.dimensions.cacheInput'),
+    image_input: t('llmOps.sourcePriceDrawer.dimensions.imageInput'),
+    image_output: t('llmOps.sourcePriceDrawer.dimensions.imageOutput'),
+    audio_input: t('llmOps.sourcePriceDrawer.dimensions.audioInput'),
+    audio_output: t('llmOps.sourcePriceDrawer.dimensions.audioOutput'),
+    video_input: t('llmOps.sourcePriceDrawer.dimensions.videoInput'),
+    video_output: t('llmOps.sourcePriceDrawer.dimensions.videoOutput')
   }
   return labels[dimension] || dimension || '-'
 }
 
 function billingUnitLabel(unit) {
   const labels = {
-    per_1m_tokens: '/ 百万 tokens',
-    per_image: '/ 张',
-    per_second: '/ 秒',
-    per_generation: '/ 次'
+    per_1m_tokens: t('llmOps.sourcePriceDrawer.billingUnits.per1mTokens'),
+    per_image: t('llmOps.sourcePriceDrawer.billingUnits.perImage'),
+    per_second: t('llmOps.sourcePriceDrawer.billingUnits.perSecond'),
+    per_generation: t('llmOps.sourcePriceDrawer.billingUnits.perGeneration')
   }
   return labels[unit] || ''
 }
 
 function modalityLabel(modality) {
   const labels = {
-    text: '文本',
-    audio: '音频',
-    video: '视频',
-    multimodal: '多模态'
+    text: t('llmOps.sourcePriceDrawer.modalities.text'),
+    audio: t('llmOps.sourcePriceDrawer.modalities.audio'),
+    video: t('llmOps.sourcePriceDrawer.modalities.video'),
+    multimodal: t('llmOps.sourcePriceDrawer.modalities.multimodal')
   }
   return labels[modality] || modality || ''
 }
 
 function sourceCategoryLabel(category) {
   const labels = {
-    official_provider: '原厂价格',
-    supplier: '供货商价格',
-    manual: '人工录入',
-    unknown: '其他'
+    official_provider: t(
+      'llmOps.sourcePriceDrawer.categories.officialProvider'
+    ),
+    supplier: t('llmOps.sourcePriceDrawer.categories.supplier'),
+    manual: t('llmOps.sourcePriceDrawer.categories.manual'),
+    unknown: t('llmOps.sourcePriceDrawer.categories.unknown')
   }
   return labels[category] || labels.unknown
 }
@@ -513,18 +539,26 @@ function businessSourceCategory(source) {
 function sourceModeLabel(source) {
   const category = source?.source_category || ''
   if (String(source?.endpoint_url || '').includes('models.dev/api.json')) {
-    return '聚合同步'
+    return t('llmOps.sourcePriceDrawer.sourceMode.aggregateSync')
   }
-  if (category === 'official_provider') return '自动采集'
-  if (category === 'supplier') return '供货商维护'
-  if (category === 'manual') return '手动维护'
-  if (source?.source_type === 'yunce') return '专用采集'
-  return '待适配'
+  if (category === 'official_provider') {
+    return t('llmOps.sourcePriceDrawer.sourceMode.autoCollect')
+  }
+  if (category === 'supplier') {
+    return t('llmOps.sourcePriceDrawer.sourceMode.supplierMaintenance')
+  }
+  if (category === 'manual') {
+    return t('llmOps.sourcePriceDrawer.sourceMode.manualMaintenance')
+  }
+  if (source?.source_type === 'yunce') {
+    return t('llmOps.sourcePriceDrawer.sourceMode.dedicatedCollect')
+  }
+  return t('llmOps.sourcePriceDrawer.sourceMode.pending')
 }
 
 function formatDateTime(value) {
   if (!value) return '-'
-  return new Intl.DateTimeFormat('zh-CN', {
+  return new Intl.DateTimeFormat(locale.value, {
     month: '2-digit',
     day: '2-digit',
     hour: '2-digit',

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -897,6 +897,909 @@
       "noChangesToSave": "No changes need to be saved",
       "draftsSaved": "Saved {count} drafts",
       "saveFailed": "Save failed"
+    },
+    "publishingDrawer": {
+      "back": "Back",
+      "title": "Immersive Model Publishing Workspace",
+      "saveDraft": "Save draft",
+      "submitting": "Submitting…",
+      "submit": "Submit listing",
+      "saveFailed": "Save failed",
+      "submitFailed": "Submit failed"
+    },
+    "publishingWorkspace": {
+      "filters": {
+        "platform": "Publishing platform",
+        "vendor": "Meta vendor",
+        "metaModel": "Meta model",
+        "supplier": "Supplier channel",
+        "all": "All",
+        "selectMetaModel": "Select meta model",
+        "selectMetaModelFirst": "Select a meta model first",
+        "allSupportedChannels": "All supported channels"
+      },
+      "context": {
+        "platformCurrency": "Platform currency",
+        "exchangeRate": "Exchange rate",
+        "pointConversion": "{point} conversion"
+      },
+      "supply": {
+        "title": "Supply Chain Selection",
+        "selectedCount": "{count} selected links",
+        "availableCount": "{count} available links",
+        "collapse": "Collapse",
+        "expand": "Expand",
+        "chain": "Commercial and physical link",
+        "empty": "No available supply links for this meta model.",
+        "supplierPrefix": "Supplier channel: {name}",
+        "sourcePrefix": "Supply source: {name}",
+        "lowest": "Lowest",
+        "lowestProcurement": "Lowest procurement link",
+        "selectRequired": "Select at least one supply link in the selection panel to continue pricing.",
+        "chainFallback": "Supply link"
+      },
+      "pricing": {
+        "cost": "Cost",
+        "price": "Price",
+        "finalPoint": "Final {point}",
+        "costPrice": "Cost price",
+        "retailPrice": "Retail price",
+        "floor": "Floor {value}",
+        "average": "Average",
+        "referenceTitle": "Minimum reference price = cost price × (1 + service fee rate + platform commission rate); current service fee {serviceFee}; current platform commission {commission}; reference price {reference}",
+        "costFormulaTitle": "Cost price = supplier cost price × discount; {formula}",
+        "noBenchmark": "No benchmark",
+        "lowerThanAverage": "↓ {pct}% lower",
+        "higherThanAverage": "↑ {pct}% higher",
+        "sameAsAverage": "- Flat",
+        "marketAverage": "Market average"
+      },
+      "performance": {
+        "title": "Link Performance Benchmark",
+        "empty": "No comparison data",
+        "resize": "Resize link performance benchmark width",
+        "rpm": "Request rate (RPM)",
+        "tpm": "Token throughput (TPM)",
+        "latency": "First-token latency (lower is better)"
+      },
+      "margin": {
+        "title": "Unified Margin Target",
+        "description": "Input, Output, and Cache prices are derived from the same margin rate.",
+        "input": "Unified margin rate",
+        "axisLabel": "Unified margin {value}",
+        "noAutoApprove": "No auto-approval margin configured",
+        "autoApproveInactive": "Auto-approval threshold inactive",
+        "withinAutoApprove": "Within auto-approval range (<= {value})",
+        "aboveAutoApprove": "Above auto-approval limit (> {value})",
+        "minTitle": "Minimum margin floor",
+        "autoApproveTitle": "Auto-approval margin limit",
+        "minSource": "Cost price × (1 + service fee rate + platform commission rate)",
+        "autoApproveSource": "Auto-approval threshold from platform settings; affects approval only",
+        "platformFloor": "Platform floor",
+        "feeBreakdown": "Service fee {serviceFee} + commission {commission}",
+        "autoApproveLimit": "Auto-approval limit"
+      },
+      "fallback": {
+        "platform": "Platform {id}",
+        "uncategorized": "Uncategorized",
+        "points": "points",
+        "currentPlatform": "Current platform",
+        "notConfigured": "Not configured"
+      }
+    },
+    "providerManagement": {
+      "title": "Supplier Price Sources",
+      "modelsCount": "{count} meta models",
+      "empty": "No supplier price sources match the current filters.",
+      "actions": {
+        "bulkImport": "Bulk import",
+        "createSource": "New price source",
+        "delete": "Delete",
+        "deleting": "Deleting",
+        "edit": "Edit",
+        "manualPricing": "Manual pricing",
+        "notSupported": "Not supported",
+        "submitting": "Submitting",
+        "syncPrice": "Sync prices",
+        "viewModels": "View meta models"
+      },
+      "filters": {
+        "activeOnly": "Active only",
+        "allStatuses": "All statuses",
+        "allTypes": "All types",
+        "inactiveOnly": "Inactive only",
+        "searchPlaceholder": "Search supplier, price source, provider, or URL"
+      },
+      "table": {
+        "actions": "Actions",
+        "metaModels": "Linked meta models",
+        "source": "Supplier / price source",
+        "status": "Status",
+        "type": "Type"
+      },
+      "metrics": {
+        "metaModels": {
+          "hint": "At least one current price is linked",
+          "label": "Covered meta models"
+        },
+        "official": {
+          "hint": "Published directly by meta model providers",
+          "label": "Official sources"
+        },
+        "sources": {
+          "hint": "Supplier and official price catalogs",
+          "label": "Price sources"
+        },
+        "supplierManual": {
+          "hint": "Supplier {supplier} · manual {manual}",
+          "label": "Supplier / manual"
+        }
+      },
+      "category": {
+        "manual": "Manual",
+        "officialProvider": "Official",
+        "supplier": "Supplier",
+        "unknown": "Other"
+      },
+      "relation": {
+        "forwardingChannel": "Forwarding channel",
+        "metaProvider": "Meta model provider",
+        "needsOwner": "Ownership needs completion",
+        "unbound": "Unbound source"
+      },
+      "sourceMode": {
+        "aggregateSync": "Aggregate sync",
+        "autoCollect": "Auto collect",
+        "custom": "Custom",
+        "dedicatedCollect": "Dedicated collection",
+        "manualMaintenance": "Manual maintenance",
+        "pending": "Pending adapter",
+        "supplierMaintenance": "Supplier maintained"
+      },
+      "sourceStatus": {
+        "active": {
+          "hint": "Participates in collection and calculation",
+          "label": "Active"
+        },
+        "failed": {
+          "hint": "Check the price URL or collector",
+          "label": "Collection failed"
+        },
+        "inactive": {
+          "hint": "Does not participate in collection",
+          "label": "Inactive"
+        },
+        "manual": {
+          "hint": "Updated through manual entry or Excel import",
+          "label": "Manual maintenance"
+        },
+        "pending": {
+          "label": "Pending adapter"
+        },
+        "syncing": {
+          "hint": "Refresh again later",
+          "label": "Syncing"
+        }
+      },
+      "collectMode": {
+        "autoCollect": "Auto collect",
+        "dedicatedCollector": "Dedicated collector",
+        "manualMaintenance": "Manual maintenance",
+        "pending": "Not adapted"
+      },
+      "confirm": {
+        "deleteSource": "Delete model price source \"{name}\"?\n\nThis removes the price source and its collection records. Linked models or channels will lose this price source."
+      },
+      "messages": {
+        "deleted": "Model price source deleted",
+        "syncSubmitted": "{name} sync task submitted{taskId}",
+        "taskId": " ({taskId})"
+      },
+      "errors": {
+        "deleteFailed": "Failed to delete model price source",
+        "syncFailed": "Failed to submit price sync task"
+      }
+    },
+    "priceSourceModal": {
+      "title": {
+        "create": "New Model Price Source",
+        "edit": "Edit Model Price Source"
+      },
+      "description": {
+        "create": "Create an official, supplier, or manually maintained price source for later price entry and collection.",
+        "edit": "Maintain the source name, pricing scope, price URL, and enabled status."
+      },
+      "sections": {
+        "basic": "Basic information",
+        "basicHint": "Only operational fields that need maintenance are shown.",
+        "notes": "Additional notes",
+        "notesHint": "Optional details for region, contract pricing, or special notes."
+      },
+      "fields": {
+        "category": "Pricing scope",
+        "currency": "Default currency",
+        "endpointUrl": "Price URL",
+        "name": "Price source name",
+        "slug": "System slug",
+        "sourceType": "Source mode"
+      },
+      "placeholders": {
+        "name": "Example: Yunce / Alibaba Bailian East China line",
+        "notes": "Example: East China line, contract price, qwen-plus only"
+      },
+      "help": {
+        "autoSlug": "The system slug will be generated after creation: {slug}",
+        "endpointUrl": "Official pricing page, supplier price API, or manual price source URL."
+      },
+      "actions": {
+        "cancel": "Cancel",
+        "close": "Close",
+        "create": "Create price source",
+        "saveChanges": "Save changes",
+        "saving": "Saving"
+      },
+      "status": {
+        "disabled": "Price source disabled",
+        "enabled": "Price source enabled"
+      },
+      "sourceTypes": {
+        "custom": "Custom"
+      },
+      "categories": {
+        "manual": "Manual maintenance",
+        "officialProvider": "Official price source",
+        "supplier": "Supplier price source",
+        "unknown": "Other"
+      },
+      "currencies": {
+        "cny": "CNY - Chinese yuan",
+        "usd": "USD - US dollar"
+      },
+      "messages": {
+        "created": "Model price source created",
+        "updated": "Model price source updated"
+      },
+      "errors": {
+        "save": "Failed to save model price source"
+      }
+    },
+    "sourcePriceDrawer": {
+      "title": "Meta Model Prices Under Supplier",
+      "searchPlaceholder": "Search meta model, provider, or code",
+      "actions": {
+        "close": "Close",
+        "delete": "Delete",
+        "deleting": "Deleting"
+      },
+      "summary": {
+        "currency": "Default currency",
+        "currentItems": "Current price items",
+        "metaModels": "Covered meta models",
+        "status": "Status"
+      },
+      "status": {
+        "disabled": "Inactive",
+        "enabled": "Active"
+      },
+      "info": {
+        "owner": "Source owner",
+        "priceUrl": "Price URL",
+        "updateMode": "Update mode"
+      },
+      "table": {
+        "metaModel": "Meta model",
+        "price": "Price (source currency / 1M tokens)",
+        "updatedAt": "Last updated"
+      },
+      "empty": {
+        "noPrice": "No price",
+        "noRows": "This price source has no model price records yet."
+      },
+      "fallback": {
+        "unbound": "Unbound",
+        "unboundProvider": "Unbound provider",
+        "unknownMetaModel": "Unknown meta model"
+      },
+      "dimensions": {
+        "audioInput": "Audio input",
+        "audioOutput": "Audio output",
+        "cacheInput": "Cache input",
+        "imageInput": "Image input",
+        "imageOutput": "Image output",
+        "textInput": "Text input",
+        "textOutput": "Text output",
+        "videoInput": "Video input",
+        "videoOutput": "Video output"
+      },
+      "billingUnits": {
+        "per1mTokens": "/ 1M tokens",
+        "perGeneration": "/ generation",
+        "perImage": "/ image",
+        "perSecond": "/ second"
+      },
+      "modalities": {
+        "audio": "Audio",
+        "multimodal": "Multimodal",
+        "text": "Text",
+        "video": "Video"
+      },
+      "categories": {
+        "manual": "Manual entry",
+        "officialProvider": "Official price",
+        "supplier": "Supplier price",
+        "unknown": "Other"
+      },
+      "sourceMode": {
+        "aggregateSync": "Aggregate sync",
+        "autoCollect": "Auto collect",
+        "dedicatedCollect": "Dedicated collection",
+        "manualMaintenance": "Manual maintenance",
+        "pending": "Pending adapter",
+        "supplierMaintenance": "Supplier maintained"
+      }
+    },
+    "manualPriceEntry": {
+      "title": "Enter Model Price",
+      "description": "Maintain one model price for the current price source. Prefer an existing official model, and create a custom model only when it does not exist.",
+      "sourceContext": "{relation} · default currency {currency}",
+      "sections": {
+        "model": "Select model",
+        "modelHint": "Channels and listings will calculate cost from this model and price source.",
+        "price": "Price details",
+        "priceHint": "Fill prices by supported billing dimension. Empty dimensions will not create price items."
+      },
+      "modelMode": {
+        "custom": "Create custom model",
+        "existing": "Select existing model"
+      },
+      "fields": {
+        "currency": "Currency",
+        "model": "Model",
+        "modelCode": "Model code",
+        "modelName": "Model name",
+        "modality": "Model type",
+        "provider": "Model provider",
+        "sourceUrl": "Source URL"
+      },
+      "placeholders": {
+        "modelCode": "Example: deepseek-v3",
+        "modelName": "Example: DeepSeek V3",
+        "searchModel": "Search model name, code, or provider",
+        "searchProvider": "Search model provider",
+        "selectProvider": "Select model provider",
+        "sourceUrl": "Optional, pricing page or quote URL"
+      },
+      "help": {
+        "existingModel": "Choose from existing system models. Provider and type will be filled automatically."
+      },
+      "actions": {
+        "cancel": "Cancel",
+        "close": "Close",
+        "save": "Save price",
+        "saving": "Saving"
+      },
+      "priceFields": {
+        "audioInput": {
+          "help": "Speech recognition or audio understanding input",
+          "label": "Audio input / second"
+        },
+        "audioOutput": {
+          "help": "Text-to-speech or audio generation output",
+          "label": "Audio output / second"
+        },
+        "cacheInput": {
+          "help": "Optional input price after cache hit",
+          "label": "Cache input / million tokens"
+        },
+        "imageOutput": {
+          "help": "Image generation priced per image",
+          "label": "Image output / image"
+        },
+        "textInput": {
+          "help": "Prompt or input token unit price",
+          "label": "Text input / million tokens"
+        },
+        "textOutput": {
+          "help": "Completion or output token unit price",
+          "label": "Text output / million tokens"
+        },
+        "videoInput": {
+          "help": "Video understanding input",
+          "label": "Video input / second"
+        },
+        "videoOutput": {
+          "help": "Video generation output",
+          "label": "Video output / second"
+        }
+      },
+      "modalities": {
+        "audio": "Audio",
+        "multimodal": "Multimodal",
+        "text": "Text",
+        "video": "Video"
+      },
+      "currencies": {
+        "cny": "CNY - Chinese yuan",
+        "usd": "USD - US dollar"
+      },
+      "categories": {
+        "manual": "Manual",
+        "officialProvider": "Official",
+        "supplier": "Supplier",
+        "unknown": "Other"
+      },
+      "relation": {
+        "channel": "Forwarding channel {name}",
+        "provider": "Model provider {name}",
+        "unbound": "No model provider bound"
+      },
+      "validation": {
+        "customModelCode": "Enter a custom model code.",
+        "customModelName": "Enter a custom model name.",
+        "customModelProvider": "Select the model provider for the custom model.",
+        "noSource": "Missing price source.",
+        "price": "Enter at least one price dimension.",
+        "selectExistingModel": "Select an existing model."
+      },
+      "groups": {
+        "currentProvider": "Current price source provider",
+        "otherModels": "Other models"
+      },
+      "fallback": {
+        "unknownProvider": "Unknown provider"
+      },
+      "messages": {
+        "saved": "Model price saved"
+      },
+      "errors": {
+        "save": "Failed to save model price"
+      }
+    },
+    "manualPriceImport": {
+      "title": "Import Manual Price Sheet",
+      "description": "For model price sources that cannot be collected automatically. Copy a full table from Excel and paste it here.",
+      "updateModelPrices": "Also update model price source prices after import. When disabled, only the model price source and standard price items are created, without overwriting model master prices.",
+      "supportedFieldsTitle": "Supported fields",
+      "emptyPreview": "Paste a price table with headers to show the preview.",
+      "fields": {
+        "currency": "Default currency",
+        "provider": "Model provider",
+        "sourceName": "Model price source name",
+        "sourceUrl": "Model price source URL",
+        "tableContent": "Excel / CSV content"
+      },
+      "placeholders": {
+        "selectProvider": "Select model owner",
+        "sourceName": "Example: OpenAI 2026-06 manual price sheet",
+        "sourceUrl": "Optional, official site or internal spreadsheet link"
+      },
+      "actions": {
+        "cancel": "Cancel",
+        "close": "Close",
+        "confirmImport": "Confirm import",
+        "importing": "Importing"
+      },
+      "preview": {
+        "needsFix": "Needs fixes",
+        "ready": "Ready to import",
+        "summary": "{valid} valid rows, {errors} errors",
+        "title": "Parse preview"
+      },
+      "table": {
+        "audio": "Audio",
+        "currency": "Currency",
+        "image": "Image",
+        "input": "Input",
+        "model": "Model",
+        "output": "Output",
+        "type": "Type",
+        "video": "Video"
+      },
+      "modalities": {
+        "audio": "Audio",
+        "multimodal": "Multimodal",
+        "text": "Text",
+        "video": "Video"
+      },
+      "parseErrors": {
+        "invalidNumber": "Line {line}: {field} is not a valid non-negative number.",
+        "missingModelCode": "Missing required header: model_code.",
+        "needHeaderAndRow": "At least one header row and one data row are required.",
+        "noPrice": "Line {line}: at least one price field is required.",
+        "rowMissingModelCode": "Line {line}: missing model_code.",
+        "unsupportedCurrency": "Line {line}: currency only supports USD or CNY."
+      }
+    },
+    "channelManagement": {
+      "title": "Forwarding Channel Configuration",
+      "description": "Maintain channel details, then manage upstream providers, cost rules, and forwarding capacity from model management.",
+      "searchPlaceholder": "Search channel name, code, or URL",
+      "createChannel": "New channel",
+      "apiConfigured": "API configured",
+      "apiNotConfigured": "API not configured",
+      "currency": "Currency {currency}",
+      "discount": "Discount {ratio}",
+      "enabled": "Enabled",
+      "configured": "Configured",
+      "empty": "No channel configurations match the current filters.",
+      "table": {
+        "channel": "Channel",
+        "defaultConfig": "Default config",
+        "modelManagement": "Model management",
+        "status": "Status",
+        "actions": "Actions"
+      },
+      "filters": {
+        "allStatus": "All statuses",
+        "activeOnly": "Active only",
+        "inactiveOnly": "Inactive only"
+      },
+      "status": {
+        "active": "Active",
+        "inactive": "Inactive"
+      },
+      "actions": {
+        "manageModels": "Manage models",
+        "edit": "Edit",
+        "delete": "Delete",
+        "cancel": "Cancel"
+      },
+      "deleteDialog": {
+        "title": "Delete forwarding channel",
+        "description": "Deleting this channel also removes its model configuration, procurement price items, and reconciliation records. Existing listings are kept but no longer linked to this channel.",
+        "confirmation": "Confirm that this channel and its model relationships are no longer needed before deleting it.",
+        "deleting": "Deleting",
+        "confirmDelete": "Confirm delete"
+      },
+      "messages": {
+        "deleted": "{name} deleted",
+        "deleteFailed": "Failed to delete channel"
+      }
+    },
+    "listingBoard": {
+      "title": "Model Listing Board",
+      "subtitle": "Only models in the current platform workflow are shown.",
+      "searchPlaceholder": "Search model / code",
+      "selectedCount": "{count} selected",
+      "createListing": "New listing",
+      "platformFallback": "Resale platform",
+      "filters": {
+        "actionable": "Actionable",
+        "all": "All",
+        "listed": "Listed",
+        "unlisted": "Unlisted"
+      },
+      "pagination": {
+        "pageSize": "Per page",
+        "summary": "Page {current} / {total} · {count} total",
+        "previous": "Previous",
+        "next": "Next"
+      },
+      "table": {
+        "platform": "Resale platform",
+        "model": "Model",
+        "supplyChain": "Supply link",
+        "cost": "Cost",
+        "retail": "Retail",
+        "points": "Points",
+        "margin": "Margin",
+        "status": "Status",
+        "actions": "Actions"
+      },
+      "batch": {
+        "offline": "Batch offline",
+        "price": "Batch reprice",
+        "confirm": "Batch confirm",
+        "confirmSubmit": "Batch confirm submit",
+        "confirmPublish": "Batch confirm publish",
+        "confirmUpdate": "Batch confirm update",
+        "confirmOffline": "Batch confirm offline"
+      },
+      "kpis": {
+        "availableModels": {
+          "label": "Listable models",
+          "hint": "{count} unlisted",
+          "delta": "This period"
+        },
+        "platforms": {
+          "label": "Resale platforms",
+          "hint": "Visible resale platform total",
+          "delta": "Stable"
+        },
+        "listed": {
+          "label": "Listed",
+          "hint": "Currently online on external platforms",
+          "activeDelta": "+ publishing",
+          "pendingDelta": "Pending"
+        },
+        "unlisted": {
+          "label": "Unlisted",
+          "hint": "Can be handled from the workspace",
+          "delta": "Needs action"
+        },
+        "averageMargin": {
+          "label": "Overall average margin",
+          "hint": "Estimated across Input / Output / Cached",
+          "delta": "Reference"
+        }
+      },
+      "empty": {
+        "actionable": "No listing models need action.",
+        "listed": "There are no listed models.",
+        "unlisted": "There are no models ready to list.",
+        "default": "No models match the current filters."
+      },
+      "supply": {
+        "activeLinks": "{count} active listing links",
+        "none": "No supply"
+      },
+      "workflowStatus": {
+        "draft": "Draft",
+        "pendingPublish": "Pending publish",
+        "online": "Listed",
+        "updateDraft": "Update draft",
+        "pendingUpdate": "Pending update",
+        "pendingOffline": "Pending offline",
+        "offlineException": "Offline exception",
+        "offline": "Offline",
+        "deleted": "Invalid"
+      },
+      "rowActions": {
+        "abandonChange": "Abandon changes",
+        "abandonUpdate": "Abandon",
+        "confirmOffline": "Confirm offline",
+        "confirmPublish": "Confirm publish",
+        "confirmSubmit": "Confirm submit",
+        "confirmUpdate": "Confirm update",
+        "continueEdit": "Continue editing",
+        "delete": "Delete",
+        "deleteData": "Delete data",
+        "directOffline": "Direct offline",
+        "edit": "Edit",
+        "goListing": "Go to listing",
+        "markOfflineException": "Mark exception",
+        "rejectOffline": "Reject offline",
+        "republish": "Republish",
+        "requestOffline": "Request offline",
+        "startEdit": "Start editing",
+        "submit": "Submit",
+        "withdraw": "Withdraw",
+        "withdrawChange": "Withdraw changes",
+        "withdrawOffline": "Withdraw offline",
+        "withdrawRequest": "Withdraw request"
+      },
+      "confirm": {
+        "batchOffline": "Request offline for {count} models?",
+        "batchConfirm": "{action} for {count} models?",
+        "batchPrice": "Open batch repricing workspace for {count} models?",
+        "requestOffline": "Request offline? The external platform will remain listed until offline is confirmed.",
+        "confirmOffline": "Confirm that the external platform is offline? This model will move to offline status.",
+        "directOffline": "Directly offline this listing? This means the external platform has already been taken down.",
+        "delete": "Delete this listing data? It will be hidden from the normal business list.",
+        "default": "Confirm this workflow action?"
+      },
+      "messages": {
+        "batchConfirmed": "{action} completed",
+        "batchOfflineRequested": "Batch offline requested",
+        "deleted": "Deleted",
+        "directOfflineDone": "Direct offline completed",
+        "offlineConfirmed": "Offline confirmed",
+        "offlineExceptionMarked": "Exception marked",
+        "offlineRejected": "Offline rejected",
+        "offlineRequested": "Offline requested",
+        "publishConfirmed": "Publish confirmed",
+        "republishSubmitted": "Republish submitted",
+        "statusUpdated": "Status updated",
+        "submitted": "Submitted",
+        "updateAbandoned": "Update abandoned",
+        "updateConfirmed": "Update confirmed",
+        "updateDraftStarted": "Update draft started",
+        "withdrawn": "Withdrawn"
+      },
+      "errors": {
+        "directOfflineFailed": "Direct offline failed",
+        "operationFailed": "Operation failed",
+        "transitionFailed": "Status transition failed"
+      }
+    },
+    "auditLog": {
+      "actions": {
+        "reset": "Reset",
+        "search": "Search"
+      },
+      "actionOptions": {
+        "all": "All actions",
+        "bulkDraft": "Save draft",
+        "bulkReplace": "Batch replace",
+        "bulkUpsert": "Batch submit",
+        "collect": "Collect",
+        "create": "Create",
+        "delete": "Delete",
+        "import": "Import",
+        "offline": "Offline",
+        "restore": "Restore",
+        "sync": "Sync",
+        "transition": "Approval transition",
+        "update": "Update"
+      },
+      "businessCategories": {
+        "all": "All categories",
+        "channelConfig": "Channel configuration",
+        "listing": "Model listing",
+        "metaModel": "Meta model",
+        "modelPrice": "Model price",
+        "priceSource": "Price source configuration",
+        "reconciliation": "Usage reconciliation"
+      },
+      "channelFallback": "Channel #{id}",
+      "channelPrefix": "Channel: {name}",
+      "detail": {
+        "contentChanges": "Content changes",
+        "statusChanges": "Status changes"
+      },
+      "empty": {
+        "description": "Adjust filters, or run a channel, price, listing, or approval operation before searching again.",
+        "noContentChanges": "No content field differences recorded.",
+        "noFieldChanges": "No field changes recorded",
+        "noStatusChanges": "No status changes recorded.",
+        "title": "No audit records"
+      },
+      "errors": {
+        "loadFailed": "Failed to load audit records"
+      },
+      "fields": {
+        "aliases": "Aliases",
+        "apiEndpoint": "API Endpoint",
+        "basePriceItem": "Base price item",
+        "billingUnit": "Billing unit",
+        "capabilities": "Capabilities",
+        "channel": "Channel",
+        "code": "Code",
+        "comparisonStatus": "Price comparison status",
+        "contextWindow": "Context window",
+        "currency": "Currency",
+        "customAudioInput": "Custom audio input price",
+        "customAudioOutput": "Custom audio output price",
+        "customInput": "Custom input price",
+        "customOutput": "Custom output price",
+        "customVideoInput": "Custom video input price",
+        "customVideoOutput": "Custom video output price",
+        "customVideoResolution": "Custom video resolution prices",
+        "deltaAmount": "Delta amount",
+        "deltaPercent": "Delta percent",
+        "dimension": "Billing dimension",
+        "endpointUrl": "Endpoint URL",
+        "family": "Model family",
+        "feeRate": "Fee rate",
+        "isActive": "Active status",
+        "isCurrent": "Current version",
+        "isEnabled": "Collection status",
+        "isListed": "Channel listing status",
+        "latency": "Latency",
+        "maxOutputTokens": "Max output tokens",
+        "metadata": "Metadata",
+        "metaModel": "Meta model",
+        "modality": "Modality",
+        "model": "Model",
+        "name": "Name",
+        "notes": "Notes",
+        "platform": "Platform",
+        "pointName": "Point name",
+        "pointRoundingMode": "Point rounding",
+        "pointsPerCurrencyUnit": "Point conversion",
+        "priceFingerprint": "Price fingerprint",
+        "priceSource": "Price source",
+        "priceSourceType": "Price source type",
+        "provider": "Provider",
+        "publishStatus": "Publish status",
+        "reason": "Reason",
+        "retailAudioInput": "Retail audio input price",
+        "retailAudioOutput": "Retail audio output price",
+        "retailCacheInput": "Retail cache input price",
+        "retailImageOutput": "Retail image output price",
+        "retailInput": "Retail input price",
+        "retailOutput": "Retail output price",
+        "retailVideoInput": "Retail video input price",
+        "retailVideoOutput": "Retail video output price",
+        "retailVideoResolution": "Retail video resolution prices",
+        "rpmLimit": "RPM limit",
+        "serviceFeeRate": "Service fee rate",
+        "settlementRatio": "Settlement ratio",
+        "sourceCategory": "Price source category",
+        "sourceType": "Source type",
+        "sourceUrl": "Source URL",
+        "spec": "Spec",
+        "status": "Status",
+        "tierEnd": "Tier end",
+        "tierStart": "Tier start",
+        "tierType": "Tier type",
+        "tpmLimit": "TPM limit",
+        "unitPrice": "Unit price",
+        "updatesModelPrices": "Updates model prices",
+        "website": "Website",
+        "workflowStatus": "Workflow status"
+      },
+      "filters": {
+        "action": "Action",
+        "actor": "Actor",
+        "actorPlaceholder": "e.g. ops",
+        "category": "Category",
+        "target": "Instance name",
+        "targetPlaceholder": "e.g. DeepSeek R1"
+      },
+      "loading": "Loading audit records...",
+      "moreChanges": "+{count} items",
+      "pagination": {
+        "emptyRange": "0 records",
+        "next": "Next",
+        "pageSize": "Per page",
+        "pageSizeOption": "{size} / page",
+        "previous": "Previous",
+        "range": "{start}-{end} / {count} records"
+      },
+      "recordCount": "{count} records",
+      "table": {
+        "actor": "Actor",
+        "category": "Category",
+        "changes": "Changes",
+        "instance": "Instance",
+        "platform": "Platform",
+        "time": "Time"
+      },
+      "targetTypes": {
+        "channel": "Channel",
+        "channelModelPrice": "Channel model configuration",
+        "channelPriceItem": "Channel price item",
+        "listing": "Model listing",
+        "listingExclusion": "Listing exclusion",
+        "metaModel": "Meta model",
+        "model": "Model",
+        "modelPrice": "Model price",
+        "priceSource": "Price source",
+        "provider": "Meta model provider",
+        "reconciliationRecord": "Reconciliation record",
+        "resalePlatform": "Resale platform"
+      },
+      "values": {
+        "boolean": {
+          "no": "No",
+          "yes": "Yes"
+        },
+        "comparison_status": {
+          "aboveOfficial": "Above upstream price",
+          "belowOfficial": "Below upstream price",
+          "sameAsOfficial": "Same as upstream price",
+          "unknown": "Pending"
+        },
+        "publish_status": {
+          "deleted": "Deleted",
+          "none": "Unpublished",
+          "offline": "Offline",
+          "online": "Published"
+        },
+        "status": {
+          "active": "Active",
+          "draft": "Draft",
+          "failed": "Failed",
+          "inactive": "Inactive",
+          "matched": "Matched",
+          "mismatch": "Mismatch",
+          "pending": "Pending",
+          "retired": "Retired",
+          "unmatched": "Unmatched"
+        },
+        "workflow_status": {
+          "deleted": "Invalid",
+          "draft": "Draft",
+          "offline": "Offline",
+          "offlineException": "Offline exception",
+          "online": "Listed",
+          "pendingOffline": "Pending offline",
+          "pendingPublish": "Pending publish",
+          "pendingUpdate": "Pending update",
+          "updateDraft": "Update draft"
+        }
+      }
     }
   },
   "sals": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -907,6 +907,909 @@
       "noChangesToSave": "没有检测到需要保存的修改",
       "draftsSaved": "已保存 {count} 条草稿",
       "saveFailed": "保存失败"
+    },
+    "publishingDrawer": {
+      "back": "返回",
+      "title": "模型沉浸式上架工作台",
+      "saveDraft": "保存草稿",
+      "submitting": "提交中…",
+      "submit": "提交上架",
+      "saveFailed": "保存失败",
+      "submitFailed": "提交失败"
+    },
+    "publishingWorkspace": {
+      "filters": {
+        "platform": "发布平台",
+        "vendor": "元厂商",
+        "metaModel": "元模型",
+        "supplier": "供货渠道",
+        "all": "全部",
+        "selectMetaModel": "选择元模型",
+        "selectMetaModelFirst": "先选择元模型",
+        "allSupportedChannels": "全部支持渠道"
+      },
+      "context": {
+        "platformCurrency": "当前平台币种",
+        "exchangeRate": "汇率",
+        "pointConversion": "{point}换算"
+      },
+      "supply": {
+        "title": "供应链路甄选",
+        "selectedCount": "已选 {count} 条链路",
+        "availableCount": "共 {count} 条可用链路",
+        "collapse": "收起",
+        "expand": "展开",
+        "chain": "商务及物理链路",
+        "empty": "当前元模型暂无可用供应链路",
+        "supplierPrefix": "供货渠道：{name}",
+        "sourcePrefix": "供应源：{name}",
+        "lowest": "最低",
+        "lowestProcurement": "最低采购链路",
+        "selectRequired": "请在链路甄选面板中勾选至少一条供应链路，继续定价。",
+        "chainFallback": "供货链路"
+      },
+      "pricing": {
+        "cost": "成本",
+        "price": "售价",
+        "finalPoint": "最终 {point}",
+        "costPrice": "成本价",
+        "retailPrice": "终端售卖价",
+        "floor": "下限 {value}",
+        "average": "均价",
+        "referenceTitle": "最低参考定价 = 成本价 × (1 + 服务费率 + 平台抽佣比例)；当前服务费率 {serviceFee}；当前平台抽佣比例 {commission}；参考价 {reference}",
+        "costFormulaTitle": "成本价 = 供应商成本价 × 折扣；{formula}",
+        "noBenchmark": "暂无对账",
+        "lowerThanAverage": "↓ 低 {pct}%",
+        "higherThanAverage": "↑ 高 {pct}%",
+        "sameAsAverage": "- 持平",
+        "marketAverage": "市场均价"
+      },
+      "performance": {
+        "title": "链路性能全景对标",
+        "empty": "暂无对比数据",
+        "resize": "调整链路性能全景对标宽度",
+        "rpm": "并发请求速率 (RPM)",
+        "tpm": "Token 吞吐量 (TPM)",
+        "latency": "首字延迟 (Latency · 越低越好)"
+      },
+      "margin": {
+        "title": "统一利润期望",
+        "description": "Input / Output / Cache 按同一利润率推导各自售价。",
+        "input": "统一利润率",
+        "axisLabel": "统一利润率 {value}",
+        "noAutoApprove": "未配置免审利润率",
+        "autoApproveInactive": "免审阈值未生效",
+        "withinAutoApprove": "免审范围内（<= {value}）",
+        "aboveAutoApprove": "超出免审上限（> {value}）",
+        "minTitle": "最低利润率下限",
+        "autoApproveTitle": "免审利润率上限",
+        "minSource": "成本价 × (1 + 服务费率 + 平台抽佣比例)",
+        "autoApproveSource": "平台配置的自动免审阈值，仅影响审批判断",
+        "platformFloor": "平台下限",
+        "feeBreakdown": "服务费 {serviceFee} + 抽佣 {commission}",
+        "autoApproveLimit": "免审上限"
+      },
+      "fallback": {
+        "platform": "平台 {id}",
+        "uncategorized": "未归类",
+        "points": "积分",
+        "currentPlatform": "当前平台",
+        "notConfigured": "未配置"
+      }
+    },
+    "providerManagement": {
+      "title": "供货商价格列表",
+      "modelsCount": "{count} 个元模型",
+      "empty": "暂无匹配的供货商价格源。",
+      "actions": {
+        "bulkImport": "批量导入",
+        "createSource": "新建价格源",
+        "delete": "删除",
+        "deleting": "删除中",
+        "edit": "编辑",
+        "manualPricing": "手工录价",
+        "notSupported": "暂不支持",
+        "submitting": "提交中",
+        "syncPrice": "同步价格",
+        "viewModels": "查看元模型"
+      },
+      "filters": {
+        "activeOnly": "仅启用",
+        "allStatuses": "全部状态",
+        "allTypes": "全部类型",
+        "inactiveOnly": "仅停用",
+        "searchPlaceholder": "搜索供货商、价格源、厂商或地址"
+      },
+      "table": {
+        "actions": "操作",
+        "metaModels": "关联元模型",
+        "source": "供货商 / 价格源",
+        "status": "状态",
+        "type": "类型"
+      },
+      "metrics": {
+        "metaModels": {
+          "hint": "至少绑定一条当前价格",
+          "label": "覆盖元模型"
+        },
+        "official": {
+          "hint": "由元模型厂商直接发布",
+          "label": "原厂源"
+        },
+        "sources": {
+          "hint": "供货商与原厂价格目录",
+          "label": "价格源"
+        },
+        "supplierManual": {
+          "hint": "供货商 {supplier} · 人工 {manual}",
+          "label": "供货商 / 人工"
+        }
+      },
+      "category": {
+        "manual": "人工",
+        "officialProvider": "原厂",
+        "supplier": "供货商",
+        "unknown": "其他"
+      },
+      "relation": {
+        "forwardingChannel": "转发渠道",
+        "metaProvider": "元模型厂商",
+        "needsOwner": "待补充归属",
+        "unbound": "未绑定来源"
+      },
+      "sourceMode": {
+        "aggregateSync": "聚合同步",
+        "autoCollect": "自动采集",
+        "custom": "自定义",
+        "dedicatedCollect": "专用采集",
+        "manualMaintenance": "手动维护",
+        "pending": "待适配",
+        "supplierMaintenance": "供货商维护"
+      },
+      "sourceStatus": {
+        "active": {
+          "hint": "可参与采集和计算",
+          "label": "启用"
+        },
+        "failed": {
+          "hint": "需要检查价格地址或采集器",
+          "label": "采集失败"
+        },
+        "inactive": {
+          "hint": "不会参与采集",
+          "label": "停用"
+        },
+        "manual": {
+          "hint": "通过录入或 Excel 导入更新",
+          "label": "手动维护"
+        },
+        "pending": {
+          "label": "待适配"
+        },
+        "syncing": {
+          "hint": "请稍后刷新",
+          "label": "同步中"
+        }
+      },
+      "collectMode": {
+        "autoCollect": "自动采集",
+        "dedicatedCollector": "专用采集器",
+        "manualMaintenance": "手工维护",
+        "pending": "未适配"
+      },
+      "confirm": {
+        "deleteSource": "确认删除模型价格源「{name}」吗？\n\n删除后会移除该价格源及其采集记录，关联模型或渠道会失去这个价格来源。"
+      },
+      "messages": {
+        "deleted": "模型价格源已删除",
+        "syncSubmitted": "{name} 同步任务已提交{taskId}",
+        "taskId": "（{taskId}）"
+      },
+      "errors": {
+        "deleteFailed": "删除模型价格源失败",
+        "syncFailed": "提交价格同步任务失败"
+      }
+    },
+    "priceSourceModal": {
+      "title": {
+        "create": "新建模型价格源",
+        "edit": "编辑模型价格源"
+      },
+      "description": {
+        "create": "新建原厂、供货商或人工维护价格源，用于后续录价和采集模型价格。",
+        "edit": "维护价格源名称、口径、价格地址和启停状态。"
+      },
+      "sections": {
+        "basic": "基础信息",
+        "basicHint": "只保留运营侧需要维护的字段。",
+        "notes": "补充说明",
+        "notesHint": "可选，用于记录区域、合同价或特殊说明。"
+      },
+      "fields": {
+        "category": "价格口径",
+        "currency": "默认币种",
+        "endpointUrl": "价格地址",
+        "name": "价格源名称",
+        "slug": "系统标识",
+        "sourceType": "来源方式"
+      },
+      "placeholders": {
+        "name": "例如：云测 / 阿里云百炼华东专线",
+        "notes": "例如：华东专线、合同价、只覆盖 qwen-plus"
+      },
+      "help": {
+        "autoSlug": "创建后系统标识将自动生成：{slug}",
+        "endpointUrl": "官方价格页、供货商价格接口或人工价格来源地址。"
+      },
+      "actions": {
+        "cancel": "取消",
+        "close": "关闭",
+        "create": "创建价格源",
+        "saveChanges": "保存修改",
+        "saving": "保存中"
+      },
+      "status": {
+        "disabled": "价格源已停用",
+        "enabled": "价格源已启用"
+      },
+      "sourceTypes": {
+        "custom": "自定义"
+      },
+      "categories": {
+        "manual": "人工维护",
+        "officialProvider": "原厂价格源",
+        "supplier": "供货商价格源",
+        "unknown": "其他"
+      },
+      "currencies": {
+        "cny": "人民币 CNY",
+        "usd": "美元 USD"
+      },
+      "messages": {
+        "created": "模型价格源已创建",
+        "updated": "模型价格源已更新"
+      },
+      "errors": {
+        "save": "保存模型价格源失败"
+      }
+    },
+    "sourcePriceDrawer": {
+      "title": "供货商下的元模型价格",
+      "searchPlaceholder": "搜索元模型、厂商或 code",
+      "actions": {
+        "close": "关闭",
+        "delete": "删除",
+        "deleting": "删除中"
+      },
+      "summary": {
+        "currency": "默认币种",
+        "currentItems": "当前价格项",
+        "metaModels": "覆盖元模型",
+        "status": "状态"
+      },
+      "status": {
+        "disabled": "停用",
+        "enabled": "启用"
+      },
+      "info": {
+        "owner": "来源归属",
+        "priceUrl": "价格地址",
+        "updateMode": "更新方式"
+      },
+      "table": {
+        "metaModel": "元模型",
+        "price": "价格（原始币种 / 1M tokens）",
+        "updatedAt": "最近更新"
+      },
+      "empty": {
+        "noPrice": "暂无价格",
+        "noRows": "当前价格源还没有模型价格记录。"
+      },
+      "fallback": {
+        "unbound": "未绑定",
+        "unboundProvider": "未绑定厂商",
+        "unknownMetaModel": "未知元模型"
+      },
+      "dimensions": {
+        "audioInput": "音频输入",
+        "audioOutput": "音频输出",
+        "cacheInput": "缓存输入",
+        "imageInput": "图片输入",
+        "imageOutput": "图片输出",
+        "textInput": "文本输入",
+        "textOutput": "文本输出",
+        "videoInput": "视频输入",
+        "videoOutput": "视频输出"
+      },
+      "billingUnits": {
+        "per1mTokens": "/ 百万 tokens",
+        "perGeneration": "/ 次",
+        "perImage": "/ 张",
+        "perSecond": "/ 秒"
+      },
+      "modalities": {
+        "audio": "音频",
+        "multimodal": "多模态",
+        "text": "文本",
+        "video": "视频"
+      },
+      "categories": {
+        "manual": "人工录入",
+        "officialProvider": "原厂价格",
+        "supplier": "供货商价格",
+        "unknown": "其他"
+      },
+      "sourceMode": {
+        "aggregateSync": "聚合同步",
+        "autoCollect": "自动采集",
+        "dedicatedCollect": "专用采集",
+        "manualMaintenance": "手动维护",
+        "pending": "待适配",
+        "supplierMaintenance": "供货商维护"
+      }
+    },
+    "manualPriceEntry": {
+      "title": "录入模型价格",
+      "description": "为当前价格源维护一条模型价格。优先选择已有原厂模型，确实不存在时可新增自定义模型。",
+      "sourceContext": "{relation} · 默认币种 {currency}",
+      "sections": {
+        "model": "选择模型",
+        "modelHint": "渠道和挂售后续会基于这个模型和价格源计算成本。",
+        "price": "价格明细",
+        "priceHint": "按模型支持的计费维度填写；未填写的维度不会生成价格项。"
+      },
+      "modelMode": {
+        "custom": "新建自定义模型",
+        "existing": "选择已有模型"
+      },
+      "fields": {
+        "currency": "币种",
+        "model": "模型",
+        "modelCode": "模型编码",
+        "modelName": "模型名称",
+        "modality": "模型类型",
+        "provider": "模型厂商",
+        "sourceUrl": "来源地址"
+      },
+      "placeholders": {
+        "modelCode": "例如 deepseek-v3",
+        "modelName": "例如 DeepSeek V3",
+        "searchModel": "搜索模型名称、编码或厂商",
+        "searchProvider": "搜索模型厂商",
+        "selectProvider": "选择模型厂商",
+        "sourceUrl": "可选，价格页或报价单链接"
+      },
+      "help": {
+        "existingModel": "只从当前系统已有模型中选择，选择后会自动带入模型厂商和类型。"
+      },
+      "actions": {
+        "cancel": "取消",
+        "close": "关闭",
+        "save": "保存价格",
+        "saving": "保存中"
+      },
+      "priceFields": {
+        "audioInput": {
+          "help": "语音识别或音频理解输入",
+          "label": "音频输入 / 秒"
+        },
+        "audioOutput": {
+          "help": "语音合成或音频生成输出",
+          "label": "音频输出 / 秒"
+        },
+        "cacheInput": {
+          "help": "可选，命中缓存后的输入价格",
+          "label": "缓存输入 / 百万 token"
+        },
+        "imageOutput": {
+          "help": "图片生成模型按张计价",
+          "label": "图片输出 / 张"
+        },
+        "textInput": {
+          "help": "Prompt 或输入 token 单价",
+          "label": "文本输入 / 百万 token"
+        },
+        "textOutput": {
+          "help": "Completion 或输出 token 单价",
+          "label": "文本输出 / 百万 token"
+        },
+        "videoInput": {
+          "help": "视频理解输入",
+          "label": "视频输入 / 秒"
+        },
+        "videoOutput": {
+          "help": "视频生成输出",
+          "label": "视频输出 / 秒"
+        }
+      },
+      "modalities": {
+        "audio": "音频",
+        "multimodal": "多模态",
+        "text": "文本",
+        "video": "视频"
+      },
+      "currencies": {
+        "cny": "人民币 CNY",
+        "usd": "美元 USD"
+      },
+      "categories": {
+        "manual": "人工",
+        "officialProvider": "原厂",
+        "supplier": "供货商",
+        "unknown": "其他"
+      },
+      "relation": {
+        "channel": "转发渠道 {name}",
+        "provider": "模型厂商 {name}",
+        "unbound": "未绑定模型厂商"
+      },
+      "validation": {
+        "customModelCode": "请填写自定义模型编码。",
+        "customModelName": "请填写自定义模型名称。",
+        "customModelProvider": "请选择自定义模型的模型厂商。",
+        "noSource": "缺少价格源。",
+        "price": "至少填写一个价格维度。",
+        "selectExistingModel": "请选择一个已有模型。"
+      },
+      "groups": {
+        "currentProvider": "当前价格源关联厂商",
+        "otherModels": "其他模型"
+      },
+      "fallback": {
+        "unknownProvider": "未知厂商"
+      },
+      "messages": {
+        "saved": "模型价格已保存"
+      },
+      "errors": {
+        "save": "保存模型价格失败"
+      }
+    },
+    "manualPriceImport": {
+      "title": "导入人工价格表",
+      "description": "适合无法自动采集的模型价格源，可从 Excel 复制整张表后粘贴。",
+      "updateModelPrices": "导入后同步更新模型价格源价格。关闭后只生成模型价格源和标准价格项，不覆盖模型主数据价格。",
+      "supportedFieldsTitle": "支持字段",
+      "emptyPreview": "粘贴带表头的价格表后会显示预览。",
+      "fields": {
+        "currency": "默认币种",
+        "provider": "模型厂商",
+        "sourceName": "模型价格源名称",
+        "sourceUrl": "模型价格源地址",
+        "tableContent": "Excel / CSV 内容"
+      },
+      "placeholders": {
+        "selectProvider": "选择模型归属方",
+        "sourceName": "例如 OpenAI 2026-06 手动价格表",
+        "sourceUrl": "可选，官网或内部表格链接"
+      },
+      "actions": {
+        "cancel": "取消",
+        "close": "关闭",
+        "confirmImport": "确认导入",
+        "importing": "导入中"
+      },
+      "preview": {
+        "needsFix": "需要修正",
+        "ready": "可导入",
+        "summary": "有效 {valid} 行，错误 {errors} 条",
+        "title": "解析预览"
+      },
+      "table": {
+        "audio": "音频",
+        "currency": "币种",
+        "image": "图片",
+        "input": "输入",
+        "model": "模型",
+        "output": "输出",
+        "type": "类型",
+        "video": "视频"
+      },
+      "modalities": {
+        "audio": "音频",
+        "multimodal": "多模态",
+        "text": "文本",
+        "video": "视频"
+      },
+      "parseErrors": {
+        "invalidNumber": "第 {line} 行 {field} 不是有效的非负数字。",
+        "missingModelCode": "缺少必填表头：model_code。",
+        "needHeaderAndRow": "至少需要表头和一行数据。",
+        "noPrice": "第 {line} 行至少需要一个价格字段。",
+        "rowMissingModelCode": "第 {line} 行缺少 model_code。",
+        "unsupportedCurrency": "第 {line} 行币种只支持 USD 或 CNY。"
+      }
+    },
+    "channelManagement": {
+      "title": "转发渠道配置",
+      "description": "维护渠道基础信息，并进入模型管理配置渠道上游、成本规则和转发能力。",
+      "searchPlaceholder": "搜索渠道名称、标识或地址",
+      "createChannel": "新建渠道",
+      "apiConfigured": "已配置 API",
+      "apiNotConfigured": "API 未配置",
+      "currency": "币种 {currency}",
+      "discount": "折扣 {ratio}",
+      "enabled": "启用",
+      "configured": "配置",
+      "empty": "暂无符合条件的渠道配置。",
+      "table": {
+        "channel": "渠道",
+        "defaultConfig": "默认配置",
+        "modelManagement": "模型管理",
+        "status": "状态",
+        "actions": "操作"
+      },
+      "filters": {
+        "allStatus": "全部状态",
+        "activeOnly": "仅启用",
+        "inactiveOnly": "仅停用"
+      },
+      "status": {
+        "active": "启用",
+        "inactive": "停用"
+      },
+      "actions": {
+        "manageModels": "管理模型",
+        "edit": "编辑",
+        "delete": "删除",
+        "cancel": "取消"
+      },
+      "deleteDialog": {
+        "title": "删除转发渠道",
+        "description": "删除后，该渠道下的模型配置、采购价格项和对账记录会一并删除；已上架记录会保留，但不再关联该渠道。",
+        "confirmation": "请确认不再需要这个渠道及其模型关系后再删除。",
+        "deleting": "删除中",
+        "confirmDelete": "确认删除"
+      },
+      "messages": {
+        "deleted": "{name} 已删除",
+        "deleteFailed": "删除渠道失败"
+      }
+    },
+    "listingBoard": {
+      "title": "模型挂售列表",
+      "subtitle": "仅展示当前平台流程内模型。",
+      "searchPlaceholder": "搜索模型 / code",
+      "selectedCount": "已选 {count}",
+      "createListing": "新建上架",
+      "platformFallback": "挂售平台",
+      "filters": {
+        "actionable": "待处理",
+        "all": "全部",
+        "listed": "已上架",
+        "unlisted": "未上架"
+      },
+      "pagination": {
+        "pageSize": "每页",
+        "summary": "第 {current} / {total} 页 · 共 {count} 条",
+        "previous": "上一页",
+        "next": "下一页"
+      },
+      "table": {
+        "platform": "挂售平台",
+        "model": "模型",
+        "supplyChain": "供货链路",
+        "cost": "成本",
+        "retail": "售价",
+        "points": "积分",
+        "margin": "利润率",
+        "status": "状态",
+        "actions": "操作"
+      },
+      "batch": {
+        "offline": "批量下架",
+        "price": "批量改价",
+        "confirm": "批量确认",
+        "confirmSubmit": "批量确认提交",
+        "confirmPublish": "批量确认上架",
+        "confirmUpdate": "批量确认更新",
+        "confirmOffline": "批量确认下架"
+      },
+      "kpis": {
+        "availableModels": {
+          "label": "可挂售模型",
+          "hint": "{count} 个未上架",
+          "delta": "本周期"
+        },
+        "platforms": {
+          "label": "挂售平台",
+          "hint": "可见挂售平台汇总",
+          "delta": "稳定"
+        },
+        "listed": {
+          "label": "已上架",
+          "hint": "外部平台当前在线",
+          "activeDelta": "+ 上架中",
+          "pendingDelta": "待上架"
+        },
+        "unlisted": {
+          "label": "未上架",
+          "hint": "可在工作台一键处理",
+          "delta": "需处理"
+        },
+        "averageMargin": {
+          "label": "整体平均利润率",
+          "hint": "按 Input / Output / Cached 统一估算",
+          "delta": "参考"
+        }
+      },
+      "empty": {
+        "actionable": "暂无需要处理的挂售模型。",
+        "listed": "当前没有已上架的模型。",
+        "unlisted": "当前没有可上架的模型。",
+        "default": "没有符合筛选条件的模型。"
+      },
+      "supply": {
+        "activeLinks": "{count} 条上架链路",
+        "none": "暂无供应"
+      },
+      "workflowStatus": {
+        "draft": "草稿",
+        "pendingPublish": "待发布",
+        "online": "已上架",
+        "updateDraft": "更新草稿",
+        "pendingUpdate": "待更新",
+        "pendingOffline": "待下架",
+        "offlineException": "下架异常",
+        "offline": "已下架",
+        "deleted": "已失效"
+      },
+      "rowActions": {
+        "abandonChange": "放弃修改",
+        "abandonUpdate": "放弃",
+        "confirmOffline": "确认下架",
+        "confirmPublish": "确认上架",
+        "confirmSubmit": "确认提交",
+        "confirmUpdate": "确认更新",
+        "continueEdit": "继续编辑",
+        "delete": "删除",
+        "deleteData": "删除数据",
+        "directOffline": "直接下架",
+        "edit": "编辑",
+        "goListing": "去挂售",
+        "markOfflineException": "标记异常",
+        "rejectOffline": "驳回",
+        "republish": "重新发布",
+        "requestOffline": "申请下架",
+        "startEdit": "发起编辑",
+        "submit": "提交",
+        "withdraw": "撤回",
+        "withdrawChange": "撤回修改",
+        "withdrawOffline": "撤回下架",
+        "withdrawRequest": "撤回申请"
+      },
+      "confirm": {
+        "batchOffline": "确认批量发起下架 {count} 个模型？",
+        "batchConfirm": "{action} {count} 个模型？",
+        "batchPrice": "确认对 {count} 个模型进入批量改价工作台？",
+        "requestOffline": "确认发起下架申请？外部平台仍保持已上架，等待确认下架。",
+        "confirmOffline": "确认外部平台已完成下架？该模型将进入已下架状态。",
+        "directOffline": "确认直接下架？该操作表示外部平台已同步下线。",
+        "delete": "确认删除该挂售数据？删除后将从常规业务列表隐藏。",
+        "default": "确认执行该状态操作？"
+      },
+      "messages": {
+        "batchConfirmed": "已{action}",
+        "batchOfflineRequested": "已批量发起下架",
+        "deleted": "已删除",
+        "directOfflineDone": "已直接下架",
+        "offlineConfirmed": "已确认下架",
+        "offlineExceptionMarked": "已标记异常",
+        "offlineRejected": "已驳回下架",
+        "offlineRequested": "已发起下架",
+        "publishConfirmed": "已确认上架",
+        "republishSubmitted": "已重新提交发布",
+        "statusUpdated": "状态已更新",
+        "submitted": "已提交",
+        "updateAbandoned": "已放弃修改",
+        "updateConfirmed": "已确认更新",
+        "updateDraftStarted": "已进入更新草稿",
+        "withdrawn": "已撤回"
+      },
+      "errors": {
+        "directOfflineFailed": "直接下架失败",
+        "operationFailed": "操作失败",
+        "transitionFailed": "状态流转失败"
+      }
+    },
+    "auditLog": {
+      "actions": {
+        "reset": "重置",
+        "search": "查询"
+      },
+      "actionOptions": {
+        "all": "全部动作",
+        "bulkDraft": "保存草稿",
+        "bulkReplace": "批量替换",
+        "bulkUpsert": "批量提交",
+        "collect": "采集",
+        "create": "创建",
+        "delete": "删除",
+        "import": "导入",
+        "offline": "下架",
+        "restore": "恢复",
+        "sync": "同步",
+        "transition": "审批流转",
+        "update": "更新"
+      },
+      "businessCategories": {
+        "all": "全部大类",
+        "channelConfig": "渠道配置",
+        "listing": "模型挂售",
+        "metaModel": "元模型",
+        "modelPrice": "模型价格",
+        "priceSource": "价格源配置",
+        "reconciliation": "用量对账"
+      },
+      "channelFallback": "渠道 #{id}",
+      "channelPrefix": "渠道：{name}",
+      "detail": {
+        "contentChanges": "内容变更",
+        "statusChanges": "状态变更"
+      },
+      "empty": {
+        "description": "调整筛选条件，或完成一次渠道、价格、上架、审批操作后再查询。",
+        "noContentChanges": "未记录内容字段差异。",
+        "noFieldChanges": "未记录字段变更",
+        "noStatusChanges": "未记录状态变更。",
+        "title": "暂无操作记录"
+      },
+      "errors": {
+        "loadFailed": "操作记录加载失败"
+      },
+      "fields": {
+        "aliases": "别名",
+        "apiEndpoint": "API Endpoint",
+        "basePriceItem": "基准价格项",
+        "billingUnit": "计费单位",
+        "capabilities": "能力",
+        "channel": "渠道",
+        "code": "编码",
+        "comparisonStatus": "价格对比状态",
+        "contextWindow": "上下文窗口",
+        "currency": "币种",
+        "customAudioInput": "自定义音频输入价",
+        "customAudioOutput": "自定义音频输出价",
+        "customInput": "自定义输入价",
+        "customOutput": "自定义输出价",
+        "customVideoInput": "自定义视频输入价",
+        "customVideoOutput": "自定义视频输出价",
+        "customVideoResolution": "自定义视频分辨率价格",
+        "deltaAmount": "价差金额",
+        "deltaPercent": "价差比例",
+        "dimension": "计费维度",
+        "endpointUrl": "端点 URL",
+        "family": "模型族",
+        "feeRate": "费率",
+        "isActive": "启用状态",
+        "isCurrent": "当前版本",
+        "isEnabled": "采集状态",
+        "isListed": "渠道上架状态",
+        "latency": "延迟",
+        "maxOutputTokens": "最大输出 Token",
+        "metadata": "扩展信息",
+        "metaModel": "元模型",
+        "modality": "模态",
+        "model": "模型",
+        "name": "名称",
+        "notes": "备注",
+        "platform": "平台",
+        "pointName": "点数名称",
+        "pointRoundingMode": "点数取整",
+        "pointsPerCurrencyUnit": "点数换算",
+        "priceFingerprint": "价格指纹",
+        "priceSource": "价格源",
+        "priceSourceType": "价格来源类型",
+        "provider": "厂商",
+        "publishStatus": "发布状态",
+        "reason": "原因",
+        "retailAudioInput": "零售音频输入价",
+        "retailAudioOutput": "零售音频输出价",
+        "retailCacheInput": "零售缓存输入价",
+        "retailImageOutput": "零售图片输出价",
+        "retailInput": "零售输入价",
+        "retailOutput": "零售输出价",
+        "retailVideoInput": "零售视频输入价",
+        "retailVideoOutput": "零售视频输出价",
+        "retailVideoResolution": "零售视频分辨率价格",
+        "rpmLimit": "RPM 限制",
+        "serviceFeeRate": "服务费率",
+        "settlementRatio": "结算比例",
+        "sourceCategory": "价格源分类",
+        "sourceType": "价格源类型",
+        "sourceUrl": "来源 URL",
+        "spec": "规格",
+        "status": "状态",
+        "tierEnd": "阶梯结束",
+        "tierStart": "阶梯起始",
+        "tierType": "阶梯类型",
+        "tpmLimit": "TPM 限制",
+        "unitPrice": "单价",
+        "updatesModelPrices": "更新模型价格",
+        "website": "官网",
+        "workflowStatus": "流程状态"
+      },
+      "filters": {
+        "action": "操作动作",
+        "actor": "操作人",
+        "actorPlaceholder": "如 ops",
+        "category": "大类",
+        "target": "实例名称",
+        "targetPlaceholder": "如 DeepSeek R1"
+      },
+      "loading": "正在加载操作记录...",
+      "moreChanges": "+{count} 项",
+      "pagination": {
+        "emptyRange": "0 条记录",
+        "next": "下一页",
+        "pageSize": "每页",
+        "pageSizeOption": "{size} 条/页",
+        "previous": "上一页",
+        "range": "{start}-{end} / {count} 条记录"
+      },
+      "recordCount": "{count} 条记录",
+      "table": {
+        "actor": "操作人",
+        "category": "大类",
+        "changes": "变更内容",
+        "instance": "实例",
+        "platform": "平台",
+        "time": "操作时间"
+      },
+      "targetTypes": {
+        "channel": "渠道",
+        "channelModelPrice": "渠道模型配置",
+        "channelPriceItem": "渠道价格项",
+        "listing": "模型挂售",
+        "listingExclusion": "挂售排除",
+        "metaModel": "元模型",
+        "model": "模型",
+        "modelPrice": "模型价格",
+        "priceSource": "价格源",
+        "provider": "元模型厂商",
+        "reconciliationRecord": "对账记录",
+        "resalePlatform": "挂售平台"
+      },
+      "values": {
+        "boolean": {
+          "no": "否",
+          "yes": "是"
+        },
+        "comparison_status": {
+          "aboveOfficial": "高于上游价",
+          "belowOfficial": "低于上游价",
+          "sameAsOfficial": "等于上游价",
+          "unknown": "待判断"
+        },
+        "publish_status": {
+          "deleted": "已删除",
+          "none": "未发布",
+          "offline": "已下架",
+          "online": "已发布"
+        },
+        "status": {
+          "active": "启用",
+          "draft": "草稿",
+          "failed": "失败",
+          "inactive": "停用",
+          "matched": "已匹配",
+          "mismatch": "不一致",
+          "pending": "待处理",
+          "retired": "停用",
+          "unmatched": "未匹配"
+        },
+        "workflow_status": {
+          "deleted": "已失效",
+          "draft": "草稿",
+          "offline": "已下架",
+          "offlineException": "下架异常",
+          "online": "已上架",
+          "pendingOffline": "待下架",
+          "pendingPublish": "待发布",
+          "pendingUpdate": "待更新",
+          "updateDraft": "更新草稿"
+        }
+      }
     }
   },
   "sals": {


### PR DESCRIPTION
## Summary
- Replace remaining hard-coded LLMOps console copy with vue-i18n lookups.
- Add matching English and Simplified Chinese locale entries for publishing, audit, provider, source, import, and price entry flows.
- Verify changed components reference existing locale keys and no longer contain Chinese UI literals.

## Test plan
- [x] npx eslint src/components/llm-ops/AgioneListingStatusBoard.vue src/components/llm-ops/AuditLogPanel.vue src/components/llm-ops/ChannelManagement.vue src/components/llm-ops/ManualPriceEntryModal.vue src/components/llm-ops/ManualPriceImportModal.vue src/components/llm-ops/PriceSourceModal.vue src/components/llm-ops/ProviderManagement.vue src/components/llm-ops/ResalePublishingDrawer.vue src/components/llm-ops/ResalePublishingWorkspace.vue src/components/llm-ops/SourcePriceDrawer.vue --ignore-path ../.gitignore
- [x] node JSON parse check for src/locales/en.json and src/locales/zh-CN.json
- [x] Custom locale-key check: 545 changed-component i18n keys exist in both locales; en/zh llmOps key counts both 732
- [x] npm run build

## Notes
- No linked GitHub Issue was found for this branch, so this PR does not include a Closes reference.
- npm run lint currently fails before checking this change because the script points to frontend/.gitignore, which does not exist; running ESLint with ../.gitignore works for the changed Vue files. Full-repo ESLint still reports pre-existing issues outside this change.

Made with [Orca](https://github.com/stablyai/orca) 🐋
