### PR TITLE
Polish LLM Ops i18n and navigation

### DIFF
--- a/frontend/src/components/llm-ops/ChannelModal.vue
+++ b/frontend/src/components/llm-ops/ChannelModal.vue
@@ -191,8 +191,8 @@ const emit = defineEmits(['close', 'saved'])
 const form = ref(defaults())
 const saving = ref(false)
 const currencyOptions = [
-  { label: 'CNY - 人民币', value: 'CNY' },
-  { label: 'USD - 美元', value: 'USD' }
+  { label: 'CNY', value: 'CNY' },
+  { label: 'USD', value: 'USD' }
 ]
 
 const settlementRatioPercent = computed({

--- a/frontend/src/components/llm-ops/ChannelModelDrawer.vue
+++ b/frontend/src/components/llm-ops/ChannelModelDrawer.vue
@@ -866,8 +866,8 @@ const currencyOptions = computed(() => [
     value: '',
     description: `保存为 ${channelCurrency.value}`
   },
-  { label: '人民币 CNY', value: 'CNY', description: '固定保存为人民币' },
-  { label: '美元 USD', value: 'USD', description: '固定保存为美元' }
+  { label: 'CNY', value: 'CNY', description: '固定保存为人民币' },
+  { label: 'USD', value: 'USD', description: '固定保存为美元' }
 ])
 
 const listedCount = computed(

--- a/frontend/src/components/llm-ops/CompactSelect.vue
+++ b/frontend/src/components/llm-ops/CompactSelect.vue
@@ -13,7 +13,7 @@
       @click="toggle"
     >
       <span class="truncate">
-        {{ selectedOption?.label || placeholder }}
+        {{ selectedOption?.label || displayPlaceholder }}
       </span>
       <span class="compact-select-caret">⌄</span>
     </button>
@@ -24,7 +24,7 @@
         ref="searchInputRef"
         v-model="search"
         class="compact-select-search"
-        :placeholder="searchPlaceholder"
+        :placeholder="displaySearchPlaceholder"
         @keydown.escape="open = false"
       />
       <button
@@ -36,10 +36,7 @@
         type="button"
         @click="select(option.value)"
       >
-        <span
-          v-if="option.type === 'group'"
-          class="compact-select-group-label"
-        >
+        <span v-if="option.type === 'group'" class="compact-select-group-label">
           {{ option.label }}
         </span>
         <span v-else class="min-w-0 flex-1">
@@ -62,7 +59,7 @@
         </span>
       </button>
       <div v-if="!filteredOptions.length" class="compact-select-empty">
-        没有匹配的选项
+        {{ displayEmptyText }}
       </div>
     </div>
   </div>
@@ -70,6 +67,7 @@
 
 <script setup>
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 const props = defineProps({
   modelValue: {
@@ -82,7 +80,7 @@ const props = defineProps({
   },
   placeholder: {
     type: String,
-    default: '请选择'
+    default: ''
   },
   size: {
     type: String,
@@ -106,7 +104,11 @@ const props = defineProps({
   },
   searchPlaceholder: {
     type: String,
-    default: '搜索选项'
+    default: ''
+  },
+  emptyText: {
+    type: String,
+    default: ''
   },
   menuMinWidth: {
     type: Number,
@@ -115,6 +117,7 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['update:modelValue', 'change'])
+const { t } = useI18n()
 
 const open = ref(false)
 const selectRef = ref(null)
@@ -127,6 +130,18 @@ const selectedOption = computed(() =>
   props.options.find(
     (option) => String(option.value) === String(props.modelValue)
   )
+)
+
+const displayPlaceholder = computed(
+  () => props.placeholder || t('common.select')
+)
+
+const displaySearchPlaceholder = computed(
+  () => props.searchPlaceholder || t('common.searchOptions')
+)
+
+const displayEmptyText = computed(
+  () => props.emptyText || t('common.noResults')
 )
 
 const filteredOptions = computed(() => {
@@ -209,10 +224,7 @@ function updateMenuPosition() {
   const spaceAbove = rect.top - gap
   const opensUp = spaceBelow < 140 && spaceAbove > spaceBelow
   const desiredWidth = Math.max(rect.width, Number(props.menuMinWidth) || 0)
-  const width = Math.min(
-    desiredWidth,
-    window.innerWidth - viewportPadding * 2
-  )
+  const width = Math.min(desiredWidth, window.innerWidth - viewportPadding * 2)
   const left = Math.min(
     Math.max(viewportPadding, rect.left),
     window.innerWidth - width - viewportPadding
@@ -224,9 +236,7 @@ function updateMenuPosition() {
   menuStyle.value = {
     left: `${left}px`,
     top: opensUp ? 'auto' : `${rect.bottom + gap}px`,
-    bottom: opensUp
-      ? `${window.innerHeight - rect.top + gap}px`
-      : 'auto',
+    bottom: opensUp ? `${window.innerHeight - rect.top + gap}px` : 'auto',
     width: `${width}px`,
     maxHeight: `${maxHeight}px`
   }

--- a/frontend/src/components/llm-ops/MetaModelManagement.vue
+++ b/frontend/src/components/llm-ops/MetaModelManagement.vue
@@ -20,9 +20,11 @@
       <article class="panel min-w-0 overflow-hidden p-0">
         <div class="table-toolbar">
           <div class="toolbar-copy">
-            <h3 class="panel-title">元模型厂商</h3>
+            <h3 class="panel-title">
+              {{ t('llmOps.metaModelManagement.title') }}
+            </h3>
             <p class="mt-1 text-xs text-slate-500">
-              展示已绑定元模型的厂商，点击后通过抽屉查看该厂商下的元模型。
+              {{ t('llmOps.metaModelManagement.description') }}
             </p>
           </div>
           <div class="vendor-toolbar-summary">
@@ -30,19 +32,21 @@
               v-model="vendorSearchKeyword"
               class="control-field vendor-search"
               name="meta-model-vendor-search"
-              placeholder="搜索厂商"
+              :placeholder="
+                t('llmOps.metaModelManagement.filters.searchVendors')
+              "
             />
             <span class="summary-pill">
-              <span>厂商</span>
+              <span>{{ t('llmOps.metaModelManagement.summary.vendors') }}</span>
               <strong>{{ vendorRows.length }}</strong>
             </span>
           </div>
         </div>
         <div class="vendor-list">
           <div class="vendor-list-header">
-            <span>厂商</span>
-            <span>元模型</span>
-            <span>操作</span>
+            <span>{{ t('llmOps.metaModelManagement.table.vendor') }}</span>
+            <span>{{ t('llmOps.metaModelManagement.table.metaModels') }}</span>
+            <span>{{ t('llmOps.metaModelManagement.table.actions') }}</span>
           </div>
           <button
             v-for="row in filteredVendorRows"
@@ -65,13 +69,15 @@
                 {{ row.meta_model_count }}
               </p>
             </div>
-            <span class="link-btn text-center">查看模型</span>
+            <span class="link-btn text-center">
+              {{ t('llmOps.metaModelManagement.actions.viewModels') }}
+            </span>
           </button>
           <div
             v-if="!filteredVendorRows.length"
             class="px-4 py-6 text-sm text-slate-500"
           >
-            暂无符合条件的元模型厂商。
+            {{ t('llmOps.metaModelManagement.empty.vendors') }}
           </div>
         </div>
       </article>
@@ -85,15 +91,20 @@
       <aside class="meta-drawer library-drawer">
         <div class="drawer-header">
           <div class="min-w-0 flex-1">
-            <p class="drawer-eyebrow">Vendor Meta Models</p>
+            <p class="drawer-eyebrow">
+              {{ t('llmOps.metaModelManagement.drawer.eyebrow') }}
+            </p>
             <h3 class="drawer-title">
-              {{ selectedVendorRow?.name || '厂商元模型' }}
+              {{
+                selectedVendorRow?.name ||
+                t('llmOps.metaModelManagement.drawer.fallbackTitle')
+              }}
             </h3>
             <p class="mt-1 font-mono text-xs text-slate-500">
               {{ selectedVendorRow?.code || '-' }}
             </p>
             <p class="drawer-desc">
-              展示该厂商下的元模型，支持状态、模态和关键字筛选。
+              {{ t('llmOps.metaModelManagement.drawer.description') }}
             </p>
           </div>
           <div class="drawer-header-actions">
@@ -103,14 +114,18 @@
               :disabled="syncingMetaModels"
               @click="syncMetaModels"
             >
-              {{ syncingMetaModels ? '同步中' : '同步元模型' }}
+              {{
+                syncingMetaModels
+                  ? t('llmOps.metaModelManagement.actions.syncing')
+                  : t('llmOps.metaModelManagement.actions.sync')
+              }}
             </button>
             <button
               class="btn-secondary btn-action-cancel"
               type="button"
               @click="closeVendorModelsDrawer"
             >
-              关闭
+              {{ t('llmOps.metaModelManagement.actions.close') }}
             </button>
           </div>
         </div>
@@ -137,11 +152,17 @@
                 v-model="searchKeyword"
                 class="control-field drawer-search"
                 name="meta-model-search"
-                placeholder="搜索名称、Code、别名或家族"
+                :placeholder="
+                  t('llmOps.metaModelManagement.filters.searchModels')
+                "
               />
               <p class="drawer-result-note">
-                {{ vendorMetaRows.length }} 个元模型 ·
-                {{ selectedVendorActiveCount }} 个可用
+                {{
+                  t('llmOps.metaModelManagement.summary.modelResult', {
+                    total: vendorMetaRows.length,
+                    active: selectedVendorActiveCount
+                  })
+                }}
               </p>
             </div>
           </div>
@@ -158,11 +179,21 @@
                 </colgroup>
                 <thead>
                   <tr>
-                    <th class="table-head">元模型</th>
-                    <th class="table-head">能力</th>
-                    <th class="table-head">上下文</th>
-                    <th class="table-head">发布日期</th>
-                    <th class="table-head">状态</th>
+                    <th class="table-head">
+                      {{ t('llmOps.metaModelManagement.table.metaModel') }}
+                    </th>
+                    <th class="table-head">
+                      {{ t('llmOps.metaModelManagement.table.capability') }}
+                    </th>
+                    <th class="table-head">
+                      {{ t('llmOps.metaModelManagement.table.context') }}
+                    </th>
+                    <th class="table-head">
+                      {{ t('llmOps.metaModelManagement.table.releaseDate') }}
+                    </th>
+                    <th class="table-head">
+                      {{ t('llmOps.metaModelManagement.table.status') }}
+                    </th>
                   </tr>
                 </thead>
                 <tbody>
@@ -220,10 +251,18 @@
                         <p
                           class="font-mono text-xs font-semibold text-slate-800"
                         >
-                          In {{ compactTokenLabel(item.context_window) }}
+                          {{
+                            t('llmOps.metaModelManagement.context.input', {
+                              value: compactTokenLabel(item.context_window)
+                            })
+                          }}
                         </p>
                         <p class="mt-1 font-mono text-xs text-slate-400">
-                          Out {{ compactTokenLabel(item.max_output_tokens) }}
+                          {{
+                            t('llmOps.metaModelManagement.context.output', {
+                              value: compactTokenLabel(item.max_output_tokens)
+                            })
+                          }}
                         </p>
                       </div>
                     </td>
@@ -244,7 +283,7 @@
                   </tr>
                   <tr v-if="!vendorMetaRows.length">
                     <td class="table-cell text-slate-500" colspan="5">
-                      当前厂商下暂无符合条件的元模型。
+                      {{ t('llmOps.metaModelManagement.empty.models') }}
                     </td>
                   </tr>
                 </tbody>
@@ -252,8 +291,13 @@
             </div>
             <div v-if="vendorMetaRows.length" class="pagination-bar">
               <p class="text-xs text-slate-500">
-                共 {{ vendorMetaRows.length }} 条，第 {{ safeCurrentPage }} /
-                {{ totalPages }} 页
+                {{
+                  t('llmOps.metaModelManagement.pagination.summary', {
+                    total: vendorMetaRows.length,
+                    current: safeCurrentPage,
+                    pages: totalPages
+                  })
+                }}
               </p>
               <div class="flex items-center gap-2">
                 <button
@@ -262,7 +306,7 @@
                   :disabled="safeCurrentPage <= 1"
                   @click="goToPreviousPage"
                 >
-                  上一页
+                  {{ t('llmOps.metaModelManagement.pagination.previous') }}
                 </button>
                 <button
                   class="btn-secondary pagination-btn btn-action-neutral"
@@ -270,7 +314,7 @@
                   :disabled="safeCurrentPage >= totalPages"
                   @click="goToNextPage"
                 >
-                  下一页
+                  {{ t('llmOps.metaModelManagement.pagination.next') }}
                 </button>
               </div>
             </div>
@@ -283,6 +327,7 @@
 
 <script setup>
 import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { llmOpsApi } from '@/api/llmOps'
 import { useToast } from '@/composables/useToast'
 import CompactSelect from '@/components/llm-ops/CompactSelect.vue'
@@ -309,6 +354,7 @@ const props = defineProps({
 
 const emit = defineEmits(['refresh'])
 const { showSuccess, showError } = useToast()
+const { t } = useI18n()
 
 const searchKeyword = ref('')
 const vendorSearchKeyword = ref('')
@@ -320,26 +366,47 @@ const selectedVendorId = ref('')
 const showVendorModelsDrawer = ref(false)
 const syncingMetaModels = ref(false)
 
-const statusOptions = [
-  { value: '', label: '全部状态' },
-  { value: 'active', label: 'Active' },
-  { value: 'deprecated', label: 'Deprecated' },
-  { value: 'unknown', label: 'Unknown' }
-]
+const statusOptions = computed(() => [
+  {
+    value: '',
+    label: t('llmOps.metaModelManagement.filters.allStatuses')
+  },
+  { value: 'active', label: t('llmOps.metaModelManagement.status.active') },
+  {
+    value: 'deprecated',
+    label: t('llmOps.metaModelManagement.status.deprecated')
+  },
+  { value: 'unknown', label: t('llmOps.metaModelManagement.status.unknown') }
+])
 
-const modalityOptions = [
-  { value: '', label: '全部模态' },
-  { value: 'text', label: 'Text' },
-  { value: 'multimodal', label: 'Multimodal' },
-  { value: 'audio', label: 'Audio' },
-  { value: 'video', label: 'Video' }
-]
+const modalityOptions = computed(() => [
+  {
+    value: '',
+    label: t('llmOps.metaModelManagement.filters.allModalities')
+  },
+  { value: 'text', label: t('llmOps.metaModelManagement.modality.text') },
+  {
+    value: 'multimodal',
+    label: t('llmOps.metaModelManagement.modality.multimodal')
+  },
+  { value: 'audio', label: t('llmOps.metaModelManagement.modality.audio') },
+  { value: 'video', label: t('llmOps.metaModelManagement.modality.video') }
+])
 
-const pageSizeOptions = [
-  { value: 10, label: '10 条/页' },
-  { value: 20, label: '20 条/页' },
-  { value: 50, label: '50 条/页' }
-]
+const pageSizeOptions = computed(() => [
+  {
+    value: 10,
+    label: t('llmOps.metaModelManagement.pagination.pageSize', { count: 10 })
+  },
+  {
+    value: 20,
+    label: t('llmOps.metaModelManagement.pagination.pageSize', { count: 20 })
+  },
+  {
+    value: 50,
+    label: t('llmOps.metaModelManagement.pagination.pageSize', { count: 50 })
+  }
+])
 
 const rows = computed(() =>
   props.metaModels.map((item) => {
@@ -473,19 +540,19 @@ const metricCards = computed(() => {
   )
   return [
     {
-      label: '元模型',
+      label: t('llmOps.metaModelManagement.metrics.metaModels.label'),
       value: props.metaModels.length,
-      hint: '归一化后的模型身份'
+      hint: t('llmOps.metaModelManagement.metrics.metaModels.hint')
     },
     {
-      label: '已绑定厂商',
+      label: t('llmOps.metaModelManagement.metrics.boundVendors.label'),
       value: boundVendorIds.size,
-      hint: '存在元模型的厂商数'
+      hint: t('llmOps.metaModelManagement.metrics.boundVendors.hint')
     },
     {
-      label: '可用 / 弃用',
+      label: t('llmOps.metaModelManagement.metrics.status.label'),
       value: `${active.length}/${deprecated.length}`,
-      hint: 'Active / Deprecated'
+      hint: t('llmOps.metaModelManagement.metrics.status.hint')
     }
   ]
 })
@@ -524,10 +591,14 @@ async function syncMetaModels() {
   try {
     const response = await llmOpsApi.syncMetaModels()
     const stats = response?.data || {}
-    showSuccess(`已同步 ${stats.models || 0} 个真实元模型`)
+    showSuccess(
+      t('llmOps.metaModelManagement.messages.synced', {
+        count: stats.models || 0
+      })
+    )
     emit('refresh')
   } catch (error) {
-    showError(errorMessage(error, '同步元模型失败'))
+    showError(errorMessage(error, t('llmOps.metaModelManagement.errors.sync')))
   } finally {
     syncingMetaModels.value = false
   }
@@ -608,12 +679,14 @@ function capabilityIconPaths(value) {
 
 function featureLabel(value) {
   const labels = {
-    attachment: 'Attachment',
-    chat: 'Chat',
-    image_generation: 'Image generation',
-    reasoning: 'Reasoning',
-    structured_output: 'Structured output',
-    tool_calling: 'Tool calling'
+    attachment: t('llmOps.metaModelManagement.features.attachment'),
+    chat: t('llmOps.metaModelManagement.features.chat'),
+    image_generation: t('llmOps.metaModelManagement.features.imageGeneration'),
+    reasoning: t('llmOps.metaModelManagement.features.reasoning'),
+    structured_output: t(
+      'llmOps.metaModelManagement.features.structuredOutput'
+    ),
+    tool_calling: t('llmOps.metaModelManagement.features.toolCalling')
   }
   return labels[value] || value || '-'
 }
@@ -679,21 +752,23 @@ function compactNumber(value) {
 
 function modalityLabel(value) {
   const labels = {
-    text: 'Text',
-    multimodal: 'Multimodal',
-    audio: 'Audio',
-    video: 'Video'
+    text: t('llmOps.metaModelManagement.modality.text'),
+    multimodal: t('llmOps.metaModelManagement.modality.multimodal'),
+    audio: t('llmOps.metaModelManagement.modality.audio'),
+    video: t('llmOps.metaModelManagement.modality.video')
   }
   return labels[value] || value || '-'
 }
 
 function statusLabel(value) {
   const labels = {
-    active: 'Active',
-    deprecated: 'Deprecated',
-    unknown: 'Unknown'
+    active: t('llmOps.metaModelManagement.status.active'),
+    deprecated: t('llmOps.metaModelManagement.status.deprecated'),
+    unknown: t('llmOps.metaModelManagement.status.unknown')
   }
-  return labels[value] || value || 'Unknown'
+  return (
+    labels[value] || value || t('llmOps.metaModelManagement.status.unknown')
+  )
 }
 
 function statusTone(value) {
@@ -737,7 +812,7 @@ function errorMessage(error, fallback) {
 }
 
 .source-summary-strip {
-  @apply grid gap-px overflow-hidden rounded-lg border border-slate-200 bg-slate-200 shadow-sm sm:grid-cols-2 lg:grid-cols-4;
+  @apply grid gap-px overflow-hidden rounded-lg border border-slate-200 bg-slate-200 shadow-sm sm:grid-cols-3;
 }
 
 .source-summary-item {

--- a/frontend/src/components/llm-ops/ReconciliationPanel.vue
+++ b/frontend/src/components/llm-ops/ReconciliationPanel.vue
@@ -2,51 +2,59 @@
   <section class="space-y-5">
     <form class="panel space-y-4" @submit.prevent="saveReconciliation">
       <div class="flex flex-col gap-1">
-        <p
-          class="text-xs font-semibold uppercase tracking-[0.18em] text-indigo-600"
-        >
-          Reconciliation
-        </p>
-        <h3 class="panel-title">生产使用对账审计</h3>
-        <p class="text-sm text-slate-500">
-          录入生产侧实际用量和渠道账单金额，用于核对系统按渠道采购价计算出的应付金额。
-        </p>
+        <h3 class="panel-title">
+          {{ t('llmOps.reconciliationPanel.title') }}
+        </h3>
       </div>
 
       <div class="grid gap-3 lg:grid-cols-3">
         <label class="form-field">
-          <span class="field-label">对账日期</span>
+          <span class="field-label">
+            {{ t('llmOps.reconciliationPanel.fields.date') }}
+          </span>
           <input v-model="form.date" class="field" type="date" required />
         </label>
         <label class="form-field">
-          <span class="field-label">转发渠道</span>
+          <span class="field-label">
+            {{ t('llmOps.reconciliationPanel.fields.channel') }}
+          </span>
           <CompactSelect
             v-model="form.channel"
             :options="channelOptions"
-            placeholder="选择账单归属渠道"
+            :empty-text="t('common.noResults')"
+            :placeholder="t('llmOps.reconciliationPanel.placeholders.channel')"
             searchable
-            search-placeholder="搜索渠道名称 / code / 接入地址"
+            :search-placeholder="
+              t('llmOps.reconciliationPanel.placeholders.searchChannel')
+            "
           />
         </label>
         <label class="form-field">
-          <span class="field-label">调用模型</span>
+          <span class="field-label">
+            {{ t('llmOps.reconciliationPanel.fields.model') }}
+          </span>
           <CompactSelect
             v-model="form.model"
             :options="modelOptions"
-            placeholder="选择本次用量对应模型"
+            :empty-text="t('common.noResults')"
+            :placeholder="t('llmOps.reconciliationPanel.placeholders.model')"
             searchable
-            search-placeholder="搜索模型名称 / code / 服务商"
+            :search-placeholder="
+              t('llmOps.reconciliationPanel.placeholders.searchModel')
+            "
           />
         </label>
       </div>
 
       <div class="usage-grid">
         <div v-if="!selectedModel" class="usage-helper lg:col-span-2">
-          选择调用模型后，只显示该模型相关的用量维度。
+          {{ t('llmOps.reconciliationPanel.helper.selectModel') }}
         </div>
         <template v-if="showTextUsage">
           <label class="form-field">
-            <span class="field-label">文本输入 Tokens</span>
+            <span class="field-label">
+              {{ t('llmOps.reconciliationPanel.fields.inputTokens') }}
+            </span>
             <input
               v-model="form.input_tokens"
               class="field"
@@ -55,7 +63,9 @@
             />
           </label>
           <label class="form-field">
-            <span class="field-label">文本输出 Tokens</span>
+            <span class="field-label">
+              {{ t('llmOps.reconciliationPanel.fields.outputTokens') }}
+            </span>
             <input
               v-model="form.output_tokens"
               class="field"
@@ -65,7 +75,9 @@
           </label>
         </template>
         <label class="form-field">
-          <span class="field-label">渠道账单金额</span>
+          <span class="field-label">
+            {{ t('llmOps.reconciliationPanel.fields.chargedAmount') }}
+          </span>
           <input
             v-model="form.charged_amount"
             class="field"
@@ -77,7 +89,9 @@
         </label>
         <template v-if="showAudioUsage">
           <label class="form-field">
-            <span class="field-label">音频输入秒数</span>
+            <span class="field-label">
+              {{ t('llmOps.reconciliationPanel.fields.audioInputSeconds') }}
+            </span>
             <input
               v-model="form.audio_input_seconds"
               class="field"
@@ -87,7 +101,9 @@
             />
           </label>
           <label class="form-field">
-            <span class="field-label">音频输出秒数</span>
+            <span class="field-label">
+              {{ t('llmOps.reconciliationPanel.fields.audioOutputSeconds') }}
+            </span>
             <input
               v-model="form.audio_output_seconds"
               class="field"
@@ -99,7 +115,9 @@
         </template>
         <template v-if="showVideoUsage">
           <label class="form-field">
-            <span class="field-label">视频输入秒数</span>
+            <span class="field-label">
+              {{ t('llmOps.reconciliationPanel.fields.videoInputSeconds') }}
+            </span>
             <input
               v-model="form.video_input_seconds"
               class="field"
@@ -109,7 +127,9 @@
             />
           </label>
           <label class="form-field">
-            <span class="field-label">视频输出秒数</span>
+            <span class="field-label">
+              {{ t('llmOps.reconciliationPanel.fields.videoOutputSeconds') }}
+            </span>
             <input
               v-model="form.video_output_seconds"
               class="field"
@@ -119,11 +139,15 @@
             />
           </label>
           <label class="form-field lg:col-span-2">
-            <span class="field-label">视频规格</span>
+            <span class="field-label">
+              {{ t('llmOps.reconciliationPanel.fields.videoResolution') }}
+            </span>
             <input
               v-model="form.video_resolution"
               class="field"
-              placeholder="如 720p / 1080p，可选"
+              :placeholder="
+                t('llmOps.reconciliationPanel.placeholders.videoResolution')
+              "
             />
           </label>
         </template>
@@ -137,7 +161,7 @@
           :title="createDisabledReason"
         >
           <span class="icon-mark" />
-          新建对账记录
+          {{ t('llmOps.reconciliationPanel.actions.create') }}
         </button>
       </div>
       <p v-if="createDisabledReason" class="form-warning">
@@ -147,19 +171,35 @@
 
     <div class="panel overflow-hidden p-0">
       <div class="table-toolbar">
-        <h3 class="panel-title">对账记录</h3>
+        <h3 class="panel-title">
+          {{ t('llmOps.reconciliationPanel.records.title') }}
+        </h3>
       </div>
       <div class="overflow-x-auto">
         <table class="data-table">
           <thead>
             <tr>
-              <th class="table-head">日期</th>
-              <th class="table-head">渠道</th>
-              <th class="table-head">模型</th>
-              <th class="table-head text-right">账单</th>
-              <th class="table-head text-right">应付</th>
-              <th class="table-head text-right">差异</th>
-              <th class="table-head">状态</th>
+              <th class="table-head">
+                {{ t('llmOps.reconciliationPanel.table.date') }}
+              </th>
+              <th class="table-head">
+                {{ t('llmOps.reconciliationPanel.table.channel') }}
+              </th>
+              <th class="table-head">
+                {{ t('llmOps.reconciliationPanel.table.model') }}
+              </th>
+              <th class="table-head text-right">
+                {{ t('llmOps.reconciliationPanel.table.bill') }}
+              </th>
+              <th class="table-head text-right">
+                {{ t('llmOps.reconciliationPanel.table.payable') }}
+              </th>
+              <th class="table-head text-right">
+                {{ t('llmOps.reconciliationPanel.table.variance') }}
+              </th>
+              <th class="table-head">
+                {{ t('llmOps.reconciliationPanel.table.status') }}
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -183,10 +223,11 @@
             <tr v-if="!records.length">
               <td class="table-cell" colspan="7">
                 <div class="empty-state">
-                  <p class="font-medium text-slate-700">暂无对账记录</p>
+                  <p class="font-medium text-slate-700">
+                    {{ t('llmOps.reconciliationPanel.empty.title') }}
+                  </p>
                   <p class="mt-1 text-sm text-slate-500">
-                    先选择转发渠道和调用模型，录入渠道账单金额与实际用量；
-                    系统会按当前渠道采购价计算应付金额并标记差异。
+                    {{ t('llmOps.reconciliationPanel.empty.description') }}
                   </p>
                 </div>
               </td>
@@ -200,6 +241,7 @@
 
 <script setup>
 import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { llmOpsApi } from '@/api/llmOps'
 import CompactSelect from '@/components/llm-ops/CompactSelect.vue'
 
@@ -219,6 +261,7 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['refresh'])
+const { t } = useI18n()
 
 const form = ref(defaults())
 
@@ -227,10 +270,14 @@ const selectedModel = computed(() =>
 )
 
 const createDisabledReason = computed(() => {
-  if (!form.value.channel) return '请选择账单归属的转发渠道。'
-  if (!form.value.model) return '请选择本次用量对应的调用模型。'
+  if (!form.value.channel) {
+    return t('llmOps.reconciliationPanel.validation.channelRequired')
+  }
+  if (!form.value.model) {
+    return t('llmOps.reconciliationPanel.validation.modelRequired')
+  }
   if (Number(form.value.charged_amount || 0) <= 0) {
-    return '请输入渠道账单金额。'
+    return t('llmOps.reconciliationPanel.validation.amountRequired')
   }
   return ''
 })
@@ -274,11 +321,17 @@ const channelOptions = computed(() =>
     description: [
       channel.code,
       channel.endpoint_url,
-      channel.currency ? `默认币种 ${channel.currency}` : ''
+      channel.currency
+        ? t('llmOps.reconciliationPanel.option.defaultCurrency', {
+            currency: channel.currency
+          })
+        : ''
     ]
       .filter(Boolean)
       .join(' · '),
-    badge: channel.is_active ? '启用' : '停用',
+    badge: channel.is_active
+      ? t('llmOps.reconciliationPanel.option.enabled')
+      : t('llmOps.reconciliationPanel.option.disabled'),
     searchText: [
       channel.name,
       channel.code,
@@ -368,19 +421,19 @@ function money(value) {
 
 function statusLabel(status) {
   const labels = {
-    perfect: '正常',
-    overcharged: '超收',
-    undercharged: '少收'
+    perfect: t('llmOps.reconciliationPanel.status.perfect'),
+    overcharged: t('llmOps.reconciliationPanel.status.overcharged'),
+    undercharged: t('llmOps.reconciliationPanel.status.undercharged')
   }
   return labels[status] || status || '-'
 }
 
 function modalityLabel(modality) {
   const labels = {
-    text: '文本',
-    audio: '音频',
-    video: '视频',
-    multimodal: '多模态'
+    text: t('llmOps.reconciliationPanel.modality.text'),
+    audio: t('llmOps.reconciliationPanel.modality.audio'),
+    video: t('llmOps.reconciliationPanel.modality.video'),
+    multimodal: t('llmOps.reconciliationPanel.modality.multimodal')
   }
   return labels[modality] || modality || ''
 }

--- a/frontend/src/components/llm-ops/ResalePlatformModal.vue
+++ b/frontend/src/components/llm-ops/ResalePlatformModal.vue
@@ -239,8 +239,8 @@ const emit = defineEmits(['close', 'saved'])
 const form = ref(defaults())
 const saving = ref(false)
 const currencyOptions = [
-  { label: 'CNY - 人民币', value: 'CNY' },
-  { label: 'USD - 美元', value: 'USD' }
+  { label: 'CNY', value: 'CNY' },
+  { label: 'USD', value: 'USD' }
 ]
 const roundingModeOptions = [
   { label: '四舍五入', value: 'half_up' },

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -17,6 +17,8 @@
     "submit": "Submit",
     "submitting": "Submitting…",
     "search": "Search",
+    "searchOptions": "Search options",
+    "select": "Select",
     "filter": "Filter",
     "all": "All",
     "refresh": "Refresh",
@@ -38,6 +40,7 @@
     "logout": "Logout",
     "profile": "Profile",
     "noData": "No data available",
+    "noResults": "No matching results found",
     "error": "Error",
     "success": "Success",
     "language": "Language",
@@ -748,8 +751,8 @@
       "createPlatform": "New platform"
     },
     "currency": {
-      "cny": "Chinese Yuan CNY",
-      "usd": "US Dollar USD"
+      "cny": "CNY",
+      "usd": "USD"
     },
     "nav": {
       "monitor": {
@@ -987,6 +990,160 @@
         "notConfigured": "Not configured"
       }
     },
+    "metaModelManagement": {
+      "title": "Meta Model Providers",
+      "description": "Shows providers with linked meta models. Open the drawer to inspect each provider's models.",
+      "actions": {
+        "close": "Close",
+        "sync": "Sync meta models",
+        "syncing": "Syncing",
+        "viewModels": "View models"
+      },
+      "context": {
+        "input": "In {value}",
+        "output": "Out {value}"
+      },
+      "drawer": {
+        "description": "Review this provider's meta models with status, modality, and keyword filters.",
+        "eyebrow": "Vendor Meta Models",
+        "fallbackTitle": "Provider meta models"
+      },
+      "empty": {
+        "models": "No meta models match the current filters for this provider.",
+        "vendors": "No meta model providers match the current filters."
+      },
+      "errors": {
+        "sync": "Failed to sync meta models"
+      },
+      "features": {
+        "attachment": "Attachment",
+        "chat": "Chat",
+        "imageGeneration": "Image generation",
+        "reasoning": "Reasoning",
+        "structuredOutput": "Structured output",
+        "toolCalling": "Tool calling"
+      },
+      "filters": {
+        "allModalities": "All modalities",
+        "allStatuses": "All statuses",
+        "searchModels": "Search name, code, aliases, or family",
+        "searchVendors": "Search providers"
+      },
+      "messages": {
+        "synced": "Synced {count} real meta models"
+      },
+      "metrics": {
+        "boundVendors": {
+          "hint": "Providers that have meta models",
+          "label": "Linked providers"
+        },
+        "metaModels": {
+          "hint": "Normalized model identities",
+          "label": "Meta models"
+        },
+        "status": {
+          "hint": "Active / deprecated",
+          "label": "Active / deprecated"
+        }
+      },
+      "modality": {
+        "audio": "Audio",
+        "multimodal": "Multimodal",
+        "text": "Text",
+        "video": "Video"
+      },
+      "pagination": {
+        "next": "Next",
+        "pageSize": "{count} / page",
+        "previous": "Previous",
+        "summary": "{total} rows, page {current} / {pages}"
+      },
+      "status": {
+        "active": "Active",
+        "deprecated": "Deprecated",
+        "unknown": "Unknown"
+      },
+      "summary": {
+        "modelResult": "{total} meta models · {active} active",
+        "vendors": "Providers"
+      },
+      "table": {
+        "actions": "Actions",
+        "capability": "Capability",
+        "context": "Context",
+        "metaModel": "Meta model",
+        "metaModels": "Meta models",
+        "releaseDate": "Release date",
+        "status": "Status",
+        "vendor": "Provider"
+      }
+    },
+    "reconciliationPanel": {
+      "title": "Production Usage Reconciliation",
+      "actions": {
+        "create": "New reconciliation record"
+      },
+      "empty": {
+        "description": "Select a channel, model, and billed amount to create a record.",
+        "title": "No reconciliation records"
+      },
+      "fields": {
+        "audioInputSeconds": "Audio input seconds",
+        "audioOutputSeconds": "Audio output seconds",
+        "channel": "Forwarding channel",
+        "chargedAmount": "Channel billed amount",
+        "date": "Reconciliation date",
+        "inputTokens": "Text input tokens",
+        "model": "Model",
+        "outputTokens": "Text output tokens",
+        "videoInputSeconds": "Video input seconds",
+        "videoOutputSeconds": "Video output seconds",
+        "videoResolution": "Video resolution"
+      },
+      "helper": {
+        "selectModel": "Select a model to show matching usage dimensions."
+      },
+      "modality": {
+        "audio": "Audio",
+        "multimodal": "Multimodal",
+        "text": "Text",
+        "video": "Video"
+      },
+      "option": {
+        "defaultCurrency": "Default currency {currency}",
+        "disabled": "Inactive",
+        "enabled": "Active"
+      },
+      "placeholders": {
+        "channel": "Select billing channel",
+        "model": "Select model",
+        "searchChannel": "Search channel name / code / endpoint",
+        "searchModel": "Search model name / code / provider",
+        "videoResolution": "Example: 720p / 1080p, optional"
+      },
+      "records": {
+        "title": "Reconciliation Records"
+      },
+      "status": {
+        "overcharged": "Overcharged",
+        "perfect": "Balanced",
+        "undercharged": "Undercharged"
+      },
+      "table": {
+        "bill": "Bill",
+        "channel": "Channel",
+        "date": "Date",
+        "model": "Model",
+        "payable": "Payable",
+        "status": "Status",
+        "variance": "Variance"
+      },
+      "validation": {
+        "amountRequired": "Enter the channel billed amount.",
+        "channelRequired": "Select the forwarding channel for this bill.",
+        "modelRequired": "Select the model used for this usage."
+      }
+    },
     "providerManagement": {
       "title": "Supplier Price Sources",
       "modelsCount": "{count} meta models",
@@ -1152,8 +1309,8 @@
         "unknown": "Other"
       },
       "currencies": {
-        "cny": "CNY - Chinese yuan",
-        "usd": "USD - US dollar"
+        "cny": "CNY",
+        "usd": "USD"
       },
       "messages": {
         "created": "Model price source created",
@@ -1319,8 +1476,8 @@
         "video": "Video"
       },
       "currencies": {
-        "cny": "CNY - Chinese yuan",
-        "usd": "USD - US dollar"
+        "cny": "CNY",
+        "usd": "USD"
       },
       "categories": {
         "manual": "Manual",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -17,6 +17,8 @@
     "submit": "提交",
     "submitting": "提交中…",
     "search": "搜索",
+    "searchOptions": "搜索选项",
+    "select": "请选择",
     "filter": "筛选",
     "all": "全部",
     "refresh": "刷新",
@@ -38,6 +40,7 @@
     "logout": "退出登录",
     "profile": "个人资料",
     "noData": "暂无数据",
+    "noResults": "未找到匹配结果",
     "error": "错误",
     "success": "成功",
     "language": "语言",
@@ -758,8 +761,8 @@
       "createPlatform": "新建平台"
     },
     "currency": {
-      "cny": "人民币 CNY",
-      "usd": "美元 USD"
+      "cny": "CNY",
+      "usd": "USD"
     },
     "nav": {
       "monitor": {
@@ -997,6 +1000,160 @@
         "notConfigured": "未配置"
       }
     },
+    "metaModelManagement": {
+      "title": "元模型厂商",
+      "description": "展示已绑定元模型的厂商，点击后通过抽屉查看该厂商下的元模型。",
+      "actions": {
+        "close": "关闭",
+        "sync": "同步元模型",
+        "syncing": "同步中",
+        "viewModels": "查看模型"
+      },
+      "context": {
+        "input": "输入 {value}",
+        "output": "输出 {value}"
+      },
+      "drawer": {
+        "description": "展示该厂商下的元模型，支持状态、模态和关键字筛选。",
+        "eyebrow": "厂商元模型",
+        "fallbackTitle": "厂商元模型"
+      },
+      "empty": {
+        "models": "当前厂商下暂无符合条件的元模型。",
+        "vendors": "暂无符合条件的元模型厂商。"
+      },
+      "errors": {
+        "sync": "同步元模型失败"
+      },
+      "features": {
+        "attachment": "附件",
+        "chat": "对话",
+        "imageGeneration": "图像生成",
+        "reasoning": "推理",
+        "structuredOutput": "结构化输出",
+        "toolCalling": "工具调用"
+      },
+      "filters": {
+        "allModalities": "全部模态",
+        "allStatuses": "全部状态",
+        "searchModels": "搜索名称、Code、别名或家族",
+        "searchVendors": "搜索厂商"
+      },
+      "messages": {
+        "synced": "已同步 {count} 个真实元模型"
+      },
+      "metrics": {
+        "boundVendors": {
+          "hint": "存在元模型的厂商数",
+          "label": "已绑定厂商"
+        },
+        "metaModels": {
+          "hint": "归一化后的模型身份",
+          "label": "元模型"
+        },
+        "status": {
+          "hint": "可用 / 弃用",
+          "label": "可用 / 弃用"
+        }
+      },
+      "modality": {
+        "audio": "音频",
+        "multimodal": "多模态",
+        "text": "文本",
+        "video": "视频"
+      },
+      "pagination": {
+        "next": "下一页",
+        "pageSize": "{count} 条/页",
+        "previous": "上一页",
+        "summary": "共 {total} 条，第 {current} / {pages} 页"
+      },
+      "status": {
+        "active": "可用",
+        "deprecated": "弃用",
+        "unknown": "未知"
+      },
+      "summary": {
+        "modelResult": "{total} 个元模型 · {active} 个可用",
+        "vendors": "厂商"
+      },
+      "table": {
+        "actions": "操作",
+        "capability": "能力",
+        "context": "上下文",
+        "metaModel": "元模型",
+        "metaModels": "元模型",
+        "releaseDate": "发布日期",
+        "status": "状态",
+        "vendor": "厂商"
+      }
+    },
+    "reconciliationPanel": {
+      "title": "生产使用对账",
+      "actions": {
+        "create": "新建对账记录"
+      },
+      "empty": {
+        "description": "选择渠道、模型和账单金额后创建记录。",
+        "title": "暂无对账记录"
+      },
+      "fields": {
+        "audioInputSeconds": "音频输入秒数",
+        "audioOutputSeconds": "音频输出秒数",
+        "channel": "转发渠道",
+        "chargedAmount": "渠道账单金额",
+        "date": "对账日期",
+        "inputTokens": "文本输入 Tokens",
+        "model": "调用模型",
+        "outputTokens": "文本输出 Tokens",
+        "videoInputSeconds": "视频输入秒数",
+        "videoOutputSeconds": "视频输出秒数",
+        "videoResolution": "视频规格"
+      },
+      "helper": {
+        "selectModel": "选择模型后显示对应用量维度。"
+      },
+      "modality": {
+        "audio": "音频",
+        "multimodal": "多模态",
+        "text": "文本",
+        "video": "视频"
+      },
+      "option": {
+        "defaultCurrency": "默认币种 {currency}",
+        "disabled": "停用",
+        "enabled": "启用"
+      },
+      "placeholders": {
+        "channel": "选择账单归属渠道",
+        "model": "选择调用模型",
+        "searchChannel": "搜索渠道名称 / code / 接入地址",
+        "searchModel": "搜索模型名称 / code / 服务商",
+        "videoResolution": "如 720p / 1080p，可选"
+      },
+      "records": {
+        "title": "对账记录"
+      },
+      "status": {
+        "overcharged": "超收",
+        "perfect": "正常",
+        "undercharged": "少收"
+      },
+      "table": {
+        "bill": "账单",
+        "channel": "渠道",
+        "date": "日期",
+        "model": "模型",
+        "payable": "应付",
+        "status": "状态",
+        "variance": "差异"
+      },
+      "validation": {
+        "amountRequired": "请输入渠道账单金额。",
+        "channelRequired": "请选择账单归属的转发渠道。",
+        "modelRequired": "请选择本次用量对应的调用模型。"
+      }
+    },
     "providerManagement": {
       "title": "供货商价格列表",
       "modelsCount": "{count} 个元模型",
@@ -1162,8 +1319,8 @@
         "unknown": "其他"
       },
       "currencies": {
-        "cny": "人民币 CNY",
-        "usd": "美元 USD"
+        "cny": "CNY",
+        "usd": "USD"
       },
       "messages": {
         "created": "模型价格源已创建",
@@ -1329,8 +1486,8 @@
         "video": "视频"
       },
       "currencies": {
-        "cny": "人民币 CNY",
-        "usd": "美元 USD"
+        "cny": "CNY",
+        "usd": "USD"
       },
       "categories": {
         "manual": "人工",

--- a/frontend/src/pages/LLMOps.vue
+++ b/frontend/src/pages/LLMOps.vue
@@ -24,7 +24,7 @@
               v-for="item in navItems"
               :key="item.key"
               type="button"
-              class="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm font-medium transition"
+              class="flex w-full items-center gap-2.5 rounded-lg py-2.5 pl-7 pr-3 text-left text-sm font-medium transition"
               :class="
                 activeSection === item.key
                   ? 'bg-agione-600 text-white shadow-sm'
@@ -32,7 +32,18 @@
               "
               @click="activeSection = item.key"
             >
-              <span class="nav-icon">{{ item.icon }}</span>
+              <svg
+                class="nav-icon"
+                aria-hidden="true"
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+              >
+                <path v-for="path in item.icon" :key="path" :d="path" />
+              </svg>
               <span class="min-w-0 flex-1 truncate">{{ item.label }}</span>
             </button>
           </nav>
@@ -716,20 +727,37 @@ const monitorStatusLabelKeys = {
   unlisted: 'llmOps.status.unlisted'
 }
 
+const navIcons = {
+  audit: ['M4 5h16', 'M4 12h16', 'M4 19h10'],
+  channels: ['M4 7h16', 'M7 7v10', 'M17 7v10', 'M4 17h16'],
+  metaModels: ['M12 3l8 4-8 4-8-4 8-4Z', 'M4 12l8 4 8-4', 'M4 17l8 4 8-4'],
+  monitor: ['M4 19V5', 'M8 19v-6', 'M12 19v-9', 'M16 19v-4', 'M20 19V8'],
+  providers: ['M5 5h14v14H5Z', 'M9 9h6', 'M9 13h6', 'M9 17h3'],
+  reconciler: [
+    'M4 7h16',
+    'M7 7v12',
+    'M17 7v12',
+    'M4 13h16',
+    'M9 17h1',
+    'M14 17h1'
+  ],
+  reseller: ['M6 8h12l-1 12H7L6 8Z', 'M9 8a3 3 0 0 1 6 0']
+}
+
 const navItems = computed(() => [
   {
     key: 'monitor',
     label: t('llmOps.nav.monitor.label'),
     eyebrow: 'Monitor',
     description: t('llmOps.nav.monitor.description'),
-    icon: 'M'
+    icon: navIcons.monitor
   },
   {
     key: 'metaModels',
     label: t('llmOps.nav.metaModels.label'),
     eyebrow: 'Meta Models',
     description: t('llmOps.nav.metaModels.description'),
-    icon: 'M',
+    icon: navIcons.metaModels,
     badge: metaModels.value.length
   },
   {
@@ -737,7 +765,7 @@ const navItems = computed(() => [
     label: t('llmOps.nav.providers.label'),
     eyebrow: 'Sources',
     description: t('llmOps.nav.providers.description'),
-    icon: 'P',
+    icon: navIcons.providers,
     badge: providerCollectionSources.value.length
   },
   {
@@ -745,7 +773,7 @@ const navItems = computed(() => [
     label: t('llmOps.nav.channels.label'),
     eyebrow: 'Channels',
     description: t('llmOps.nav.channels.description'),
-    icon: 'C',
+    icon: navIcons.channels,
     badge: channels.value.length
   },
   {
@@ -753,7 +781,7 @@ const navItems = computed(() => [
     label: t('llmOps.nav.reseller.label'),
     eyebrow: 'Reseller',
     description: t('llmOps.nav.reseller.description'),
-    icon: 'R',
+    icon: navIcons.reseller,
     badge: agioneListingRows.value.length
   },
   {
@@ -761,14 +789,14 @@ const navItems = computed(() => [
     label: t('llmOps.nav.reconciler.label'),
     eyebrow: 'Reconciliation',
     description: t('llmOps.nav.reconciler.description'),
-    icon: 'A'
+    icon: navIcons.reconciler
   },
   {
     key: 'audit',
     label: t('llmOps.nav.audit.label'),
     eyebrow: 'Audit',
     description: t('llmOps.nav.audit.description'),
-    icon: 'L'
+    icon: navIcons.audit
   }
 ])
 
@@ -2250,17 +2278,9 @@ onBeforeUnmount(() => {
 }
 
 .nav-icon {
-  display: flex;
-  height: 1.25rem;
-  width: 1.25rem;
+  height: 1rem;
+  width: 1rem;
   flex-shrink: 0;
-  align-items: center;
-  justify-content: center;
-  border-radius: 4px;
-  background-color: #1e293b;
-  font-size: 10px;
-  font-weight: 700;
-  color: #cbd5e1;
 }
 
 .icon-mark {


### PR DESCRIPTION
## Summary
- Internationalize the LLM Ops meta model and reconciliation UI text.
- Make the meta model summary strip evenly divide the current 3-card row instead of leaving an unused fourth column on large screens.
- Simplify the reconciliation panel by removing the redundant \"Reconciliation\" eyebrow and long explanatory subtitle, keeping a concise localized title and shorter helper/empty-state copy.
- Normalize LLM Ops currency labels to CNY/USD across toolbar selects and related modals.
- Update the LLM Ops side navigation with centered text and real SVG icons instead of letter prefixes.

## Test plan
- [x] npm run build
- [x] Targeted ESLint for touched Vue files
- [x] Locale JSON and i18n key validation
- [x] git diff --check