### PR TITLE
Localize LLM Ops workflow view

### DIFF
--- a/frontend/src/components/llm-ops/GlobalConfigPanel.vue
+++ b/frontend/src/components/llm-ops/GlobalConfigPanel.vue
@@ -3,8 +3,8 @@
     <div class="global-config-toolbar">
       <div>
         <p class="global-config-eyebrow">Global Config</p>
-        <h3>全局配置</h3>
-        <p>统一管理元模型同步、模型价格采集和审核集成参数。</p>
+        <h3>{{ t('llmOps.globalConfigPanel.title') }}</h3>
+        <p>{{ t('llmOps.globalConfigPanel.description') }}</p>
       </div>
       <div class="global-config-actions">
         <button
@@ -13,7 +13,7 @@
           :disabled="loading || saving"
           @click="loadConfig"
         >
-          重新加载
+          {{ t('llmOps.globalConfigPanel.actions.reload') }}
         </button>
         <button
           type="button"
@@ -21,7 +21,7 @@
           :disabled="loading || saving"
           @click="resetConfig"
         >
-          恢复默认
+          {{ t('llmOps.globalConfigPanel.actions.reset') }}
         </button>
         <button
           type="button"
@@ -29,7 +29,11 @@
           :disabled="loading || saving"
           @click="saveConfig"
         >
-          {{ saving ? '保存中' : '保存并同步任务' }}
+          {{
+            saving
+              ? t('llmOps.globalConfigPanel.actions.saving')
+              : t('llmOps.globalConfigPanel.actions.save')
+          }}
         </button>
       </div>
     </div>
@@ -41,17 +45,21 @@
         <section class="config-section">
           <div class="config-section-header">
             <div>
-              <h4>元模型采集</h4>
-              <p>同步模型厂商、模型族和能力标签。</p>
+              <h4>{{ t('llmOps.globalConfigPanel.metaSync.title') }}</h4>
+              <p>{{ t('llmOps.globalConfigPanel.metaSync.description') }}</p>
             </div>
             <label class="config-switch">
-              <span>{{ form.meta_model_sync_enabled ? '启用' : '停用' }}</span>
+              <span>{{
+                form.meta_model_sync_enabled
+                  ? t('llmOps.globalConfigPanel.status.enabled')
+                  : t('llmOps.globalConfigPanel.status.disabled')
+              }}</span>
               <input v-model="form.meta_model_sync_enabled" type="checkbox" />
             </label>
           </div>
 
           <label class="config-field">
-            <span>数据源 URL</span>
+            <span>{{ t('llmOps.globalConfigPanel.fields.sourceUrl') }}</span>
             <input
               v-model.trim="form.meta_model_sync_source_url"
               type="url"
@@ -60,7 +68,7 @@
             />
           </label>
           <label class="config-field">
-            <span>执行周期</span>
+            <span>{{ t('llmOps.globalConfigPanel.fields.cron') }}</span>
             <input
               v-model.trim="form.meta_model_sync_cron"
               type="text"
@@ -73,17 +81,23 @@
         <section class="config-section">
           <div class="config-section-header">
             <div>
-              <h4>模型价格采集</h4>
-              <p>同步官方或供货商模型价格数据。</p>
+              <h4>{{ t('llmOps.globalConfigPanel.priceCollection.title') }}</h4>
+              <p>
+                {{ t('llmOps.globalConfigPanel.priceCollection.description') }}
+              </p>
             </div>
             <label class="config-switch">
-              <span>{{ form.price_collection_enabled ? '启用' : '停用' }}</span>
+              <span>{{
+                form.price_collection_enabled
+                  ? t('llmOps.globalConfigPanel.status.enabled')
+                  : t('llmOps.globalConfigPanel.status.disabled')
+              }}</span>
               <input v-model="form.price_collection_enabled" type="checkbox" />
             </label>
           </div>
 
           <label class="config-field">
-            <span>执行周期</span>
+            <span>{{ t('llmOps.globalConfigPanel.fields.cron') }}</span>
             <input
               v-model.trim="form.price_collection_cron"
               type="text"
@@ -126,7 +140,7 @@
               </span>
             </label>
             <div v-if="!priceSourceOptions.length" class="empty-source">
-              暂无可用于自动采集的模型价格源。
+              {{ t('llmOps.globalConfigPanel.empty.noPriceSources') }}
             </div>
           </div>
         </section>
@@ -136,15 +150,17 @@
         <section class="config-section">
           <div class="config-section-header">
             <div>
-              <h4>飞书审核认证</h4>
-              <p>用于模型上架审核流程提交审批实例。</p>
+              <h4>{{ t('llmOps.globalConfigPanel.feishu.title') }}</h4>
+              <p>{{ t('llmOps.globalConfigPanel.feishu.description') }}</p>
             </div>
             <span
               class="secret-status"
               :class="{ active: config?.feishu_app_secret_configured }"
             >
               {{
-                config?.feishu_app_secret_configured ? '密钥已配置' : '未配置'
+                config?.feishu_app_secret_configured
+                  ? t('llmOps.globalConfigPanel.feishu.secretConfigured')
+                  : t('llmOps.globalConfigPanel.feishu.secretMissing')
               }}
             </span>
           </div>
@@ -165,13 +181,13 @@
               autocomplete="new-password"
               :placeholder="
                 config?.feishu_app_secret_configured
-                  ? '留空则保留当前密钥'
+                  ? t('llmOps.globalConfigPanel.feishu.secretPlaceholder')
                   : ''
               "
             />
           </label>
           <label class="config-field">
-            <span>审批定义 Code</span>
+            <span>{{ t('llmOps.globalConfigPanel.fields.approvalCode') }}</span>
             <input
               v-model.trim="form.feishu_approval_code"
               type="text"
@@ -191,13 +207,13 @@
         <section class="config-section">
           <div class="config-section-header">
             <div>
-              <h4>备注</h4>
-              <p>记录配置变更背景或外部系统关联信息。</p>
+              <h4>{{ t('llmOps.globalConfigPanel.notes.title') }}</h4>
+              <p>{{ t('llmOps.globalConfigPanel.notes.description') }}</p>
             </div>
           </div>
           <textarea v-model.trim="form.notes" rows="5" />
           <div class="config-runtime">
-            <span>最近更新</span>
+            <span>{{ t('llmOps.globalConfigPanel.fields.updatedAt') }}</span>
             <strong>{{ formatDateTime(config?.updated_at) }}</strong>
           </div>
         </section>
@@ -208,6 +224,7 @@
 
 <script setup>
 import { computed, onMounted, reactive, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import BaseLoading from '@/components/ui/BaseLoading.vue'
 import { llmOpsApi } from '@/api/llmOps'
@@ -222,6 +239,7 @@ const props = defineProps({
 
 const emit = defineEmits(['saved'])
 const { showSuccess, showError } = useToast()
+const { t } = useI18n()
 
 const loading = ref(false)
 const saving = ref(false)
@@ -242,10 +260,16 @@ const form = reactive({
   notes: ''
 })
 
-const sourceModes = [
-  { label: '全部启用的数据源', value: 'all' },
-  { label: '指定数据源', value: 'selected' }
-]
+const sourceModes = computed(() => [
+  {
+    label: t('llmOps.globalConfigPanel.sourceModes.all'),
+    value: 'all'
+  },
+  {
+    label: t('llmOps.globalConfigPanel.sourceModes.selected'),
+    value: 'selected'
+  }
+])
 
 const priceSourceOptions = computed(() =>
   props.sources.filter((source) => source.updates_model_prices)
@@ -261,7 +285,9 @@ async function loadConfig() {
     const response = await llmOpsApi.getGlobalConfig()
     applyConfig(extract(response))
   } catch (error) {
-    showError(errorMessage(error, '加载全局配置失败'))
+    showError(
+      errorMessage(error, t('llmOps.globalConfigPanel.errors.loadFailed'))
+    )
   } finally {
     loading.value = false
   }
@@ -269,10 +295,9 @@ async function loadConfig() {
 
 async function saveConfig() {
   const missingSelectedSource =
-    sourceMode.value === 'selected' &&
-    !form.price_collection_source_ids.length
+    sourceMode.value === 'selected' && !form.price_collection_source_ids.length
   if (missingSelectedSource) {
-    showError('请至少选择一个模型价格源')
+    showError(t('llmOps.globalConfigPanel.errors.sourceRequired'))
     return
   }
   saving.value = true
@@ -283,9 +308,7 @@ async function saveConfig() {
       meta_model_sync_cron: form.meta_model_sync_cron,
       price_collection_enabled: form.price_collection_enabled,
       price_collection_source_ids:
-        sourceMode.value === 'all'
-          ? []
-          : form.price_collection_source_ids,
+        sourceMode.value === 'all' ? [] : form.price_collection_source_ids,
       price_collection_cron: form.price_collection_cron,
       feishu_app_id: form.feishu_app_id,
       feishu_approval_code: form.feishu_approval_code,
@@ -297,25 +320,29 @@ async function saveConfig() {
     }
     const response = await llmOpsApi.updateGlobalConfig(payload)
     applyConfig(extract(response))
-    showSuccess('全局配置已保存，采集任务已同步')
+    showSuccess(t('llmOps.globalConfigPanel.messages.saved'))
     emit('saved')
   } catch (error) {
-    showError(errorMessage(error, '保存全局配置失败'))
+    showError(
+      errorMessage(error, t('llmOps.globalConfigPanel.errors.saveFailed'))
+    )
   } finally {
     saving.value = false
   }
 }
 
 async function resetConfig() {
-  if (!window.confirm('确认恢复 LLM Ops 全局配置默认值？')) return
+  if (!window.confirm(t('llmOps.globalConfigPanel.confirm.reset'))) return
   saving.value = true
   try {
     const response = await llmOpsApi.resetGlobalConfig()
     applyConfig(extract(response))
-    showSuccess('全局配置已恢复默认值')
+    showSuccess(t('llmOps.globalConfigPanel.messages.reset'))
     emit('saved')
   } catch (error) {
-    showError(errorMessage(error, '恢复默认配置失败'))
+    showError(
+      errorMessage(error, t('llmOps.globalConfigPanel.errors.resetFailed'))
+    )
   } finally {
     saving.value = false
   }
@@ -343,7 +370,9 @@ function applyConfig(nextConfig) {
 
 function sourceMeta(source) {
   return [
-    source.is_enabled === false ? '已停用' : '已启用',
+    source.is_enabled === false
+      ? t('llmOps.globalConfigPanel.status.disabled')
+      : t('llmOps.globalConfigPanel.status.enabled'),
     source.provider_name,
     source.channel_name,
     source.currency,

--- a/frontend/src/components/llm-ops/ResaleWorkflowConfigPanel.vue
+++ b/frontend/src/components/llm-ops/ResaleWorkflowConfigPanel.vue
@@ -15,7 +15,7 @@
           :disabled="loading || !localPlatformId"
           @click="loadConfig"
         >
-          重新加载
+          {{ t('llmOps.workflowConfig.actions.reload') }}
         </button>
         <button
           type="button"
@@ -23,7 +23,7 @@
           :disabled="saving || loading || !workflow"
           @click="resetConfig"
         >
-          恢复默认
+          {{ t('llmOps.workflowConfig.actions.reset') }}
         </button>
         <button
           type="button"
@@ -31,7 +31,7 @@
           :disabled="saving || loading || !workflow"
           @click="saveConfig"
         >
-          保存并生效
+          {{ t('llmOps.workflowConfig.actions.save') }}
         </button>
       </div>
     </div>
@@ -39,38 +39,53 @@
     <BaseLoading v-if="loading" />
 
     <div v-else-if="!localPlatformId" class="workflow-empty">
-      请先创建或选择一个上架平台。
+      {{ t('llmOps.workflowConfig.empty.noPlatform') }}
     </div>
 
     <div v-else-if="workflow" class="workflow-blueprint-layout">
       <div class="workflow-blueprint-main">
-        <section class="workflow-flowchart" aria-label="上架流程图">
+        <section
+          class="workflow-flowchart"
+          :aria-label="t('llmOps.workflowConfig.flowchart.title')"
+        >
           <header class="workflow-flowchart-header">
             <div>
-              <h4>上架流程图</h4>
-              <p>主干流程固定只读，仅策略分支可配置。</p>
+              <h4>{{ t('llmOps.workflowConfig.flowchart.title') }}</h4>
+              <p>{{ t('llmOps.workflowConfig.flowchart.description') }}</p>
             </div>
-            <span>只读主干</span>
+            <span>{{ t('llmOps.workflowConfig.flowchart.badge') }}</span>
           </header>
 
           <div class="workflow-flowchart-body">
             <div class="workflow-flow-row">
               <article class="workflow-flow-node is-fixed">
                 <small>01</small>
-                <strong>选择元模型</strong>
-                <span>模型与版本</span>
+                <strong>{{
+                  t('llmOps.workflowConfig.nodes.selectModel.title')
+                }}</strong>
+                <span>{{
+                  t('llmOps.workflowConfig.nodes.selectModel.subtitle')
+                }}</span>
               </article>
               <span class="workflow-flow-arrow">→</span>
               <article class="workflow-flow-node is-fixed">
                 <small>02</small>
-                <strong>选择采购渠道</strong>
-                <span>渠道与成本</span>
+                <strong>{{
+                  t('llmOps.workflowConfig.nodes.selectChannel.title')
+                }}</strong>
+                <span>{{
+                  t('llmOps.workflowConfig.nodes.selectChannel.subtitle')
+                }}</span>
               </article>
               <span class="workflow-flow-arrow">→</span>
               <article class="workflow-flow-node is-fixed">
                 <small>03</small>
-                <strong>设置利润率</strong>
-                <span>生成上架价格</span>
+                <strong>{{
+                  t('llmOps.workflowConfig.nodes.setMargin.title')
+                }}</strong>
+                <span>{{
+                  t('llmOps.workflowConfig.nodes.setMargin.subtitle')
+                }}</span>
               </article>
             </div>
 
@@ -81,8 +96,12 @@
             <div class="workflow-flow-split is-submit">
               <article class="workflow-flow-node is-fixed">
                 <small>04</small>
-                <strong>提交上架</strong>
-                <span>进入判断</span>
+                <strong>{{
+                  t('llmOps.workflowConfig.nodes.submit.title')
+                }}</strong>
+                <span>{{
+                  t('llmOps.workflowConfig.nodes.submit.subtitle')
+                }}</span>
               </article>
             </div>
 
@@ -92,7 +111,9 @@
                 :class="{ 'is-disabled': !policies.auto_approve_enabled }"
               >
                 <div class="workflow-node-top">
-                  <small>免审路径</small>
+                  <small>{{
+                    t('llmOps.workflowConfig.policy.autoPath')
+                  }}</small>
                   <label class="workflow-node-toggle">
                     <input
                       id="workflow-auto-approve-enabled"
@@ -102,40 +123,58 @@
                       @change="onAutoApproveToggle"
                     />
                     <span>{{
-                      policies.auto_approve_enabled ? '启用' : '停用'
+                      policies.auto_approve_enabled
+                        ? t('llmOps.workflowConfig.status.enabled')
+                        : t('llmOps.workflowConfig.status.disabled')
                     }}</span>
                   </label>
                 </div>
-                <strong>利润率 ≤ {{ autoApproveRateLabel }}</strong>
-                <span>直接确认</span>
+                <strong>{{
+                  t('llmOps.workflowConfig.policy.autoApproveThreshold', {
+                    rate: autoApproveRateLabel
+                  })
+                }}</strong>
+                <span>{{
+                  t('llmOps.workflowConfig.policy.directConfirm')
+                }}</span>
               </article>
               <article
                 class="workflow-flow-node is-policy"
                 :class="{ 'is-disabled': !approvalFlowEnabled }"
               >
                 <div class="workflow-node-top">
-                  <small>审核路径</small>
+                  <small>{{
+                    t('llmOps.workflowConfig.policy.approvalPath')
+                  }}</small>
                   <select
                     id="workflow-approval-mode"
                     class="workflow-node-select"
                     name="workflow_approval_mode"
                     :value="approvalMode"
-                    aria-label="审核路径"
+                    :aria-label="t('llmOps.workflowConfig.policy.approvalPath')"
                     @change="setApprovalMode($event.target.value)"
                   >
-                    <option value="internal">内部人工确认</option>
-                    <option value="external">外部飞书审核</option>
-                    <option value="both">内部 + 外部审核</option>
+                    <option value="internal">
+                      {{ t('llmOps.workflowConfig.approvalModes.internal') }}
+                    </option>
+                    <option value="external">
+                      {{ t('llmOps.workflowConfig.approvalModes.external') }}
+                    </option>
+                    <option value="both">
+                      {{ t('llmOps.workflowConfig.approvalModes.both') }}
+                    </option>
                     <option
                       value="disabled"
                       :disabled="!policies.auto_approve_enabled"
                     >
-                      仅保留免审路径
+                      {{ t('llmOps.workflowConfig.approvalModes.disabled') }}
                     </option>
                   </select>
                 </div>
                 <strong>{{ approvalFlowLabel }}</strong>
-                <span>超阈值复核</span>
+                <span>{{
+                  t('llmOps.workflowConfig.policy.reviewOverLimit')
+                }}</span>
               </article>
             </div>
 
@@ -146,17 +185,25 @@
             <div class="workflow-flow-split">
               <article class="workflow-flow-node is-policy">
                 <div class="workflow-node-top">
-                  <small>发布策略</small>
+                  <small>{{
+                    t('llmOps.workflowConfig.policy.publishPolicy')
+                  }}</small>
                   <select
                     id="workflow-publish-mode"
                     class="workflow-node-select"
                     name="workflow_publish_mode"
                     :value="publishMode"
-                    aria-label="发布策略"
+                    :aria-label="
+                      t('llmOps.workflowConfig.policy.publishPolicy')
+                    "
                     @change="setPublishMode($event.target.value)"
                   >
-                    <option value="auto">免审后自动上线</option>
-                    <option value="manual">提交后待确认</option>
+                    <option value="auto">
+                      {{ t('llmOps.workflowConfig.publishModes.auto') }}
+                    </option>
+                    <option value="manual">
+                      {{ t('llmOps.workflowConfig.publishModes.manual') }}
+                    </option>
                   </select>
                 </div>
                 <strong>{{ publishFlowLabel }}</strong>
@@ -167,8 +214,12 @@
             <div class="workflow-flow-split is-terminal">
               <article class="workflow-flow-node is-fixed">
                 <small>06</small>
-                <strong>下架/异常处理</strong>
-                <span>确认 / 驳回 / 异常</span>
+                <strong>{{
+                  t('llmOps.workflowConfig.nodes.terminal.title')
+                }}</strong>
+                <span>{{
+                  t('llmOps.workflowConfig.nodes.terminal.subtitle')
+                }}</span>
               </article>
             </div>
           </div>
@@ -180,6 +231,7 @@
 
 <script setup>
 import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import BaseLoading from '@/components/ui/BaseLoading.vue'
 import CompactSelect from '@/components/llm-ops/CompactSelect.vue'
@@ -200,6 +252,7 @@ const props = defineProps({
 
 const emit = defineEmits(['update:platformId', 'saved'])
 const { showSuccess, showError } = useToast()
+const { t } = useI18n()
 
 const loading = ref(false)
 const saving = ref(false)
@@ -230,11 +283,15 @@ const approvalFlowLabel = computed(() => {
     policies.value.manual_confirm_required &&
     policies.value.feishu_approval_enabled
   ) {
-    return '内部 + 外部审核'
+    return t('llmOps.workflowConfig.approvalModes.both')
   }
-  if (policies.value.feishu_approval_enabled) return '外部飞书审核'
-  if (policies.value.manual_confirm_required) return '内部人工确认'
-  return '审核路径停用'
+  if (policies.value.feishu_approval_enabled) {
+    return t('llmOps.workflowConfig.approvalModes.external')
+  }
+  if (policies.value.manual_confirm_required) {
+    return t('llmOps.workflowConfig.approvalModes.internal')
+  }
+  return t('llmOps.workflowConfig.approvalModes.disabledState')
 })
 const approvalMode = computed(() => {
   if (
@@ -248,8 +305,10 @@ const approvalMode = computed(() => {
   return 'disabled'
 })
 const publishFlowLabel = computed(() => {
-  if (policies.value.auto_apply_after_approval) return '免审后自动上线'
-  return '提交后待确认'
+  if (policies.value.auto_apply_after_approval) {
+    return t('llmOps.workflowConfig.publishModes.auto')
+  }
+  return t('llmOps.workflowConfig.publishModes.manual')
 })
 const publishMode = computed(() => {
   if (policies.value.auto_apply_after_approval) return 'auto'
@@ -257,9 +316,9 @@ const publishMode = computed(() => {
 })
 const publishFlowDescription = computed(() => {
   if (policies.value.auto_apply_after_approval) {
-    return '免审命中后确认发布'
+    return t('llmOps.workflowConfig.publishDescriptions.auto')
   }
-  return '保留人工确认'
+  return t('llmOps.workflowConfig.publishDescriptions.manual')
 })
 
 watch(
@@ -294,7 +353,9 @@ async function loadConfig() {
     workflow.value = normalizeWorkflowPayload(response.data)
     syncPolicyEdges()
   } catch (error) {
-    showError(errorMessage(error) || '加载上架流程配置失败')
+    showError(
+      errorMessage(error) || t('llmOps.workflowConfig.errors.loadFailed')
+    )
   } finally {
     loading.value = false
   }
@@ -303,7 +364,7 @@ async function loadConfig() {
 async function saveConfig() {
   if (!workflow.value || !localPlatformId.value) return
   if (!hasPublishPath(editableConfig.value.policies)) {
-    showError('至少需要保留免审、内部确认或外部审核中的一种上架路径')
+    showError(t('llmOps.workflowConfig.errors.noPublishPath'))
     return
   }
   saving.value = true
@@ -319,10 +380,12 @@ async function saveConfig() {
     )
     workflow.value = normalizeWorkflowPayload(response.data)
     syncPolicyEdges()
-    showSuccess('上架流程配置已生效')
+    showSuccess(t('llmOps.workflowConfig.messages.saved'))
     emit('saved', workflow.value)
   } catch (error) {
-    showError(errorMessage(error) || '保存上架流程配置失败')
+    showError(
+      errorMessage(error) || t('llmOps.workflowConfig.errors.saveFailed')
+    )
   } finally {
     saving.value = false
   }
@@ -330,7 +393,7 @@ async function saveConfig() {
 
 async function resetConfig() {
   if (!localPlatformId.value) return
-  if (!confirm('恢复默认流程配置？当前平台的自定义配置会被删除。')) return
+  if (!confirm(t('llmOps.workflowConfig.confirm.reset'))) return
   saving.value = true
   try {
     const response = await llmOpsApi.resetResaleWorkflowConfig(
@@ -338,10 +401,12 @@ async function resetConfig() {
     )
     workflow.value = normalizeWorkflowPayload(response.data)
     syncPolicyEdges()
-    showSuccess('已恢复默认上架流程')
+    showSuccess(t('llmOps.workflowConfig.messages.reset'))
     emit('saved', workflow.value)
   } catch (error) {
-    showError(errorMessage(error) || '恢复默认流程失败')
+    showError(
+      errorMessage(error) || t('llmOps.workflowConfig.errors.resetFailed')
+    )
   } finally {
     saving.value = false
   }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -775,6 +775,14 @@
         "label": "Resale Platforms",
         "description": "Manage listing prices, credit conversion, and procurement channels."
       },
+      "workflow": {
+        "label": "Workflow Settings",
+        "description": "Configure listing, auto-approval, approval, and offline paths per platform."
+      },
+      "globalConfig": {
+        "label": "Global Settings",
+        "description": "Configure meta-model sync, model price collection, and Feishu approval authentication."
+      },
       "reconciler": {
         "label": "Usage Reconciliation",
         "description": "Enter production usage and billing amounts to calculate payables and variances."
@@ -989,6 +997,158 @@
         "points": "points",
         "currentPlatform": "Current platform",
         "notConfigured": "Not configured"
+      }
+    },
+    "resalePlatform": {
+      "types": {
+        "agione": "Agione",
+        "apiGateway": "API Gateway",
+        "cloudMarketplace": "Cloud marketplace",
+        "internal": "Internal platform",
+        "other": "Other platform",
+        "reseller": "Reseller platform"
+      },
+      "environments": {
+        "production": "Production",
+        "sandbox": "Sandbox",
+        "staging": "Staging",
+        "test": "Test"
+      }
+    },
+    "globalConfigPanel": {
+      "actions": {
+        "reload": "Reload",
+        "reset": "Restore defaults",
+        "save": "Save and sync tasks",
+        "saving": "Saving"
+      },
+      "confirm": {
+        "reset": "Restore default LLM Ops global settings?"
+      },
+      "description": "Manage meta-model sync, model price collection, and approval integration settings in one place.",
+      "empty": {
+        "noPriceSources": "No model price sources are available for automatic collection."
+      },
+      "errors": {
+        "loadFailed": "Failed to load global settings",
+        "resetFailed": "Failed to restore default settings",
+        "saveFailed": "Failed to save global settings",
+        "sourceRequired": "Select at least one model price source"
+      },
+      "fields": {
+        "approvalCode": "Approval definition code",
+        "cron": "Schedule",
+        "sourceUrl": "Source URL",
+        "updatedAt": "Last updated"
+      },
+      "feishu": {
+        "description": "Used to submit approval instances for model listing workflows.",
+        "secretConfigured": "Secret configured",
+        "secretMissing": "Not configured",
+        "secretPlaceholder": "Leave blank to keep the current secret",
+        "title": "Feishu Approval Authentication"
+      },
+      "messages": {
+        "reset": "Global settings restored to defaults",
+        "saved": "Global settings saved and collection tasks synced"
+      },
+      "metaSync": {
+        "description": "Sync model providers, model families, and capability tags.",
+        "title": "Meta-model Collection"
+      },
+      "notes": {
+        "description": "Record configuration background or external system references.",
+        "title": "Notes"
+      },
+      "priceCollection": {
+        "description": "Sync official or supplier model price data.",
+        "title": "Model Price Collection"
+      },
+      "sourceModes": {
+        "all": "All enabled sources",
+        "selected": "Selected sources"
+      },
+      "status": {
+        "disabled": "Disabled",
+        "enabled": "Enabled"
+      },
+      "title": "Global Settings"
+    },
+    "workflowConfig": {
+      "actions": {
+        "reload": "Reload",
+        "reset": "Restore defaults",
+        "save": "Save and apply"
+      },
+      "approvalModes": {
+        "both": "Internal + external approval",
+        "disabled": "Auto-approval path only",
+        "disabledState": "Approval path disabled",
+        "external": "External Feishu approval",
+        "internal": "Internal manual confirmation"
+      },
+      "confirm": {
+        "reset": "Restore the default workflow configuration? Custom configuration for the current platform will be deleted."
+      },
+      "empty": {
+        "noPlatform": "Create or select a resale platform first."
+      },
+      "errors": {
+        "loadFailed": "Failed to load listing workflow configuration",
+        "noPublishPath": "Keep at least one listing path: auto-approval, internal confirmation, or external approval.",
+        "resetFailed": "Failed to restore default workflow",
+        "saveFailed": "Failed to save listing workflow configuration"
+      },
+      "flowchart": {
+        "badge": "Read-only main flow",
+        "description": "The main workflow is fixed and read-only; only policy branches can be configured.",
+        "title": "Listing Workflow"
+      },
+      "messages": {
+        "reset": "Default listing workflow restored",
+        "saved": "Listing workflow configuration is now active"
+      },
+      "nodes": {
+        "selectChannel": {
+          "subtitle": "Channel and cost",
+          "title": "Select procurement channel"
+        },
+        "selectModel": {
+          "subtitle": "Model and version",
+          "title": "Select meta model"
+        },
+        "setMargin": {
+          "subtitle": "Generate listing price",
+          "title": "Set margin"
+        },
+        "submit": {
+          "subtitle": "Enter decision gate",
+          "title": "Submit listing"
+        },
+        "terminal": {
+          "subtitle": "Confirm / reject / exception",
+          "title": "Offline / exception handling"
+        }
+      },
+      "policy": {
+        "approvalPath": "Approval path",
+        "autoApproveThreshold": "Margin <= {rate}",
+        "autoPath": "Auto-approval path",
+        "directConfirm": "Direct confirmation",
+        "publishPolicy": "Publishing policy",
+        "reviewOverLimit": "Review over threshold"
+      },
+      "publishDescriptions": {
+        "auto": "Confirm publishing after auto-approval hits",
+        "manual": "Keep manual confirmation"
+      },
+      "publishModes": {
+        "auto": "Auto-publish after auto-approval",
+        "manual": "Pending confirmation after submission"
+      },
+      "status": {
+        "disabled": "Disabled",
+        "enabled": "Enabled"
       }
     },
     "metaModelManagement": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -785,6 +785,14 @@
         "label": "挂售平台",
         "description": "管理挂售定价、积分换算与供货渠道。"
       },
+      "workflow": {
+        "label": "流程配置",
+        "description": "配置上架、免审、审批和下架路径，并按平台动态生效。"
+      },
+      "globalConfig": {
+        "label": "全局配置",
+        "description": "配置元模型同步、模型价格采集和飞书审核认证。"
+      },
       "reconciler": {
         "label": "用量对账",
         "description": "录入生产用量和账单金额，自动计算应付金额与差异。"
@@ -999,6 +1007,158 @@
         "points": "积分",
         "currentPlatform": "当前平台",
         "notConfigured": "未配置"
+      }
+    },
+    "resalePlatform": {
+      "types": {
+        "agione": "Agione",
+        "apiGateway": "API 网关",
+        "cloudMarketplace": "云市场",
+        "internal": "内部平台",
+        "other": "其他平台",
+        "reseller": "代理商平台"
+      },
+      "environments": {
+        "production": "生产",
+        "sandbox": "沙箱",
+        "staging": "预发",
+        "test": "测试"
+      }
+    },
+    "globalConfigPanel": {
+      "actions": {
+        "reload": "重新加载",
+        "reset": "恢复默认",
+        "save": "保存并同步任务",
+        "saving": "保存中"
+      },
+      "confirm": {
+        "reset": "确认恢复 LLM Ops 全局配置默认值？"
+      },
+      "description": "统一管理元模型同步、模型价格采集和审核集成参数。",
+      "empty": {
+        "noPriceSources": "暂无可用于自动采集的模型价格源。"
+      },
+      "errors": {
+        "loadFailed": "加载全局配置失败",
+        "resetFailed": "恢复默认配置失败",
+        "saveFailed": "保存全局配置失败",
+        "sourceRequired": "请至少选择一个模型价格源"
+      },
+      "fields": {
+        "approvalCode": "审批定义 Code",
+        "cron": "执行周期",
+        "sourceUrl": "数据源 URL",
+        "updatedAt": "最近更新"
+      },
+      "feishu": {
+        "description": "用于模型上架审核流程提交审批实例。",
+        "secretConfigured": "密钥已配置",
+        "secretMissing": "未配置",
+        "secretPlaceholder": "留空则保留当前密钥",
+        "title": "飞书审核认证"
+      },
+      "messages": {
+        "reset": "全局配置已恢复默认值",
+        "saved": "全局配置已保存，采集任务已同步"
+      },
+      "metaSync": {
+        "description": "同步模型厂商、模型族和能力标签。",
+        "title": "元模型采集"
+      },
+      "notes": {
+        "description": "记录配置变更背景或外部系统关联信息。",
+        "title": "备注"
+      },
+      "priceCollection": {
+        "description": "同步官方或供货商模型价格数据。",
+        "title": "模型价格采集"
+      },
+      "sourceModes": {
+        "all": "全部启用的数据源",
+        "selected": "指定数据源"
+      },
+      "status": {
+        "disabled": "已停用",
+        "enabled": "已启用"
+      },
+      "title": "全局配置"
+    },
+    "workflowConfig": {
+      "actions": {
+        "reload": "重新加载",
+        "reset": "恢复默认",
+        "save": "保存并生效"
+      },
+      "approvalModes": {
+        "both": "内部 + 外部审核",
+        "disabled": "仅保留免审路径",
+        "disabledState": "审核路径停用",
+        "external": "外部飞书审核",
+        "internal": "内部人工确认"
+      },
+      "confirm": {
+        "reset": "恢复默认流程配置？当前平台的自定义配置会被删除。"
+      },
+      "empty": {
+        "noPlatform": "请先创建或选择一个上架平台。"
+      },
+      "errors": {
+        "loadFailed": "加载上架流程配置失败",
+        "noPublishPath": "至少需要保留免审、内部确认或外部审核中的一种上架路径",
+        "resetFailed": "恢复默认流程失败",
+        "saveFailed": "保存上架流程配置失败"
+      },
+      "flowchart": {
+        "badge": "只读主干",
+        "description": "主干流程固定只读，仅策略分支可配置。",
+        "title": "上架流程图"
+      },
+      "messages": {
+        "reset": "已恢复默认上架流程",
+        "saved": "上架流程配置已生效"
+      },
+      "nodes": {
+        "selectChannel": {
+          "subtitle": "渠道与成本",
+          "title": "选择采购渠道"
+        },
+        "selectModel": {
+          "subtitle": "模型与版本",
+          "title": "选择元模型"
+        },
+        "setMargin": {
+          "subtitle": "生成上架价格",
+          "title": "设置利润率"
+        },
+        "submit": {
+          "subtitle": "进入判断",
+          "title": "提交上架"
+        },
+        "terminal": {
+          "subtitle": "确认 / 驳回 / 异常",
+          "title": "下架/异常处理"
+        }
+      },
+      "policy": {
+        "approvalPath": "审核路径",
+        "autoApproveThreshold": "利润率 <= {rate}",
+        "autoPath": "免审路径",
+        "directConfirm": "直接确认",
+        "publishPolicy": "发布策略",
+        "reviewOverLimit": "超阈值复核"
+      },
+      "publishDescriptions": {
+        "auto": "免审命中后确认发布",
+        "manual": "保留人工确认"
+      },
+      "publishModes": {
+        "auto": "免审后自动上线",
+        "manual": "提交后待确认"
+      },
+      "status": {
+        "disabled": "停用",
+        "enabled": "启用"
       }
     },
     "metaModelManagement": {

--- a/frontend/src/pages/LLMOps.vue
+++ b/frontend/src/pages/LLMOps.vue
@@ -751,13 +751,7 @@ const monitorStatusLabelKeys = {
 const navIcons = {
   audit: ['M4 5h16', 'M4 12h16', 'M4 19h10'],
   channels: ['M4 7h16', 'M7 7v10', 'M17 7v10', 'M4 17h16'],
-  globalConfig: [
-    'M4 7h16',
-    'M7 7v10',
-    'M17 7v10',
-    'M4 17h16',
-    'M9 12h6'
-  ],
+  globalConfig: ['M4 7h16', 'M7 7v10', 'M17 7v10', 'M4 17h16', 'M9 12h6'],
   metaModels: ['M12 3l8 4-8 4-8-4 8-4Z', 'M4 12l8 4 8-4', 'M4 17l8 4 8-4'],
   monitor: ['M4 19V5', 'M8 19v-6', 'M12 19v-9', 'M16 19v-4', 'M20 19V8'],
   providers: ['M5 5h14v14H5Z', 'M9 9h6', 'M9 13h6', 'M9 17h3'],
@@ -824,16 +818,16 @@ const navItems = computed(() => [
   },
   {
     key: 'workflow',
-    label: '流程配置',
+    label: t('llmOps.nav.workflow.label'),
     eyebrow: 'Workflow',
-    description: '配置上架、免审、审批和下架路径，并按平台动态生效。',
+    description: t('llmOps.nav.workflow.description'),
     icon: navIcons.workflow
   },
   {
     key: 'globalConfig',
-    label: '全局配置',
+    label: t('llmOps.nav.globalConfig.label'),
     eyebrow: 'Global Config',
-    description: '配置元模型同步、模型价格采集和飞书审核认证。',
+    description: t('llmOps.nav.globalConfig.description'),
     icon: navIcons.globalConfig
   },
   {
@@ -869,27 +863,29 @@ const resalePlatformOptions = computed(() =>
   }))
 )
 
-const platformTypeLabels = {
-  agione: 'Agione',
-  api_gateway: 'API 网关',
-  cloud_marketplace: '云市场',
-  internal: '内部平台',
-  other: '其他平台',
-  reseller: '代理商平台'
+const platformTypeLabelKeys = {
+  agione: 'llmOps.resalePlatform.types.agione',
+  api_gateway: 'llmOps.resalePlatform.types.apiGateway',
+  cloud_marketplace: 'llmOps.resalePlatform.types.cloudMarketplace',
+  internal: 'llmOps.resalePlatform.types.internal',
+  other: 'llmOps.resalePlatform.types.other',
+  reseller: 'llmOps.resalePlatform.types.reseller'
 }
 
-const environmentLabels = {
-  production: '生产',
-  sandbox: '沙箱',
-  staging: '预发',
-  test: '测试'
+const environmentLabelKeys = {
+  production: 'llmOps.resalePlatform.environments.production',
+  sandbox: 'llmOps.resalePlatform.environments.sandbox',
+  staging: 'llmOps.resalePlatform.environments.staging',
+  test: 'llmOps.resalePlatform.environments.test'
 }
 
 function resalePlatformOptionLabel(platform) {
-  const typeLabel =
-    platformTypeLabels[platform.platform_type] || platform.platform_type
+  const typeLabelKey = platformTypeLabelKeys[platform.platform_type]
+  const typeLabel = typeLabelKey ? t(typeLabelKey) : platform.platform_type
+  const environmentLabelKey = environmentLabelKeys[platform.environment]
   const regionLabel = platform.region_name || platform.region_code
-  const meta = [typeLabel, regionLabel, environmentLabels[platform.environment]]
+  const environmentLabel = environmentLabelKey ? t(environmentLabelKey) : ''
+  const meta = [typeLabel, regionLabel, environmentLabel]
     .filter(Boolean)
     .join(' · ')
   return meta ? `${platform.name} · ${meta}` : platform.name


### PR DESCRIPTION
## Summary

- Localize the LLM Ops workflow configuration panel with vue-i18n keys.
- Localize the LLM Ops global configuration panel that exists in the current main view.
- Localize LLM Ops nav entries plus resale platform type and environment labels.
- Add matching English and Chinese locale entries.

## Verification

- locale JSON parse passed
- target ESLint passed for LLMOps.vue, ResaleWorkflowConfigPanel.vue, and GlobalConfigPanel.vue
- no Chinese hardcoded text remains in those target view files
- git diff --check passed
- npm run build passed; only existing Vite/Browserslist warnings remain

Follow-up for merged PR #73: the earlier PR was already merged, so this i18n fix is submitted as a clean follow-up PR from latest main.

Made with [Orca](https://github.com/stablyai/orca) 🐋
