### PR TITLE
Fix notification silence minute normalization

### DIFF
--- a/frontend/src/admin/pages/Notifications/Channels.vue
+++ b/frontend/src/admin/pages/Notifications/Channels.vue
@@ -1440,10 +1440,7 @@ function openEditModal(row) {
       language: c.language || 'zh-hans',
       sign_secret: (c.sign_secret || '').trim(),
       merge_window_minutes: c.merge_window_minutes ?? 0,
-      silence_window_minutes: Math.max(
-        0,
-        Math.min(1440, Number(c.silence_window_minutes) ?? 0)
-      ),
+      silence_window_minutes: clampNumber(c.silence_window_minutes, 0, 1440, 0),
       silence_time_window: normalizeSilenceTimeWindow(c)
     }
   } else if (row.channel_type === 'email') {
@@ -1454,10 +1451,7 @@ function openEditModal(row) {
       smtp_port: c.smtp_port ?? 587,
       use_tls: c.use_tls !== false,
       use_ssl: c.use_ssl === true,
-      silence_window_minutes: Math.max(
-        0,
-        Math.min(1440, Number(c.silence_window_minutes) ?? 0)
-      ),
+      silence_window_minutes: clampNumber(c.silence_window_minutes, 0, 1440, 0),
       silence_time_window: normalizeSilenceTimeWindow(c)
     }
   } else {


### PR DESCRIPTION
## Summary
- Fix the PR #71 review finding where editing existing webhook/email channels could show NaN for silence_window_minutes.
- Reuse the existing clampNumber helper so missing or invalid values fall back to 0 and valid values stay within 0-1440.

## Verification
- npx eslint src/admin/pages/Notifications/Channels.vue --ext .vue --ignore-path ../.gitignore
- npm run build

## Notes
- Checked merge conflict markers with rg; none found.
- npm run lint still fails before linting because the script references frontend/.gitignore, which does not exist in this repo. The targeted ESLint command above uses ../.gitignore and passes.

Made with [Orca](https://github.com/stablyai/orca) 🐋
