### PR TITLE
Fix backend root URL redirect

### DIFF
--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -1,12 +1,21 @@
 from django.contrib import admin
 from django.http import JsonResponse
-from django.urls import path, include
+from django.urls import include, path
+from django.views.generic import RedirectView
 
 from accounts.views import OAuthCallbackRedirectView
 from .swagger import schema_view, swagger_view, redoc_view
 
 # Define project URL routing configuration
 urlpatterns = [
+    # Backend root entry point
+    # Redirects direct backend visits to the API documentation.
+    path(
+        '',
+        RedirectView.as_view(pattern_name='swagger-ui', permanent=False),
+        name='root'
+    ),
+
     # Health check endpoint
     # Used by Docker/Kubernetes for container health monitoring
     # Returns a simple 'OK' response to indicate the application is running

--- a/backend/tests/test_core_urls.py
+++ b/backend/tests/test_core_urls.py
@@ -1,0 +1,18 @@
+import os
+import sys
+from pathlib import Path
+
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "core.settings")
+
+
+def test_root_redirects_to_swagger():
+    from django.test import Client
+
+    response = Client().get("/")
+
+    assert response.status_code == 302
+    assert response["Location"] == "/swagger"


### PR DESCRIPTION
## Summary
- Add an explicit Django root URL route that redirects direct backend visits to `/swagger`
- Keep the route before the catch-all `accounts.urls` include so the empty path resolves correctly
- Add a regression test for `/` returning a 302 redirect to `/swagger`

## Test plan
- [x] `python3 -m py_compile backend/core/urls.py backend/tests/test_core_urls.py`
- [x] `git diff --check -- backend/core/urls.py backend/tests/test_core_urls.py`
- [x] `codex review --uncommitted`
- [ ] `python3 -m pytest backend/tests/test_core_urls.py` (blocked locally: missing project dependency `dj_database_url`)

Made with [Orca](https://github.com/stablyai/orca) 🐋
