### PR TITLE
Add LLM Ops global configuration

### DIFF
--- a/backend/llm_ops/admin.py
+++ b/backend/llm_ops/admin.py
@@ -7,6 +7,7 @@ from .models import (
     ChannelPriceItem,
     CollectedModelPriceHistory,
     CollectedModelPriceSnapshot,
+    LLMOpsGlobalConfig,
     LLMModel,
     LLMProvider,
     MetaModel,
@@ -21,6 +22,19 @@ from .models import (
     ResaleWorkflowConfig,
     UsageReconciliationRecord,
 )
+
+
+@admin.register(LLMOpsGlobalConfig)
+class LLMOpsGlobalConfigAdmin(admin.ModelAdmin):
+    list_display = (
+        "singleton_key",
+        "meta_model_sync_enabled",
+        "price_collection_enabled",
+        "updated_by",
+        "updated_at",
+    )
+    readonly_fields = ("singleton_key", "created_at", "updated_at")
+    search_fields = ("notes", "feishu_app_id", "feishu_approval_code")
 
 
 @admin.register(AuditLog)

--- a/backend/llm_ops/audit.py
+++ b/backend/llm_ops/audit.py
@@ -24,6 +24,18 @@ AUDIT_FIELD_ALLOWLIST: dict[str, tuple[str, ...]] = {
         "updates_model_prices",
         "notes",
     ),
+    "llm_ops.LLMOpsGlobalConfig": (
+        "meta_model_sync_enabled",
+        "meta_model_sync_source_url",
+        "meta_model_sync_cron",
+        "price_collection_enabled",
+        "price_collection_source_ids",
+        "price_collection_cron",
+        "feishu_app_id",
+        "feishu_approval_code",
+        "feishu_tenant_key",
+        "notes",
+    ),
     "llm_ops.LLMProvider": (
         "name",
         "code",

--- a/backend/llm_ops/global_config.py
+++ b/backend/llm_ops/global_config.py
@@ -64,6 +64,51 @@ def normalize_source_ids(source_ids) -> list[int]:
     return [source_id for source_id in normalized if source_id in allowed_ids]
 
 
+def validate_price_collection_source_ids(source_ids) -> list[int]:
+    """Validate and normalize user-selected source ids."""
+    if not isinstance(source_ids, list):
+        raise ValueError("Expected a list of source ids.")
+
+    normalized = []
+    invalid_values = []
+    for value in source_ids:
+        try:
+            normalized.append(int(value))
+        except (TypeError, ValueError):
+            invalid_values.append(value)
+    if invalid_values:
+        raise ValueError(
+            "Invalid source id values: "
+            + ", ".join(str(value) for value in invalid_values)
+        )
+    if not normalized:
+        return []
+
+    allowed_ids = set(
+        PriceCollectionSource.objects.filter(
+            id__in=normalized,
+            updates_model_prices=True,
+        ).values_list("id", flat=True)
+    )
+    missing_ids = [
+        source_id for source_id in normalized if source_id not in allowed_ids
+    ]
+    if missing_ids:
+        raise ValueError(
+            "Unknown or unsupported source ids: "
+            + ", ".join(str(source_id) for source_id in missing_ids)
+        )
+
+    result = []
+    seen = set()
+    for source_id in normalized:
+        if source_id in seen:
+            continue
+        seen.add(source_id)
+        result.append(source_id)
+    return result
+
+
 def selected_price_collection_sources(config):
     """Return sources selected by config, falling back to enabled sources."""
     queryset = PriceCollectionSource.objects.filter(
@@ -78,7 +123,16 @@ def selected_price_collection_sources(config):
 
 
 def sync_global_config_to_beat(config: LLMOpsGlobalConfig) -> None:
-    """Create or update django-celery-beat rows for global LLM Ops config."""
+    """Create or update beat rows owned by the global config UI.
+
+    ``register_periodic_tasks`` and ``TASK_REGISTRY`` remain the bootstrap
+    path for code-defined default tasks, and they skip existing rows to
+    preserve admin changes during deploy. This runtime sync is narrower:
+    it only updates task names owned by ``LLMOpsGlobalConfig`` after an
+    explicit API/admin config save. Legacy registry tasks, including
+    ``llm_ops_official_collect``, are left untouched so operator-managed
+    schedules are not disabled or overwritten implicitly.
+    """
     from django_celery_beat.models import PeriodicTask, PeriodicTasks
 
     meta_crontab = parse_cron(config.meta_model_sync_cron)
@@ -86,10 +140,6 @@ def sync_global_config_to_beat(config: LLMOpsGlobalConfig) -> None:
     if meta_crontab is None or price_crontab is None:
         logger.warning("llm_ops: skipped beat sync due to invalid cron")
         return
-
-    PeriodicTask.objects.filter(
-        name=LEGACY_OFFICIAL_COLLECT_TASK_NAME
-    ).update(enabled=False)
 
     PeriodicTask.objects.update_or_create(
         name=META_MODEL_SYNC_TASK_NAME,

--- a/backend/llm_ops/global_config.py
+++ b/backend/llm_ops/global_config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+from typing import Optional
 
 from .models import LLMOpsGlobalConfig, PriceCollectionSource
 
@@ -15,6 +16,23 @@ META_MODEL_SYNC_TASK = "llm_ops.tasks.sync_meta_models_from_models_dev"
 LEGACY_OFFICIAL_COLLECT_TASK_NAME = "llm_ops_official_collect"
 PRICE_SOURCE_TASK_PREFIX = "llm_ops_price_source_collect_"
 PRICE_SOURCE_TASK = "llm_ops.tasks.collect_price_source_prices"
+
+
+def price_source_task_name(source_id: int) -> str:
+    """Return the beat task name for a price source."""
+    return f"{PRICE_SOURCE_TASK_PREFIX}{source_id}"
+
+
+def extract_price_source_id(task_name: str) -> Optional[int]:
+    """Return the source id encoded in a managed price task name."""
+    if not task_name.startswith(PRICE_SOURCE_TASK_PREFIX):
+        return None
+
+    suffix = task_name[len(PRICE_SOURCE_TASK_PREFIX) :]
+    try:
+        return int(suffix)
+    except ValueError:
+        return None
 
 
 def parse_cron(cron_expr: str):
@@ -155,12 +173,25 @@ def sync_global_config_to_beat(config: LLMOpsGlobalConfig) -> None:
         },
     )
 
-    PeriodicTask.objects.filter(
+    selected_sources = selected_price_collection_sources(config)
+    selected_source_ids = {source.id for source in selected_sources}
+    existing_source_task_names = PeriodicTask.objects.filter(
         name__startswith=PRICE_SOURCE_TASK_PREFIX
-    ).delete()
-    for source in selected_price_collection_sources(config):
+    ).values_list("name", flat=True)
+    obsolete_task_names = []
+    for task_name in existing_source_task_names:
+        source_id = extract_price_source_id(task_name)
+        if source_id is None:
+            continue
+        if source_id not in selected_source_ids:
+            obsolete_task_names.append(task_name)
+
+    if obsolete_task_names:
+        PeriodicTask.objects.filter(name__in=obsolete_task_names).delete()
+
+    for source in selected_sources:
         PeriodicTask.objects.update_or_create(
-            name=f"{PRICE_SOURCE_TASK_PREFIX}{source.id}",
+            name=price_source_task_name(source.id),
             defaults={
                 "task": PRICE_SOURCE_TASK,
                 "args": json.dumps([]),

--- a/backend/llm_ops/global_config.py
+++ b/backend/llm_ops/global_config.py
@@ -1,0 +1,130 @@
+"""Runtime configuration helpers for LLM operations."""
+from __future__ import annotations
+
+import json
+import logging
+import re
+
+from .models import LLMOpsGlobalConfig, PriceCollectionSource
+
+logger = logging.getLogger(__name__)
+
+CRON_FIELD_PATTERN = re.compile(r"^[0-9*,/\-]+$")
+META_MODEL_SYNC_TASK_NAME = "llm_ops_meta_models_dev_sync"
+META_MODEL_SYNC_TASK = "llm_ops.tasks.sync_meta_models_from_models_dev"
+LEGACY_OFFICIAL_COLLECT_TASK_NAME = "llm_ops_official_collect"
+PRICE_SOURCE_TASK_PREFIX = "llm_ops_price_source_collect_"
+PRICE_SOURCE_TASK = "llm_ops.tasks.collect_price_source_prices"
+
+
+def parse_cron(cron_expr: str):
+    """Parse a five-field cron expression into a CrontabSchedule."""
+    from django_celery_beat.models import CrontabSchedule
+
+    parts = (cron_expr or "").strip().split()
+    if len(parts) != 5:
+        return None
+    minute, hour, day_of_month, month_of_year, day_of_week = parts
+    obj, _created = CrontabSchedule.objects.get_or_create(
+        minute=minute,
+        hour=hour,
+        day_of_week=day_of_week,
+        day_of_month=day_of_month,
+        month_of_year=month_of_year,
+    )
+    return obj
+
+
+def is_valid_cron(cron_expr: str) -> bool:
+    """Return whether a five-field cron expression is structurally valid."""
+    parts = (cron_expr or "").strip().split()
+    if len(parts) != 5:
+        return False
+    return all(CRON_FIELD_PATTERN.match(part) for part in parts)
+
+
+def normalize_source_ids(source_ids) -> list[int]:
+    """Return enabled source ids that support model price updates."""
+    if not isinstance(source_ids, list):
+        return []
+    normalized = []
+    for value in source_ids:
+        try:
+            normalized.append(int(value))
+        except (TypeError, ValueError):
+            continue
+    if not normalized:
+        return []
+    allowed_ids = set(
+        PriceCollectionSource.objects.filter(
+            id__in=normalized,
+            updates_model_prices=True,
+        ).values_list("id", flat=True)
+    )
+    return [source_id for source_id in normalized if source_id in allowed_ids]
+
+
+def selected_price_collection_sources(config):
+    """Return sources selected by config, falling back to enabled sources."""
+    queryset = PriceCollectionSource.objects.filter(
+        updates_model_prices=True,
+    ).select_related("provider", "channel")
+    source_ids = normalize_source_ids(config.price_collection_source_ids)
+    if source_ids:
+        queryset = queryset.filter(id__in=source_ids)
+    else:
+        queryset = queryset.filter(is_enabled=True)
+    return list(queryset.order_by("source_category", "name", "id"))
+
+
+def sync_global_config_to_beat(config: LLMOpsGlobalConfig) -> None:
+    """Create or update django-celery-beat rows for global LLM Ops config."""
+    from django_celery_beat.models import PeriodicTask, PeriodicTasks
+
+    meta_crontab = parse_cron(config.meta_model_sync_cron)
+    price_crontab = parse_cron(config.price_collection_cron)
+    if meta_crontab is None or price_crontab is None:
+        logger.warning("llm_ops: skipped beat sync due to invalid cron")
+        return
+
+    PeriodicTask.objects.filter(
+        name=LEGACY_OFFICIAL_COLLECT_TASK_NAME
+    ).update(enabled=False)
+
+    PeriodicTask.objects.update_or_create(
+        name=META_MODEL_SYNC_TASK_NAME,
+        defaults={
+            "task": META_MODEL_SYNC_TASK,
+            "args": json.dumps([]),
+            "kwargs": json.dumps(
+                {"source_url": config.meta_model_sync_source_url}
+            ),
+            "crontab": meta_crontab,
+            "interval": None,
+            "enabled": config.meta_model_sync_enabled,
+        },
+    )
+
+    PeriodicTask.objects.filter(
+        name__startswith=PRICE_SOURCE_TASK_PREFIX
+    ).delete()
+    for source in selected_price_collection_sources(config):
+        PeriodicTask.objects.update_or_create(
+            name=f"{PRICE_SOURCE_TASK_PREFIX}{source.id}",
+            defaults={
+                "task": PRICE_SOURCE_TASK,
+                "args": json.dumps([]),
+                "kwargs": json.dumps(
+                    {"source_id": source.id, "verify_source": True}
+                ),
+                "crontab": price_crontab,
+                "interval": None,
+                "enabled": (
+                    config.price_collection_enabled
+                    and source.is_enabled
+                    and source.updates_model_prices
+                ),
+            },
+        )
+
+    PeriodicTasks.update_changed()

--- a/backend/llm_ops/migrations/0005_llmopsglobalconfig.py
+++ b/backend/llm_ops/migrations/0005_llmopsglobalconfig.py
@@ -1,0 +1,103 @@
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("llm_ops", "0004_alter_pricecollectionrun_source"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="LLMOpsGlobalConfig",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "singleton_key",
+                    models.CharField(
+                        default="default",
+                        editable=False,
+                        max_length=50,
+                        unique=True,
+                    ),
+                ),
+                (
+                    "meta_model_sync_enabled",
+                    models.BooleanField(default=True),
+                ),
+                (
+                    "meta_model_sync_source_url",
+                    models.URLField(
+                        default="https://models.dev/api.json",
+                        max_length=1000,
+                    ),
+                ),
+                (
+                    "meta_model_sync_cron",
+                    models.CharField(
+                        default="35 2 * * *",
+                        max_length=100,
+                    ),
+                ),
+                (
+                    "price_collection_enabled",
+                    models.BooleanField(default=True),
+                ),
+                (
+                    "price_collection_source_ids",
+                    models.JSONField(blank=True, default=list),
+                ),
+                (
+                    "price_collection_cron",
+                    models.CharField(
+                        default="15 1,7,13,19 * * *",
+                        max_length=100,
+                    ),
+                ),
+                (
+                    "feishu_app_id",
+                    models.CharField(blank=True, default="", max_length=255),
+                ),
+                (
+                    "feishu_app_secret",
+                    models.CharField(blank=True, default="", max_length=500),
+                ),
+                (
+                    "feishu_approval_code",
+                    models.CharField(blank=True, default="", max_length=255),
+                ),
+                (
+                    "feishu_tenant_key",
+                    models.CharField(blank=True, default="", max_length=255),
+                ),
+                ("notes", models.TextField(blank=True, default="")),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "updated_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="llm_ops_global_config_updates",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "LLM Ops Global Config",
+                "verbose_name_plural": "LLM Ops Global Config",
+            },
+        ),
+    ]

--- a/backend/llm_ops/migrations/0006_alter_llmopsglobalconfig_feishu_app_secret.py
+++ b/backend/llm_ops/migrations/0006_alter_llmopsglobalconfig_feishu_app_secret.py
@@ -1,0 +1,54 @@
+from django.db import migrations, models
+
+
+ENCRYPTED_SECRET_PREFIX = "fernet:"
+
+
+def encrypt_existing_feishu_app_secrets(apps, schema_editor):
+    """Encrypt existing Feishu app secrets after widening the field."""
+    from hyperbdr_dashboard.encryption import encryption_service
+
+    global_config = apps.get_model("llm_ops", "LLMOpsGlobalConfig")
+    queryset = global_config.objects.exclude(feishu_app_secret="")
+    for config in queryset.iterator():
+        value = config.feishu_app_secret
+        if value.startswith(ENCRYPTED_SECRET_PREFIX):
+            continue
+        config.feishu_app_secret = (
+            ENCRYPTED_SECRET_PREFIX + encryption_service.encrypt(value)
+        )
+        config.save(update_fields=["feishu_app_secret"])
+
+
+def decrypt_existing_feishu_app_secrets(apps, schema_editor):
+    """Restore plaintext secrets when reversing the migration."""
+    from hyperbdr_dashboard.encryption import encryption_service
+
+    global_config = apps.get_model("llm_ops", "LLMOpsGlobalConfig")
+    queryset = global_config.objects.exclude(feishu_app_secret="")
+    for config in queryset.iterator():
+        value = config.feishu_app_secret
+        if not value.startswith(ENCRYPTED_SECRET_PREFIX):
+            continue
+        encrypted = value[len(ENCRYPTED_SECRET_PREFIX) :]
+        config.feishu_app_secret = encryption_service.decrypt(encrypted)
+        config.save(update_fields=["feishu_app_secret"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("llm_ops", "0005_llmopsglobalconfig"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="llmopsglobalconfig",
+            name="feishu_app_secret",
+            field=models.TextField(blank=True, default=""),
+        ),
+        migrations.RunPython(
+            encrypt_existing_feishu_app_secrets,
+            decrypt_existing_feishu_app_secrets,
+        ),
+    ]

--- a/backend/llm_ops/models.py
+++ b/backend/llm_ops/models.py
@@ -84,6 +84,77 @@ class PriceCollectionSource(models.Model):
         return f"{self.name} ({self.slug})"
 
 
+class LLMOpsGlobalConfig(models.Model):
+    """Singleton runtime configuration for LLM operations."""
+
+    DEFAULT_META_MODEL_SYNC_CRON = "35 2 * * *"
+    DEFAULT_PRICE_COLLECTION_CRON = "15 1,7,13,19 * * *"
+    DEFAULT_META_MODEL_SOURCE_URL = "https://models.dev/api.json"
+
+    singleton_key = models.CharField(
+        max_length=50,
+        unique=True,
+        default="default",
+        editable=False,
+    )
+    meta_model_sync_enabled = models.BooleanField(default=True)
+    meta_model_sync_source_url = models.URLField(
+        max_length=1000,
+        default=DEFAULT_META_MODEL_SOURCE_URL,
+    )
+    meta_model_sync_cron = models.CharField(
+        max_length=100,
+        default=DEFAULT_META_MODEL_SYNC_CRON,
+    )
+    price_collection_enabled = models.BooleanField(default=True)
+    price_collection_source_ids = models.JSONField(blank=True, default=list)
+    price_collection_cron = models.CharField(
+        max_length=100,
+        default=DEFAULT_PRICE_COLLECTION_CRON,
+    )
+    feishu_app_id = models.CharField(max_length=255, blank=True, default="")
+    feishu_app_secret = models.CharField(
+        max_length=500,
+        blank=True,
+        default="",
+    )
+    feishu_approval_code = models.CharField(
+        max_length=255,
+        blank=True,
+        default="",
+    )
+    feishu_tenant_key = models.CharField(
+        max_length=255,
+        blank=True,
+        default="",
+    )
+    notes = models.TextField(blank=True, default="")
+    updated_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        related_name="llm_ops_global_config_updates",
+        blank=True,
+        null=True,
+        on_delete=models.SET_NULL,
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        verbose_name = "LLM Ops Global Config"
+        verbose_name_plural = "LLM Ops Global Config"
+
+    def __str__(self) -> str:
+        return "LLM Ops global config"
+
+    @classmethod
+    def get_solo(cls):
+        """Return the singleton config row."""
+        instance, _created = cls.objects.get_or_create(
+            singleton_key="default"
+        )
+        return instance
+
+
 class LLMProvider(models.Model):
     """Original model vendor, such as OpenAI, Anthropic, or DeepSeek."""
 

--- a/backend/llm_ops/models.py
+++ b/backend/llm_ops/models.py
@@ -1,6 +1,8 @@
 from django.conf import settings
 from django.db import models
 
+from hyperbdr_dashboard.encryption import encryption_service
+
 
 def _ensure_meta_model_from_model(instance, kwargs):
     """Copy the canonical model reference from the selected model."""
@@ -90,6 +92,7 @@ class LLMOpsGlobalConfig(models.Model):
     DEFAULT_META_MODEL_SYNC_CRON = "35 2 * * *"
     DEFAULT_PRICE_COLLECTION_CRON = "15 1,7,13,19 * * *"
     DEFAULT_META_MODEL_SOURCE_URL = "https://models.dev/api.json"
+    ENCRYPTED_SECRET_PREFIX = "fernet:"
 
     singleton_key = models.CharField(
         max_length=50,
@@ -113,11 +116,7 @@ class LLMOpsGlobalConfig(models.Model):
         default=DEFAULT_PRICE_COLLECTION_CRON,
     )
     feishu_app_id = models.CharField(max_length=255, blank=True, default="")
-    feishu_app_secret = models.CharField(
-        max_length=500,
-        blank=True,
-        default="",
-    )
+    feishu_app_secret = models.TextField(blank=True, default="")
     feishu_approval_code = models.CharField(
         max_length=255,
         blank=True,
@@ -145,6 +144,42 @@ class LLMOpsGlobalConfig(models.Model):
 
     def __str__(self) -> str:
         return "LLM Ops global config"
+
+    @classmethod
+    def encrypt_secret(cls, value: str) -> str:
+        """Encrypt a secret unless it already uses the storage format."""
+        if not value:
+            return ""
+        if value.startswith(cls.ENCRYPTED_SECRET_PREFIX):
+            return value
+        encrypted = encryption_service.encrypt(value)
+        return f"{cls.ENCRYPTED_SECRET_PREFIX}{encrypted}"
+
+    @classmethod
+    def decrypt_secret(cls, value: str) -> str:
+        """Decrypt a stored secret with plaintext fallback."""
+        if not value:
+            return ""
+        if value.startswith(cls.ENCRYPTED_SECRET_PREFIX):
+            encrypted = value[len(cls.ENCRYPTED_SECRET_PREFIX) :]
+            return encryption_service.decrypt(encrypted)
+        return encryption_service.decrypt(value)
+
+    def set_feishu_app_secret(self, value: str) -> None:
+        """Store the Feishu app secret in encrypted form."""
+        self.feishu_app_secret = self.encrypt_secret(value)
+
+    def get_feishu_app_secret(self) -> str:
+        """Return the decrypted Feishu app secret."""
+        return self.decrypt_secret(self.feishu_app_secret)
+
+    def save(self, *args, **kwargs):
+        """Encrypt sensitive credentials before writing to the database."""
+        if self.feishu_app_secret:
+            self.feishu_app_secret = self.encrypt_secret(
+                self.feishu_app_secret
+            )
+        super().save(*args, **kwargs)
 
     @classmethod
     def get_solo(cls):

--- a/backend/llm_ops/serializers.py
+++ b/backend/llm_ops/serializers.py
@@ -3,12 +3,14 @@ from decimal import Decimal
 from rest_framework import serializers
 
 from .collectors.official import OFFICIAL_PROVIDER_CONFIGS
+from .global_config import is_valid_cron, normalize_source_ids
 from .models import (
     AuditLog,
     ChannelModelPrice,
     ChannelModelPriceHistory,
     CollectedModelPriceHistory,
     CollectedModelPriceSnapshot,
+    LLMOpsGlobalConfig,
     LLMModel,
     ModelPriceItem,
     LLMProvider,
@@ -56,6 +58,73 @@ class PriceCollectionSourceSerializer(serializers.ModelSerializer):
 
     def get_business_source_category(self, instance):
         return business_source_category_for_catalog(instance)
+
+
+class LLMOpsGlobalConfigSerializer(serializers.ModelSerializer):
+    """Serializer for singleton LLM operations runtime configuration."""
+
+    selected_price_collection_sources = serializers.SerializerMethodField()
+
+    class Meta:
+        model = LLMOpsGlobalConfig
+        fields = "__all__"
+        read_only_fields = (
+            "singleton_key",
+            "updated_by",
+            "created_at",
+            "updated_at",
+        )
+        extra_kwargs = {
+            "feishu_app_secret": {
+                "write_only": True,
+                "required": False,
+                "allow_blank": True,
+            }
+        }
+
+    def validate_meta_model_sync_cron(self, value):
+        if not is_valid_cron(value):
+            raise serializers.ValidationError(
+                "Use a five-field cron expression."
+            )
+        return value
+
+    def validate_price_collection_cron(self, value):
+        if not is_valid_cron(value):
+            raise serializers.ValidationError(
+                "Use a five-field cron expression."
+            )
+        return value
+
+    def validate_price_collection_source_ids(self, value):
+        if not isinstance(value, list):
+            raise serializers.ValidationError("Expected a list of source ids.")
+        return normalize_source_ids(value)
+
+    def update(self, instance, validated_data):
+        secret = validated_data.get("feishu_app_secret")
+        if secret == "":
+            validated_data.pop("feishu_app_secret", None)
+        return super().update(instance, validated_data)
+
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        data["feishu_app_secret_configured"] = bool(
+            instance.feishu_app_secret
+        )
+        return data
+
+    def get_selected_price_collection_sources(self, instance):
+        source_ids = normalize_source_ids(
+            instance.price_collection_source_ids
+        )
+        if not source_ids:
+            return []
+        queryset = PriceCollectionSource.objects.filter(id__in=source_ids)
+        return PriceCollectionSourceSerializer(
+            queryset.order_by("name", "id"),
+            many=True,
+        ).data
 
 
 class AuditLogSerializer(serializers.ModelSerializer):

--- a/backend/llm_ops/serializers.py
+++ b/backend/llm_ops/serializers.py
@@ -3,7 +3,11 @@ from decimal import Decimal
 from rest_framework import serializers
 
 from .collectors.official import OFFICIAL_PROVIDER_CONFIGS
-from .global_config import is_valid_cron, normalize_source_ids
+from .global_config import (
+    is_valid_cron,
+    normalize_source_ids,
+    validate_price_collection_source_ids,
+)
 from .models import (
     AuditLog,
     ChannelModelPrice,
@@ -97,14 +101,16 @@ class LLMOpsGlobalConfigSerializer(serializers.ModelSerializer):
         return value
 
     def validate_price_collection_source_ids(self, value):
-        if not isinstance(value, list):
-            raise serializers.ValidationError("Expected a list of source ids.")
-        return normalize_source_ids(value)
+        try:
+            return validate_price_collection_source_ids(value)
+        except ValueError as exc:
+            raise serializers.ValidationError(str(exc)) from exc
 
     def update(self, instance, validated_data):
-        secret = validated_data.get("feishu_app_secret")
-        if secret == "":
-            validated_data.pop("feishu_app_secret", None)
+        secret_marker = object()
+        secret = validated_data.pop("feishu_app_secret", secret_marker)
+        if secret not in (secret_marker, ""):
+            instance.set_feishu_app_secret(secret)
         return super().update(instance, validated_data)
 
     def to_representation(self, instance):

--- a/backend/llm_ops/tasks.py
+++ b/backend/llm_ops/tasks.py
@@ -144,13 +144,18 @@ def collect_price_source_prices(
     default_retry_delay=300,
     acks_late=True,
 )
-def sync_meta_models_from_models_dev_task(self) -> dict[str, int]:
+def sync_meta_models_from_models_dev_task(
+    self,
+    *,
+    source_url: str | None = None,
+) -> dict[str, int]:
     """Refresh canonical meta models from models.dev."""
     from .collection_services import sync_meta_models_from_models_dev
 
     logger.info("llm_ops.sync_meta_models_from_models_dev start")
     try:
-        results = sync_meta_models_from_models_dev()
+        kwargs = {"source_url": source_url} if source_url else {}
+        results = sync_meta_models_from_models_dev(**kwargs)
     except Exception as exc:
         logger.exception("llm_ops.sync_meta_models_from_models_dev failed")
         if self.request.retries < self.max_retries:

--- a/backend/llm_ops/tests/test_views.py
+++ b/backend/llm_ops/tests/test_views.py
@@ -143,6 +143,13 @@ class LLMOpsViewTests(TestCase):
         config = LLMOpsGlobalConfig.objects.get()
         self.assertEqual(config.updated_by, self.user)
         self.assertEqual(config.price_collection_source_ids, [source.id])
+        self.assertNotEqual(config.feishu_app_secret, "secret")
+        self.assertTrue(
+            config.feishu_app_secret.startswith(
+                LLMOpsGlobalConfig.ENCRYPTED_SECRET_PREFIX
+            )
+        )
+        self.assertEqual(config.get_feishu_app_secret(), "secret")
         self.assertNotIn("feishu_app_secret", response.data)
         self.assertTrue(response.data["feishu_app_secret_configured"])
 
@@ -158,6 +165,70 @@ class LLMOpsViewTests(TestCase):
         self.assertEqual(price_task.crontab.minute, "10")
         self.assertEqual(price_task.crontab.hour, "*/6")
         self.assertIn(str(source.id), price_task.kwargs)
+
+    def test_global_config_blank_secret_preserves_existing_secret(self):
+        config = LLMOpsGlobalConfig.get_solo()
+        config.set_feishu_app_secret("existing-secret")
+        config.save()
+        stored_secret = config.feishu_app_secret
+
+        response = self.client.patch(
+            reverse("llm-ops-global-config"),
+            {
+                "feishu_app_secret": "",
+                "notes": "updated without rotating the secret",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        config.refresh_from_db()
+        self.assertEqual(config.feishu_app_secret, stored_secret)
+        self.assertEqual(config.get_feishu_app_secret(), "existing-secret")
+
+    def test_global_config_rejects_unknown_price_source_ids(self):
+        response = self.client.patch(
+            reverse("llm-ops-global-config"),
+            {"price_collection_source_ids": [99999]},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("price_collection_source_ids", response.data)
+
+    def test_global_config_sync_preserves_legacy_periodic_task(self):
+        from django_celery_beat.models import CrontabSchedule, PeriodicTask
+
+        legacy_crontab = CrontabSchedule.objects.create(
+            minute="0",
+            hour="4",
+            day_of_week="*",
+            day_of_month="*",
+            month_of_year="*",
+        )
+        PeriodicTask.objects.create(
+            name="llm_ops_official_collect",
+            task="llm_ops.tasks.collect_official_model_prices",
+            crontab=legacy_crontab,
+            kwargs='{"provider_codes": null, "verify_source": true}',
+            enabled=True,
+        )
+
+        response = self.client.patch(
+            reverse("llm-ops-global-config"),
+            {
+                "price_collection_enabled": False,
+                "price_collection_cron": "10 */6 * * *",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        legacy_task = PeriodicTask.objects.get(
+            name="llm_ops_official_collect"
+        )
+        self.assertTrue(legacy_task.enabled)
+        self.assertEqual(legacy_task.crontab_id, legacy_crontab.id)
 
     def test_global_config_rejects_invalid_cron(self):
         response = self.client.patch(

--- a/backend/llm_ops/tests/test_views.py
+++ b/backend/llm_ops/tests/test_views.py
@@ -11,6 +11,7 @@ from llm_ops.models import (
     ChannelModelPriceHistory,
     ChannelPriceItem,
     CollectedModelPriceSnapshot,
+    LLMOpsGlobalConfig,
     LLMModel,
     LLMProvider,
     ModelPriceItem,
@@ -104,6 +105,69 @@ class LLMOpsViewTests(TestCase):
             source=source,
             base_url="https://example.com/admin/api",
         )
+
+    def test_global_config_patch_syncs_periodic_tasks(self):
+        from django_celery_beat.models import PeriodicTask
+
+        provider = LLMProvider.objects.create(name="OpenAI", code="openai")
+        source = PriceCollectionSource.objects.create(
+            name="OpenAI Official",
+            slug="openai-official",
+            provider=provider,
+            source_category=(
+                PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
+            ),
+            endpoint_url="https://models.dev/api.json",
+            updates_model_prices=True,
+        )
+
+        response = self.client.patch(
+            reverse("llm-ops-global-config"),
+            {
+                "meta_model_sync_enabled": True,
+                "meta_model_sync_source_url": "https://models.dev/api.json",
+                "meta_model_sync_cron": "5 3 * * *",
+                "price_collection_enabled": True,
+                "price_collection_source_ids": [source.id],
+                "price_collection_cron": "10 */6 * * *",
+                "feishu_app_id": "cli_xxx",
+                "feishu_app_secret": "secret",
+                "feishu_approval_code": "approval_code",
+                "feishu_tenant_key": "tenant",
+                "notes": "global runtime config",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        config = LLMOpsGlobalConfig.objects.get()
+        self.assertEqual(config.updated_by, self.user)
+        self.assertEqual(config.price_collection_source_ids, [source.id])
+        self.assertNotIn("feishu_app_secret", response.data)
+        self.assertTrue(response.data["feishu_app_secret_configured"])
+
+        meta_task = PeriodicTask.objects.get(
+            name="llm_ops_meta_models_dev_sync"
+        )
+        price_task = PeriodicTask.objects.get(
+            name=f"llm_ops_price_source_collect_{source.id}"
+        )
+        self.assertEqual(meta_task.crontab.minute, "5")
+        self.assertEqual(meta_task.crontab.hour, "3")
+        self.assertIn("models.dev", meta_task.kwargs)
+        self.assertEqual(price_task.crontab.minute, "10")
+        self.assertEqual(price_task.crontab.hour, "*/6")
+        self.assertIn(str(source.id), price_task.kwargs)
+
+    def test_global_config_rejects_invalid_cron(self):
+        response = self.client.patch(
+            reverse("llm-ops-global-config"),
+            {"meta_model_sync_cron": "invalid"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("meta_model_sync_cron", response.data)
 
     @patch("llm_ops.views.import_manual_model_prices")
     def test_manual_price_import_records_pricing_audit(self, mock_import):

--- a/backend/llm_ops/tests/test_views.py
+++ b/backend/llm_ops/tests/test_views.py
@@ -230,6 +230,74 @@ class LLMOpsViewTests(TestCase):
         self.assertTrue(legacy_task.enabled)
         self.assertEqual(legacy_task.crontab_id, legacy_crontab.id)
 
+    def test_global_config_sync_only_deletes_obsolete_source_tasks(self):
+        from django_celery_beat.models import CrontabSchedule, PeriodicTask
+
+        current_source = PriceCollectionSource.objects.create(
+            name="Current Source",
+            slug="current-source",
+            endpoint_url="https://current.example.com",
+            updates_model_prices=True,
+        )
+        obsolete_source = PriceCollectionSource.objects.create(
+            name="Obsolete Source",
+            slug="obsolete-source",
+            endpoint_url="https://obsolete.example.com",
+            updates_model_prices=True,
+        )
+        custom_crontab = CrontabSchedule.objects.create(
+            minute="0",
+            hour="8",
+            day_of_week="*",
+            day_of_month="*",
+            month_of_year="*",
+        )
+        PeriodicTask.objects.create(
+            name=f"llm_ops_price_source_collect_{obsolete_source.id}",
+            task="llm_ops.tasks.collect_price_source_prices",
+            crontab=custom_crontab,
+            kwargs=f'{{"source_id": {obsolete_source.id}}}',
+            enabled=True,
+        )
+        PeriodicTask.objects.create(
+            name="llm_ops_price_source_collect_custom",
+            task="llm_ops.tasks.collect_price_source_prices",
+            crontab=custom_crontab,
+            kwargs='{"source_id": "custom"}',
+            enabled=True,
+        )
+
+        response = self.client.patch(
+            reverse("llm-ops-global-config"),
+            {
+                "price_collection_enabled": True,
+                "price_collection_source_ids": [current_source.id],
+                "price_collection_cron": "10 */6 * * *",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            PeriodicTask.objects.filter(
+                name=(
+                    f"llm_ops_price_source_collect_{current_source.id}"
+                )
+            ).exists()
+        )
+        self.assertFalse(
+            PeriodicTask.objects.filter(
+                name=(
+                    f"llm_ops_price_source_collect_{obsolete_source.id}"
+                )
+            ).exists()
+        )
+        self.assertTrue(
+            PeriodicTask.objects.filter(
+                name="llm_ops_price_source_collect_custom"
+            ).exists()
+        )
+
     def test_global_config_rejects_invalid_cron(self):
         response = self.client.patch(
             reverse("llm-ops-global-config"),

--- a/backend/llm_ops/urls.py
+++ b/backend/llm_ops/urls.py
@@ -8,6 +8,7 @@ from .views import (
     ChannelPriceItemViewSet,
     CollectedModelPriceHistoryViewSet,
     CollectedModelPriceSnapshotViewSet,
+    LLMOpsGlobalConfigAPIView,
     LLMModelViewSet,
     LLMProviderViewSet,
     ManualPriceImportAPIView,
@@ -105,6 +106,11 @@ router.register(
 
 urlpatterns = [
     path("", include(router.urls)),
+    path(
+        "global-config/",
+        LLMOpsGlobalConfigAPIView.as_view(),
+        name="llm-ops-global-config",
+    ),
     path("summary/", SummaryAPIView.as_view(), name="llm-ops-summary"),
     path(
         "collect/yunce/",

--- a/backend/llm_ops/views.py
+++ b/backend/llm_ops/views.py
@@ -16,6 +16,7 @@ from .collection_services import (
     sync_yunce_model_prices,
 )
 from .constants import SUPPLIER_SOURCE_VENDOR_ALIASES
+from .global_config import sync_global_config_to_beat
 from .models import (
     AuditLog,
     ChannelModelPrice,
@@ -23,6 +24,7 @@ from .models import (
     ChannelPriceItem,
     CollectedModelPriceHistory,
     CollectedModelPriceSnapshot,
+    LLMOpsGlobalConfig,
     LLMModel,
     LLMProvider,
     MetaModel,
@@ -44,6 +46,7 @@ from .serializers import (
     ChannelPriceItemSerializer,
     CollectedModelPriceHistorySerializer,
     CollectedModelPriceSnapshotSerializer,
+    LLMOpsGlobalConfigSerializer,
     LLMModelSerializer,
     LLMProviderSerializer,
     ManualPriceImportRequestSerializer,
@@ -253,6 +256,58 @@ class PriceCollectionSourceViewSet(
             },
             status=status.HTTP_400_BAD_REQUEST,
         )
+
+
+class LLMOpsGlobalConfigAPIView(LLMOpsPermissionMixin, APIView):
+    """Read and update the singleton global LLM Ops configuration."""
+
+    def get(self, request):
+        config = LLMOpsGlobalConfig.get_solo()
+        serializer = LLMOpsGlobalConfigSerializer(config)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def patch(self, request):
+        config = LLMOpsGlobalConfig.get_solo()
+        before = snapshot_instance(config)
+        serializer = LLMOpsGlobalConfigSerializer(
+            config,
+            data=request.data,
+            partial=True,
+        )
+        serializer.is_valid(raise_exception=True)
+        with transaction.atomic():
+            instance = serializer.save(updated_by=request.user)
+            sync_global_config_to_beat(instance)
+            record_audit_log(
+                request=request,
+                action=AuditLog.ACTION_UPDATE,
+                category=AuditLog.CATEGORY_CONFIGURATION,
+                target=instance,
+                summary="Updated LLM Ops global configuration",
+                before=before,
+                after=snapshot_instance(instance),
+            )
+        output = LLMOpsGlobalConfigSerializer(instance)
+        return Response(output.data, status=status.HTTP_200_OK)
+
+    def delete(self, request):
+        config = LLMOpsGlobalConfig.get_solo()
+        before = snapshot_instance(config)
+        with transaction.atomic():
+            config.delete()
+            instance = LLMOpsGlobalConfig.get_solo()
+            sync_global_config_to_beat(instance)
+            record_audit_log(
+                request=request,
+                action=AuditLog.ACTION_RESTORE,
+                category=AuditLog.CATEGORY_CONFIGURATION,
+                target=instance,
+                summary="Reset LLM Ops global configuration",
+                before=before,
+                after=snapshot_instance(instance),
+            )
+        serializer = LLMOpsGlobalConfigSerializer(instance)
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
 
 class AuditLogViewSet(LLMOpsPermissionMixin, viewsets.ReadOnlyModelViewSet):

--- a/frontend/src/api/llmOps.js
+++ b/frontend/src/api/llmOps.js
@@ -35,6 +35,18 @@ export const llmOpsApi = {
     return apiClient.post(`${base}/collection-sources/${id}/collect/`)
   },
 
+  getGlobalConfig() {
+    return apiClient.get(`${base}/global-config/`)
+  },
+
+  updateGlobalConfig(payload) {
+    return apiClient.patch(`${base}/global-config/`, payload)
+  },
+
+  resetGlobalConfig() {
+    return apiClient.delete(`${base}/global-config/`)
+  },
+
   listCollectionRuns(params) {
     return apiClient.get(`${base}/collection-runs/`, paramsOrEmpty(params))
   },

--- a/frontend/src/components/llm-ops/GlobalConfigPanel.vue
+++ b/frontend/src/components/llm-ops/GlobalConfigPanel.vue
@@ -1,0 +1,612 @@
+<template>
+  <section class="global-config-panel">
+    <div class="global-config-toolbar">
+      <div>
+        <p class="global-config-eyebrow">Global Config</p>
+        <h3>全局配置</h3>
+        <p>统一管理元模型同步、模型价格采集和审核集成参数。</p>
+      </div>
+      <div class="global-config-actions">
+        <button
+          type="button"
+          class="btn-secondary btn-action-refresh"
+          :disabled="loading || saving"
+          @click="loadConfig"
+        >
+          重新加载
+        </button>
+        <button
+          type="button"
+          class="btn-secondary btn-action-cancel"
+          :disabled="loading || saving"
+          @click="resetConfig"
+        >
+          恢复默认
+        </button>
+        <button
+          type="button"
+          class="btn-primary btn-action-save"
+          :disabled="loading || saving"
+          @click="saveConfig"
+        >
+          {{ saving ? '保存中' : '保存并同步任务' }}
+        </button>
+      </div>
+    </div>
+
+    <BaseLoading v-if="loading" />
+
+    <form v-else class="global-config-grid" @submit.prevent="saveConfig">
+      <div class="global-config-main">
+        <section class="config-section">
+          <div class="config-section-header">
+            <div>
+              <h4>元模型采集</h4>
+              <p>同步模型厂商、模型族和能力标签。</p>
+            </div>
+            <label class="config-switch">
+              <span>{{ form.meta_model_sync_enabled ? '启用' : '停用' }}</span>
+              <input v-model="form.meta_model_sync_enabled" type="checkbox" />
+            </label>
+          </div>
+
+          <label class="config-field">
+            <span>数据源 URL</span>
+            <input
+              v-model.trim="form.meta_model_sync_source_url"
+              type="url"
+              required
+              placeholder="https://models.dev/api.json"
+            />
+          </label>
+          <label class="config-field">
+            <span>执行周期</span>
+            <input
+              v-model.trim="form.meta_model_sync_cron"
+              type="text"
+              required
+              placeholder="35 2 * * *"
+            />
+          </label>
+        </section>
+
+        <section class="config-section">
+          <div class="config-section-header">
+            <div>
+              <h4>模型价格采集</h4>
+              <p>同步官方或供货商模型价格数据。</p>
+            </div>
+            <label class="config-switch">
+              <span>{{ form.price_collection_enabled ? '启用' : '停用' }}</span>
+              <input v-model="form.price_collection_enabled" type="checkbox" />
+            </label>
+          </div>
+
+          <label class="config-field">
+            <span>执行周期</span>
+            <input
+              v-model.trim="form.price_collection_cron"
+              type="text"
+              required
+              placeholder="15 1,7,13,19 * * *"
+            />
+          </label>
+
+          <div class="source-mode-group" role="radiogroup">
+            <label
+              v-for="mode in sourceModes"
+              :key="mode.value"
+              class="source-mode"
+              :class="{ active: sourceMode === mode.value }"
+            >
+              <input
+                v-model="sourceMode"
+                type="radio"
+                name="price_source_mode"
+                :value="mode.value"
+              />
+              <span>{{ mode.label }}</span>
+            </label>
+          </div>
+
+          <div v-if="sourceMode === 'selected'" class="source-list">
+            <label
+              v-for="source in priceSourceOptions"
+              :key="source.id"
+              class="source-row"
+            >
+              <input
+                v-model="form.price_collection_source_ids"
+                type="checkbox"
+                :value="source.id"
+              />
+              <span>
+                <strong>{{ source.name }}</strong>
+                <small>{{ sourceMeta(source) }}</small>
+              </span>
+            </label>
+            <div v-if="!priceSourceOptions.length" class="empty-source">
+              暂无可用于自动采集的模型价格源。
+            </div>
+          </div>
+        </section>
+      </div>
+
+      <aside class="global-config-side">
+        <section class="config-section">
+          <div class="config-section-header">
+            <div>
+              <h4>飞书审核认证</h4>
+              <p>用于模型上架审核流程提交审批实例。</p>
+            </div>
+            <span
+              class="secret-status"
+              :class="{ active: config?.feishu_app_secret_configured }"
+            >
+              {{
+                config?.feishu_app_secret_configured ? '密钥已配置' : '未配置'
+              }}
+            </span>
+          </div>
+
+          <label class="config-field">
+            <span>App ID</span>
+            <input
+              v-model.trim="form.feishu_app_id"
+              type="text"
+              autocomplete="off"
+            />
+          </label>
+          <label class="config-field">
+            <span>App Secret</span>
+            <input
+              v-model.trim="form.feishu_app_secret"
+              type="password"
+              autocomplete="new-password"
+              :placeholder="
+                config?.feishu_app_secret_configured
+                  ? '留空则保留当前密钥'
+                  : ''
+              "
+            />
+          </label>
+          <label class="config-field">
+            <span>审批定义 Code</span>
+            <input
+              v-model.trim="form.feishu_approval_code"
+              type="text"
+              autocomplete="off"
+            />
+          </label>
+          <label class="config-field">
+            <span>Tenant Key</span>
+            <input
+              v-model.trim="form.feishu_tenant_key"
+              type="text"
+              autocomplete="off"
+            />
+          </label>
+        </section>
+
+        <section class="config-section">
+          <div class="config-section-header">
+            <div>
+              <h4>备注</h4>
+              <p>记录配置变更背景或外部系统关联信息。</p>
+            </div>
+          </div>
+          <textarea v-model.trim="form.notes" rows="5" />
+          <div class="config-runtime">
+            <span>最近更新</span>
+            <strong>{{ formatDateTime(config?.updated_at) }}</strong>
+          </div>
+        </section>
+      </aside>
+    </form>
+  </section>
+</template>
+
+<script setup>
+import { computed, onMounted, reactive, ref } from 'vue'
+
+import BaseLoading from '@/components/ui/BaseLoading.vue'
+import { llmOpsApi } from '@/api/llmOps'
+import { useToast } from '@/composables/useToast'
+
+const props = defineProps({
+  sources: {
+    type: Array,
+    default: () => []
+  }
+})
+
+const emit = defineEmits(['saved'])
+const { showSuccess, showError } = useToast()
+
+const loading = ref(false)
+const saving = ref(false)
+const config = ref(null)
+const sourceMode = ref('all')
+
+const form = reactive({
+  meta_model_sync_enabled: true,
+  meta_model_sync_source_url: 'https://models.dev/api.json',
+  meta_model_sync_cron: '35 2 * * *',
+  price_collection_enabled: true,
+  price_collection_source_ids: [],
+  price_collection_cron: '15 1,7,13,19 * * *',
+  feishu_app_id: '',
+  feishu_app_secret: '',
+  feishu_approval_code: '',
+  feishu_tenant_key: '',
+  notes: ''
+})
+
+const sourceModes = [
+  { label: '全部启用的数据源', value: 'all' },
+  { label: '指定数据源', value: 'selected' }
+]
+
+const priceSourceOptions = computed(() =>
+  props.sources.filter((source) => source.updates_model_prices)
+)
+
+onMounted(() => {
+  loadConfig()
+})
+
+async function loadConfig() {
+  loading.value = true
+  try {
+    const response = await llmOpsApi.getGlobalConfig()
+    applyConfig(extract(response))
+  } catch (error) {
+    showError(errorMessage(error, '加载全局配置失败'))
+  } finally {
+    loading.value = false
+  }
+}
+
+async function saveConfig() {
+  const missingSelectedSource =
+    sourceMode.value === 'selected' &&
+    !form.price_collection_source_ids.length
+  if (missingSelectedSource) {
+    showError('请至少选择一个模型价格源')
+    return
+  }
+  saving.value = true
+  try {
+    const payload = {
+      meta_model_sync_enabled: form.meta_model_sync_enabled,
+      meta_model_sync_source_url: form.meta_model_sync_source_url,
+      meta_model_sync_cron: form.meta_model_sync_cron,
+      price_collection_enabled: form.price_collection_enabled,
+      price_collection_source_ids:
+        sourceMode.value === 'all'
+          ? []
+          : form.price_collection_source_ids,
+      price_collection_cron: form.price_collection_cron,
+      feishu_app_id: form.feishu_app_id,
+      feishu_approval_code: form.feishu_approval_code,
+      feishu_tenant_key: form.feishu_tenant_key,
+      notes: form.notes
+    }
+    if (form.feishu_app_secret) {
+      payload.feishu_app_secret = form.feishu_app_secret
+    }
+    const response = await llmOpsApi.updateGlobalConfig(payload)
+    applyConfig(extract(response))
+    showSuccess('全局配置已保存，采集任务已同步')
+    emit('saved')
+  } catch (error) {
+    showError(errorMessage(error, '保存全局配置失败'))
+  } finally {
+    saving.value = false
+  }
+}
+
+async function resetConfig() {
+  if (!window.confirm('确认恢复 LLM Ops 全局配置默认值？')) return
+  saving.value = true
+  try {
+    const response = await llmOpsApi.resetGlobalConfig()
+    applyConfig(extract(response))
+    showSuccess('全局配置已恢复默认值')
+    emit('saved')
+  } catch (error) {
+    showError(errorMessage(error, '恢复默认配置失败'))
+  } finally {
+    saving.value = false
+  }
+}
+
+function applyConfig(nextConfig) {
+  config.value = nextConfig
+  form.meta_model_sync_enabled = nextConfig.meta_model_sync_enabled
+  form.meta_model_sync_source_url = nextConfig.meta_model_sync_source_url
+  form.meta_model_sync_cron = nextConfig.meta_model_sync_cron
+  form.price_collection_enabled = nextConfig.price_collection_enabled
+  form.price_collection_source_ids = [
+    ...(nextConfig.price_collection_source_ids || [])
+  ]
+  form.price_collection_cron = nextConfig.price_collection_cron
+  form.feishu_app_id = nextConfig.feishu_app_id || ''
+  form.feishu_app_secret = ''
+  form.feishu_approval_code = nextConfig.feishu_approval_code || ''
+  form.feishu_tenant_key = nextConfig.feishu_tenant_key || ''
+  form.notes = nextConfig.notes || ''
+  sourceMode.value = form.price_collection_source_ids.length
+    ? 'selected'
+    : 'all'
+}
+
+function sourceMeta(source) {
+  return [
+    source.is_enabled === false ? '已停用' : '已启用',
+    source.provider_name,
+    source.channel_name,
+    source.currency,
+    source.endpoint_url
+  ]
+    .filter(Boolean)
+    .join(' · ')
+}
+
+function formatDateTime(value) {
+  if (!value) return '-'
+  return new Date(value).toLocaleString()
+}
+
+function extract(response) {
+  const payload = response?.data ?? response
+  return payload?.results ?? payload
+}
+
+function errorMessage(error, fallback) {
+  const data = error?.response?.data
+  if (typeof data?.detail === 'string') return data.detail
+  if (typeof data === 'string') return data
+  return error?.message || fallback
+}
+</script>
+
+<style scoped>
+.global-config-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.global-config-toolbar {
+  align-items: flex-start;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.5rem;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  padding: 1rem;
+}
+
+.global-config-eyebrow {
+  color: #059669;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.global-config-toolbar h3,
+.config-section h4 {
+  color: #0f172a;
+  font-weight: 700;
+  margin: 0;
+}
+
+.global-config-toolbar h3 {
+  font-size: 1.125rem;
+  margin-top: 0.25rem;
+}
+
+.global-config-toolbar p,
+.config-section-header p {
+  color: #64748b;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  margin: 0.25rem 0 0;
+}
+
+.global-config-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.global-config-grid {
+  align-items: start;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: minmax(0, 1.45fr) minmax(20rem, 0.8fr);
+}
+
+.global-config-main,
+.global-config-side {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-width: 0;
+}
+
+.config-section {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.config-section-header {
+  align-items: flex-start;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+}
+
+.config-switch {
+  align-items: center;
+  color: #334155;
+  display: inline-flex;
+  flex: 0 0 auto;
+  font-size: 0.875rem;
+  font-weight: 700;
+  gap: 0.5rem;
+}
+
+.config-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.config-field span {
+  color: #334155;
+  font-size: 0.8125rem;
+  font-weight: 700;
+}
+
+.config-field input,
+.config-section textarea {
+  border: 1px solid #cbd5e1;
+  border-radius: 0.5rem;
+  color: #0f172a;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  outline: none;
+  padding: 0.625rem 0.75rem;
+  width: 100%;
+}
+
+.config-field input:focus,
+.config-section textarea:focus {
+  border-color: #059669;
+  box-shadow: 0 0 0 3px rgba(5, 150, 105, 0.12);
+}
+
+.source-mode-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.source-mode {
+  align-items: center;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.5rem;
+  color: #475569;
+  display: inline-flex;
+  font-size: 0.875rem;
+  font-weight: 700;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+}
+
+.source-mode.active {
+  background: #ecfdf5;
+  border-color: #10b981;
+  color: #047857;
+}
+
+.source-list {
+  border: 1px solid #e2e8f0;
+  border-radius: 0.5rem;
+  display: grid;
+  gap: 0;
+  overflow: hidden;
+}
+
+.source-row {
+  align-items: flex-start;
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.75rem;
+}
+
+.source-row + .source-row {
+  border-top: 1px solid #e2e8f0;
+}
+
+.source-row strong,
+.source-row small {
+  display: block;
+}
+
+.source-row strong {
+  color: #0f172a;
+  font-size: 0.875rem;
+}
+
+.source-row small {
+  color: #64748b;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  margin-top: 0.2rem;
+}
+
+.empty-source {
+  color: #64748b;
+  font-size: 0.875rem;
+  padding: 0.9rem;
+}
+
+.secret-status {
+  background: #f1f5f9;
+  border-radius: 999px;
+  color: #64748b;
+  flex: 0 0 auto;
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 0.35rem 0.65rem;
+}
+
+.secret-status.active {
+  background: #dcfce7;
+  color: #15803d;
+}
+
+.config-runtime {
+  align-items: center;
+  border-top: 1px solid #e2e8f0;
+  color: #64748b;
+  display: flex;
+  font-size: 0.8125rem;
+  justify-content: space-between;
+  padding-top: 0.75rem;
+}
+
+.config-runtime strong {
+  color: #0f172a;
+  font-weight: 700;
+}
+
+@media (max-width: 1024px) {
+  .global-config-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  .global-config-toolbar,
+  .config-section-header {
+    flex-direction: column;
+  }
+
+  .global-config-actions {
+    justify-content: flex-start;
+    width: 100%;
+  }
+}
+</style>

--- a/frontend/src/pages/LLMOps.vue
+++ b/frontend/src/pages/LLMOps.vue
@@ -568,6 +568,12 @@
               @saved="handleWorkflowConfigSaved"
             />
 
+            <GlobalConfigPanel
+              v-else-if="activeSection === 'globalConfig'"
+              :sources="providerCollectionSources"
+              @saved="refreshLight"
+            />
+
             <ProviderManagement
               v-else-if="activeSection === 'providers'"
               :providers="providers"
@@ -659,6 +665,7 @@ import BaseLoading from '@/components/ui/BaseLoading.vue'
 import AgioneListingStatusBoard from '@/components/llm-ops/AgioneListingStatusBoard.vue'
 import AuditLogPanel from '@/components/llm-ops/AuditLogPanel.vue'
 import ChannelManagement from '@/components/llm-ops/ChannelManagement.vue'
+import GlobalConfigPanel from '@/components/llm-ops/GlobalConfigPanel.vue'
 import MetaModelManagement from '@/components/llm-ops/MetaModelManagement.vue'
 import ProviderManagement from '@/components/llm-ops/ProviderManagement.vue'
 import ReconciliationPanel from '@/components/llm-ops/ReconciliationPanel.vue'
@@ -675,6 +682,7 @@ const sectionKeys = new Set([
   'metaModels',
   'providers',
   'channels',
+  'globalConfig',
   'reseller',
   'workflow',
   'reconciler',
@@ -742,6 +750,13 @@ const monitorStatusLabelKeys = {
 const navIcons = {
   audit: ['M4 5h16', 'M4 12h16', 'M4 19h10'],
   channels: ['M4 7h16', 'M7 7v10', 'M17 7v10', 'M4 17h16'],
+  globalConfig: [
+    'M4 7h16',
+    'M7 7v10',
+    'M17 7v10',
+    'M4 17h16',
+    'M9 12h6'
+  ],
   metaModels: ['M12 3l8 4-8 4-8-4 8-4Z', 'M4 12l8 4 8-4', 'M4 17l8 4 8-4'],
   monitor: ['M4 19V5', 'M8 19v-6', 'M12 19v-9', 'M16 19v-4', 'M20 19V8'],
   providers: ['M5 5h14v14H5Z', 'M9 9h6', 'M9 13h6', 'M9 17h3'],
@@ -812,6 +827,13 @@ const navItems = computed(() => [
     eyebrow: 'Workflow',
     description: '配置上架、免审、审批和下架路径，并按平台动态生效。',
     icon: navIcons.workflow
+  },
+  {
+    key: 'globalConfig',
+    label: '全局配置',
+    eyebrow: 'Global Config',
+    description: '配置元模型同步、模型价格采集和飞书审核认证。',
+    icon: navIcons.globalConfig
   },
   {
     key: 'reconciler',


### PR DESCRIPTION
## Summary
- Add a singleton LLM Ops global configuration model, API, admin entry, and audit coverage
- Synchronize model sync and price collection schedules into django-celery-beat from the global config
- Add a Vue global configuration panel for meta-model sync, price collection sources, and Feishu approval credentials
- Encrypt stored Feishu app secrets and preserve existing secrets on blank updates
- Reject unknown price collection source ids and preserve legacy official collection beat tasks

## Test plan
- [x] git diff --check HEAD
- [ ] python3 -m pytest backend/llm_ops/tests/test_views.py (blocked: local environment missing django_celery_beat)
- [ ] npm run build (blocked: local frontend dependencies missing vite)

Made with [Orca](https://github.com/stablyai/orca)