### PR TITLE
Fix LLM Ops resale workflow automation

### DIFF
--- a/backend/llm_ops/tests/test_views.py
+++ b/backend/llm_ops/tests/test_views.py
@@ -1573,6 +1573,30 @@ class LLMOpsViewTests(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertIn("unknown node", str(response.data))
 
+    def test_resale_workflow_config_rejects_missing_publish_path(self):
+        platform = ResalePlatform.objects.create(
+            name="Agione",
+            code="agione",
+        )
+        response = self.client.get(
+            reverse("resale-workflow-config-effective"),
+            {"platform": platform.id},
+        )
+        config = response.data["config"]
+        config["policies"]["auto_approve_enabled"] = False
+        config["policies"]["manual_confirm_required"] = False
+        config["policies"]["feishu_approval_enabled"] = False
+
+        patch_response = self.client.patch(
+            f"{reverse('resale-workflow-config-effective')}"
+            f"?platform={platform.id}",
+            {"config": config},
+            format="json",
+        )
+
+        self.assertEqual(patch_response.status_code, 400)
+        self.assertIn("publishing path", str(patch_response.data))
+
     def test_resale_listing_bulk_transition_publish_and_offline(self):
         provider = LLMProvider.objects.create(name="OpenAI", code="openai")
         model = LLMModel.objects.create(

--- a/backend/llm_ops/workflow_config.py
+++ b/backend/llm_ops/workflow_config.py
@@ -261,6 +261,26 @@ def validate_resale_workflow_config(value: Any) -> dict[str, Any]:
         raise serializers.ValidationError("config.edges must be a list.")
     if not isinstance(policies, dict):
         raise serializers.ValidationError("config.policies must be an object.")
+    merged_policies = deepcopy(DEFAULT_POLICIES)
+    merged_policies.update(
+        {
+            key: value
+            for key, value in policies.items()
+            if key in DEFAULT_POLICIES
+        }
+    )
+    has_publish_path = any(
+        bool(merged_policies[key])
+        for key in (
+            "auto_approve_enabled",
+            "manual_confirm_required",
+            "feishu_approval_enabled",
+        )
+    )
+    if not has_publish_path:
+        raise serializers.ValidationError(
+            "At least one publishing path must be enabled."
+        )
 
     node_ids: set[str] = set()
     for node in nodes:

--- a/frontend/src/components/llm-ops/ResaleWorkflowConfigPanel.vue
+++ b/frontend/src/components/llm-ops/ResaleWorkflowConfigPanel.vue
@@ -184,6 +184,7 @@ import { computed, ref, watch } from 'vue'
 import BaseLoading from '@/components/ui/BaseLoading.vue'
 import CompactSelect from '@/components/llm-ops/CompactSelect.vue'
 import { llmOpsApi } from '@/api/llmOps'
+import { DEFAULT_WORKFLOW_POLICIES } from '@/constants/llmOpsWorkflow'
 import { useToast } from '@/composables/useToast'
 
 const props = defineProps({
@@ -204,14 +205,6 @@ const loading = ref(false)
 const saving = ref(false)
 const workflow = ref(null)
 const localPlatformId = ref(props.platformId || '')
-
-const DEFAULT_POLICIES = {
-  auto_approve_enabled: true,
-  manual_confirm_required: true,
-  feishu_approval_enabled: false,
-  auto_apply_after_approval: true,
-  offline_approval_enabled: false
-}
 
 const platformOptions = computed(() =>
   props.platforms.map((platform) => ({
@@ -423,7 +416,7 @@ function normalizeWorkflowPayload(payload) {
   next.config = {
     ...config,
     policies: {
-      ...DEFAULT_POLICIES,
+      ...DEFAULT_WORKFLOW_POLICIES,
       ...(isPlainObject(config.policies) ? config.policies : {})
     },
     nodes: Array.isArray(config.nodes) ? config.nodes : [],

--- a/frontend/src/components/llm-ops/ResaleWorkflowConfigPanel.vue
+++ b/frontend/src/components/llm-ops/ResaleWorkflowConfigPanel.vue
@@ -1,11 +1,6 @@
 <template>
   <section class="workflow-panel">
     <div class="workflow-toolbar">
-      <div>
-        <p class="workflow-eyebrow">Workflow</p>
-        <h3>上架流程配置</h3>
-        <p>配置按平台生效，保存后上架工作台会按这里的免审和审批策略加载。</p>
-      </div>
       <div class="workflow-toolbar-actions">
         <CompactSelect
           v-model="localPlatformId"
@@ -47,113 +42,138 @@
       请先创建或选择一个上架平台。
     </div>
 
-    <div v-else-if="workflow" class="workflow-grid">
-      <div class="workflow-map">
-        <div class="workflow-runtime">
-          <span>当前平台：{{ workflow.platform_name }}</span>
-          <span>
-            免审利润率：
-            {{ runtime.auto_approve_max_margin_rate ?? '-' }}%
-          </span>
-          <span>
-            飞书审批：
-            {{ policies.feishu_approval_enabled ? '启用' : '未启用' }}
-          </span>
-        </div>
-
-        <div class="workflow-lanes">
-          <div v-for="lane in lanes" :key="lane.key" class="workflow-lane">
-            <div class="workflow-lane-title">
-              <span>{{ lane.label }}</span>
-              <small>{{ nodesByLane(lane.key).length }} 个节点</small>
+    <div v-else-if="workflow" class="workflow-blueprint-layout">
+      <div class="workflow-blueprint-main">
+        <section class="workflow-flowchart" aria-label="上架流程图">
+          <header class="workflow-flowchart-header">
+            <div>
+              <h4>上架流程图</h4>
+              <p>主干流程固定只读，仅策略分支可配置。</p>
             </div>
-            <div class="workflow-node-list">
+            <span>只读主干</span>
+          </header>
+
+          <div class="workflow-flowchart-body">
+            <div class="workflow-flow-row">
+              <article class="workflow-flow-node is-fixed">
+                <small>01</small>
+                <strong>选择元模型</strong>
+                <span>模型与版本</span>
+              </article>
+              <span class="workflow-flow-arrow">→</span>
+              <article class="workflow-flow-node is-fixed">
+                <small>02</small>
+                <strong>选择采购渠道</strong>
+                <span>渠道与成本</span>
+              </article>
+              <span class="workflow-flow-arrow">→</span>
+              <article class="workflow-flow-node is-fixed">
+                <small>03</small>
+                <strong>设置利润率</strong>
+                <span>生成上架价格</span>
+              </article>
+            </div>
+
+            <div class="workflow-flow-elbow" aria-hidden="true">
+              <span></span>
+            </div>
+
+            <div class="workflow-flow-split is-submit">
+              <article class="workflow-flow-node is-fixed">
+                <small>04</small>
+                <strong>提交上架</strong>
+                <span>进入判断</span>
+              </article>
+            </div>
+
+            <div class="workflow-flow-branches">
               <article
-                v-for="node in nodesByLane(lane.key)"
-                :key="node.id"
-                class="workflow-node"
-                :class="[
-                  node.enabled === false ? 'is-disabled' : '',
-                  `status-${node.status || 'implemented'}`
-                ]"
+                class="workflow-flow-node is-policy"
+                :class="{ 'is-disabled': !policies.auto_approve_enabled }"
               >
-                <div class="workflow-node-header">
-                  <span class="workflow-node-dot"></span>
-                  <strong>{{ node.label }}</strong>
+                <div class="workflow-node-top">
+                  <small>免审路径</small>
+                  <label class="workflow-node-toggle">
+                    <input
+                      id="workflow-auto-approve-enabled"
+                      v-model="editableConfig.policies.auto_approve_enabled"
+                      name="workflow_auto_approve_enabled"
+                      type="checkbox"
+                      @change="onAutoApproveToggle"
+                    />
+                    <span>{{
+                      policies.auto_approve_enabled ? '启用' : '停用'
+                    }}</span>
+                  </label>
                 </div>
-                <p>{{ node.description || node.id }}</p>
-                <div class="workflow-node-meta">
-                  <span>{{ nodeStatusLabel(node.status) }}</span>
-                  <span>{{
-                    node.enabled === false ? '已停用' : '已启用'
-                  }}</span>
+                <strong>利润率 ≤ {{ autoApproveRateLabel }}</strong>
+                <span>直接确认</span>
+              </article>
+              <article
+                class="workflow-flow-node is-policy"
+                :class="{ 'is-disabled': !approvalFlowEnabled }"
+              >
+                <div class="workflow-node-top">
+                  <small>审核路径</small>
+                  <select
+                    id="workflow-approval-mode"
+                    class="workflow-node-select"
+                    name="workflow_approval_mode"
+                    :value="approvalMode"
+                    aria-label="审核路径"
+                    @change="setApprovalMode($event.target.value)"
+                  >
+                    <option value="internal">内部人工确认</option>
+                    <option value="external">外部飞书审核</option>
+                    <option value="both">内部 + 外部审核</option>
+                    <option
+                      value="disabled"
+                      :disabled="!policies.auto_approve_enabled"
+                    >
+                      仅保留免审路径
+                    </option>
+                  </select>
                 </div>
+                <strong>{{ approvalFlowLabel }}</strong>
+                <span>超阈值复核</span>
+              </article>
+            </div>
+
+            <div class="workflow-flow-join" aria-hidden="true">
+              <span></span>
+            </div>
+
+            <div class="workflow-flow-split">
+              <article class="workflow-flow-node is-policy">
+                <div class="workflow-node-top">
+                  <small>发布策略</small>
+                  <select
+                    id="workflow-publish-mode"
+                    class="workflow-node-select"
+                    name="workflow_publish_mode"
+                    :value="publishMode"
+                    aria-label="发布策略"
+                    @change="setPublishMode($event.target.value)"
+                  >
+                    <option value="auto">免审后自动上线</option>
+                    <option value="manual">提交后待确认</option>
+                  </select>
+                </div>
+                <strong>{{ publishFlowLabel }}</strong>
+                <span>{{ publishFlowDescription }}</span>
+              </article>
+            </div>
+
+            <div class="workflow-flow-split is-terminal">
+              <article class="workflow-flow-node is-fixed">
+                <small>06</small>
+                <strong>下架/异常处理</strong>
+                <span>确认 / 驳回 / 异常</span>
               </article>
             </div>
           </div>
-        </div>
-
-        <div class="workflow-edge-band">
-          <div class="workflow-edge-title">条件连线</div>
-          <div class="workflow-edge-list">
-            <span
-              v-for="edge in editableConfig.edges"
-              :key="edge.id"
-              class="workflow-edge"
-              :class="{ 'is-disabled': edge.enabled === false }"
-            >
-              {{ nodeLabel(edge.from) }} → {{ nodeLabel(edge.to) }}
-              <em>{{ edge.label }}</em>
-            </span>
-          </div>
-        </div>
+        </section>
       </div>
-
-      <aside class="workflow-editor">
-        <section class="workflow-editor-section">
-          <h4>策略开关</h4>
-          <label
-            v-for="policy in policyOptions"
-            :key="policy.key"
-            class="workflow-switch-row"
-          >
-            <span>
-              <strong>{{ policy.label }}</strong>
-              <small>{{ policy.description }}</small>
-            </span>
-            <input
-              v-model="editableConfig.policies[policy.key]"
-              type="checkbox"
-            />
-          </label>
-        </section>
-
-        <section class="workflow-editor-section">
-          <h4>节点控制</h4>
-          <label
-            v-for="node in editableConfig.nodes"
-            :key="node.id"
-            class="workflow-switch-row compact"
-          >
-            <span>
-              <strong>{{ node.label }}</strong>
-              <small>{{ node.id }}</small>
-            </span>
-            <input v-model="node.enabled" type="checkbox" />
-          </label>
-        </section>
-
-        <section class="workflow-editor-section">
-          <h4>生效说明</h4>
-          <ul class="workflow-impact-list">
-            <li>免审开关关闭后，上架工作台不再显示“免审通过”状态。</li>
-            <li>
-              飞书审批开启后，流程图展示审批路径；审批提交接口仍需后续接入。
-            </li>
-            <li>下架审批开关用于预留下架审批路径，不改变现有下架状态机。</li>
-          </ul>
-        </section>
-      </aside>
     </div>
   </section>
 </template>
@@ -185,39 +205,13 @@ const saving = ref(false)
 const workflow = ref(null)
 const localPlatformId = ref(props.platformId || '')
 
-const lanes = [
-  { key: 'pricing', label: '价格准备' },
-  { key: 'approval', label: '审批判断' },
-  { key: 'publishing', label: '发布/下架' }
-]
-
-const policyOptions = [
-  {
-    key: 'auto_approve_enabled',
-    label: '启用免审路径',
-    description: '低于平台免审利润率时展示免审确认路径'
-  },
-  {
-    key: 'manual_confirm_required',
-    label: '保留人工确认',
-    description: '保留现有 confirm_publish / confirm_update 操作'
-  },
-  {
-    key: 'feishu_approval_enabled',
-    label: '启用飞书审批路径',
-    description: '高于免审阈值时展示飞书审批路径'
-  },
-  {
-    key: 'auto_apply_after_approval',
-    label: '审批通过后自动发布',
-    description: '审批通过后可自动执行确认发布动作'
-  },
-  {
-    key: 'offline_approval_enabled',
-    label: '启用下架审批',
-    description: '下架操作进入审批路径后再确认下架'
-  }
-]
+const DEFAULT_POLICIES = {
+  auto_approve_enabled: true,
+  manual_confirm_required: true,
+  feishu_approval_enabled: false,
+  auto_apply_after_approval: true,
+  offline_approval_enabled: false
+}
 
 const platformOptions = computed(() =>
   props.platforms.map((platform) => ({
@@ -229,6 +223,51 @@ const platformOptions = computed(() =>
 const editableConfig = computed(() => workflow.value?.config || {})
 const policies = computed(() => editableConfig.value.policies || {})
 const runtime = computed(() => editableConfig.value.runtime || {})
+const autoApproveRateLabel = computed(
+  () => `${runtime.value.auto_approve_max_margin_rate ?? '-'}%`
+)
+const approvalFlowEnabled = computed(() =>
+  Boolean(
+    policies.value.manual_confirm_required ||
+      policies.value.feishu_approval_enabled
+  )
+)
+const approvalFlowLabel = computed(() => {
+  if (
+    policies.value.manual_confirm_required &&
+    policies.value.feishu_approval_enabled
+  ) {
+    return '内部 + 外部审核'
+  }
+  if (policies.value.feishu_approval_enabled) return '外部飞书审核'
+  if (policies.value.manual_confirm_required) return '内部人工确认'
+  return '审核路径停用'
+})
+const approvalMode = computed(() => {
+  if (
+    policies.value.manual_confirm_required &&
+    policies.value.feishu_approval_enabled
+  ) {
+    return 'both'
+  }
+  if (policies.value.feishu_approval_enabled) return 'external'
+  if (policies.value.manual_confirm_required) return 'internal'
+  return 'disabled'
+})
+const publishFlowLabel = computed(() => {
+  if (policies.value.auto_apply_after_approval) return '免审后自动上线'
+  return '提交后待确认'
+})
+const publishMode = computed(() => {
+  if (policies.value.auto_apply_after_approval) return 'auto'
+  return 'manual'
+})
+const publishFlowDescription = computed(() => {
+  if (policies.value.auto_apply_after_approval) {
+    return '免审命中后确认发布'
+  }
+  return '保留人工确认'
+})
 
 watch(
   () => props.platformId,
@@ -259,7 +298,7 @@ async function loadConfig() {
     const response = await llmOpsApi.getResaleWorkflowConfig(
       localPlatformId.value
     )
-    workflow.value = clone(response.data)
+    workflow.value = normalizeWorkflowPayload(response.data)
     syncPolicyEdges()
   } catch (error) {
     showError(errorMessage(error) || '加载上架流程配置失败')
@@ -270,6 +309,10 @@ async function loadConfig() {
 
 async function saveConfig() {
   if (!workflow.value || !localPlatformId.value) return
+  if (!hasPublishPath(editableConfig.value.policies)) {
+    showError('至少需要保留免审、内部确认或外部审核中的一种上架路径')
+    return
+  }
   saving.value = true
   try {
     syncPolicyEdges()
@@ -281,7 +324,7 @@ async function saveConfig() {
         notes: workflow.value.notes || ''
       }
     )
-    workflow.value = clone(response.data)
+    workflow.value = normalizeWorkflowPayload(response.data)
     syncPolicyEdges()
     showSuccess('上架流程配置已生效')
     emit('saved', workflow.value)
@@ -300,7 +343,7 @@ async function resetConfig() {
     const response = await llmOpsApi.resetResaleWorkflowConfig(
       localPlatformId.value
     )
-    workflow.value = clone(response.data)
+    workflow.value = normalizeWorkflowPayload(response.data)
     syncPolicyEdges()
     showSuccess('已恢复默认上架流程')
     emit('saved', workflow.value)
@@ -315,6 +358,7 @@ function syncPolicyEdges() {
   const config = editableConfig.value
   if (!config?.edges || !config?.nodes || !config?.policies) return
   setNodeEnabled('auto_confirm', config.policies.auto_approve_enabled)
+  setNodeEnabled('manual_review', config.policies.manual_confirm_required)
   setNodeEnabled('feishu_approval', config.policies.feishu_approval_enabled)
   setEdgeEnabled('gate_to_auto', config.policies.auto_approve_enabled)
   setEdgeEnabled('auto_to_online', config.policies.auto_approve_enabled)
@@ -322,6 +366,36 @@ function syncPolicyEdges() {
   setEdgeEnabled('manual_to_online', config.policies.manual_confirm_required)
   setEdgeEnabled('gate_to_feishu', config.policies.feishu_approval_enabled)
   setEdgeEnabled('feishu_to_online', config.policies.feishu_approval_enabled)
+}
+
+function onAutoApproveToggle() {
+  const config = editableConfig.value
+  if (!config?.policies) return
+  if (!config.policies.auto_approve_enabled && !approvalFlowEnabled.value) {
+    config.policies.manual_confirm_required = true
+  }
+  syncPolicyEdges()
+}
+
+function setApprovalMode(mode) {
+  const config = editableConfig.value
+  if (!config?.policies) return
+  if (mode === 'disabled' && !config.policies.auto_approve_enabled) {
+    config.policies.manual_confirm_required = true
+    config.policies.feishu_approval_enabled = false
+    syncPolicyEdges()
+    return
+  }
+  config.policies.manual_confirm_required = ['internal', 'both'].includes(mode)
+  config.policies.feishu_approval_enabled = ['external', 'both'].includes(mode)
+  syncPolicyEdges()
+}
+
+function setPublishMode(mode) {
+  const config = editableConfig.value
+  if (!config?.policies) return
+  config.policies.auto_apply_after_approval = mode === 'auto'
+  syncPolicyEdges()
 }
 
 function setNodeEnabled(id, enabled) {
@@ -334,24 +408,33 @@ function setEdgeEnabled(id, enabled) {
   if (edge) edge.enabled = Boolean(enabled)
 }
 
-function nodesByLane(lane) {
-  return (editableConfig.value.nodes || []).filter(
-    (node) => (node.lane || 'pricing') === lane
+function hasPublishPath(policyState = {}) {
+  return Boolean(
+    policyState.auto_approve_enabled ||
+      policyState.manual_confirm_required ||
+      policyState.feishu_approval_enabled
   )
 }
 
-function nodeLabel(id) {
-  const node = (editableConfig.value.nodes || []).find((item) => item.id === id)
-  return node?.label || id
+function normalizeWorkflowPayload(payload) {
+  const source = isPlainObject(payload?.data) ? payload.data : payload
+  const next = clone(isPlainObject(source) ? source : {})
+  const config = isPlainObject(next.config) ? next.config : {}
+  next.config = {
+    ...config,
+    policies: {
+      ...DEFAULT_POLICIES,
+      ...(isPlainObject(config.policies) ? config.policies : {})
+    },
+    nodes: Array.isArray(config.nodes) ? config.nodes : [],
+    edges: Array.isArray(config.edges) ? config.edges : [],
+    runtime: isPlainObject(config.runtime) ? config.runtime : {}
+  }
+  return next
 }
 
-function nodeStatusLabel(status) {
-  const labels = {
-    configurable: '可配置',
-    implemented: '已实现',
-    planned: '规划中'
-  }
-  return labels[status] || '已实现'
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
 }
 
 function clone(value) {
@@ -382,31 +465,6 @@ function errorMessage(error) {
   gap: 1rem;
 }
 
-.workflow-toolbar h3 {
-  margin: 0.25rem 0 0;
-  color: #0f172a;
-  font-size: 1.125rem;
-  font-weight: 700;
-  letter-spacing: 0;
-}
-
-.workflow-toolbar p {
-  margin: 0.35rem 0 0;
-  max-width: 48rem;
-  color: #64748b;
-  font-size: 0.875rem;
-  line-height: 1.5;
-}
-
-.workflow-eyebrow {
-  margin: 0;
-  color: #2563eb;
-  font-size: 0.6875rem;
-  font-weight: 800;
-  letter-spacing: 0;
-  text-transform: uppercase;
-}
-
 .workflow-toolbar-actions {
   display: flex;
   flex-wrap: wrap;
@@ -422,232 +480,400 @@ function errorMessage(error) {
   text-align: center;
 }
 
-.workflow-grid {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: minmax(0, 1fr) minmax(18rem, 24rem);
-}
-
-.workflow-map,
-.workflow-editor {
-  border: 1px solid #e2e8f0;
-  border-radius: 8px;
-  background: #ffffff;
-}
-
-.workflow-map {
-  min-width: 0;
-  padding: 1rem;
-}
-
-.workflow-runtime {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  margin-bottom: 1rem;
-}
-
-.workflow-runtime span,
-.workflow-edge {
-  border: 1px solid #dbeafe;
-  border-radius: 999px;
-  background: #eff6ff;
-  color: #1e40af;
-  font-size: 0.75rem;
-  font-weight: 700;
-  padding: 0.35rem 0.65rem;
-}
-
-.workflow-lanes {
-  display: grid;
-  gap: 0.75rem;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-.workflow-lane {
-  min-width: 0;
-}
-
-.workflow-lane-title {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  color: #334155;
-  font-size: 0.8125rem;
-  font-weight: 800;
-  margin-bottom: 0.5rem;
-}
-
-.workflow-lane-title small {
-  color: #94a3b8;
-  font-size: 0.6875rem;
-  font-weight: 700;
-}
-
-.workflow-node-list {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.workflow-node {
-  border: 1px solid #d1d5db;
-  border-radius: 8px;
-  background: #f8fafc;
-  padding: 0.75rem;
-}
-
-.workflow-node.is-disabled,
-.workflow-edge.is-disabled {
-  opacity: 0.45;
-}
-
-.workflow-node.status-planned {
-  border-color: #fed7aa;
-  background: #fff7ed;
-}
-
-.workflow-node.status-configurable {
-  border-color: #bae6fd;
-  background: #f0f9ff;
-}
-
-.workflow-node-header {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.workflow-node-header strong {
-  min-width: 0;
-  color: #0f172a;
-  font-size: 0.875rem;
-  line-height: 1.35;
-}
-
-.workflow-node-dot {
-  width: 0.5rem;
-  height: 0.5rem;
-  flex: 0 0 auto;
-  border-radius: 999px;
-  background: #2563eb;
-}
-
-.workflow-node p {
-  margin: 0.5rem 0 0;
-  color: #64748b;
-  font-size: 0.75rem;
-  line-height: 1.45;
-}
-
-.workflow-node-meta {
-  display: flex;
-  gap: 0.4rem;
-  margin-top: 0.65rem;
-}
-
-.workflow-node-meta span {
-  border-radius: 999px;
-  background: #e2e8f0;
-  color: #475569;
-  font-size: 0.6875rem;
-  font-weight: 800;
-  padding: 0.2rem 0.45rem;
-}
-
-.workflow-edge-band {
-  border-top: 1px solid #e2e8f0;
-  margin-top: 1rem;
-  padding-top: 1rem;
-}
-
-.workflow-edge-title {
-  color: #334155;
-  font-size: 0.8125rem;
-  font-weight: 800;
-  margin-bottom: 0.5rem;
-}
-
-.workflow-edge-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-
-.workflow-edge em {
-  color: #64748b;
-  font-style: normal;
-  font-weight: 600;
-  margin-left: 0.4rem;
-}
-
-.workflow-editor {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  padding: 1rem;
-}
-
-.workflow-editor-section h4 {
-  margin: 0 0 0.65rem;
-  color: #0f172a;
-  font-size: 0.875rem;
-  font-weight: 800;
-}
-
-.workflow-switch-row {
-  align-items: center;
-  border: 1px solid #e2e8f0;
-  border-radius: 8px;
-  display: flex;
-  gap: 0.75rem;
-  justify-content: space-between;
-  padding: 0.7rem;
-}
-
-.workflow-switch-row + .workflow-switch-row {
-  margin-top: 0.5rem;
-}
-
-.workflow-switch-row strong,
-.workflow-switch-row small {
+.workflow-blueprint-layout {
   display: block;
 }
 
-.workflow-switch-row strong {
-  color: #0f172a;
-  font-size: 0.8125rem;
+.workflow-blueprint-main {
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  background: #ffffff;
+  min-width: 0;
+  padding: 1rem;
 }
 
-.workflow-switch-row small {
+.workflow-flowchart {
+  border: 1px solid #dbeafe;
+  border-radius: 8px;
+  background: #f8fbff;
+  overflow: hidden;
+}
+
+.workflow-flowchart-header {
+  align-items: flex-start;
+  border-bottom: 1px solid #dbeafe;
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.9rem 1rem;
+}
+
+.workflow-flowchart-header h4,
+.workflow-flowchart-header p {
+  margin: 0;
+}
+
+.workflow-flowchart-header h4 {
+  color: #0f172a;
+  font-size: 0.9375rem;
+  font-weight: 800;
+}
+
+.workflow-flowchart-header p {
   color: #64748b;
   font-size: 0.75rem;
-  line-height: 1.4;
+  line-height: 1.45;
+  margin-top: 0.25rem;
+}
+
+.workflow-flowchart-header > span {
+  border-radius: 999px;
+  background: #ecfdf5;
+  color: #047857;
+  flex: 0 0 auto;
+  font-size: 0.75rem;
+  font-weight: 800;
+  padding: 0.25rem 0.55rem;
+}
+
+.workflow-flowchart-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem 1.25rem 1.25rem;
+}
+
+.workflow-flow-row {
+  align-items: stretch;
+  display: grid;
+  grid-template-columns:
+    minmax(8rem, 9rem) auto minmax(8rem, 9rem) auto
+    minmax(8rem, 9rem);
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.workflow-flow-row.is-two {
+  grid-template-columns: minmax(9.75rem, 11.75rem) auto minmax(
+      9.75rem,
+      11.75rem
+    );
+}
+
+.workflow-flow-split {
+  display: flex;
+  justify-content: center;
+  position: relative;
+}
+
+.workflow-flow-split::before,
+.workflow-flow-split::after {
+  background: #bfdbfe;
+  content: '';
+  height: 1rem;
+  left: 50%;
+  position: absolute;
+  transform: translateX(-50%);
+  width: 2px;
+}
+
+.workflow-flow-split::before {
+  top: -1rem;
+}
+
+.workflow-flow-split::after {
+  bottom: -1rem;
+}
+
+.workflow-flow-split.is-terminal::after {
+  display: none;
+}
+
+.workflow-flow-split .workflow-flow-node {
+  max-width: 11.75rem;
+  width: 100%;
+}
+
+.workflow-flow-split.is-submit::before {
+  display: none;
+}
+
+.workflow-flow-elbow {
+  --workflow-elbow-offset: 16rem;
+  height: 2rem;
+  margin: -1rem auto;
+  max-width: 41rem;
+  position: relative;
+  width: 100%;
+}
+
+.workflow-flow-elbow::before,
+.workflow-flow-elbow::after,
+.workflow-flow-elbow span {
+  background: #bfdbfe;
+  content: '';
+  position: absolute;
+}
+
+.workflow-flow-elbow::before {
+  bottom: 50%;
+  left: calc(50% + var(--workflow-elbow-offset));
+  top: 0;
+  transform: translateX(-50%);
+  width: 2px;
+}
+
+.workflow-flow-elbow::after {
+  height: 2px;
+  left: 50%;
+  top: 50%;
+  width: var(--workflow-elbow-offset);
+}
+
+.workflow-flow-elbow span {
+  bottom: 0;
+  left: 50%;
+  top: 50%;
+  transform: translateX(-50%);
+  width: 2px;
+}
+
+.workflow-flow-branches {
+  display: grid;
+  gap: 4.5rem;
+  grid-template-columns: repeat(2, minmax(10.25rem, 11.75rem));
+  justify-content: center;
+  position: relative;
+}
+
+.workflow-flow-branches::before {
+  background: #bfdbfe;
+  content: '';
+  height: 2px;
+  left: 22%;
+  position: absolute;
+  right: 22%;
+  top: -0.5rem;
+}
+
+.workflow-flow-join {
+  --workflow-join-offset: 11.25rem;
+  height: 2rem;
+  margin: -1rem auto;
+  max-width: 32rem;
+  position: relative;
+  width: 100%;
+}
+
+.workflow-flow-join::before,
+.workflow-flow-join::after,
+.workflow-flow-join span,
+.workflow-flow-join span::before {
+  background: #bfdbfe;
+  content: '';
+  position: absolute;
+}
+
+.workflow-flow-join::before {
+  height: 2px;
+  left: calc(50% - var(--workflow-join-offset));
+  right: calc(50% - var(--workflow-join-offset));
+  top: 0;
+}
+
+.workflow-flow-join::after {
+  bottom: 0;
+  left: 50%;
+  top: 0;
+  transform: translateX(-50%);
+  width: 2px;
+}
+
+.workflow-flow-join span,
+.workflow-flow-join span::before {
+  height: 0.75rem;
+  top: 0;
+  width: 2px;
+}
+
+.workflow-flow-join span {
+  left: calc(50% - var(--workflow-join-offset));
+}
+
+.workflow-flow-join span::before {
+  left: calc(var(--workflow-join-offset) + var(--workflow-join-offset));
+}
+
+.workflow-flow-node {
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  background: #ffffff;
+  min-width: 0;
+  padding: 0.45rem 0.55rem;
+}
+
+.workflow-flow-node small,
+.workflow-flow-node strong,
+.workflow-flow-node span {
+  display: block;
+}
+
+.workflow-flow-node small {
+  color: #64748b;
+  font-size: 0.625rem;
+  font-weight: 800;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.workflow-flow-node strong {
+  color: #0f172a;
+  font-size: 0.8125rem;
+  line-height: 1.3;
   margin-top: 0.2rem;
 }
 
-.workflow-switch-row input {
-  width: 1rem;
-  height: 1rem;
+.workflow-flow-node span {
+  color: #64748b;
+  font-size: 0.6875rem;
+  line-height: 1.35;
+  margin-top: 0.2rem;
+}
+
+.workflow-node-top {
+  align-items: flex-start;
+  display: flex;
+  gap: 0.4rem;
+  justify-content: space-between;
+}
+
+.workflow-node-select {
+  appearance: none;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #334155;
+  cursor: pointer;
+  flex: 0 0 auto;
+  font-size: 0.75rem;
+  font-weight: 800;
+  line-height: 1.2;
+  max-width: 6.9rem;
+  padding: 0.22rem 1.15rem 0.22rem 0.45rem;
+}
+
+.workflow-node-toggle {
+  align-items: center;
+  border: 1px solid #d1d5db;
+  border-radius: 999px;
+  background: #ffffff;
+  color: #334155;
+  cursor: pointer;
+  display: inline-flex;
+  flex: 0 0 auto;
+  gap: 0.35rem;
+  min-height: 1.4rem;
+  padding: 0.16rem 0.42rem;
+}
+
+.workflow-node-toggle input {
+  width: 0.8rem;
+  height: 0.8rem;
   flex: 0 0 auto;
 }
 
-.workflow-switch-row.compact {
-  padding: 0.55rem 0.65rem;
+.workflow-node-toggle span {
+  color: inherit;
+  font-size: 0.6875rem;
+  font-weight: 800;
+  line-height: 1;
+  margin: 0;
 }
 
-.workflow-impact-list {
-  color: #64748b;
-  font-size: 0.75rem;
-  line-height: 1.55;
-  margin: 0;
-  padding-left: 1rem;
+.workflow-flow-node.is-fixed {
+  background: #ffffff;
+  border-color: #cbd5e1;
+  box-shadow: inset 0 3px 0 #64748b;
+}
+
+.workflow-flow-node.is-fixed small {
+  color: #475569;
+}
+
+.workflow-flow-node.is-policy {
+  background: #fffbeb;
+  border-color: #fde68a;
+  box-shadow: inset 0 3px 0 #f59e0b;
+}
+
+.workflow-flow-node.is-policy small {
+  color: #b45309;
+}
+
+.workflow-flow-node.is-disabled {
+  background: #f8fafc;
+  border-color: #e2e8f0;
+  box-shadow: inset 0 3px 0 #cbd5e1;
+  opacity: 0.62;
+}
+
+.workflow-flow-arrow {
+  align-items: center;
+  color: #2563eb;
+  display: flex;
+  font-size: 0;
+  font-weight: 900;
+  justify-content: center;
+  min-width: 5.5rem;
+  position: relative;
+}
+
+.workflow-flow-arrow::before {
+  background: #60a5fa;
+  content: '';
+  height: 2px;
+  width: 100%;
+}
+
+.workflow-flow-arrow::after {
+  border-bottom: 4px solid transparent;
+  border-left: 6px solid #2563eb;
+  border-top: 4px solid transparent;
+  content: '';
+  position: absolute;
+  right: 0;
 }
 
 @media (max-width: 1180px) {
-  .workflow-grid,
-  .workflow-lanes {
-    grid-template-columns: 1fr;
+  .workflow-flowchart-body {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  .workflow-flow-elbow {
+    --workflow-elbow-offset: 15rem;
+    max-width: 39.5rem;
+  }
+
+  .workflow-flow-row {
+    grid-template-columns:
+      minmax(8rem, 9rem) auto minmax(8rem, 9rem) auto
+      minmax(8rem, 9rem);
+  }
+
+  .workflow-flow-row.is-two {
+    grid-template-columns: minmax(9.75rem, 11.75rem) auto minmax(
+        9.75rem,
+        11.75rem
+      );
+  }
+
+  .workflow-flow-branches {
+    grid-template-columns: repeat(2, minmax(10.25rem, 11.75rem));
+  }
+
+  .workflow-flow-arrow {
+    min-width: 4.75rem;
   }
 
   .workflow-toolbar {
@@ -656,6 +882,61 @@ function errorMessage(error) {
 
   .workflow-toolbar-actions {
     justify-content: flex-start;
+  }
+}
+
+@media (max-width: 760px) {
+  .workflow-flow-branches {
+    grid-template-columns: 1fr;
+  }
+
+  .workflow-flow-branches {
+    justify-items: center;
+  }
+
+  .workflow-flow-row {
+    grid-template-columns: 1fr;
+    justify-items: center;
+  }
+
+  .workflow-flow-row.is-two {
+    grid-template-columns: 1fr;
+  }
+
+  .workflow-flow-arrow {
+    min-height: 0.5rem;
+    min-width: 3rem;
+    transform: rotate(90deg);
+  }
+
+  .workflow-flow-arrow::before {
+    width: 3rem;
+  }
+
+  .workflow-flow-split::before,
+  .workflow-flow-split::after,
+  .workflow-flow-branches::before,
+  .workflow-flow-elbow,
+  .workflow-flow-join {
+    display: none;
+  }
+
+  .workflow-flow-split .workflow-flow-node {
+    max-width: 14rem;
+  }
+
+  .workflow-flow-node {
+    width: min(100%, 14rem);
+  }
+
+  .workflow-node-top {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .workflow-node-select,
+  .workflow-node-toggle {
+    width: 100%;
   }
 }
 </style>

--- a/frontend/src/constants/llmOpsWorkflow.js
+++ b/frontend/src/constants/llmOpsWorkflow.js
@@ -1,0 +1,7 @@
+export const DEFAULT_WORKFLOW_POLICIES = Object.freeze({
+  auto_approve_enabled: true,
+  manual_confirm_required: true,
+  feishu_approval_enabled: false,
+  auto_apply_after_approval: true,
+  offline_approval_enabled: false
+})

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -895,6 +895,7 @@
       "noListingsToPublish": "No links need to be listed",
       "invalidListingPrices": "Enter valid In/Out listing prices for every link before publishing",
       "publishSubmitted": "Submitted {count} publishing requests",
+      "publishAutoConfirmed": "Submitted {count} publishing requests; {confirmed} were auto-approved and published",
       "submitFailed": "Submit failed",
       "noDraftsToSave": "No drafts need to be saved",
       "noChangesToSave": "No changes need to be saved",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -905,6 +905,7 @@
       "noListingsToPublish": "没有需要上架的链路",
       "invalidListingPrices": "请为每条链路填写有效的 In/Out 售价后再发布",
       "publishSubmitted": "已提交 {count} 条发布申请",
+      "publishAutoConfirmed": "已提交 {count} 条发布申请，其中 {confirmed} 条命中免审并自动上线",
       "submitFailed": "提交失败",
       "noDraftsToSave": "没有需要保存的草稿",
       "noChangesToSave": "没有检测到需要保存的修改",

--- a/frontend/src/pages/LLMOps.vue
+++ b/frontend/src/pages/LLMOps.vue
@@ -668,14 +668,9 @@ import ResaleWorkflowConfigPanel from '@/components/llm-ops/ResaleWorkflowConfig
 import CompactSelect from '@/components/llm-ops/CompactSelect.vue'
 import { useToast } from '@/composables/useToast'
 import { llmOpsApi } from '@/api/llmOps'
+import { DEFAULT_WORKFLOW_POLICIES } from '@/constants/llmOpsWorkflow'
 
 const FULL_LIST_PARAMS = { page_size: 10000 }
-const DEFAULT_WORKFLOW_POLICIES = {
-  auto_approve_enabled: true,
-  manual_confirm_required: true,
-  feishu_approval_enabled: false,
-  auto_apply_after_approval: true
-}
 const sectionKeys = new Set([
   'monitor',
   'metaModels',
@@ -1673,13 +1668,15 @@ async function confirmAutoApprovedListings(submittedListings, sourceListings) {
     { ids: updateIds, action: 'confirm_update' }
   ].filter((item) => item.ids.length)
 
-  for (const item of actions) {
-    await llmOpsApi.bulkTransitionResaleListings({
-      platform: agionePlatform.value?.id,
-      listings: item.ids,
-      action: item.action
-    })
-  }
+  await Promise.all(
+    actions.map((item) =>
+      llmOpsApi.bulkTransitionResaleListings({
+        platform: agionePlatform.value?.id,
+        listings: item.ids,
+        action: item.action
+      })
+    )
+  )
   return publishIds.length + updateIds.length
 }
 

--- a/frontend/src/pages/LLMOps.vue
+++ b/frontend/src/pages/LLMOps.vue
@@ -100,8 +100,8 @@
                   {{ activeNav.description }}
                 </p>
               </div>
-              <div class="page-hero-actions">
-                <div class="page-hero-group">
+              <div v-if="showHeroActions" class="page-hero-actions">
+                <div v-if="showGlobalToolbar" class="page-hero-group">
                   <div class="currency-control page-toolbar-control">
                     <span>{{ t('llmOps.toolbar.displayCurrency') }}</span>
                     <CompactSelect
@@ -670,6 +670,12 @@ import { useToast } from '@/composables/useToast'
 import { llmOpsApi } from '@/api/llmOps'
 
 const FULL_LIST_PARAMS = { page_size: 10000 }
+const DEFAULT_WORKFLOW_POLICIES = {
+  auto_approve_enabled: true,
+  manual_confirm_required: true,
+  feishu_approval_enabled: false,
+  auto_apply_after_approval: true
+}
 const sectionKeys = new Set([
   'monitor',
   'metaModels',
@@ -866,11 +872,7 @@ function resalePlatformOptionLabel(platform) {
   const typeLabel =
     platformTypeLabels[platform.platform_type] || platform.platform_type
   const regionLabel = platform.region_name || platform.region_code
-  const meta = [
-    typeLabel,
-    regionLabel,
-    environmentLabels[platform.environment]
-  ]
+  const meta = [typeLabel, regionLabel, environmentLabels[platform.environment]]
     .filter(Boolean)
     .join(' · ')
   return meta ? `${platform.name} · ${meta}` : platform.name
@@ -895,7 +897,11 @@ const agionePlatform = computed(
 )
 
 const showPlatformControl = computed(() =>
-  ['monitor', 'reseller', 'workflow'].includes(activeSection.value)
+  ['monitor', 'reseller'].includes(activeSection.value)
+)
+const showGlobalToolbar = computed(() => activeSection.value !== 'workflow')
+const showHeroActions = computed(
+  () => showGlobalToolbar.value || showPlatformControl.value
 )
 
 const workflowConfigForWorkspace = computed(
@@ -1368,7 +1374,7 @@ async function loadResaleWorkflowConfig(
   try {
     const response = await llmOpsApi.getResaleWorkflowConfig(platformId)
     if (String(platformId) === String(selectedResalePlatformId.value)) {
-      resaleWorkflowConfig.value = response.data
+      resaleWorkflowConfig.value = response.data?.data || response.data
     }
   } catch (error) {
     resaleWorkflowConfig.value = null
@@ -1603,16 +1609,30 @@ async function handleResaleWorkspacePublished(payload) {
     showInfo(t('llmOps.messages.noListingsToPublish'))
     return
   }
-  const items = payload.listings
-    .filter((item) => Number(item.priceIn) > 0 && Number(item.priceOut) > 0)
-    .map(mapWorkspaceListingToPayload)
+  const publishListings = payload.listings.filter(
+    (item) => Number(item.priceIn) > 0 && Number(item.priceOut) > 0
+  )
+  const items = publishListings.map(mapWorkspaceListingToPayload)
   if (!items.length) {
     showError(t('llmOps.messages.invalidListingPrices'))
     return
   }
   try {
-    await llmOpsApi.bulkUpsertResaleListings(items)
-    showSuccess(t('llmOps.messages.publishSubmitted', { count: items.length }))
+    const response = await llmOpsApi.bulkUpsertResaleListings(items)
+    const submittedListings = extract(response)
+    const autoConfirmedCount = await confirmAutoApprovedListings(
+      submittedListings,
+      publishListings
+    )
+    const messageKey = autoConfirmedCount
+      ? 'llmOps.messages.publishAutoConfirmed'
+      : 'llmOps.messages.publishSubmitted'
+    showSuccess(
+      t(messageKey, {
+        count: items.length,
+        confirmed: autoConfirmedCount
+      })
+    )
     resalePublishingDrawerOpen.value = false
     refreshLight()
   } catch (error) {
@@ -1622,6 +1642,51 @@ async function handleResaleWorkspacePublished(payload) {
       error?.message ||
       ''
     showError(message || t('llmOps.messages.submitFailed'))
+  }
+}
+
+async function confirmAutoApprovedListings(submittedListings, sourceListings) {
+  const policies = currentWorkflowPolicies()
+  if (!policies.auto_approve_enabled || !policies.auto_apply_after_approval) {
+    return 0
+  }
+  const limit = Number(
+    resaleWorkflowConfig.value?.config?.runtime?.auto_approve_max_margin_rate
+  )
+  if (!Number.isFinite(limit)) return 0
+
+  const publishIds = []
+  const updateIds = []
+  submittedListings.forEach((listing, index) => {
+    const source = sourceListings[index]
+    const margin = Number(source?.margin)
+    if (!Number.isFinite(margin) || margin > limit) return
+    if (listing.workflow_status === 'pending_publish') {
+      publishIds.push(listing.id)
+    } else if (listing.workflow_status === 'pending_update') {
+      updateIds.push(listing.id)
+    }
+  })
+
+  const actions = [
+    { ids: publishIds, action: 'confirm_publish' },
+    { ids: updateIds, action: 'confirm_update' }
+  ].filter((item) => item.ids.length)
+
+  for (const item of actions) {
+    await llmOpsApi.bulkTransitionResaleListings({
+      platform: agionePlatform.value?.id,
+      listings: item.ids,
+      action: item.action
+    })
+  }
+  return publishIds.length + updateIds.length
+}
+
+function currentWorkflowPolicies() {
+  return {
+    ...DEFAULT_WORKFLOW_POLICIES,
+    ...(resaleWorkflowConfig.value?.config?.policies || {})
   }
 }
 


### PR DESCRIPTION
## Summary
- Redesign the resale workflow configuration panel around a fixed publishing flow with editable policy branches.
- Auto-confirm resale listings that hit the configured no-review margin path when auto-apply is enabled.
- Validate workflow configs so at least one publishing path remains enabled, with a regression test.

## Review notes
- Bulk upsert returns listings in input order, so the auto-confirm mapping from submitted rows to source rows is stable.
- No linked issue was detected for this branch, so this PR does not auto-close an issue.

## Test plan
- [x] npm run build
- [x] git diff --check
- [ ] pytest backend/llm_ops/tests/test_views.py -k resale_workflow_config_rejects_missing_publish_path (blocked locally: missing django_celery_beat in current Python environment)

Made with [Orca](https://github.com/stablyai/orca) 🐋
