### PR TITLE
Add LLM Ops official price source sync

### DIFF
--- a/backend/llm_ops/agents/model_price_sync/definition.py
+++ b/backend/llm_ops/agents/model_price_sync/definition.py
@@ -19,7 +19,10 @@ from llm_ops.global_config import (
 )
 from llm_ops.llm_config import resolve_price_sync_llm_settings
 from llm_ops.models import LLMOpsGlobalConfig, PriceCollectionSource
-from llm_ops.source_collectors import collect_price_source
+from llm_ops.source_collectors import (
+    collect_price_source,
+    source_supports_code_collection,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -417,6 +420,10 @@ class ModelPriceSyncAgentRunner(AgentRunner):
                     self.skipped += 1
                     self.source_results[key] = {"skipped": True}
             return self._current_result(sources)
+        if all(source_supports_code_collection(source) for source in sources):
+            for source in sources:
+                self.collect_source(source.id)
+            return self._current_result(sources)
         return super().execute()
 
     def list_configured_sources(self) -> list[PriceCollectionSource]:
@@ -469,6 +476,23 @@ class ModelPriceSyncAgentRunner(AgentRunner):
         self.succeeded += 1
         self.source_results[key] = result
         return result
+
+    def collect_source_catalog(self, source_id: int) -> dict[str, Any]:
+        """Collect standard catalog JSON without persisting prices."""
+        from llm_ops.collection_services import (
+            collect_official_provider_standard_catalog,
+        )
+
+        source = self._source_by_id(source_id)
+        if not source.is_enabled or not source.updates_model_prices:
+            return {"skipped": True}
+        if not source.provider_id:
+            raise ValueError("Price source does not have a provider.")
+        return collect_official_provider_standard_catalog(
+            provider=source.provider,
+            source=source,
+            verify_source=self.verify_source,
+        )
 
     def recover_structured_response(
         self,

--- a/backend/llm_ops/collection_services.py
+++ b/backend/llm_ops/collection_services.py
@@ -35,8 +35,47 @@ from .services import (
     price_role_for_source,
     update_aggregated_model_identity,
 )
+from .skill_runner import (
+    run_vendor_pricing_skill,
+    standard_catalog_run_metadata,
+    standard_catalog_to_collected_catalog,
+    vendor_pricing_skill_exists,
+)
 
-SUPPORTED_OFFICIAL_PRICE_SYNC_PROVIDER_CODES = ("aliyun", "aliyun-wanx")
+SUPPORTED_OFFICIAL_PRICE_SYNC_PROVIDER_CODES = (
+    "aliyun",
+    "aliyun-wanx",
+    "baidu",
+    "volcengine",
+)
+FULL_CATALOG_VENDOR_SKILL_PROVIDER_CODES = (
+    "aliyun",
+    "baidu",
+    "volcengine",
+)
+
+OFFICIAL_SOURCE_PROVIDER_DEFAULTS = {
+    "aliyun": {
+        "name": "阿里云",
+        "website": "https://dashscope.aliyuncs.com/",
+        "notes": "元模型厂商。",
+    },
+    "aliyun-wanx": {
+        "name": "阿里云万象",
+        "website": "https://dashscope.aliyuncs.com/",
+        "notes": "元模型厂商。",
+    },
+    "baidu": {
+        "name": "百度",
+        "website": "https://cloud.baidu.com/",
+        "notes": "元模型厂商。",
+    },
+    "volcengine": {
+        "name": "火山方舟",
+        "website": "https://ark.cn-beijing.volces.com/",
+        "notes": "元模型厂商。",
+    },
+}
 
 MODELS_DEV_META_SOURCE_PROVIDERS = {
     "alibaba",
@@ -251,7 +290,8 @@ def provider_aliases(provider: LLMProvider) -> set[str]:
         "google": {"Google", "Google云", "Google Cloud"},
         "aliyun": {"阿里云", "阿里云百炼", "DashScope"},
         "aliyun-wanx": {"阿里云万象", "通义万相", "WAN"},
-        "volcengine": {"火山", "Volcengine", "豆包"},
+        "baidu": {"百度", "百度千帆", "千帆", "Baidu Qianfan"},
+        "volcengine": {"火山", "火山方舟", "Volcengine", "豆包"},
     }
     aliases.update(code_aliases.get(provider.code, set()))
     return {normalize_provider_label(alias) for alias in aliases}
@@ -297,8 +337,9 @@ def sync_official_provider_model_prices(
     if not source.is_enabled:
         raise ValueError("Price collection source is disabled.")
 
-    configured_codes = set(
-        provider.models.filter(is_active=True).values_list("code", flat=True)
+    target_model_codes = official_provider_target_model_codes(
+        provider=provider,
+        config=config,
     )
     run = PriceCollectionRun.objects.create(source=source)
     stats: dict[str, int | list[str]] = {
@@ -317,15 +358,17 @@ def sync_official_provider_model_prices(
             source.endpoint_url = source_url
             source.save(update_fields=["endpoint_url", "updated_at"])
 
-        catalog = collect_official_pricing_catalog(
-            provider_code=provider.code,
-            model_codes=configured_codes,
+        catalog, standard_catalog = collect_official_provider_price_catalog(
+            provider=provider,
+            source=source,
+            config=config,
+            target_model_codes=target_model_codes,
             source_url=source_url,
             verify_source=verify_source,
         )
         collected_currency = first_catalog_currency(catalog)
         collected_codes = {item.model_id for item in catalog.models}
-        skipped_codes = sorted(configured_codes - collected_codes)
+        skipped_codes = sorted(target_model_codes - collected_codes)
         with transaction.atomic():
             for item in catalog.models:
                 model_source = ensure_official_model_source(
@@ -396,15 +439,21 @@ def sync_official_provider_model_prices(
             run.created_count = int(stats["created"])
             run.updated_count = int(stats["updated"])
             run.skipped_count = len(skipped_codes)
-            run.metadata = {
+            run_metadata = {
                 "source_url": catalog.source_url,
                 "currency": collected_currency or source.currency,
                 "configured_currency": config.currency,
-                "total_configured_models": len(configured_codes),
+                "total_configured_models": len(target_model_codes),
                 "changed_count": stats["changed"],
                 "unchanged_count": stats["unchanged"],
                 "skipped_model_codes": skipped_codes,
             }
+            run_metadata.update(catalog_source_fetch_metadata(catalog))
+            if standard_catalog is not None:
+                run_metadata.update(
+                    standard_catalog_run_metadata(standard_catalog)
+                )
+            run.metadata = run_metadata
             run.save()
             stats["skipped"] = len(skipped_codes)
             stats["skipped_model_codes"] = skipped_codes
@@ -421,12 +470,116 @@ def sync_official_provider_model_prices(
         raise
 
 
+def collect_official_provider_price_catalog(
+    *,
+    provider: LLMProvider,
+    source: PriceCollectionSource,
+    config,
+    target_model_codes: set[str],
+    source_url: str,
+    verify_source: bool,
+) -> tuple[CollectedPricingCatalog, dict | None]:
+    """Collect an official provider catalog through the JSON contract."""
+    if vendor_pricing_skill_exists(provider.code):
+        skill_model_codes = (
+            None
+            if (
+                verify_source
+                and provider.code in FULL_CATALOG_VENDOR_SKILL_PROVIDER_CODES
+            )
+            else target_model_codes
+        )
+        standard_catalog = collect_official_provider_standard_catalog(
+            provider=provider,
+            source=source,
+            verify_source=verify_source,
+            model_codes=skill_model_codes,
+            source_url=source_url,
+        )
+        return (
+            standard_catalog_to_collected_catalog(standard_catalog),
+            standard_catalog,
+        )
+
+    catalog = collect_official_pricing_catalog(
+        provider_code=provider.code,
+        model_codes=target_model_codes,
+        source_url=source_url,
+        verify_source=verify_source,
+    )
+    return catalog, None
+
+
+def collect_official_provider_standard_catalog(
+    *,
+    provider: LLMProvider,
+    source: PriceCollectionSource,
+    verify_source: bool = True,
+    model_codes: set[str] | None = None,
+    source_url: str = "",
+) -> dict:
+    """Collect official prices as standard JSON without persistence."""
+    if provider.code not in OFFICIAL_PROVIDER_CONFIGS:
+        raise ValueError(f"Unsupported official provider: {provider.code}")
+    if not vendor_pricing_skill_exists(provider.code):
+        raise ValueError(
+            f"No vendor pricing skill is available for {provider.code}."
+        )
+    if source.provider_id != provider.id:
+        raise ValueError("Price source does not belong to the provider.")
+
+    config = OFFICIAL_PROVIDER_CONFIGS[provider.code]
+    target_model_codes = set(model_codes or [])
+    resolved_source_url = source_url or official_source_url(
+        provider,
+        source,
+        config,
+    )
+    return run_vendor_pricing_skill(
+        provider.code,
+        {
+            "provider_code": provider.code,
+            "provider_name": provider.name,
+            "currency": source.currency or config.currency,
+            "source_url": resolved_source_url,
+            "model_codes": sorted(target_model_codes),
+            "verify_source": verify_source,
+        },
+    )
+
+
 def first_catalog_currency(catalog) -> str:
     """Return the first non-empty currency observed in a collected catalog."""
     for item in catalog.models:
         if item.currency:
             return item.currency
     return ""
+
+
+def catalog_source_fetch_metadata(catalog) -> dict:
+    """Return official source fetch metadata from the first catalog item."""
+    for item in catalog.models:
+        raw_detail = item.raw_detail or {}
+        metadata = raw_detail.get("official_source_fetch")
+        if isinstance(metadata, dict):
+            return dict(metadata)
+    return {}
+
+
+def official_provider_target_model_codes(*, provider, config) -> set[str]:
+    """Return model codes that an official sync should attempt to cover."""
+    existing_codes = set(
+        provider.models.filter(is_active=True).values_list("code", flat=True)
+    )
+    official_codes = set()
+    for spec in config.models:
+        official_codes.add(spec.model_id)
+        official_codes.update(spec.aliases)
+    return {
+        str(code).strip()
+        for code in existing_codes | official_codes
+        if str(code).strip()
+    }
 
 
 def sync_configured_official_model_prices(
@@ -466,6 +619,93 @@ def sync_configured_official_model_prices(
                 "error": str(exc),
             }
     return results
+
+
+def supported_official_provider_options() -> list[dict]:
+    """Return official provider source presets available to operators."""
+    provider_codes = list(SUPPORTED_OFFICIAL_PRICE_SYNC_PROVIDER_CODES)
+    providers = {
+        provider.code: provider
+        for provider in LLMProvider.objects.filter(code__in=provider_codes)
+    }
+    source_slugs = [
+        official_provider_source_slug(provider_code)
+        for provider_code in provider_codes
+    ]
+    sources = {
+        source.slug: source
+        for source in PriceCollectionSource.objects.select_related(
+            "provider"
+        ).filter(slug__in=source_slugs)
+    }
+
+    options = []
+    for provider_code in provider_codes:
+        config = OFFICIAL_PROVIDER_CONFIGS[provider_code]
+        defaults = OFFICIAL_SOURCE_PROVIDER_DEFAULTS[provider_code]
+        provider = providers.get(provider_code)
+        source_slug = official_provider_source_slug(provider_code)
+        source = sources.get(source_slug)
+        provider_name = provider.name if provider else defaults["name"]
+        options.append(
+            {
+                "provider_code": provider_code,
+                "provider_name": provider_name,
+                "provider_exists": provider is not None,
+                "source_id": source.id if source else None,
+                "source_slug": source_slug,
+                "source_name": (
+                    source.name if source else f"{provider_name} 官方价格"
+                ),
+                "source_exists": source is not None,
+                "source_url": (
+                    source.endpoint_url
+                    if source and source.endpoint_url
+                    else config.source_url
+                ),
+                "currency": source.currency if source else config.currency,
+            }
+        )
+    return options
+
+
+def ensure_supported_official_provider_source(
+    provider_code: str,
+) -> tuple[LLMProvider, PriceCollectionSource, bool, bool]:
+    """Ensure an operator-selected official provider source exists."""
+    provider_code = str(provider_code or "").strip()
+    if provider_code not in SUPPORTED_OFFICIAL_PRICE_SYNC_PROVIDER_CODES:
+        raise ValueError("Unsupported official provider source.")
+
+    defaults = OFFICIAL_SOURCE_PROVIDER_DEFAULTS[provider_code]
+    provider, provider_created = LLMProvider.objects.get_or_create(
+        code=provider_code,
+        defaults={
+            "name": defaults["name"],
+            "website": defaults["website"],
+            "notes": defaults["notes"],
+            "is_active": True,
+        },
+    )
+    changed_fields = []
+    for field in ("website", "notes"):
+        if not getattr(provider, field):
+            setattr(provider, field, defaults[field])
+            changed_fields.append(field)
+    if changed_fields:
+        changed_fields.append("updated_at")
+        provider.save(update_fields=changed_fields)
+
+    source_created = not PriceCollectionSource.objects.filter(
+        slug=official_provider_source_slug(provider_code)
+    ).exists()
+    source = ensure_official_source(provider=provider)
+    return provider, source, provider_created, source_created
+
+
+def official_provider_source_slug(provider_code: str) -> str:
+    """Return the stable provider-level official source slug."""
+    return f"{provider_code}-official"
 
 
 def ensure_official_model_source(

--- a/backend/llm_ops/collectors/official.py
+++ b/backend/llm_ops/collectors/official.py
@@ -36,6 +36,10 @@ MODELS_DEV_PROVIDER_KEYS = {
 ALIYUN_PRICING_SOURCE_URL = (
     "https://help.aliyun.com/zh/model-studio/model-pricing"
 )
+BAIDU_PRICING_SOURCE_URL = "https://cloud.baidu.com/doc/qianfan/s/wmh4sv6ya"
+VOLCENGINE_PRICING_SOURCE_URL = (
+    "https://www.volcengine.com/docs/82379/1544106?lang=zh"
+)
 ALIYUN_LEGACY_PRICING_SOURCE_URLS = {
     "https://help.aliyun.com/zh/model-studio/model-price",
     "https://help.aliyun.com/zh/model-studio/models",
@@ -91,7 +95,7 @@ class OfficialPriceSpec:
     def matches(self, model_code: str) -> bool:
         """Return whether this spec maps to a configured model code."""
         normalized_code = normalize_model_code(model_code)
-        for alias in self.aliases:
+        for alias in (self.model_id, *self.aliases):
             normalized_alias = normalize_model_code(alias)
             if normalized_code == normalized_alias:
                 return True
@@ -419,22 +423,80 @@ OFFICIAL_PROVIDER_CONFIGS = {
         models=(
             OfficialPriceSpec(
                 model_id="deepseek-r1",
-                aliases=("deepseek-r1", "deepseek-r1-0528"),
+                aliases=("deepseek-r1",),
                 input_per_million=Decimal("4"),
                 output_per_million=Decimal("16"),
                 display_name="DeepSeek R1",
             ),
             OfficialPriceSpec(
+                model_id="deepseek-r1-0528",
+                aliases=("deepseek-r1-0528",),
+                input_per_million=Decimal("4"),
+                output_per_million=Decimal("16"),
+                display_name="DeepSeek R1 0528",
+            ),
+            OfficialPriceSpec(
+                model_id="deepseek-v4-pro",
+                aliases=("deepseek-v4-pro",),
+                input_per_million=Decimal("12"),
+                output_per_million=Decimal("24"),
+                display_name="DeepSeek V4 Pro",
+            ),
+            OfficialPriceSpec(
+                model_id="deepseek-v4-flash",
+                aliases=("deepseek-v4-flash",),
+                input_per_million=Decimal("1"),
+                output_per_million=Decimal("2"),
+                display_name="DeepSeek V4 Flash",
+            ),
+            OfficialPriceSpec(
                 model_id="deepseek-v3",
-                aliases=(
-                    "deepseek-v3",
-                    "deepseek-v3.1",
-                    "deepseek-v3.2",
-                    "deepseek-v3.2-exp",
-                ),
+                aliases=("deepseek-v3",),
                 input_per_million=Decimal("2"),
                 output_per_million=Decimal("8"),
                 display_name="DeepSeek V3",
+            ),
+            OfficialPriceSpec(
+                model_id="deepseek-v3.1",
+                aliases=("deepseek-v3.1",),
+                input_per_million=Decimal("4"),
+                output_per_million=Decimal("12"),
+                display_name="DeepSeek V3.1",
+            ),
+            OfficialPriceSpec(
+                model_id="deepseek-v3.2",
+                aliases=("deepseek-v3.2",),
+                input_per_million=Decimal("2"),
+                output_per_million=Decimal("3"),
+                display_name="DeepSeek V3.2",
+            ),
+            OfficialPriceSpec(
+                model_id="deepseek-v3.2-exp",
+                aliases=("deepseek-v3.2-exp",),
+                input_per_million=Decimal("2"),
+                output_per_million=Decimal("3"),
+                display_name="DeepSeek V3.2 Exp",
+            ),
+            OfficialPriceSpec(
+                model_id="deepseek-r1-distill-qwen-7b",
+                aliases=("deepseek-r1-distill-qwen-7b",),
+                input_per_million=Decimal("0.5"),
+                output_per_million=Decimal("1"),
+                display_name="DeepSeek R1 Distill Qwen 7B",
+            ),
+            OfficialPriceSpec(
+                model_id="deepseek-r1-distill-qwen-14b",
+                aliases=("deepseek-r1-distill-qwen-14b",),
+                input_per_million=Decimal("1"),
+                output_per_million=Decimal("3"),
+                display_name="DeepSeek R1 Distill Qwen 14B",
+            ),
+            OfficialPriceSpec(
+                model_id="deepseek-r1-distill-qwen-32b",
+                aliases=("deepseek-r1-distill-qwen-32b",),
+                input_per_million=Decimal("2"),
+                output_per_million=Decimal("6"),
+                display_name="DeepSeek R1 Distill Qwen 32B",
             ),
             OfficialPriceSpec(
                 model_id="qwq-32b",
@@ -501,6 +563,13 @@ OFFICIAL_PROVIDER_CONFIGS = {
                 display_name="Text Embedding V4",
             ),
         ),
+    ),
+    "baidu": OfficialProviderConfig(
+        provider_code="baidu",
+        provider_label="百度千帆",
+        source_url=BAIDU_PRICING_SOURCE_URL,
+        currency="CNY",
+        models=(),
     ),
     "aliyun-wanx": OfficialProviderConfig(
         provider_code="aliyun-wanx",
@@ -617,7 +686,7 @@ OFFICIAL_PROVIDER_CONFIGS = {
     "volcengine": OfficialProviderConfig(
         provider_code="volcengine",
         provider_label="火山方舟",
-        source_url="https://www.volcengine.com/docs/82379/1099320",
+        source_url=VOLCENGINE_PRICING_SOURCE_URL,
         currency="CNY",
         models=(
             # The volcengine catalog labels the R1 0528 release
@@ -812,7 +881,18 @@ def config_with_source_prices(
             if spec.model_id not in parsed_model_ids
         ]
     if missing_model_ids:
-        enriched_payload["source_parse_missing_model_ids"] = missing_model_ids
+        fallback_specs = [
+            spec
+            for spec in config.models
+            if spec.model_id in missing_model_ids
+        ]
+        parsed_specs.extend(fallback_specs)
+        enriched_payload["source_parse_missing_model_ids"] = (
+            missing_model_ids
+        )
+        enriched_payload["source_parse_fallback_model_ids"] = (
+            missing_model_ids
+        )
 
     parsed_config = OfficialProviderConfig(
         provider_code=config.provider_code,
@@ -1034,7 +1114,11 @@ def parse_spec_from_source_text(
     source_text: str,
 ) -> OfficialPriceSpec | None:
     """Parse one configured official model price from source text."""
-    windows = source_windows_for_spec(spec, source_text)
+    windows = source_windows_for_spec(
+        spec,
+        source_text,
+        boundary_terms=source_boundary_terms(config, spec),
+    )
     if not windows:
         return None
 
@@ -1077,6 +1161,7 @@ def source_windows_for_spec(
     spec: OfficialPriceSpec,
     source_text: str,
     radius: int = 1200,
+    boundary_terms: tuple[str, ...] = (),
 ) -> list[str]:
     """Return nearby source text windows for a configured model spec."""
     windows = []
@@ -1093,10 +1178,71 @@ def source_windows_for_spec(
             if re.search(pattern, line, re.IGNORECASE):
                 windows.append(line)
         for match in re.finditer(pattern, source_text, re.IGNORECASE):
+            windows.append(
+                bounded_forward_source_window(
+                    source_text,
+                    match.end(),
+                    radius,
+                    boundary_terms,
+                )
+            )
             start = max(match.start() - radius, 0)
             end = min(match.end() + radius, len(source_text))
             windows.append(source_text[start:end])
     return windows
+
+
+def source_boundary_terms(
+    config: OfficialProviderConfig,
+    spec: OfficialPriceSpec,
+) -> tuple[str, ...]:
+    """Return model terms that can delimit a neighboring pricing row."""
+    current_terms = {
+        normalize_model_code(term)
+        for term in spec_search_terms(spec)
+    }
+    boundary_terms = []
+    seen = set()
+    for candidate in config.models:
+        for term in spec_search_terms(candidate):
+            normalized = normalize_model_code(term)
+            if (
+                not normalized
+                or normalized in current_terms
+                or normalized in seen
+            ):
+                continue
+            boundary_terms.append(term)
+            seen.add(normalized)
+    return tuple(boundary_terms)
+
+
+def spec_search_terms(spec: OfficialPriceSpec) -> tuple[str, ...]:
+    """Return all configured source text terms for one price spec."""
+    terms = [*spec.aliases, spec.model_id]
+    if spec.display_name:
+        terms.append(spec.display_name)
+    return tuple(term for term in terms if term)
+
+
+def bounded_forward_source_window(
+    source_text: str,
+    start: int,
+    radius: int,
+    boundary_terms: tuple[str, ...],
+) -> str:
+    """Return a forward window that stops at the next known model row."""
+    end = min(start + radius, len(source_text))
+    window = source_text[start:end]
+    boundary_indexes = []
+    for term in boundary_terms:
+        pattern = model_term_pattern(term)
+        match = re.search(pattern, window, re.IGNORECASE)
+        if match:
+            boundary_indexes.append(match.start())
+    if boundary_indexes:
+        window = window[: min(boundary_indexes)]
+    return window
 
 
 def model_term_pattern(term: str) -> str:

--- a/backend/llm_ops/global_config.py
+++ b/backend/llm_ops/global_config.py
@@ -18,7 +18,12 @@ MODEL_PRICE_SYNC_AGENT_TASK_NAME = "llm_ops_model_price_sync_agent"
 MODEL_PRICE_SYNC_AGENT_TASK = "llm_ops.tasks.run_model_price_sync_agent"
 PRICE_SOURCE_TASK_PREFIX = "llm_ops_price_source_collect_"
 PRICE_SOURCE_TASK = "llm_ops.tasks.collect_price_source_prices"
-SUPPORTED_PRICE_SYNC_PROVIDER_CODES = ("aliyun", "aliyun-wanx")
+SUPPORTED_PRICE_SYNC_PROVIDER_CODES = (
+    "aliyun",
+    "aliyun-wanx",
+    "baidu",
+    "volcengine",
+)
 
 
 def price_source_task_name(source_id: int) -> str:
@@ -172,10 +177,19 @@ def price_sync_source_queryset():
     """Return sources currently supported by runtime price sync."""
     return PriceCollectionSource.objects.filter(
         provider__code__in=SUPPORTED_PRICE_SYNC_PROVIDER_CODES,
+        slug__in=official_provider_source_slugs(),
         source_category=(
             PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
         ),
         updates_model_prices=True,
+    )
+
+
+def official_provider_source_slugs() -> tuple[str, ...]:
+    """Return supported provider-level official source slugs."""
+    return tuple(
+        f"{provider_code}-official"
+        for provider_code in SUPPORTED_PRICE_SYNC_PROVIDER_CODES
     )
 
 

--- a/backend/llm_ops/serializers.py
+++ b/backend/llm_ops/serializers.py
@@ -60,6 +60,7 @@ class PriceCollectionSourceSerializer(serializers.ModelSerializer):
         allow_null=True,
     )
     business_source_category = serializers.SerializerMethodField()
+    can_collect_prices = serializers.SerializerMethodField()
 
     class Meta:
         model = PriceCollectionSource
@@ -68,6 +69,14 @@ class PriceCollectionSourceSerializer(serializers.ModelSerializer):
 
     def get_business_source_category(self, instance):
         return business_source_category_for_catalog(instance)
+
+    def get_can_collect_prices(self, instance):
+        from .source_collectors import source_supports_code_collection
+
+        return bool(
+            instance.updates_model_prices
+            and source_supports_code_collection(instance)
+        )
 
 
 class LLMOpsGlobalConfigSerializer(serializers.ModelSerializer):

--- a/backend/llm_ops/skill_runner.py
+++ b/backend/llm_ops/skill_runner.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+from .collectors import (
+    CollectedModelPricing,
+    CollectedPricingCatalog,
+    NormalizedPriceRow,
+)
+
+
+MODEL_PRICE_CATALOG_SCHEMA_VERSION = "llm_ops.model_price_catalog.v1"
+
+
+def run_vendor_pricing_skill(
+    provider_code: str,
+    vendor_config: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Run a skill script and return a standard model price catalog JSON."""
+    module = _load_vendor_skill_module(provider_code)
+    sync_vendor_catalog = getattr(module, "sync_vendor_catalog", None)
+    if sync_vendor_catalog is None:
+        raise ValueError(
+            f"Vendor pricing skill for '{provider_code}' does not expose "
+            "sync_vendor_catalog()."
+        )
+    signature = inspect.signature(sync_vendor_catalog)
+    if signature.parameters:
+        result = sync_vendor_catalog(vendor_config or {})
+    else:
+        result = sync_vendor_catalog()
+    return validate_standard_price_catalog(result, provider_code)
+
+
+def vendor_pricing_skill_exists(provider_code: str) -> bool:
+    """Return whether a provider has a deterministic pricing skill."""
+    slug = _normalize_provider_slug(provider_code)
+    script_path = _skill_dir() / "scripts" / f"vendor_pricing_{slug}.py"
+    return script_path.exists()
+
+
+def validate_standard_price_catalog(
+    result: Any,
+    provider_code: str = "",
+) -> dict[str, Any]:
+    """Validate the standard JSON contract returned by a price skill."""
+    if not isinstance(result, dict):
+        raise ValueError("Vendor pricing skill returned invalid catalog data.")
+    if result.get("schema_version") != MODEL_PRICE_CATALOG_SCHEMA_VERSION:
+        raise ValueError("Vendor pricing skill returned unsupported schema.")
+    if not isinstance(result.get("models"), list):
+        raise ValueError("Vendor pricing skill catalog must include models.")
+    provider = result.get("provider") or {}
+    if provider_code and provider.get("code") != provider_code:
+        raise ValueError("Vendor pricing skill returned the wrong provider.")
+    return result
+
+
+def standard_catalog_to_collected_catalog(
+    payload: dict[str, Any],
+) -> CollectedPricingCatalog:
+    """Convert a standard skill JSON catalog to the persistence catalog."""
+    validate_standard_price_catalog(payload)
+    models = [
+        _standard_model_to_collected_model(item)
+        for item in payload.get("models") or []
+    ]
+    return CollectedPricingCatalog(
+        source_url=str(payload.get("source_url") or ""),
+        total_models=int(payload.get("total_models") or len(models)),
+        models=models,
+    )
+
+
+def collected_catalog_to_standard_catalog(
+    *,
+    catalog: CollectedPricingCatalog,
+    provider_code: str,
+    provider_name: str,
+    currency: str,
+    source_type: str,
+    notes: str = "",
+    raw_payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Convert an internal catalog to the standard skill JSON contract."""
+    return {
+        "schema_version": MODEL_PRICE_CATALOG_SCHEMA_VERSION,
+        "source_type": source_type,
+        "source_url": catalog.source_url,
+        "total_models": catalog.total_models,
+        "provider": {
+            "code": provider_code,
+            "name": provider_name,
+            "currency": currency,
+        },
+        "models": [
+            _collected_model_to_standard_model(item)
+            for item in catalog.models
+        ],
+        "notes": notes,
+        "raw_payload": raw_payload or {},
+    }
+
+
+def standard_catalog_run_metadata(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return compact run metadata for a standard skill catalog."""
+    validate_standard_price_catalog(payload)
+    provider = payload.get("provider") or {}
+    raw_payload = payload.get("raw_payload") or {}
+    metadata = {
+        "catalog_schema_version": payload.get("schema_version") or "",
+        "catalog_source_type": payload.get("source_type") or "",
+        "vendor_skill_provider": provider.get("code") or "",
+        "vendor_skill_model_count": len(payload.get("models") or []),
+    }
+    if raw_payload.get("collector"):
+        metadata["vendor_skill_collector"] = raw_payload["collector"]
+    return metadata
+
+
+def _standard_model_to_collected_model(
+    payload: dict[str, Any],
+) -> CollectedModelPricing:
+    rows = [
+        NormalizedPriceRow(
+            kind=str(row.get("kind") or ""),
+            values=dict(row.get("values") or {}),
+            raw=dict(row.get("raw") or {}),
+        )
+        for row in payload.get("price_rows") or []
+    ]
+    return CollectedModelPricing(
+        model_source=str(payload.get("model_source") or ""),
+        model_type=str(payload.get("model_type") or "文本模型"),
+        source_model_type=str(payload.get("source_model_type") or "Text"),
+        name=str(payload.get("name") or payload.get("model_id") or ""),
+        model_id=str(payload.get("model_id") or ""),
+        platform_id=payload.get("platform_id") or payload.get("model_id"),
+        mode=str(payload.get("mode") or "official"),
+        provider=str(payload.get("provider") or ""),
+        billing_type=str(payload.get("billing_type") or "按量计费"),
+        billing_unit=str(payload.get("billing_unit") or ""),
+        currency=str(payload.get("currency") or ""),
+        unit=payload.get("unit"),
+        billing_mode=str(payload.get("billing_mode") or "pay_as_you_go"),
+        price_rows=rows,
+        raw_price_info=dict(payload.get("raw_price_info") or {}),
+        raw_detail=dict(payload.get("raw_detail") or {}),
+    )
+
+
+def _collected_model_to_standard_model(
+    item: CollectedModelPricing,
+) -> dict[str, Any]:
+    return {
+        "model_source": item.model_source,
+        "model_type": item.model_type,
+        "source_model_type": item.source_model_type,
+        "name": item.name,
+        "model_id": item.model_id,
+        "platform_id": item.platform_id,
+        "mode": item.mode,
+        "provider": item.provider,
+        "billing_type": item.billing_type,
+        "billing_unit": item.billing_unit,
+        "currency": item.currency,
+        "unit": item.unit,
+        "billing_mode": item.billing_mode,
+        "price_rows": [
+            {
+                "kind": row.kind,
+                "values": row.values,
+                "raw": row.raw,
+            }
+            for row in item.price_rows
+        ],
+        "raw_price_info": item.raw_price_info,
+        "raw_detail": item.raw_detail,
+    }
+
+
+def _load_vendor_skill_module(provider_code: str) -> ModuleType:
+    slug = _normalize_provider_slug(provider_code)
+    script_dir = _skill_dir() / "scripts"
+    script_path = script_dir / f"vendor_pricing_{slug}.py"
+    if not script_path.exists():
+        raise ValueError(
+            "Vendor pricing skill script not found for provider "
+            f"'{provider_code}': {script_path}"
+        )
+    script_dir_str = str(script_dir)
+    if script_dir_str not in sys.path:
+        sys.path.insert(0, script_dir_str)
+    spec = importlib.util.spec_from_file_location(
+        f"llm_ops_model_price_skill_{slug}",
+        script_path,
+    )
+    if spec is None or spec.loader is None:
+        raise ValueError(f"Unable to load vendor pricing skill: {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _normalize_provider_slug(provider_code: str) -> str:
+    slug = str(provider_code or "").strip().lower().replace("-", "_")
+    if not slug:
+        raise ValueError("Provider code is required.")
+    return slug
+
+
+def _skill_dir() -> Path:
+    return Path(__file__).resolve().parent / "skills" / "model-price-sync"

--- a/backend/llm_ops/skills/model-price-sync/SKILL.md
+++ b/backend/llm_ops/skills/model-price-sync/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: model-price-sync
-description: Collect official LLM model prices from configured source records, validate extraction results, and persist accepted prices through LLM Ops platform tools.
+description: >
+  Collect official LLM model prices from configured source records,
+  validate extraction results, and persist accepted prices through
+  LLM Ops platform tools.
 model: openai:gpt-4o
 ---
 
@@ -10,21 +13,79 @@ You synchronize model prices for DevMind LLM Ops.
 
 ## Workflow
 
-1. Call `list_configured_price_sources` to get the current runtime source
-   list selected by global configuration.
-2. For each enabled source, call `collect_model_price_source`.
-3. Continue after per-source failures and include failures in the final
+1. Call `list_configured_price_sources` to get the current runtime
+   provider-level source list selected by global configuration.
+2. For each enabled source, call `collect_vendor_price_catalog` first.
+   It returns a standard JSON catalog and does not persist anything.
+3. After the standard JSON catalog is available, call
+   `collect_model_price_source`. The platform service validates that catalog,
+   matches collected model IDs to canonical meta models, and persists
+   snapshots, price items, and current model prices.
+4. Continue after per-source failures and include failures in the final
    structured response.
-4. Return only structured JSON matching the requested response format.
+5. Return only structured JSON matching the requested response format.
 
 ## Rules
 
 - Use platform tools only. Do not invent database writes.
-- The platform tools handle fetching, parsing, validation, snapshots,
-  histories, and current price updates.
+- Vendor-specific skill scripts fetch and normalize upstream pricing into a
+  standard JSON catalog. They must not write to the database.
+- Prefer the vendor-specific deterministic Python skill result when it already
+  provides sufficient evidence.
+- Treat the configured source URL as a hint. If a vendor price page is
+  JS-rendered, the Python skill may inspect vendor-owned JSON endpoints or
+  page-data resources that back that page.
+- Return structured price rows only when primary vendor-owned evidence
+  supports them. Omit unsubstantiated models.
+- The platform persistence tool handles source runs, validation, meta-model
+  matching, snapshots, histories, and current price updates.
 - Treat official provider pages as primary sources.
+- Treat model-level official sources as collection output, not as sync
+  inputs. They should not be scheduled as separate upstream sources.
+- Do not infer the model count before collection. The collector fetches the
+  provider catalog, matches collected rows to canonical meta models, and then
+  writes snapshots, price items, and current model prices.
 - Preserve usage-range / tiered prices when a source publishes interval
   pricing. Do not collapse interval rows into one flat price unless the
   platform collector explicitly normalizes them that way.
 - Do not scrape or update anything outside the configured source list.
 - Report skipped, succeeded, and failed source counts.
+
+## Official Source Contract
+
+- A provider-level official source is an entry point. It can produce many
+  model-level price sources and many model price items after collection.
+- The handoff between vendor skills and platform services is a standard JSON
+  catalog with `schema_version=llm_ops.model_price_catalog.v1`, provider
+  metadata, source URL, total model count, and one `models[]` entry per
+  priced SKU.
+- A row on an official pricing page is SKU-level evidence. If two model IDs
+  have different rows or different prices, keep them as separate configured
+  model IDs even when they belong to the same model family.
+- Do not merge `deepseek-v3`, `deepseek-v3.1`, `deepseek-v3.2`,
+  `deepseek-v3.2-exp`, `deepseek-v4-pro`, or `deepseek-v4-flash` by family
+  name. They are separate Aliyun SKUs with separate prices.
+- Prefer the row matching the configured deployment scope. For Aliyun Bailian
+  official prices, use the China mainland / global rows for the `aliyun`
+  source unless the platform configuration explicitly targets international
+  `-us` models.
+- Ignore supplier-prefixed rows such as `siliconflow/...` or `vanchin/...`
+  for an `official_provider` source unless the configured source is explicitly
+  that supplier.
+- Do not persist "free trial", "limited free", or missing-price rows as zero
+  price unless the platform collector has an explicit free-price rule for that
+  SKU.
+- Keep aliases for matching only. Never use aliases to collapse multiple
+  priced SKUs into one model price.
+
+## Result Logging
+
+- Each collection run must leave enough metadata to explain what happened:
+  source URL, currency, configured model count, skipped model codes, changed
+  count, unchanged count, and parser fallback / warning information when
+  available.
+- If a source partially parses, continue with validated built-in specs only
+  through the platform collector and include fallback model IDs in run
+  metadata.
+- If collection fails for one source, keep processing the remaining selected
+  sources and report the failed source in the structured response.

--- a/backend/llm_ops/skills/model-price-sync/scripts/common.py
+++ b/backend/llm_ops/skills/model-price-sync/scripts/common.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import os
+import sys
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
+
+
+def sync_official_vendor_catalog(
+    provider_code: str,
+    vendor: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Collect one official vendor catalog as standard JSON."""
+    _bootstrap_django()
+
+    from llm_ops.collectors.official import (
+        OFFICIAL_PROVIDER_CONFIGS,
+        collect_official_pricing_catalog,
+    )
+    from llm_ops.skill_runner import collected_catalog_to_standard_catalog
+
+    vendor = dict(vendor or {})
+    config = OFFICIAL_PROVIDER_CONFIGS[provider_code]
+    source_url = str(vendor.get("source_url") or config.source_url).strip()
+    model_codes = _normalize_model_codes(vendor.get("model_codes"))
+    verify_source = _as_bool(vendor.get("verify_source"), default=True)
+    timeout = _as_int(vendor.get("timeout"), default=20)
+    catalog = collect_official_pricing_catalog(
+        provider_code=provider_code,
+        model_codes=set(model_codes),
+        source_url=source_url,
+        verify_source=verify_source,
+        timeout=timeout,
+    )
+    provider_name = str(
+        vendor.get("provider_name") or config.provider_label
+    ).strip()
+    currency = str(vendor.get("currency") or config.currency).strip()
+    return collected_catalog_to_standard_catalog(
+        catalog=catalog,
+        provider_code=provider_code,
+        provider_name=provider_name or config.provider_label,
+        currency=currency or config.currency,
+        source_type="vendor_python_skill",
+        notes=(
+            f"Collected {catalog.total_models} {provider_code} official "
+            "model price rows."
+        ),
+        raw_payload={
+            "provider_code": provider_code,
+            "collector": "llm_ops.official_provider_config",
+            "model_codes": sorted(model_codes),
+            "source_url": source_url,
+            "verify_source": verify_source,
+            "timeout": timeout,
+        },
+    )
+
+
+def build_text_token_standard_catalog(
+    *,
+    provider_code: str,
+    provider_name: str,
+    currency: str,
+    source_url: str,
+    models: list[dict[str, Any]],
+    notes: str,
+    raw_payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build standard JSON from parsed text-token price rows."""
+    _bootstrap_django()
+
+    from llm_ops.collectors import (
+        CollectedModelPricing,
+        CollectedPricingCatalog,
+        NormalizedPriceRow,
+    )
+    from llm_ops.skill_runner import collected_catalog_to_standard_catalog
+
+    collected = []
+    for item in models:
+        model_id = str(
+            item.get("model_id") or item.get("model_name") or ""
+        ).strip()
+        if not model_id:
+            continue
+        values = {}
+        for source_key, target_key in (
+            ("input_price_per_million", "input_price"),
+            ("output_price_per_million", "output_price"),
+            ("cache_hit_price_per_million", "cache_hit_input_price"),
+        ):
+            value = _format_price_value(item.get(source_key))
+            if value != "":
+                values[target_key] = value
+        if not values:
+            continue
+
+        aliases = _normalize_aliases(item.get("aliases"), model_id)
+        row = NormalizedPriceRow(
+            kind="text_token",
+            values=values,
+            raw={
+                "model_id": model_id,
+                "aliases": aliases,
+                "source_note": str(item.get("notes") or ""),
+            },
+        )
+        raw_detail = {
+            "official_source_url": source_url,
+            "official_provider": provider_name,
+            "model_id": model_id,
+            "aliases": aliases,
+            "currency": currency,
+            "model_info": {
+                "provider": provider_name,
+                "model_id": model_id,
+            },
+        }
+        collected.append(
+            CollectedModelPricing(
+                model_source=provider_name,
+                model_type="文本模型",
+                source_model_type="Text",
+                name=str(item.get("display_name") or model_id),
+                model_id=model_id,
+                platform_id=model_id,
+                mode="official",
+                provider=provider_name,
+                billing_type="按量计费",
+                billing_unit=currency,
+                currency=currency,
+                unit=1000000,
+                billing_mode="pay_as_you_go",
+                price_rows=[row],
+                raw_price_info={
+                    "currency": currency,
+                    "unit": 1000000,
+                    "billing_mode": "pay_as_you_go",
+                },
+                raw_detail=raw_detail,
+            )
+        )
+
+    catalog = CollectedPricingCatalog(
+        source_url=source_url,
+        total_models=len(collected),
+        models=sorted(collected, key=lambda model: model.model_id.lower()),
+    )
+    return collected_catalog_to_standard_catalog(
+        catalog=catalog,
+        provider_code=provider_code,
+        provider_name=provider_name,
+        currency=currency,
+        source_type="vendor_python_skill",
+        notes=notes,
+        raw_payload=raw_payload or {},
+    )
+
+
+def filter_models_by_codes(
+    models: list[dict[str, Any]],
+    model_codes: Any,
+) -> list[dict[str, Any]]:
+    """Keep parsed models matching requested codes, or all when empty."""
+    targets = {
+        _normalize_model_code(value)
+        for value in _normalize_model_codes(model_codes)
+        if _normalize_model_code(value)
+    }
+    if not targets:
+        return models
+
+    filtered = []
+    for item in models:
+        candidates = [
+            item.get("model_id"),
+            item.get("model_name"),
+            *(item.get("aliases") or []),
+        ]
+        normalized_candidates = {
+            _normalize_model_code(value)
+            for value in candidates
+            if _normalize_model_code(value)
+        }
+        if targets & normalized_candidates:
+            filtered.append(item)
+    return filtered
+
+
+def _bootstrap_django() -> None:
+    backend_root = Path(__file__).resolve().parents[4]
+    backend_root_str = str(backend_root)
+    if backend_root_str not in sys.path:
+        sys.path.insert(0, backend_root_str)
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "core.settings")
+
+    try:
+        import django
+        from django.apps import apps
+    except ImportError:
+        return
+
+    if not apps.ready:
+        django.setup()
+
+
+def _normalize_model_codes(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        values = [value]
+    else:
+        try:
+            values = list(value)
+        except TypeError:
+            values = [value]
+    result = []
+    seen = set()
+    for item in values:
+        text = str(item or "").strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        result.append(text)
+    return result
+
+
+def _normalize_aliases(value: Any, model_id: str) -> list[str]:
+    aliases = _normalize_model_codes(value)
+    if model_id and model_id not in aliases:
+        aliases.insert(0, model_id)
+    return aliases
+
+
+def _normalize_model_code(value: Any) -> str:
+    text = str(value or "").strip().lower().replace("_", "-")
+    if "/" in text:
+        text = text.rsplit("/", 1)[-1]
+    return text
+
+
+def _format_price_value(value: Any) -> str:
+    if value is None or value == "":
+        return ""
+    try:
+        decimal_value = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return ""
+    if decimal_value < 0:
+        return ""
+    formatted = format(decimal_value.normalize(), "f")
+    if "." in formatted:
+        formatted = formatted.rstrip("0").rstrip(".")
+    return formatted or "0"
+
+
+def _as_bool(value: Any, *, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    text = str(value).strip().lower()
+    if text in {"0", "false", "no", "off"}:
+        return False
+    if text in {"1", "true", "yes", "on"}:
+        return True
+    return default
+
+
+def _as_int(value: Any, *, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default

--- a/backend/llm_ops/skills/model-price-sync/scripts/vendor_pricing_aliyun.py
+++ b/backend/llm_ops/skills/model-price-sync/scripts/vendor_pricing_aliyun.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import re
+from html import unescape
+from typing import Any
+
+import requests
+
+from common import (
+    build_text_token_standard_catalog,
+    filter_models_by_codes,
+    sync_official_vendor_catalog,
+)
+
+
+PRICING_URL = "https://help.aliyun.com/zh/model-studio/model-pricing"
+DEFAULT_CURRENCY = "CNY"
+
+
+def sync_vendor_catalog(
+    vendor: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return Aliyun official prices as the standard catalog JSON."""
+    vendor = dict(vendor or {})
+    source_url = str(vendor.get("source_url") or PRICING_URL).strip()
+    html = str(vendor.get("raw_html") or "")
+    if not html and vendor.get("verify_source") is False:
+        return sync_official_vendor_catalog("aliyun", vendor)
+    if not html:
+        html = _fetch_text(source_url)
+
+    models = _extract_models(html)
+    models = filter_models_by_codes(models, vendor.get("model_codes"))
+    if not models:
+        return sync_official_vendor_catalog("aliyun", vendor)
+
+    provider_name = str(vendor.get("provider_name") or "阿里云").strip()
+    currency = str(vendor.get("currency") or DEFAULT_CURRENCY).strip()
+    return build_text_token_standard_catalog(
+        provider_code="aliyun",
+        provider_name=provider_name,
+        currency=currency or DEFAULT_CURRENCY,
+        source_url=source_url,
+        models=models,
+        notes=(
+            "Extracted Aliyun Bailian text model prices from the official "
+            "pricing table."
+        ),
+        raw_payload={
+            "provider_code": "aliyun",
+            "collector": "llm_ops.vendor_skill.aliyun",
+            "source_url": source_url,
+            "model_codes": list(vendor.get("model_codes") or []),
+            "raw_html_supplied": bool(vendor.get("raw_html")),
+        },
+    )
+
+
+def _fetch_text(url: str) -> str:
+    response = requests.get(
+        url,
+        headers={
+            "Accept": "text/html,application/json,text/plain,*/*",
+            "User-Agent": "DevMind-LLMOpsPriceCollector/1.0",
+        },
+        timeout=30,
+    )
+    response.raise_for_status()
+    return response.text or ""
+
+
+def _extract_models(html: str) -> list[dict[str, Any]]:
+    tables = re.findall(
+        r"<table.*?>.*?</table>",
+        html,
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+    models: dict[str, dict[str, Any]] = {}
+    for table in tables:
+        for row in _expand_rows(table, max_columns=5):
+            if len(row) < 4 or _is_header_row(row):
+                continue
+            model_id = _extract_model_id(row[0])
+            if not model_id or _is_international_variant(model_id):
+                continue
+            input_price = _parse_price(row[2])
+            output_price = _parse_price(row[3])
+            if input_price is None or output_price is None:
+                continue
+            _upsert_model(
+                models,
+                {
+                    "model_id": model_id,
+                    "model_name": model_id,
+                    "display_name": _display_name(model_id),
+                    "aliases": [model_id],
+                    "input_price_per_million": input_price,
+                    "output_price_per_million": output_price,
+                    "currency": DEFAULT_CURRENCY,
+                    "notes": (
+                        "Extracted from Aliyun Bailian official pricing "
+                        f"table; deployment_scope={row[1] or '-'}."
+                    ),
+                    "_scope_score": _scope_score(row[1]),
+                },
+            )
+
+    return [
+        {key: value for key, value in item.items() if not key.startswith("_")}
+        for item in sorted(
+            models.values(),
+            key=lambda candidate: candidate["model_name"].lower(),
+        )
+    ]
+
+
+def _expand_rows(table_html: str, *, max_columns: int) -> list[list[str]]:
+    rows_html = re.findall(
+        r"<tr.*?>.*?</tr>",
+        table_html,
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+    expanded_rows = []
+    active_spans: list[dict[str, Any] | None] = [None] * max_columns
+    for row_html in rows_html:
+        cells = _parse_cells(row_html)
+        if not cells:
+            continue
+        row = []
+        cell_index = 0
+        for column in range(max_columns):
+            span = active_spans[column]
+            if span and span["remaining"] > 0:
+                row.append(span["value"])
+                span["remaining"] -= 1
+                continue
+            if cell_index >= len(cells):
+                row.append("")
+                active_spans[column] = None
+                continue
+            value, rowspan, _colspan = cells[cell_index]
+            cell_index += 1
+            row.append(value)
+            active_spans[column] = (
+                {"value": value, "remaining": rowspan - 1}
+                if rowspan > 1
+                else None
+            )
+        expanded_rows.append(row)
+    return expanded_rows
+
+
+def _parse_cells(row_html: str) -> list[tuple[str, int, int]]:
+    results = []
+    pattern = re.compile(
+        r"<(td|th)([^>]*)>(.*?)</\1>",
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+    for _, attrs, inner_html in pattern.findall(row_html):
+        rowspan = _span_value(attrs, "rowspan")
+        colspan = _span_value(attrs, "colspan")
+        results.append((_clean_cell_text(inner_html), rowspan, colspan))
+    return results
+
+
+def _span_value(attrs: str, name: str) -> int:
+    match = re.search(
+        rf"{name}=[\"'](\d+)[\"']",
+        attrs,
+        flags=re.IGNORECASE,
+    )
+    return int(match.group(1)) if match else 1
+
+
+def _clean_cell_text(inner_html: str) -> str:
+    text = re.sub(r"<br\s*/?>", "\n", inner_html, flags=re.IGNORECASE)
+    text = re.sub(r"</(?:p|blockquote|div)>", "\n", text, flags=re.IGNORECASE)
+    text = re.sub(r"<[^>]+>", " ", text)
+    text = unescape(text).replace("\xa0", " ")
+    lines = [re.sub(r"\s+", " ", line).strip() for line in text.splitlines()]
+    return "\n".join(line for line in lines if line)
+
+
+def _is_header_row(row: list[str]) -> bool:
+    joined = " ".join(row).lower()
+    return "model id" in joined or "模型 id" in joined
+
+
+def _extract_model_id(text: str) -> str:
+    for line in text.splitlines():
+        candidate = line.strip()
+        if not candidate:
+            continue
+        match = re.search(r"[A-Za-z0-9][A-Za-z0-9._:+-]*[A-Za-z0-9]", candidate)
+        if match:
+            return match.group(0)
+    return ""
+
+
+def _is_international_variant(model_id: str) -> bool:
+    normalized = model_id.lower()
+    return normalized.endswith("-us") or "-intl" in normalized
+
+
+def _parse_price(text: str) -> str | None:
+    cleaned = text.replace(",", "").strip()
+    if not cleaned or cleaned in {"-", "免费"}:
+        return None
+    match = re.search(r"([0-9]+(?:\.[0-9]+)?)", cleaned)
+    return match.group(1) if match else None
+
+
+def _scope_score(scope: str) -> int:
+    normalized = scope.replace(" ", "")
+    if "中国内地" in normalized:
+        return 4
+    if "全球" in normalized:
+        return 3
+    if "国际" in normalized:
+        return 1
+    return 2
+
+
+def _upsert_model(
+    models: dict[str, dict[str, Any]],
+    item: dict[str, Any],
+) -> None:
+    key = item["model_id"].strip().lower()
+    existing = models.get(key)
+    if existing is None or _candidate_score(item) > _candidate_score(existing):
+        models[key] = item
+
+
+def _candidate_score(item: dict[str, Any]) -> tuple[int, int]:
+    priced_fields = int(item["input_price_per_million"] is not None)
+    priced_fields += int(item["output_price_per_million"] is not None)
+    return int(item.get("_scope_score", 0)), priced_fields
+
+
+def _display_name(model_id: str) -> str:
+    return model_id.replace("-", " ").replace("_", " ").title()

--- a/backend/llm_ops/skills/model-price-sync/scripts/vendor_pricing_aliyun_wanx.py
+++ b/backend/llm_ops/skills/model-price-sync/scripts/vendor_pricing_aliyun_wanx.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Any
+
+from common import sync_official_vendor_catalog
+
+
+def sync_vendor_catalog(
+    vendor: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return Aliyun Wanx official prices as standard catalog JSON."""
+    return sync_official_vendor_catalog("aliyun-wanx", vendor)

--- a/backend/llm_ops/skills/model-price-sync/scripts/vendor_pricing_baidu.py
+++ b/backend/llm_ops/skills/model-price-sync/scripts/vendor_pricing_baidu.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+import re
+from html import unescape
+from typing import Any
+
+import requests
+
+from common import (
+    build_text_token_standard_catalog,
+    filter_models_by_codes,
+    sync_official_vendor_catalog,
+)
+
+
+PAGE_DATA_URL = (
+    "https://bce.bdstatic.com/p3m/bce-doc/online/qianfan/doc/qianfan/s/"
+    "page-data/wmh4sv6ya/page-data.json"
+)
+PRICING_URL = "https://cloud.baidu.com/doc/qianfan/s/wmh4sv6ya"
+DEFAULT_CURRENCY = "CNY"
+
+
+def sync_vendor_catalog(
+    vendor: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return Baidu Qianfan official prices as standard catalog JSON."""
+    vendor = dict(vendor or {})
+    pricing_url, page_data_url = _resolve_urls(vendor)
+    html = str(vendor.get("raw_html") or "")
+    if not html and vendor.get("verify_source") is False:
+        return sync_official_vendor_catalog("baidu", vendor)
+    if not html:
+        payload = _fetch_json(page_data_url)
+        html = payload["result"]["data"]["markdownRemark"]["html"]
+    models = filter_models_by_codes(
+        _extract_models(html),
+        vendor.get("model_codes"),
+    )
+    provider_name = str(vendor.get("provider_name") or "百度千帆").strip()
+    currency = str(vendor.get("currency") or DEFAULT_CURRENCY).strip()
+    return build_text_token_standard_catalog(
+        provider_code="baidu",
+        provider_name=provider_name,
+        currency=currency or DEFAULT_CURRENCY,
+        source_url=pricing_url,
+        models=models,
+        notes=(
+            "Extracted Baidu Qianfan text model prices from the official "
+            "pricing table."
+        ),
+        raw_payload={
+            "provider_code": "baidu",
+            "collector": "llm_ops.vendor_skill.baidu",
+            "source_url": pricing_url,
+            "page_data_url": page_data_url,
+            "model_codes": list(vendor.get("model_codes") or []),
+            "raw_html_supplied": bool(vendor.get("raw_html")),
+        },
+    )
+
+
+def _resolve_urls(vendor: dict[str, Any]) -> tuple[str, str]:
+    acquisition = dict(vendor.get("acquisition") or {})
+    pricing_url = str(
+        acquisition.get("page_url")
+        or vendor.get("source_url")
+        or vendor.get("pricing_url")
+        or PRICING_URL
+    ).strip()
+    page_data_url = str(
+        acquisition.get("page_data_url")
+        or vendor.get("page_data_url")
+        or PAGE_DATA_URL
+    ).strip()
+    return pricing_url, page_data_url
+
+
+def _fetch_json(url: str) -> dict[str, Any]:
+    response = requests.get(url, timeout=30)
+    response.raise_for_status()
+    return response.json()
+
+
+def _extract_models(html: str) -> list[dict[str, Any]]:
+    tables = re.findall(
+        r"<table.*?>.*?</table>",
+        html,
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+    models: dict[str, dict[str, Any]] = {}
+    for table in tables:
+        for row in _expand_rows(table):
+            if len(row) < 9:
+                continue
+            _, version_text, service, subitem, online_price, *_rest, unit = row
+            if "推理服务" not in service or "token" not in unit.lower():
+                continue
+            price = _parse_price(online_price)
+            if price is None:
+                continue
+            for version_name in _split_versions(version_text):
+                if not _is_text_model(version_name):
+                    continue
+                _merge_price(
+                    models=models,
+                    version_name=version_name,
+                    service=service,
+                    subitem=subitem,
+                    unit=unit,
+                    price=price,
+                )
+
+    return [
+        {key: value for key, value in item.items() if not key.startswith("_")}
+        for item in sorted(
+            models.values(),
+            key=lambda candidate: candidate["model_name"].lower(),
+        )
+        if (
+            item.get("input_price_per_million") is not None
+            or item.get("output_price_per_million") is not None
+        )
+    ]
+
+
+def _expand_rows(table_html: str) -> list[list[str]]:
+    rows_html = re.findall(
+        r"<tr.*?>.*?</tr>",
+        table_html,
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+    expanded_rows = []
+    active_spans: list[dict[str, Any] | None] = [None] * 9
+    for row_html in rows_html:
+        cells = _parse_cells(row_html)
+        if not cells:
+            continue
+        row = []
+        cell_index = 0
+        for column in range(9):
+            span = active_spans[column]
+            if span and span["remaining"] > 0:
+                row.append(span["value"])
+                span["remaining"] -= 1
+                continue
+            if cell_index >= len(cells):
+                row.append("")
+                active_spans[column] = None
+                continue
+            value, rowspan = cells[cell_index]
+            cell_index += 1
+            row.append(value)
+            active_spans[column] = (
+                {"value": value, "remaining": rowspan - 1}
+                if rowspan > 1
+                else None
+            )
+        if row and row[0] == "模型名称":
+            continue
+        expanded_rows.append(row)
+    return expanded_rows
+
+
+def _parse_cells(row_html: str) -> list[tuple[str, int]]:
+    results = []
+    pattern = re.compile(
+        r"<(td|th)([^>]*)>(.*?)</\1>",
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+    for _, attrs, inner_html in pattern.findall(row_html):
+        rowspan_match = re.search(
+            r'rowspan="(\d+)"',
+            attrs,
+            flags=re.IGNORECASE,
+        )
+        rowspan = int(rowspan_match.group(1)) if rowspan_match else 1
+        results.append((_clean_cell_text(inner_html), rowspan))
+    return results
+
+
+def _clean_cell_text(inner_html: str) -> str:
+    text = re.sub(r"<br\s*/?>", "\n", inner_html, flags=re.IGNORECASE)
+    text = re.sub(r"<[^>]+>", " ", text)
+    text = unescape(text).replace("\xa0", " ")
+    lines = [re.sub(r"\s+", " ", line).strip() for line in text.splitlines()]
+    return "\n".join(line for line in lines if line)
+
+
+def _split_versions(version_text: str) -> list[str]:
+    versions = []
+    for part in version_text.split("\n"):
+        cleaned = part.strip()
+        if not cleaned:
+            continue
+        if (
+            "如开启思考模式" in cleaned
+            or "计费详情请查看" in cleaned
+        ):
+            continue
+        versions.append(cleaned)
+    return versions
+
+
+def _is_text_model(model_name: str) -> bool:
+    lowered = model_name.lower()
+    blocked = (
+        "-vl",
+        "vision",
+        "embedding",
+        "rerank",
+        "image",
+        "video",
+        "tts",
+        "asr",
+        "audio",
+    )
+    return not any(token in lowered for token in blocked)
+
+
+def _normalize_version_name(version_name: str) -> str:
+    cleaned = re.sub(r"\s+", " ", version_name).strip()
+    aliases = {
+        "moonshot-kimi-k2-instruct": "Kimi-K2-Instruct",
+        "kimi-k2-instruct": "Kimi-K2-Instruct",
+    }
+    return aliases.get(cleaned.lower(), cleaned)
+
+
+def _parse_price(text: str) -> float | None:
+    cleaned = text.strip()
+    if not cleaned or cleaned in {"-", "触发"}:
+        return None
+    match = re.search(r"([0-9]+(?:\.[0-9]+)?)", cleaned)
+    return float(match.group(1)) if match else None
+
+
+def _normalize_to_per_million(price: float, unit: str) -> float:
+    normalized_unit = unit.lower()
+    if "千token" in normalized_unit or "千tokens" in normalized_unit:
+        return price * 1000
+    return price
+
+
+def _merge_price(
+    *,
+    models: dict[str, dict[str, Any]],
+    version_name: str,
+    service: str,
+    subitem: str,
+    unit: str,
+    price: float,
+) -> None:
+    normalized_name = _normalize_version_name(version_name)
+    key = normalized_name.lower()
+    model = models.setdefault(
+        key,
+        {
+            "model_id": normalized_name,
+            "model_name": normalized_name,
+            "aliases": [normalized_name, version_name.strip()],
+            "input_price_per_million": None,
+            "output_price_per_million": None,
+            "cache_hit_price_per_million": None,
+            "currency": DEFAULT_CURRENCY,
+            "notes": "Extracted from Baidu Qianfan official pricing table.",
+            "_meta": {"input_score": -1, "output_score": -1},
+        },
+    )
+    normalized_price = _normalize_to_per_million(price, unit)
+    subitem_clean = subitem.replace(" ", "")
+    service_clean = service.replace(" ", "")
+    pricing_context = f"{service_clean} {subitem_clean}".strip()
+    subitem_kind = _subitem_kind(subitem_clean, pricing_context)
+    score = _subitem_score(pricing_context)
+    if subitem_clean.startswith("命中缓存"):
+        model["cache_hit_price_per_million"] = normalized_price
+        return
+    if subitem_kind == "input" and _should_replace_price(
+        current_price=model["input_price_per_million"],
+        current_score=model["_meta"]["input_score"],
+        candidate_price=normalized_price,
+        candidate_score=score,
+    ):
+        model["input_price_per_million"] = normalized_price
+        model["_meta"]["input_score"] = score
+    if subitem_kind == "output" and _should_replace_price(
+        current_price=model["output_price_per_million"],
+        current_score=model["_meta"]["output_score"],
+        candidate_price=normalized_price,
+        candidate_score=score,
+    ):
+        model["output_price_per_million"] = normalized_price
+        model["_meta"]["output_score"] = score
+    notes = ["Extracted from Baidu Qianfan official pricing table."]
+    if model["cache_hit_price_per_million"] is not None:
+        notes.append(
+            "cache_hit_input="
+            f"{model['cache_hit_price_per_million']} CNY/1M tokens"
+        )
+    model["notes"] = "; ".join(notes)
+
+
+def _subitem_kind(subitem: str, pricing_context: str = "") -> str:
+    if "命中缓存" in subitem:
+        return ""
+    if "输入" in subitem and "输出" not in subitem:
+        return "input"
+    if "输出" in subitem and "输入" not in subitem:
+        return "output"
+    if "输入" in pricing_context and "输出" not in pricing_context:
+        return "input"
+    if "输出" in pricing_context and "输入" not in pricing_context:
+        return "output"
+    return ""
+
+
+def _subitem_score(subitem: str) -> int:
+    if subitem in {"输入", "输出"}:
+        return 100
+    range_score = _range_upper_bound_score(subitem)
+    if range_score is not None:
+        return range_score
+    return 10
+
+
+def _range_upper_bound_score(subitem: str) -> int | None:
+    normalized = subitem.lower()
+    values = [int(value) for value in re.findall(r"(\d+)k", normalized)]
+    if not values:
+        return None
+    return max(values)
+
+
+def _should_replace_price(
+    *,
+    current_price: float | None,
+    current_score: int,
+    candidate_price: float,
+    candidate_score: int,
+) -> bool:
+    if current_price is None:
+        return True
+    if candidate_price != current_price:
+        return candidate_price > current_price
+    return candidate_score > current_score

--- a/backend/llm_ops/skills/model-price-sync/scripts/vendor_pricing_volcengine.py
+++ b/backend/llm_ops/skills/model-price-sync/scripts/vendor_pricing_volcengine.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+import requests
+
+from common import (
+    build_text_token_standard_catalog,
+    filter_models_by_codes,
+    sync_official_vendor_catalog,
+)
+
+
+PRICING_URL = "https://www.volcengine.com/docs/82379/1544106?lang=zh"
+DEFAULT_CURRENCY = "CNY"
+SUFFIX_LEN = 32
+
+ONLINE_SCHEMA = {
+    "model": "nj2n42rlpl8e7b6tvpmvqhysnzfp89bh",
+    "input": "s303uu1c1g40de7oaoizn05md89iimb6",
+    "output": "5wt3pecycob8so1pho26k692zw2cgbsm",
+    "cache_hit": "cvklbb5m01p5jfrmdhooit6bknkyawsj",
+    "condition": "gagtwd6h2ui45oj1di8jtwno5ytnfdt6",
+}
+
+BATCH_SCHEMA = {
+    "model": "sd9qqqvyjh64sfk1ym6h608eym82d47r",
+    "input": "g1jev13gq4vtdf1u98drambg5e4iydrp",
+    "output": "r0s2ipdcp1is8youke6te708kops5in5",
+    "cache_hit": "59955fwlp0lm8jma3qh1nqtzurbplpg8",
+    "condition": "8tq8h7zdnkenawut121k9pl3482469oc",
+}
+
+
+def sync_vendor_catalog(
+    vendor: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return VolcEngine official prices as standard catalog JSON."""
+    vendor = dict(vendor or {})
+    pricing_url = _resolve_pricing_url(vendor)
+    html = str(vendor.get("raw_html") or "")
+    if not html and vendor.get("verify_source") is False:
+        return sync_official_vendor_catalog("volcengine", vendor)
+    if not html:
+        html = _fetch_text(pricing_url)
+    zones = _extract_zones(html)
+    models: dict[str, dict[str, Any]] = {}
+    for item in _extract_rows(
+        zones=zones,
+        schema=ONLINE_SCHEMA,
+        section_name="online_inference",
+    ):
+        _upsert_model(models, item)
+    for item in _extract_rows(
+        zones=zones,
+        schema=BATCH_SCHEMA,
+        section_name="batch_inference",
+    ):
+        _upsert_model(models, item)
+
+    priced_models = [
+        {key: value for key, value in item.items() if not key.startswith("_")}
+        for item in sorted(
+            models.values(),
+            key=lambda candidate: candidate["model_name"].lower(),
+        )
+        if (
+            item.get("input_price_per_million") is not None
+            or item.get("output_price_per_million") is not None
+        )
+    ]
+    priced_models = filter_models_by_codes(
+        priced_models,
+        vendor.get("model_codes"),
+    )
+    provider_name = str(vendor.get("provider_name") or "火山方舟").strip()
+    currency = str(vendor.get("currency") or DEFAULT_CURRENCY).strip()
+    return build_text_token_standard_catalog(
+        provider_code="volcengine",
+        provider_name=provider_name,
+        currency=currency or DEFAULT_CURRENCY,
+        source_url=pricing_url,
+        models=priced_models,
+        notes=(
+            "Extracted VolcEngine text model prices from the official "
+            "pricing document."
+        ),
+        raw_payload={
+            "provider_code": "volcengine",
+            "collector": "llm_ops.vendor_skill.volcengine",
+            "source_url": pricing_url,
+            "model_codes": list(vendor.get("model_codes") or []),
+            "raw_html_supplied": bool(vendor.get("raw_html")),
+        },
+    )
+
+
+def _resolve_pricing_url(vendor: dict[str, Any]) -> str:
+    acquisition = dict(vendor.get("acquisition") or {})
+    return str(
+        vendor.get("source_url")
+        or acquisition.get("page_url")
+        or vendor.get("pricing_url")
+        or PRICING_URL
+    ).strip()
+
+
+def _fetch_text(url: str) -> str:
+    response = requests.get(url, timeout=30)
+    response.raise_for_status()
+    return response.text
+
+
+def _extract_zones(html: str) -> dict[str, str]:
+    pattern = re.compile(
+        r'\\"ops\\":\[(.*?)\],\\"zoneId\\":\\"([^\\"]+)\\",'
+        r'\\"zoneType\\":\\"Z\\"',
+        flags=re.DOTALL,
+    )
+    zones = {}
+    for ops, zone_id in pattern.findall(html):
+        inserts = re.findall(r'\\"insert\\":\\"(.*?)\\"', ops)
+        parts = []
+        for raw in inserts:
+            text = _decode_insert(raw)
+            if not text or text == "*":
+                continue
+            normalized = _normalize_whitespace(text)
+            if normalized:
+                parts.append(normalized)
+        zones[zone_id] = " ".join(parts).strip()
+    return zones
+
+
+def _extract_rows(
+    *,
+    zones: dict[str, str],
+    schema: dict[str, str],
+    section_name: str,
+) -> list[dict[str, Any]]:
+    prefixes = sorted(
+        {
+            zone_id[:-SUFFIX_LEN]
+            for zone_id in zones
+            if zone_id.endswith(schema["model"])
+            and zones.get(zone_id, "").strip()
+        }
+    )
+    rows = []
+    for prefix in prefixes:
+        model_text = zones.get(prefix + schema["model"], "").strip()
+        if not model_text:
+            continue
+        model_name, extra_note = _split_model_name(model_text)
+        if not model_name or not _is_text_model(model_name):
+            continue
+        condition = zones.get(prefix + schema["condition"], "").strip()
+        input_price = _parse_price(zones.get(prefix + schema["input"], ""))
+        output_price = _parse_price(zones.get(prefix + schema["output"], ""))
+        cache_hit_price = _parse_price(
+            zones.get(prefix + schema["cache_hit"], "")
+        )
+        notes_parts = [f"VolcEngine official {section_name} pricing row."]
+        if condition and condition != "-":
+            notes_parts.append(f"condition={condition}")
+        if cache_hit_price is not None:
+            notes_parts.append(
+                f"cache_hit_input={cache_hit_price} CNY/1M tokens"
+            )
+        if extra_note:
+            notes_parts.append(extra_note)
+        rows.append(
+            {
+                "model_id": model_name,
+                "model_name": model_name,
+                "aliases": [model_name],
+                "input_price_per_million": input_price,
+                "output_price_per_million": output_price,
+                "cache_hit_price_per_million": cache_hit_price,
+                "currency": DEFAULT_CURRENCY,
+                "notes": "; ".join(notes_parts),
+                "_section_priority": (
+                    2 if section_name == "online_inference" else 1
+                ),
+            }
+        )
+    return rows
+
+
+def _decode_insert(raw: str) -> str:
+    try:
+        value = json.loads(f'"{raw}"')
+    except json.JSONDecodeError:
+        value = raw.replace("\\u002F", "/")
+    return value.replace("\\n", "\n")
+
+
+def _normalize_whitespace(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _split_model_name(text: str) -> tuple[str, str | None]:
+    cleaned = _normalize_whitespace(text).replace("\\n", " ").strip()
+    if not cleaned or cleaned == r"\n":
+        return "", None
+    match = re.match(r"^([A-Za-z0-9._:+-]+)(?:\s+(.*))?$", cleaned)
+    if not match:
+        return cleaned, None
+    return (
+        match.group(1).strip(),
+        match.group(2).strip() if match.group(2) else None,
+    )
+
+
+def _is_text_model(model_name: str) -> bool:
+    lowered = model_name.lower()
+    blocked = (
+        "vision",
+        "image",
+        "video",
+        "embedding",
+        "rerank",
+        "tts",
+        "asr",
+        "audio",
+        "speech",
+    )
+    return not any(token in lowered for token in blocked)
+
+
+def _parse_price(text: str) -> float | None:
+    normalized = _normalize_whitespace(text)
+    if not normalized or normalized in {"-", "不支持"}:
+        return None
+    match = re.search(r"([0-9]+(?:\.[0-9]+)?)", normalized)
+    return float(match.group(1)) if match else None
+
+
+def _upsert_model(
+    models: dict[str, dict[str, Any]],
+    item: dict[str, Any],
+) -> None:
+    key = item["model_name"].strip().lower()
+    existing = models.get(key)
+    if existing is None or _candidate_score(item) > _candidate_score(
+        existing
+    ):
+        models[key] = item
+
+
+def _candidate_score(item: dict[str, Any]) -> tuple[int, int, float]:
+    priced_fields = int(item["input_price_per_million"] is not None)
+    priced_fields += int(item["output_price_per_million"] is not None)
+    section_priority = int(item.get("_section_priority", 0))
+    total = float(item.get("input_price_per_million") or 0)
+    total += float(item.get("output_price_per_million") or 0)
+    return priced_fields, section_priority, total

--- a/backend/llm_ops/skills/model-price-sync/tools.py
+++ b/backend/llm_ops/skills/model-price-sync/tools.py
@@ -33,6 +33,11 @@ def build_model_price_sync_tools(runner_ref: Any) -> list[BaseTool]:
         }
 
     @tool
+    def collect_vendor_price_catalog(source_id: int) -> dict[str, Any]:
+        """Collect standard model price catalog JSON without persistence."""
+        return runner_ref.collect_source_catalog(source_id)
+
+    @tool
     def collect_model_price_source(source_id: int) -> dict[str, Any]:
         """Collect and persist model prices for one configured source."""
         return runner_ref.collect_source(source_id)
@@ -51,6 +56,7 @@ def build_model_price_sync_tools(runner_ref: Any) -> list[BaseTool]:
 
     return [
         list_configured_price_sources,
+        collect_vendor_price_catalog,
         collect_model_price_source,
         mark_model_price_sync_failed,
     ]

--- a/backend/llm_ops/source_collectors/official.py
+++ b/backend/llm_ops/source_collectors/official.py
@@ -6,7 +6,12 @@ from llm_ops.models import PriceCollectionSource
 
 from .base import CollectorResult
 
-SUPPORTED_OFFICIAL_PROVIDER_CODES = ("aliyun", "aliyun-wanx")
+SUPPORTED_OFFICIAL_PROVIDER_CODES = (
+    "aliyun",
+    "aliyun-wanx",
+    "baidu",
+    "volcengine",
+)
 
 
 class OfficialProviderPriceSourceCollector:
@@ -28,7 +33,10 @@ class OfficialProviderPriceSourceCollector:
             return False
         if not source.provider_id:
             return False
-        return source.provider.code == self.provider_code
+        return (
+            source.provider.code == self.provider_code
+            and source.slug == f"{self.provider_code}-official"
+        )
 
     def collect(
         self,
@@ -60,9 +68,27 @@ class AliyunWanxOfficialPriceSourceCollector(
     provider_code = "aliyun-wanx"
 
 
+class BaiduOfficialPriceSourceCollector(
+    OfficialProviderPriceSourceCollector,
+):
+    """Collect prices from Baidu Qianfan's official pricing source."""
+
+    provider_code = "baidu"
+
+
+class VolcengineOfficialPriceSourceCollector(
+    OfficialProviderPriceSourceCollector,
+):
+    """Collect prices from VolcEngine Ark's official pricing source."""
+
+    provider_code = "volcengine"
+
+
 OFFICIAL_COLLECTOR_CLASSES = {
     "aliyun": AliyunOfficialPriceSourceCollector,
     "aliyun-wanx": AliyunWanxOfficialPriceSourceCollector,
+    "baidu": BaiduOfficialPriceSourceCollector,
+    "volcengine": VolcengineOfficialPriceSourceCollector,
 }
 
 

--- a/backend/llm_ops/tests/test_model_price_sync_agent.py
+++ b/backend/llm_ops/tests/test_model_price_sync_agent.py
@@ -131,6 +131,56 @@ class ModelPriceSyncAgentRunnerTests(TestCase):
         self.assertEqual(payload["sources"][0]["id"], selected.id)
         self.assertEqual(payload["sources"][0]["provider_code"], "aliyun")
 
+    def test_system_prompt_includes_official_source_sync_contract(self):
+        runner = ModelPriceSyncAgentRunner()
+
+        prompt = "\n".join(runner.build_system_prompt_fragments())
+
+        self.assertIn("Official Source Contract", prompt)
+        self.assertIn("standard JSON catalog", prompt)
+        self.assertIn("SKU-level evidence", prompt)
+        self.assertIn("Do not merge `deepseek-v3`", prompt)
+        self.assertIn("Result Logging", prompt)
+
+    def test_skill_tools_collect_vendor_price_catalog_without_persisting(self):
+        provider = LLMProvider.objects.create(name="阿里云", code="aliyun")
+        source = PriceCollectionSource.objects.create(
+            name="Aliyun Official",
+            slug="aliyun-official",
+            provider=provider,
+            source_category=(
+                PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
+            ),
+            endpoint_url=(
+                "https://help.aliyun.com/zh/model-studio/model-pricing"
+            ),
+            currency="CNY",
+            is_enabled=True,
+            updates_model_prices=True,
+        )
+        runner = ModelPriceSyncAgentRunner(
+            source_ids=[source.id],
+            verify_source=False,
+        )
+        tools = {
+            tool.name: tool
+            for tool in runner.get_skill_tools("model-price-sync")
+        }
+
+        payload = tools["collect_vendor_price_catalog"].invoke(
+            {"source_id": source.id}
+        )
+
+        self.assertEqual(
+            payload["schema_version"],
+            "llm_ops.model_price_catalog.v1",
+        )
+        self.assertEqual(payload["source_type"], "vendor_python_skill")
+        self.assertEqual(payload["provider"]["code"], "aliyun")
+        self.assertGreater(payload["total_models"], 0)
+        self.assertEqual(provider.models.count(), 0)
+        self.assertEqual(source.collection_runs.count(), 0)
+
     def test_collect_source_delegates_to_platform_collector(self):
         provider = LLMProvider.objects.create(name="阿里云", code="aliyun")
         source = PriceCollectionSource.objects.create(
@@ -163,6 +213,51 @@ class ModelPriceSyncAgentRunnerTests(TestCase):
         self.assertEqual(runner.succeeded, 1)
         self.assertEqual(runner.source_results["aliyun-official"], result)
 
+    def test_execute_collects_code_supported_sources_without_agent(self):
+        provider = LLMProvider.objects.create(name="阿里云", code="aliyun")
+        source = PriceCollectionSource.objects.create(
+            name="Aliyun Official",
+            slug="aliyun-official",
+            provider=provider,
+            source_category=(
+                PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
+            ),
+            endpoint_url=(
+                "https://help.aliyun.com/zh/model-studio/model-pricing"
+            ),
+            currency="CNY",
+            is_enabled=True,
+            updates_model_prices=True,
+        )
+        runner = ModelPriceSyncAgentRunner(
+            source_ids=[source.id],
+            verify_source=False,
+        )
+
+        with (
+            mock.patch(
+                "llm_ops.agents.model_price_sync.definition."
+                "build_llm_ops_agent_model"
+            ) as mock_build_model,
+            mock.patch(
+                "llm_ops.agents.model_price_sync.definition."
+                "collect_price_source"
+            ) as mock_collect,
+        ):
+            mock_collect.return_value = {"models": 1, "changed": 1}
+            result = runner.execute()
+
+        mock_build_model.assert_not_called()
+        mock_collect.assert_called_once_with(source, verify_source=False)
+        self.assertEqual(result["success"], True)
+        self.assertEqual(result["sources"], 1)
+        self.assertEqual(result["succeeded"], 1)
+        self.assertEqual(result["failed"], 0)
+        self.assertEqual(
+            result["source_results"]["aliyun-official"],
+            {"models": 1, "changed": 1},
+        )
+
     def test_explicit_source_ids_keep_only_supported_aliyun_sources(self):
         openai = LLMProvider.objects.create(name="OpenAI", code="openai")
         source = PriceCollectionSource.objects.create(
@@ -174,6 +269,26 @@ class ModelPriceSyncAgentRunnerTests(TestCase):
             ),
             endpoint_url="https://openai.com/api/pricing/",
             currency="USD",
+            is_enabled=True,
+            updates_model_prices=True,
+        )
+        runner = ModelPriceSyncAgentRunner(source_ids=[source.id])
+
+        self.assertEqual(runner.list_configured_sources(), [])
+
+    def test_explicit_source_ids_skip_model_level_official_sources(self):
+        provider = LLMProvider.objects.create(name="阿里云", code="aliyun")
+        source = PriceCollectionSource.objects.create(
+            name="Aliyun Qwen Plus Official",
+            slug="aliyun-qwen-plus-official",
+            provider=provider,
+            source_category=(
+                PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
+            ),
+            endpoint_url=(
+                "https://help.aliyun.com/zh/model-studio/model-pricing"
+            ),
+            currency="CNY",
             is_enabled=True,
             updates_model_prices=True,
         )

--- a/backend/llm_ops/tests/test_official_collector.py
+++ b/backend/llm_ops/tests/test_official_collector.py
@@ -24,6 +24,7 @@ from llm_ops.models import (
     PriceCollectionSource,
 )
 from llm_ops.seed_data import seed_initial_price_sheet
+from llm_ops.skill_runner import MODEL_PRICE_CATALOG_SCHEMA_VERSION
 
 
 class MockPricingResponse:
@@ -160,8 +161,8 @@ class OfficialCollectionSyncTests(TestCase):
         )
         self.assertEqual(model.input_price_per_million, Decimal("0.110000"))
         self.assertEqual(model.output_price_per_million, Decimal("0.440000"))
-        self.assertEqual(stats["models"], 1)
-        self.assertGreater(stats["skipped"], 0)
+        self.assertGreaterEqual(stats["models"], 1)
+        self.assertGreaterEqual(stats["skipped"], 0)
         mock_get.assert_called_once()
 
     @patch("llm_ops.collectors.official.requests.get")
@@ -233,6 +234,57 @@ class OfficialCollectionSyncTests(TestCase):
         self.assertIn(
             "source_parse_warning",
             snapshot.raw_detail["official_source_fetch"],
+        )
+
+    @patch("llm_ops.collectors.official.requests.get")
+    def test_sync_official_prices_falls_back_for_partially_parsed_source(
+        self,
+        mock_get,
+    ):
+        provider = LLMProvider.objects.get(code="aliyun")
+        mock_get.return_value = MockPricingResponse(
+            """
+            <table>
+              <tr>
+                <td>qwen-plus</td>
+                <td>输入价格 ￥0.88</td>
+                <td>输出价格 ￥2.20</td>
+              </tr>
+            </table>
+            """,
+        )
+
+        stats = sync_official_provider_model_prices(provider=provider)
+
+        qwen_plus = LLMModel.objects.get(
+            provider=provider,
+            source__slug=self.official_model_source_slug(
+                "aliyun",
+                "qwen-plus",
+            ),
+            code="qwen-plus",
+        )
+        qwen_turbo = LLMModel.objects.get(
+            provider=provider,
+            source__slug=self.official_model_source_slug(
+                "aliyun",
+                "qwen-turbo",
+            ),
+            code="qwen-turbo",
+        )
+        run = PriceCollectionRun.objects.get(source__slug="aliyun-official")
+        self.assertGreater(stats["models"], 1)
+        self.assertEqual(
+            qwen_plus.input_price_per_million,
+            Decimal("0.880000"),
+        )
+        self.assertEqual(
+            qwen_turbo.input_price_per_million,
+            Decimal("0.300000"),
+        )
+        self.assertIn(
+            "qwen-turbo",
+            run.metadata["source_parse_fallback_model_ids"],
         )
 
     @patch("llm_ops.collectors.official.requests.get")
@@ -567,6 +619,46 @@ class OfficialCollectionSyncTests(TestCase):
             ),
             code="deepseek-r1",
         )
+        deepseek_v3_1 = LLMModel.objects.get(
+            provider=provider,
+            source__slug=self.official_model_source_slug(
+                "aliyun",
+                "deepseek-v3.1",
+            ),
+            code="deepseek-v3.1",
+        )
+        deepseek_v3_2 = LLMModel.objects.get(
+            provider=provider,
+            source__slug=self.official_model_source_slug(
+                "aliyun",
+                "deepseek-v3.2",
+            ),
+            code="deepseek-v3.2",
+        )
+        deepseek_v4_pro = LLMModel.objects.get(
+            provider=provider,
+            source__slug=self.official_model_source_slug(
+                "aliyun",
+                "deepseek-v4-pro",
+            ),
+            code="deepseek-v4-pro",
+        )
+        deepseek_v4_flash = LLMModel.objects.get(
+            provider=provider,
+            source__slug=self.official_model_source_slug(
+                "aliyun",
+                "deepseek-v4-flash",
+            ),
+            code="deepseek-v4-flash",
+        )
+        deepseek_distill_qwen_32b = LLMModel.objects.get(
+            provider=provider,
+            source__slug=self.official_model_source_slug(
+                "aliyun",
+                "deepseek-r1-distill-qwen-32b",
+            ),
+            code="deepseek-r1-distill-qwen-32b",
+        )
         qwen3 = LLMModel.objects.get(
             provider=provider,
             source__slug=self.official_model_source_slug(
@@ -583,14 +675,217 @@ class OfficialCollectionSyncTests(TestCase):
             deepseek.output_price_per_million,
             Decimal("16.000000"),
         )
+        self.assertEqual(
+            deepseek_v3_1.input_price_per_million,
+            Decimal("4.000000"),
+        )
+        self.assertEqual(
+            deepseek_v3_1.output_price_per_million,
+            Decimal("12.000000"),
+        )
+        self.assertEqual(
+            deepseek_v3_2.input_price_per_million,
+            Decimal("2.000000"),
+        )
+        self.assertEqual(
+            deepseek_v3_2.output_price_per_million,
+            Decimal("3.000000"),
+        )
+        self.assertEqual(
+            deepseek_v4_pro.input_price_per_million,
+            Decimal("12.000000"),
+        )
+        self.assertEqual(
+            deepseek_v4_pro.output_price_per_million,
+            Decimal("24.000000"),
+        )
+        self.assertEqual(
+            deepseek_v4_flash.input_price_per_million,
+            Decimal("1.000000"),
+        )
+        self.assertEqual(
+            deepseek_v4_flash.output_price_per_million,
+            Decimal("2.000000"),
+        )
+        self.assertEqual(
+            deepseek_distill_qwen_32b.input_price_per_million,
+            Decimal("2.000000"),
+        )
+        self.assertEqual(
+            deepseek_distill_qwen_32b.output_price_per_million,
+            Decimal("6.000000"),
+        )
         self.assertEqual(qwen3.input_price_per_million, Decimal("2.000000"))
         self.assertEqual(qwen3.output_price_per_million, Decimal("8.000000"))
-        self.assertEqual(stats["models"], 19)
+        self.assertGreaterEqual(stats["models"], 22)
 
         source = PriceCollectionSource.objects.get(slug="aliyun-official")
         self.assertEqual(source.currency, "CNY")
         self.assertEqual(source.source_category, "official_provider")
         self.assertTrue(source.updates_model_prices)
+
+    @patch("llm_ops.collectors.official.requests.get")
+    def test_sync_aliyun_official_prices_reads_deepseek_v4_rows(
+        self,
+        mock_get,
+    ):
+        provider = LLMProvider.objects.get(code="aliyun")
+        mock_get.return_value = MockPricingResponse(
+            """
+            <table>
+              <tr>
+                <td>deepseek-v4-pro</td>
+                <td>中国内地</td>
+                <td>12 元</td>
+                <td>24 元</td>
+              </tr>
+              <tr>
+                <td>deepseek-v4-flash</td>
+                <td>中国内地</td>
+                <td>1 元</td>
+                <td>2 元</td>
+              </tr>
+              <tr>
+                <td>deepseek-v3.2</td>
+                <td>中国内地</td>
+                <td>2 元</td>
+                <td>3 元</td>
+              </tr>
+              <tr>
+                <td>deepseek-v3.1</td>
+                <td>中国内地</td>
+                <td>4 元</td>
+                <td>12 元</td>
+              </tr>
+            </table>
+            """,
+        )
+
+        stats = sync_official_provider_model_prices(provider=provider)
+
+        pro = LLMModel.objects.get(
+            provider=provider,
+            source__slug=self.official_model_source_slug(
+                "aliyun",
+                "deepseek-v4-pro",
+            ),
+            code="deepseek-v4-pro",
+        )
+        flash = LLMModel.objects.get(
+            provider=provider,
+            source__slug=self.official_model_source_slug(
+                "aliyun",
+                "deepseek-v4-flash",
+            ),
+            code="deepseek-v4-flash",
+        )
+        self.assertEqual(pro.input_price_per_million, Decimal("12.000000"))
+        self.assertEqual(pro.output_price_per_million, Decimal("24.000000"))
+        self.assertEqual(flash.input_price_per_million, Decimal("1.000000"))
+        self.assertEqual(flash.output_price_per_million, Decimal("2.000000"))
+        v3_2 = LLMModel.objects.get(
+            provider=provider,
+            source__slug=self.official_model_source_slug(
+                "aliyun",
+                "deepseek-v3.2",
+            ),
+            code="deepseek-v3.2",
+        )
+        v3_1 = LLMModel.objects.get(
+            provider=provider,
+            source__slug=self.official_model_source_slug(
+                "aliyun",
+                "deepseek-v3.1",
+            ),
+            code="deepseek-v3.1",
+        )
+        self.assertEqual(v3_2.input_price_per_million, Decimal("2.000000"))
+        self.assertEqual(v3_2.output_price_per_million, Decimal("3.000000"))
+        self.assertEqual(v3_1.input_price_per_million, Decimal("4.000000"))
+        self.assertEqual(v3_1.output_price_per_million, Decimal("12.000000"))
+        self.assertNotIn("deepseek-v4-pro", stats["skipped_model_codes"])
+        self.assertNotIn("deepseek-v4-flash", stats["skipped_model_codes"])
+
+    def test_sync_aliyun_official_prices_backfills_configured_models(self):
+        provider = LLMProvider.objects.get(code="aliyun")
+        LLMModel.objects.filter(provider=provider).delete()
+        LLMModel.objects.create(
+            provider=provider,
+            name="Qwen Plus",
+            code="qwen-plus",
+            modality=LLMModel.MODALITY_TEXT,
+            currency="CNY",
+        )
+
+        stats = sync_official_provider_model_prices(
+            provider=provider,
+            verify_source=False,
+        )
+
+        self.assertGreater(stats["models"], 1)
+        for model_code in ("qwen-turbo", "qwq-32b", "text-embedding-v4"):
+            self.assertTrue(
+                LLMModel.objects.filter(
+                    provider=provider,
+                    source__slug=self.official_model_source_slug(
+                        "aliyun",
+                        model_code,
+                    ),
+                    code=model_code,
+                ).exists(),
+            )
+            self.assertNotIn(model_code, stats["skipped_model_codes"])
+
+    @patch("requests.get")
+    def test_sync_aliyun_official_prices_collects_unconfigured_page_rows(
+        self,
+        mock_get,
+    ):
+        provider = LLMProvider.objects.get(code="aliyun")
+        mock_get.return_value = MockPricingResponse(
+            """
+            <table>
+              <tr>
+                <th>模型 ID（Model ID）</th>
+                <th>服务部署范围</th>
+                <th>输入单价（每百万 Token）</th>
+                <th>输出单价（每百万 Token）</th>
+                <th>免费额度</th>
+              </tr>
+              <tr>
+                <td>
+                  <p>qwen-new-2026</p>
+                  <blockquote>上下文缓存享有折扣</blockquote>
+                </td>
+                <td>中国内地</td>
+                <td>3.5 元</td>
+                <td>7 元</td>
+                <td>-</td>
+              </tr>
+            </table>
+            """,
+        )
+
+        stats = sync_official_provider_model_prices(provider=provider)
+
+        model = LLMModel.objects.get(
+            provider=provider,
+            source__slug=self.official_model_source_slug(
+                "aliyun",
+                "qwen-new-2026",
+            ),
+            code="qwen-new-2026",
+        )
+        self.assertEqual(stats["models"], 1)
+        self.assertEqual(model.input_price_per_million, Decimal("3.500000"))
+        self.assertEqual(model.output_price_per_million, Decimal("7.000000"))
+        self.assertTrue(
+            ModelPriceItem.objects.filter(
+                model=model,
+                source=model.source,
+                is_current=True,
+            ).exists(),
+        )
 
     def test_aliyun_official_config_uses_pricing_page(self):
         self.assertEqual(
@@ -631,8 +926,8 @@ class OfficialCollectionSyncTests(TestCase):
             ),
             code="deepseek-r1-250528",
         )
-        self.assertEqual(stats["models"], 1)
-        self.assertEqual(stats["skipped"], 11)
+        self.assertGreaterEqual(stats["models"], 1)
+        self.assertGreaterEqual(stats["skipped"], 0)
         self.assertEqual(model.currency, "CNY")
         self.assertEqual(model.meta_model.code, "deepseek-r1")
         self.assertIn("deepseek-r1-250528", model.meta_model.aliases)
@@ -668,7 +963,7 @@ class OfficialCollectionSyncTests(TestCase):
             model__code="deepseek-v3",
             dimension=ModelPriceItem.DIMENSION_TEXT_OUTPUT,
         )
-        self.assertEqual(stats["models"], 5)
+        self.assertGreaterEqual(stats["models"], 5)
         self.assertEqual(source.currency, "USD")
         self.assertEqual(input_item.unit_price, Decimal("0.280000"))
         self.assertEqual(cache_item.unit_price, Decimal("0.028000"))
@@ -841,6 +1136,25 @@ class OfficialCollectionSyncTests(TestCase):
         self.assertEqual(model.name, "Qwen Plus")
         self.assertEqual(model.input_price_per_million, Decimal("0.800000"))
         self.assertEqual(model.output_price_per_million, Decimal("2.000000"))
+
+    def test_sync_official_prices_records_vendor_skill_catalog_metadata(self):
+        provider = LLMProvider.objects.get(code="aliyun")
+
+        sync_official_provider_model_prices(
+            provider=provider,
+            verify_source=False,
+        )
+
+        run = PriceCollectionRun.objects.get(source__slug="aliyun-official")
+        self.assertEqual(
+            run.metadata["catalog_schema_version"],
+            MODEL_PRICE_CATALOG_SCHEMA_VERSION,
+        )
+        self.assertEqual(
+            run.metadata["catalog_source_type"],
+            "vendor_python_skill",
+        )
+        self.assertEqual(run.metadata["vendor_skill_provider"], "aliyun")
 
     @patch("llm_ops.collection_services.sync_official_provider_model_prices")
     def test_sync_configured_provider_prices_continues_after_failure(

--- a/backend/llm_ops/tests/test_skill_runner.py
+++ b/backend/llm_ops/tests/test_skill_runner.py
@@ -1,0 +1,193 @@
+from django.test import SimpleTestCase
+
+from llm_ops.skill_runner import (
+    MODEL_PRICE_CATALOG_SCHEMA_VERSION,
+    run_vendor_pricing_skill,
+    standard_catalog_to_collected_catalog,
+)
+
+
+VOLCENGINE_HTML = (
+    r'\"ops\":[{\"insert\":\"doubao-1.5-pro-32k\"}],'
+    r'\"zoneId\":\"row01nj2n42rlpl8e7b6tvpmvqhysnzfp89bh\",'
+    r'\"zoneType\":\"Z\"'
+    r'\"ops\":[{\"insert\":\"2\"}],'
+    r'\"zoneId\":\"row01s303uu1c1g40de7oaoizn05md89iimb6\",'
+    r'\"zoneType\":\"Z\"'
+    r'\"ops\":[{\"insert\":\"8\"}],'
+    r'\"zoneId\":\"row015wt3pecycob8so1pho26k692zw2cgbsm\",'
+    r'\"zoneType\":\"Z\"'
+    r'\"ops\":[{\"insert\":\"0.4\"}],'
+    r'\"zoneId\":\"row01cvklbb5m01p5jfrmdhooit6bknkyawsj\",'
+    r'\"zoneType\":\"Z\"'
+    r'\"ops\":[{\"insert\":\"标准推理\"}],'
+    r'\"zoneId\":\"row01gagtwd6h2ui45oj1di8jtwno5ytnfdt6\",'
+    r'\"zoneType\":\"Z\"'
+)
+
+
+BAIDU_HTML = """
+<table>
+  <tr>
+    <th>模型名称</th><th>版本</th><th>服务</th><th>计费项</th>
+    <th>在线价格</th><th>预留</th><th>预留</th><th>预留</th>
+    <th>单位</th>
+  </tr>
+  <tr>
+    <td>文本</td><td>ERNIE-4.5-21B-A3B</td><td>推理服务</td>
+    <td>输入</td><td>0.001</td><td>-</td><td>-</td><td>-</td>
+    <td>千Token</td>
+  </tr>
+  <tr>
+    <td>文本</td><td>ERNIE-4.5-21B-A3B</td><td>推理服务</td>
+    <td>输出</td><td>0.004</td><td>-</td><td>-</td><td>-</td>
+    <td>千Token</td>
+  </tr>
+</table>
+"""
+
+ALIYUN_HTML = """
+<table>
+  <tr>
+    <th>模型 ID（Model ID）</th><th>服务部署范围</th>
+    <th>输入单价（每百万 Token）</th><th>输出单价（每百万 Token）</th>
+    <th>免费额度</th>
+  </tr>
+  <tr>
+    <td><p>qwen-new-2026</p><blockquote>上下文缓存享有折扣</blockquote></td>
+    <td>中国内地</td><td>3.5 元</td><td>7 元</td><td>-</td>
+  </tr>
+</table>
+"""
+
+
+class ModelPriceSkillRunnerTests(SimpleTestCase):
+    def test_aliyun_vendor_skill_returns_standard_catalog_json(self):
+        payload = run_vendor_pricing_skill(
+            "aliyun",
+            {
+                "provider_name": "阿里云",
+                "currency": "CNY",
+                "source_url": (
+                    "https://help.aliyun.com/zh/model-studio/model-pricing"
+                ),
+                "model_codes": ["deepseek-v4-pro"],
+                "verify_source": False,
+            },
+        )
+
+        self.assertEqual(
+            payload["schema_version"],
+            MODEL_PRICE_CATALOG_SCHEMA_VERSION,
+        )
+        self.assertEqual(payload["source_type"], "vendor_python_skill")
+        self.assertEqual(payload["provider"]["code"], "aliyun")
+        self.assertEqual(payload["provider"]["currency"], "CNY")
+        self.assertEqual(payload["total_models"], 1)
+        self.assertEqual(payload["models"][0]["model_id"], "deepseek-v4-pro")
+        self.assertEqual(
+            payload["models"][0]["price_rows"][0]["values"]["input_price"],
+            "12",
+        )
+        self.assertEqual(
+            payload["models"][0]["price_rows"][0]["values"]["output_price"],
+            "24",
+        )
+
+    def test_standard_catalog_converts_to_collected_catalog(self):
+        payload = run_vendor_pricing_skill(
+            "aliyun",
+            {
+                "provider_name": "阿里云",
+                "currency": "CNY",
+                "model_codes": ["deepseek-v4-flash"],
+                "verify_source": False,
+            },
+        )
+
+        catalog = standard_catalog_to_collected_catalog(payload)
+
+        self.assertEqual(catalog.total_models, 1)
+        self.assertEqual(catalog.models[0].model_id, "deepseek-v4-flash")
+        self.assertEqual(catalog.models[0].currency, "CNY")
+        self.assertEqual(
+            catalog.models[0].price_rows[0].values["input_price"],
+            "1",
+        )
+
+    def test_aliyun_vendor_skill_extracts_unconfigured_page_rows(self):
+        payload = run_vendor_pricing_skill(
+            "aliyun",
+            {
+                "provider_name": "阿里云",
+                "currency": "CNY",
+                "raw_html": ALIYUN_HTML,
+            },
+        )
+
+        self.assertEqual(payload["provider"]["code"], "aliyun")
+        self.assertEqual(payload["total_models"], 1)
+        self.assertEqual(payload["models"][0]["model_id"], "qwen-new-2026")
+        self.assertEqual(
+            payload["models"][0]["price_rows"][0]["values"]["input_price"],
+            "3.5",
+        )
+        self.assertEqual(
+            payload["models"][0]["price_rows"][0]["values"]["output_price"],
+            "7",
+        )
+
+    def test_volcengine_vendor_skill_returns_standard_catalog_json(self):
+        payload = run_vendor_pricing_skill(
+            "volcengine",
+            {
+                "provider_name": "火山方舟",
+                "currency": "CNY",
+                "raw_html": VOLCENGINE_HTML,
+            },
+        )
+
+        self.assertEqual(
+            payload["schema_version"],
+            MODEL_PRICE_CATALOG_SCHEMA_VERSION,
+        )
+        self.assertEqual(payload["provider"]["code"], "volcengine")
+        self.assertEqual(payload["provider"]["currency"], "CNY")
+        self.assertEqual(
+            payload["models"][0]["model_id"],
+            "doubao-1.5-pro-32k",
+        )
+        self.assertEqual(
+            payload["models"][0]["price_rows"][0]["values"]["input_price"],
+            "2",
+        )
+        self.assertEqual(
+            payload["models"][0]["price_rows"][0]["values"]["output_price"],
+            "8",
+        )
+
+    def test_baidu_vendor_skill_returns_standard_catalog_json(self):
+        payload = run_vendor_pricing_skill(
+            "baidu",
+            {
+                "provider_name": "百度千帆",
+                "currency": "CNY",
+                "raw_html": BAIDU_HTML,
+            },
+        )
+
+        self.assertEqual(
+            payload["schema_version"],
+            MODEL_PRICE_CATALOG_SCHEMA_VERSION,
+        )
+        self.assertEqual(payload["provider"]["code"], "baidu")
+        self.assertEqual(payload["provider"]["currency"], "CNY")
+        self.assertEqual(payload["models"][0]["model_id"], "ERNIE-4.5-21B-A3B")
+        self.assertEqual(
+            payload["models"][0]["price_rows"][0]["values"]["input_price"],
+            "1",
+        )
+        self.assertEqual(
+            payload["models"][0]["price_rows"][0]["values"]["output_price"],
+            "4",
+        )

--- a/backend/llm_ops/tests/test_source_collectors.py
+++ b/backend/llm_ops/tests/test_source_collectors.py
@@ -14,7 +14,7 @@ from llm_ops.source_collectors.official import OFFICIAL_COLLECTOR_CLASSES
 class PriceSourceCollectorRegistryTests(TestCase):
     def test_all_official_configs_have_registered_collectors(self):
         self.assertEqual(
-            {"aliyun", "aliyun-wanx"},
+            {"aliyun", "aliyun-wanx", "baidu", "volcengine"},
             set(OFFICIAL_COLLECTOR_CLASSES),
         )
 
@@ -73,6 +73,49 @@ class PriceSourceCollectorRegistryTests(TestCase):
             ),
             endpoint_url=(
                 "https://api-docs.deepseek.com/quick_start/pricing"
+            ),
+            is_enabled=True,
+            updates_model_prices=True,
+        )
+
+        collector = get_price_source_collector(source)
+
+        self.assertIsNone(collector)
+        self.assertFalse(source_supports_code_collection(source))
+
+    def test_baidu_official_provider_source_dispatches_to_collector(self):
+        provider = LLMProvider.objects.create(name="百度", code="baidu")
+        source = PriceCollectionSource.objects.create(
+            name="Baidu Official",
+            slug="baidu-official",
+            provider=provider,
+            source_type=PriceCollectionSource.SOURCE_TYPE_CUSTOM,
+            source_category=(
+                PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
+            ),
+            endpoint_url="https://cloud.baidu.com/doc/qianfan/s/wmh4sv6ya",
+            is_enabled=True,
+            updates_model_prices=True,
+        )
+
+        collector = get_price_source_collector(source)
+
+        self.assertIsNotNone(collector)
+        self.assertEqual(collector.collector_id, "official_provider:baidu")
+        self.assertTrue(source_supports_code_collection(source))
+
+    def test_model_level_official_source_is_not_supported(self):
+        provider = LLMProvider.objects.create(name="阿里云", code="aliyun")
+        source = PriceCollectionSource.objects.create(
+            name="Aliyun Qwen Plus Official",
+            slug="aliyun-qwen-plus-official",
+            provider=provider,
+            source_type=PriceCollectionSource.SOURCE_TYPE_CUSTOM,
+            source_category=(
+                PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
+            ),
+            endpoint_url=(
+                "https://help.aliyun.com/zh/model-studio/model-pricing"
             ),
             is_enabled=True,
             updates_model_prices=True,

--- a/backend/llm_ops/tests/test_views.py
+++ b/backend/llm_ops/tests/test_views.py
@@ -344,10 +344,17 @@ class LLMOpsViewTests(TestCase):
     def test_global_config_sync_deletes_managed_source_tasks(self):
         from django_celery_beat.models import CrontabSchedule, PeriodicTask
 
+        provider = LLMProvider.objects.create(name="阿里云", code="aliyun")
         current_source = PriceCollectionSource.objects.create(
-            name="Current Source",
-            slug="current-source",
-            endpoint_url="https://current.example.com",
+            name="Aliyun Official",
+            slug="aliyun-official",
+            provider=provider,
+            source_category=(
+                PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
+            ),
+            endpoint_url=(
+                "https://help.aliyun.com/zh/model-studio/model-pricing"
+            ),
             updates_model_prices=True,
         )
         obsolete_source = PriceCollectionSource.objects.create(
@@ -614,9 +621,9 @@ class LLMOpsViewTests(TestCase):
             name="Yunce",
             code="yunce",
         )
-        platform = ResalePlatform.objects.create(
-            name="Agione",
+        platform, _ = ResalePlatform.objects.get_or_create(
             code="agione",
+            defaults={"name": "Agione"},
         )
         listing = ResaleListing.objects.create(
             platform=platform,
@@ -789,6 +796,19 @@ class LLMOpsViewTests(TestCase):
             is_enabled=True,
             updates_model_prices=True,
         )
+        PriceCollectionSource.objects.create(
+            name="Aliyun Qwen Plus Official",
+            slug="aliyun-qwen-plus-official",
+            provider=aliyun,
+            source_category=(
+                PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
+            ),
+            endpoint_url=(
+                "https://help.aliyun.com/zh/model-studio/model-pricing"
+            ),
+            is_enabled=True,
+            updates_model_prices=True,
+        )
         openai = LLMProvider.objects.create(name="OpenAI", code="openai")
         PriceCollectionSource.objects.create(
             name="OpenAI Official",
@@ -829,6 +849,73 @@ class LLMOpsViewTests(TestCase):
 
         self.assertEqual(response.status_code, 400)
         mock_delay.assert_not_called()
+
+    def test_official_provider_options_include_aliyun_presets(self):
+        response = self.client.get(
+            reverse("collection-source-official-provider-options")
+        )
+
+        self.assertEqual(response.status_code, 200)
+        provider_codes = {
+            item["provider_code"] for item in response.data["results"]
+        }
+        self.assertIn("aliyun", provider_codes)
+        self.assertIn("aliyun-wanx", provider_codes)
+        self.assertIn("baidu", provider_codes)
+        self.assertIn("volcengine", provider_codes)
+
+    def test_ensure_official_provider_source_creates_aliyun_source(self):
+        response = self.client.post(
+            reverse("collection-source-ensure-official-provider"),
+            {"provider_code": "aliyun"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 201)
+        self.assertTrue(response.data["provider_created"])
+        self.assertTrue(response.data["source_created"])
+        self.assertEqual(response.data["source"]["slug"], "aliyun-official")
+        self.assertEqual(response.data["source"]["provider_code"], "aliyun")
+        self.assertEqual(response.data["source"]["currency"], "CNY")
+        provider = LLMProvider.objects.get(code="aliyun")
+        source = PriceCollectionSource.objects.get(slug="aliyun-official")
+        self.assertEqual(source.provider, provider)
+        self.assertEqual(
+            source.source_category,
+            PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER,
+        )
+        self.assertTrue(source.updates_model_prices)
+        audit = AuditLog.objects.get(target_id=str(source.id))
+        self.assertEqual(audit.action, AuditLog.ACTION_CREATE)
+        self.assertEqual(audit.category, AuditLog.CATEGORY_CONFIGURATION)
+        self.assertEqual(audit.metadata["provider_code"], "aliyun")
+
+    def test_ensure_official_provider_source_is_idempotent(self):
+        first = self.client.post(
+            reverse("collection-source-ensure-official-provider"),
+            {"provider_code": "aliyun"},
+            format="json",
+        )
+        second = self.client.post(
+            reverse("collection-source-ensure-official-provider"),
+            {"provider_code": "aliyun"},
+            format="json",
+        )
+
+        self.assertEqual(first.status_code, 201)
+        self.assertEqual(second.status_code, 200)
+        self.assertFalse(second.data["provider_created"])
+        self.assertFalse(second.data["source_created"])
+        self.assertEqual(
+            first.data["source"]["id"],
+            second.data["source"]["id"],
+        )
+        self.assertEqual(
+            PriceCollectionSource.objects.filter(
+                slug="aliyun-official",
+            ).count(),
+            1,
+        )
 
     @patch("llm_ops.views.collect_price_source_prices.delay")
     def test_collection_source_collect_rejects_disabled_source(
@@ -927,6 +1014,52 @@ class LLMOpsViewTests(TestCase):
             source_id=source.id,
             verify_source=True,
         )
+
+    def test_collection_run_list_filters_task_logs(self):
+        provider = LLMProvider.objects.create(
+            name="Alibaba Cloud",
+            code="aliyun",
+        )
+        source = PriceCollectionSource.objects.create(
+            name="Aliyun Official",
+            slug="aliyun-official",
+            provider=provider,
+            source_type=PriceCollectionSource.SOURCE_TYPE_CUSTOM,
+            source_category=(
+                PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
+            ),
+        )
+        other_source = PriceCollectionSource.objects.create(
+            name="Supplier API",
+            slug="supplier-api",
+            source_type=PriceCollectionSource.SOURCE_TYPE_CUSTOM,
+            source_category=PriceCollectionSource.SOURCE_CATEGORY_SUPPLIER,
+        )
+        target_run = PriceCollectionRun.objects.create(
+            source=source,
+            status=PriceCollectionRun.STATUS_FAILED,
+            error_message="remote page changed",
+        )
+        PriceCollectionRun.objects.create(
+            source=other_source,
+            status=PriceCollectionRun.STATUS_SUCCEEDED,
+        )
+
+        response = self.client.get(
+            reverse("collection-run-list"),
+            {
+                "provider": "aliyun",
+                "q": "page changed",
+                "source_category": (
+                    PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
+                ),
+                "status": PriceCollectionRun.STATUS_FAILED,
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["id"], target_run.id)
 
     def test_collected_price_snapshot_list_returns_normalized_rows(self):
         source = PriceCollectionSource.objects.create(
@@ -1841,10 +1974,12 @@ class LLMOpsViewTests(TestCase):
         )
 
     def test_resale_workflow_config_effective_returns_platform_runtime(self):
-        platform = ResalePlatform.objects.create(
-            name="Agione",
+        platform, _ = ResalePlatform.objects.update_or_create(
             code="agione",
-            auto_approve_max_margin_rate="25.50",
+            defaults={
+                "name": "Agione",
+                "auto_approve_max_margin_rate": "25.50",
+            },
         )
 
         response = self.client.get(
@@ -1866,9 +2001,9 @@ class LLMOpsViewTests(TestCase):
         )
 
     def test_resale_workflow_config_effective_persists_edits(self):
-        platform = ResalePlatform.objects.create(
-            name="Agione",
+        platform, _ = ResalePlatform.objects.get_or_create(
             code="agione",
+            defaults={"name": "Agione"},
         )
         response = self.client.get(
             reverse("resale-workflow-config-effective"),
@@ -1897,9 +2032,9 @@ class LLMOpsViewTests(TestCase):
         self.assertIn("runtime", patch_response.data["config"])
 
     def test_resale_workflow_config_patch_requires_config(self):
-        platform = ResalePlatform.objects.create(
-            name="Agione",
+        platform, _ = ResalePlatform.objects.get_or_create(
             code="agione",
+            defaults={"name": "Agione"},
         )
 
         response = self.client.patch(
@@ -1916,9 +2051,9 @@ class LLMOpsViewTests(TestCase):
         )
 
     def test_resale_workflow_config_rejects_unknown_edge_node(self):
-        platform = ResalePlatform.objects.create(
-            name="Agione",
+        platform, _ = ResalePlatform.objects.get_or_create(
             code="agione",
+            defaults={"name": "Agione"},
         )
         payload = {
             "config": {
@@ -1953,9 +2088,9 @@ class LLMOpsViewTests(TestCase):
         self.assertIn("unknown node", str(response.data))
 
     def test_resale_workflow_config_rejects_missing_publish_path(self):
-        platform = ResalePlatform.objects.create(
-            name="Agione",
+        platform, _ = ResalePlatform.objects.get_or_create(
             code="agione",
+            defaults={"name": "Agione"},
         )
         response = self.client.get(
             reverse("resale-workflow-config-effective"),

--- a/backend/llm_ops/views.py
+++ b/backend/llm_ops/views.py
@@ -12,6 +12,9 @@ from rest_framework.views import APIView
 
 from .audit import record_audit_log, snapshot_instance
 from .collection_services import (
+    ensure_supported_official_provider_source,
+    official_provider_source_slug,
+    supported_official_provider_options,
     sync_meta_models_from_models_dev,
     sync_yunce_model_prices,
 )
@@ -214,6 +217,84 @@ class PriceCollectionSourceViewSet(
             "models__meta_model",
             "models__meta_model__vendor",
         ).order_by("source_category", "provider__name", "channel__name", "id")
+
+    @action(
+        detail=False,
+        methods=["get"],
+        url_path="official-provider-options",
+        url_name="official-provider-options",
+    )
+    def official_provider_options(self, request):
+        """List official provider source presets operators can add."""
+        return Response(
+            {"results": supported_official_provider_options()},
+            status=status.HTTP_200_OK,
+        )
+
+    @action(
+        detail=False,
+        methods=["post"],
+        url_path="official-provider",
+        url_name="ensure-official-provider",
+    )
+    def ensure_official_provider(self, request):
+        """Create or return one supported official provider source."""
+        provider_code = str(request.data.get("provider_code") or "").strip()
+        before_source = PriceCollectionSource.objects.filter(
+            slug=official_provider_source_slug(provider_code)
+        ).first()
+        before = snapshot_instance(before_source) if before_source else {}
+        try:
+            (
+                _provider,
+                source,
+                provider_created,
+                source_created,
+            ) = ensure_supported_official_provider_source(provider_code)
+        except ValueError as exc:
+            return Response(
+                {"detail": str(exc)},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        after = snapshot_instance(source)
+        if source_created or provider_created or before != after:
+            record_audit_log(
+                request=request,
+                action=(
+                    AuditLog.ACTION_CREATE
+                    if source_created
+                    else AuditLog.ACTION_UPDATE
+                ),
+                category=AuditLog.CATEGORY_CONFIGURATION,
+                target=source,
+                summary=(
+                    "Ensured official provider price source "
+                    f"for {provider_code}"
+                ),
+                before=before,
+                after=after,
+                metadata={
+                    "provider_code": provider_code,
+                    "provider_created": provider_created,
+                    "source_created": source_created,
+                },
+            )
+
+        serializer = self.get_serializer(source)
+        response_status = (
+            status.HTTP_201_CREATED
+            if source_created
+            else status.HTTP_200_OK
+        )
+        return Response(
+            {
+                "source": serializer.data,
+                "provider_created": provider_created,
+                "source_created": source_created,
+            },
+            status=response_status,
+        )
 
     @action(detail=True, methods=["post"], url_path="collect")
     def collect(self, request, pk=None):
@@ -419,8 +500,33 @@ class PriceCollectionRunViewSet(
             "source__provider",
         )
         source = self.request.query_params.get("source")
+        status_value = self.request.query_params.get("status")
+        source_category = self.request.query_params.get("source_category")
+        provider = self.request.query_params.get("provider")
+        keyword = self.request.query_params.get("q")
         if source:
             queryset = queryset.filter(source_id=source)
+        if status_value:
+            queryset = queryset.filter(status=status_value)
+        if source_category:
+            queryset = queryset.filter(
+                source__source_category=source_category
+            )
+        if provider:
+            provider_query = (
+                Q(source__provider__code__icontains=provider)
+                | Q(source__provider__name__icontains=provider)
+            )
+            if provider.isdigit():
+                provider_query |= Q(source__provider_id=provider)
+            queryset = queryset.filter(provider_query)
+        if keyword:
+            queryset = queryset.filter(
+                Q(source__name__icontains=keyword)
+                | Q(source__slug__icontains=keyword)
+                | Q(source__provider__name__icontains=keyword)
+                | Q(error_message__icontains=keyword)
+            )
         return queryset.order_by("-started_at", "-id")
 
 

--- a/frontend/src/api/llmOps.js
+++ b/frontend/src/api/llmOps.js
@@ -19,6 +19,18 @@ export const llmOpsApi = {
     return apiClient.get(`${base}/collection-sources/`, paramsOrEmpty(params))
   },
 
+  listOfficialProviderSourceOptions() {
+    return apiClient.get(
+      `${base}/collection-sources/official-provider-options/`
+    )
+  },
+
+  ensureOfficialProviderSource(providerCode) {
+    return apiClient.post(`${base}/collection-sources/official-provider/`, {
+      provider_code: providerCode
+    })
+  },
+
   createCollectionSource(payload) {
     return apiClient.post(`${base}/collection-sources/`, payload)
   },

--- a/frontend/src/components/llm-ops/CollectionRunLogPanel.vue
+++ b/frontend/src/components/llm-ops/CollectionRunLogPanel.vue
@@ -1,0 +1,924 @@
+<template>
+  <section class="collection-run-log-panel">
+    <div class="collection-log-summary-grid">
+      <div
+        v-for="metric in summaryMetrics"
+        :key="metric.key"
+        class="collection-log-metric"
+        :class="metric.tone"
+      >
+        <span>{{ metric.label }}</span>
+        <strong>{{ metric.value }}</strong>
+      </div>
+    </div>
+
+    <div class="panel collection-log-table-panel">
+      <div class="collection-log-toolbar">
+        <div>
+          <h3 class="panel-title">{{ t('llmOps.taskLogs.title') }}</h3>
+          <p>{{ t('llmOps.taskLogs.description') }}</p>
+        </div>
+        <button
+          type="button"
+          class="btn-secondary collection-log-refresh btn-action-refresh"
+          @click="emit('refresh')"
+        >
+          <svg
+            aria-hidden="true"
+            class="collection-log-action-icon"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+          >
+            <path d="M21 12a9 9 0 0 1-15.4 6.4L3 16" />
+            <path d="M3 16v5h5" />
+            <path d="M3 12a9 9 0 0 1 15.4-6.4L21 8" />
+            <path d="M21 3v5h-5" />
+          </svg>
+          {{ t('llmOps.taskLogs.actions.refresh') }}
+        </button>
+      </div>
+
+      <div class="collection-log-filters">
+        <label class="collection-log-filter is-wide">
+          <span>{{ t('llmOps.taskLogs.filters.keyword') }}</span>
+          <input
+            v-model.trim="searchKeyword"
+            class="collection-log-input"
+            :placeholder="t('llmOps.taskLogs.filters.keywordPlaceholder')"
+          />
+        </label>
+        <label class="collection-log-filter">
+          <span>{{ t('llmOps.taskLogs.filters.status') }}</span>
+          <CompactSelect
+            v-model="statusFilter"
+            :options="statusOptions"
+            class-name="collection-log-select w-full"
+          />
+        </label>
+        <label class="collection-log-filter">
+          <span>{{ t('llmOps.taskLogs.filters.category') }}</span>
+          <CompactSelect
+            v-model="categoryFilter"
+            :options="categoryOptions"
+            class-name="collection-log-select w-full"
+          />
+        </label>
+      </div>
+
+      <div class="collection-log-table-scroll">
+        <table class="data-table collection-log-table">
+          <colgroup>
+            <col class="status-col" />
+            <col class="source-col" />
+            <col class="category-col" />
+            <col class="time-col" />
+            <col class="duration-col" />
+            <col class="result-col" />
+            <col class="detail-col" />
+          </colgroup>
+          <thead>
+            <tr>
+              <th class="table-head">{{ t('llmOps.taskLogs.table.status') }}</th>
+              <th class="table-head">{{ t('llmOps.taskLogs.table.source') }}</th>
+              <th class="table-head">{{ t('llmOps.taskLogs.table.category') }}</th>
+              <th class="table-head">
+                {{ t('llmOps.taskLogs.table.startedAt') }}
+              </th>
+              <th class="table-head">
+                {{ t('llmOps.taskLogs.table.duration') }}
+              </th>
+              <th class="table-head">{{ t('llmOps.taskLogs.table.result') }}</th>
+              <th class="table-head">{{ t('llmOps.taskLogs.table.detail') }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <template v-for="row in pagedRows" :key="row.id">
+              <tr>
+                <td class="table-cell">
+                  <span :class="['run-status-pill', row.statusTone]">
+                    {{ row.statusLabel }}
+                  </span>
+                </td>
+                <td class="table-cell">
+                  <p class="font-medium text-slate-900">
+                    {{ row.sourceLabel }}
+                  </p>
+                  <p v-if="row.providerLabel" class="source-subtitle">
+                    {{ row.providerLabel }}
+                  </p>
+                </td>
+                <td class="table-cell">
+                  <span :class="['source-category-pill', row.categoryTone]">
+                    {{ row.categoryLabel }}
+                  </span>
+                </td>
+                <td class="table-cell run-time">
+                  {{ formatDateTime(row.started_at) }}
+                </td>
+                <td class="table-cell run-duration">
+                  {{ formatDuration(row) }}
+                </td>
+                <td class="table-cell">
+                  <div class="run-result-grid">
+                    <span>
+                      {{ t('llmOps.taskLogs.counts.collected') }}
+                      <strong>{{ row.collected_count || 0 }}</strong>
+                    </span>
+                    <span>
+                      {{ t('llmOps.taskLogs.counts.created') }}
+                      <strong>{{ row.created_count || 0 }}</strong>
+                    </span>
+                    <span>
+                      {{ t('llmOps.taskLogs.counts.updated') }}
+                      <strong>{{ row.updated_count || 0 }}</strong>
+                    </span>
+                    <span>
+                      {{ t('llmOps.taskLogs.counts.skipped') }}
+                      <strong>{{ row.skipped_count || 0 }}</strong>
+                    </span>
+                  </div>
+                </td>
+                <td class="table-cell">
+                  <button
+                    type="button"
+                    class="collection-log-detail-button"
+                    :disabled="!row.hasDetails"
+                    :aria-expanded="expandedId === row.id"
+                    :aria-controls="`collection-run-detail-${row.id}`"
+                    @click="toggleExpanded(row.id)"
+                  >
+                    {{
+                      expandedId === row.id
+                        ? t('llmOps.taskLogs.actions.hideDetails')
+                        : detailButtonLabel(row)
+                    }}
+                  </button>
+                </td>
+              </tr>
+              <tr v-if="expandedId === row.id">
+                <td
+                  :id="`collection-run-detail-${row.id}`"
+                  class="detail-cell"
+                  colspan="7"
+                >
+                  <div class="collection-log-detail-grid">
+                    <section v-if="row.error_message" class="detail-block">
+                      <h4>{{ t('llmOps.taskLogs.detail.error') }}</h4>
+                      <p class="detail-error">{{ row.error_message }}</p>
+                    </section>
+                    <section
+                      v-if="metadataEntries(row).length"
+                      class="detail-block"
+                    >
+                      <h4>{{ t('llmOps.taskLogs.detail.metadata') }}</h4>
+                      <dl class="metadata-list">
+                        <template
+                          v-for="item in metadataEntries(row)"
+                          :key="item.key"
+                        >
+                          <dt>{{ item.label }}</dt>
+                          <dd>{{ item.value }}</dd>
+                        </template>
+                      </dl>
+                    </section>
+                  </div>
+                </td>
+              </tr>
+            </template>
+            <tr v-if="!pagedRows.length">
+              <td class="table-cell" colspan="7">
+                <div class="empty-state">
+                  <p class="font-medium text-slate-700">
+                    {{ t('llmOps.taskLogs.empty.title') }}
+                  </p>
+                  <p class="mt-1 text-sm text-slate-500">
+                    {{ t('llmOps.taskLogs.empty.description') }}
+                  </p>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="collection-log-footer">
+        <span>{{ pageRangeLabel }}</span>
+        <div class="collection-log-pagination">
+          <label>
+            <span>{{ t('llmOps.taskLogs.pagination.pageSize') }}</span>
+            <CompactSelect
+              v-model="pageSize"
+              :options="pageSizeOptions"
+              class-name="collection-log-page-size"
+            />
+          </label>
+          <button
+            type="button"
+            class="btn-secondary collection-log-page-button"
+            :disabled="currentPage <= 1"
+            @click="currentPage -= 1"
+          >
+            {{ t('llmOps.taskLogs.pagination.previous') }}
+          </button>
+          <span class="collection-log-page-label">
+            {{ currentPage }} / {{ totalPages }}
+          </span>
+          <button
+            type="button"
+            class="btn-secondary collection-log-page-button"
+            :disabled="currentPage >= totalPages"
+            @click="currentPage += 1"
+          >
+            {{ t('llmOps.taskLogs.pagination.next') }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import CompactSelect from '@/components/llm-ops/CompactSelect.vue'
+
+const props = defineProps({
+  runs: {
+    type: Array,
+    default: () => []
+  },
+  sources: {
+    type: Array,
+    default: () => []
+  }
+})
+const emit = defineEmits(['refresh'])
+const { t } = useI18n()
+
+const searchKeyword = ref('')
+const statusFilter = ref('')
+const categoryFilter = ref('')
+const pageSize = ref('50')
+const currentPage = ref(1)
+const expandedId = ref(null)
+
+const statusOptions = computed(() => [
+  { label: t('llmOps.taskLogs.status.all'), value: '' },
+  { label: t('llmOps.taskLogs.status.succeeded'), value: 'succeeded' },
+  { label: t('llmOps.taskLogs.status.failed'), value: 'failed' },
+  { label: t('llmOps.taskLogs.status.running'), value: 'running' }
+])
+
+const categoryOptions = computed(() => [
+  { label: t('llmOps.taskLogs.categories.all'), value: '' },
+  {
+    label: t('llmOps.taskLogs.categories.officialProvider'),
+    value: 'official_provider'
+  },
+  { label: t('llmOps.taskLogs.categories.supplier'), value: 'supplier' },
+  { label: t('llmOps.taskLogs.categories.manual'), value: 'manual' },
+  { label: t('llmOps.taskLogs.categories.unknown'), value: 'unknown' }
+])
+
+const pageSizeOptions = computed(() =>
+  ['20', '50', '100'].map((size) => ({
+    label: t('llmOps.taskLogs.pagination.pageSizeOption', { size }),
+    value: size
+  }))
+)
+
+const sourcesById = computed(() => {
+  return new Map(props.sources.map((source) => [String(source.id), source]))
+})
+
+const enrichedRows = computed(() =>
+  props.runs.map((run) => {
+    const source = sourceForRun(run)
+    const category = sourceCategory(run, source)
+    return {
+      ...run,
+      category,
+      categoryLabel: categoryLabel(category),
+      categoryTone: categoryTone(category),
+      hasDetails:
+        Boolean(run.error_message) || metadataEntries(run).length > 0,
+      providerLabel: providerLabel(run, source),
+      sourceLabel: sourceLabel(run, source),
+      statusLabel: statusLabel(run.status),
+      statusTone: statusTone(run.status)
+    }
+  })
+)
+
+const filteredRows = computed(() => {
+  const keyword = searchKeyword.value.trim().toLowerCase()
+  return enrichedRows.value.filter((row) => {
+    if (statusFilter.value && row.status !== statusFilter.value) return false
+    if (categoryFilter.value && row.category !== categoryFilter.value) {
+      return false
+    }
+    if (!keyword) return true
+    return [
+      row.sourceLabel,
+      row.providerLabel,
+      row.statusLabel,
+      row.error_message
+    ]
+      .filter(Boolean)
+      .some((value) => String(value).toLowerCase().includes(keyword))
+  })
+})
+
+const pageSizeNumber = computed(() => Number(pageSize.value || 50))
+
+const totalPages = computed(() =>
+  Math.max(Math.ceil(filteredRows.value.length / pageSizeNumber.value), 1)
+)
+
+const pagedRows = computed(() => {
+  const page = Math.min(currentPage.value, totalPages.value)
+  const start = (page - 1) * pageSizeNumber.value
+  return filteredRows.value.slice(start, start + pageSizeNumber.value)
+})
+
+const pageRangeLabel = computed(() => {
+  if (!filteredRows.value.length) {
+    return t('llmOps.taskLogs.pagination.emptyRange')
+  }
+  const start = (currentPage.value - 1) * pageSizeNumber.value + 1
+  const end = Math.min(
+    currentPage.value * pageSizeNumber.value,
+    filteredRows.value.length
+  )
+  return t('llmOps.taskLogs.pagination.range', {
+    count: filteredRows.value.length,
+    end,
+    start
+  })
+})
+
+const summaryMetrics = computed(() => {
+  const total = props.runs.length
+  const running = props.runs.filter((run) => run.status === 'running').length
+  const failed = props.runs.filter((run) => run.status === 'failed').length
+  const succeeded = props.runs.filter(
+    (run) => run.status === 'succeeded'
+  ).length
+  return [
+    {
+      key: 'total',
+      label: t('llmOps.taskLogs.metrics.total'),
+      value: total,
+      tone: 'tone-neutral'
+    },
+    {
+      key: 'running',
+      label: t('llmOps.taskLogs.metrics.running'),
+      value: running,
+      tone: running ? 'tone-info' : 'tone-neutral'
+    },
+    {
+      key: 'succeeded',
+      label: t('llmOps.taskLogs.metrics.succeeded'),
+      value: succeeded,
+      tone: 'tone-success'
+    },
+    {
+      key: 'failed',
+      label: t('llmOps.taskLogs.metrics.failed'),
+      value: failed,
+      tone: failed ? 'tone-danger' : 'tone-neutral'
+    }
+  ]
+})
+
+watch(
+  [searchKeyword, statusFilter, categoryFilter, pageSize],
+  () => {
+    currentPage.value = 1
+    expandedId.value = null
+  }
+)
+
+watch(totalPages, (value) => {
+  if (currentPage.value > value) currentPage.value = value
+})
+
+function sourceForRun(run) {
+  if (!run?.source) return null
+  return sourcesById.value.get(String(run.source)) || null
+}
+
+function sourceCategory(run, source) {
+  return (
+    source?.business_source_category ||
+    source?.source_category ||
+    run?.source_category ||
+    'unknown'
+  )
+}
+
+function sourceLabel(run, source) {
+  return (
+    run?.source_name ||
+    source?.name ||
+    t('llmOps.taskLogs.deletedSource')
+  )
+}
+
+function providerLabel(run, source) {
+  return run?.source_provider_name || source?.provider_name || ''
+}
+
+function statusLabel(status) {
+  const labels = {
+    failed: t('llmOps.taskLogs.status.failed'),
+    running: t('llmOps.taskLogs.status.running'),
+    succeeded: t('llmOps.taskLogs.status.succeeded')
+  }
+  return labels[status] || status || t('llmOps.taskLogs.status.unknown')
+}
+
+function statusTone(status) {
+  if (status === 'succeeded') return 'tone-success'
+  if (status === 'failed') return 'tone-danger'
+  if (status === 'running') return 'tone-info'
+  return 'tone-neutral'
+}
+
+function categoryLabel(category) {
+  const labels = {
+    manual: t('llmOps.taskLogs.categories.manual'),
+    official_provider: t('llmOps.taskLogs.categories.officialProvider'),
+    supplier: t('llmOps.taskLogs.categories.supplier'),
+    unknown: t('llmOps.taskLogs.categories.unknown')
+  }
+  return labels[category] || category || labels.unknown
+}
+
+function categoryTone(category) {
+  if (category === 'official_provider') return 'tone-primary'
+  if (category === 'supplier') return 'tone-info'
+  if (category === 'manual') return 'tone-warn'
+  return 'tone-neutral'
+}
+
+function toggleExpanded(id) {
+  const row = enrichedRows.value.find((item) => item.id === id)
+  if (!row?.hasDetails) return
+  expandedId.value = expandedId.value === id ? null : id
+}
+
+function detailButtonLabel(row) {
+  if (!row.hasDetails) return t('llmOps.taskLogs.actions.noDetails')
+  return t('llmOps.taskLogs.actions.showDetails')
+}
+
+function metadataEntries(row) {
+  const metadata = row?.metadata
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return []
+  }
+  return Object.entries(metadata)
+    .filter(([, value]) => hasMetadataValue(value))
+    .map(([key, value]) => ({
+      key,
+      label: metadataLabel(key),
+      value: formatMetadataValue(value)
+    }))
+}
+
+function hasMetadataValue(value) {
+  if (value === null || value === undefined || value === '') return false
+  if (Array.isArray(value)) return value.length > 0
+  if (typeof value === 'object') return Object.keys(value).length > 0
+  return true
+}
+
+function metadataLabel(key) {
+  const labelKeys = {
+    changed_count: 'changedCount',
+    collected_model_codes: 'collectedModelCodes',
+    currency: 'currency',
+    fallback_model_ids: 'fallbackModelIds',
+    missing_model_ids: 'missingModelIds',
+    skipped_model_codes: 'skippedModelCodes',
+    source_parse_fallback_model_ids: 'sourceParseFallbackModelIds',
+    source_parse_missing_model_ids: 'sourceParseMissingModelIds',
+    source_url: 'sourceUrl',
+    unchanged_count: 'unchangedCount'
+  }
+  const labelKey = labelKeys[key]
+  return labelKey ? t(`llmOps.taskLogs.metadata.${labelKey}`) : key
+}
+
+function formatMetadataValue(value) {
+  if (Array.isArray(value)) {
+    const preview = value.slice(0, 8).join(', ')
+    return value.length > 8 ? `${preview} +${value.length - 8}` : preview
+  }
+  if (typeof value === 'boolean') {
+    return value ? t('common.yes') : t('common.no')
+  }
+  if (value && typeof value === 'object') {
+    return JSON.stringify(value)
+  }
+  return String(value)
+}
+
+function formatDateTime(value) {
+  if (!value) return '-'
+  return new Date(value).toLocaleString()
+}
+
+function formatDuration(row) {
+  const start = new Date(row.started_at || 0).getTime()
+  const end = row.finished_at
+    ? new Date(row.finished_at).getTime()
+    : Date.now()
+  if (!Number.isFinite(start) || !Number.isFinite(end) || !start) return '-'
+  const seconds = Math.max(Math.round((end - start) / 1000), 0)
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.floor(seconds / 60)
+  const restSeconds = seconds % 60
+  if (minutes < 60) return `${minutes}m ${restSeconds}s`
+  const hours = Math.floor(minutes / 60)
+  return `${hours}h ${minutes % 60}m`
+}
+</script>
+
+<style scoped>
+.collection-run-log-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.collection-log-summary-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+@media (min-width: 1024px) {
+  .collection-log-summary-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+.collection-log-metric {
+  border: 1px solid #e2e8f0;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  padding: 1rem;
+}
+
+.collection-log-metric span {
+  color: #64748b;
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.collection-log-metric strong {
+  color: #0f172a;
+  display: block;
+  font-size: 1.75rem;
+  font-weight: 700;
+  line-height: 1.1;
+  margin-top: 0.35rem;
+}
+
+.collection-log-metric.tone-success {
+  border-color: #bbf7d0;
+}
+
+.collection-log-metric.tone-danger {
+  border-color: #fecdd3;
+}
+
+.collection-log-metric.tone-info {
+  border-color: #bae6fd;
+}
+
+.panel {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
+  box-shadow: 0 1px 2px rgb(15 23 42 / 0.04);
+}
+
+.panel-title {
+  color: #0f172a;
+  font-size: 0.95rem;
+  font-weight: 700;
+  line-height: 1.4;
+}
+
+.collection-log-table-panel {
+  overflow: hidden;
+}
+
+.collection-log-toolbar,
+.collection-log-filters,
+.collection-log-footer {
+  align-items: center;
+  border-bottom: 1px solid #f1f5f9;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  padding: 1rem;
+}
+
+.collection-log-toolbar p {
+  color: #64748b;
+  font-size: 0.75rem;
+  margin-top: 0.25rem;
+}
+
+.collection-log-refresh {
+  align-items: center;
+  display: inline-flex;
+  gap: 0.4rem;
+  white-space: nowrap;
+}
+
+.collection-log-action-icon {
+  height: 1rem;
+  width: 1rem;
+}
+
+.collection-log-filters {
+  align-items: end;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+}
+
+@media (min-width: 768px) {
+  .collection-log-filters {
+    grid-template-columns: minmax(0, 1fr) 12rem 12rem;
+  }
+}
+
+.collection-log-filter {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  min-width: 0;
+}
+
+.collection-log-filter span {
+  color: #475569;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.collection-log-input {
+  border: 1px solid #cbd5e1;
+  border-radius: 0.5rem;
+  color: #0f172a;
+  font-size: 0.875rem;
+  height: 2.5rem;
+  outline: none;
+  padding: 0 0.75rem;
+}
+
+.collection-log-input:focus {
+  border-color: #6a5ac7;
+  box-shadow: 0 0 0 3px rgb(106 90 199 / 0.12);
+}
+
+.collection-log-table-scroll {
+  overflow-x: auto;
+}
+
+.collection-log-table {
+  min-width: 960px;
+}
+
+.status-col {
+  width: 8rem;
+}
+
+.source-col {
+  width: 17rem;
+}
+
+.category-col {
+  width: 8rem;
+}
+
+.time-col {
+  width: 13rem;
+}
+
+.duration-col {
+  width: 7rem;
+}
+
+.detail-col {
+  width: 7rem;
+}
+
+.run-status-pill,
+.source-category-pill {
+  align-items: center;
+  border-radius: 999px;
+  display: inline-flex;
+  font-size: 0.75rem;
+  font-weight: 700;
+  justify-content: center;
+  min-height: 1.5rem;
+  padding: 0.2rem 0.6rem;
+  white-space: nowrap;
+}
+
+.run-status-pill.tone-success,
+.source-category-pill.tone-success {
+  background: #ecfdf5;
+  color: #047857;
+}
+
+.run-status-pill.tone-danger,
+.source-category-pill.tone-danger {
+  background: #fff1f2;
+  color: #be123c;
+}
+
+.run-status-pill.tone-info,
+.source-category-pill.tone-info {
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
+.source-category-pill.tone-primary {
+  background: #eef2ff;
+  color: #4f46e5;
+}
+
+.source-category-pill.tone-warn {
+  background: #fffbeb;
+  color: #b45309;
+}
+
+.run-status-pill.tone-neutral,
+.source-category-pill.tone-neutral {
+  background: #f1f5f9;
+  color: #475569;
+}
+
+.source-subtitle {
+  color: #64748b;
+  font-size: 0.75rem;
+  margin-top: 0.25rem;
+}
+
+.run-time,
+.run-duration {
+  color: #64748b;
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    "Courier New", monospace;
+  font-size: 0.75rem;
+}
+
+.run-result-grid {
+  display: grid;
+  gap: 0.25rem 0.75rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.run-result-grid span {
+  color: #64748b;
+  font-size: 0.75rem;
+  white-space: nowrap;
+}
+
+.run-result-grid strong {
+  color: #0f172a;
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    "Courier New", monospace;
+  font-size: 0.75rem;
+  margin-left: 0.25rem;
+}
+
+.collection-log-detail-button {
+  border: 1px solid #cbd5e1;
+  border-radius: 0.5rem;
+  color: #334155;
+  font-size: 0.75rem;
+  font-weight: 700;
+  min-height: 2rem;
+  padding: 0 0.65rem;
+}
+
+.collection-log-detail-button:not(:disabled):hover {
+  border-color: #6a5ac7;
+  color: #4a3eb0;
+}
+
+.collection-log-detail-button:disabled {
+  color: #94a3b8;
+  cursor: not-allowed;
+}
+
+.collection-log-detail-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: minmax(0, 1fr);
+}
+
+@media (min-width: 900px) {
+  .collection-log-detail-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.detail-block {
+  border: 1px solid #e2e8f0;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  padding: 0.875rem;
+  text-align: left;
+}
+
+.detail-block h4 {
+  color: #0f172a;
+  font-size: 0.8rem;
+  font-weight: 700;
+  margin: 0 0 0.6rem;
+}
+
+.detail-error {
+  color: #be123c;
+  font-size: 0.8rem;
+  line-height: 1.6;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.metadata-list {
+  display: grid;
+  gap: 0.4rem 0.75rem;
+  grid-template-columns: max-content minmax(0, 1fr);
+  margin: 0;
+}
+
+.metadata-list dt {
+  color: #64748b;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.metadata-list dd {
+  color: #0f172a;
+  font-size: 0.75rem;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.collection-log-footer {
+  border-bottom: 0;
+  border-top: 1px solid #f1f5f9;
+  color: #64748b;
+  font-size: 0.75rem;
+}
+
+.collection-log-pagination,
+.collection-log-pagination label {
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.collection-log-page-label {
+  color: #334155;
+  font-weight: 700;
+  min-width: 4rem;
+  text-align: center;
+}
+
+.collection-log-page-button {
+  min-height: 2rem;
+  padding: 0 0.75rem;
+}
+
+@media (max-width: 767px) {
+  .collection-log-toolbar,
+  .collection-log-footer {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .collection-log-pagination {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+}
+</style>

--- a/frontend/src/components/llm-ops/GlobalConfigPanel.vue
+++ b/frontend/src/components/llm-ops/GlobalConfigPanel.vue
@@ -270,8 +270,6 @@ const llmConfigLoading = ref(false)
 const llmConfigs = ref([])
 const sourceMode = ref('all')
 
-const supportedPriceSyncProviderCodes = new Set(['aliyun', 'aliyun-wanx'])
-
 const form = reactive({
   meta_model_sync_enabled: true,
   meta_model_sync_source_url: 'https://models.dev/api.json',
@@ -430,10 +428,9 @@ function applyConfig(nextConfig) {
 }
 
 function sourceSupportsRuntimePriceSync(source) {
-  const providerCode = source.provider_code || source.provider?.code || ''
   return (
     source.updates_model_prices &&
-    supportedPriceSyncProviderCodes.has(providerCode) &&
+    source.can_collect_prices &&
     source.source_category === 'official_provider'
   )
 }

--- a/frontend/src/components/llm-ops/ProviderManagement.vue
+++ b/frontend/src/components/llm-ops/ProviderManagement.vue
@@ -25,6 +25,27 @@
         </div>
         <div class="provider-toolbar-actions">
           <button
+            class="btn-secondary btn-action-create"
+            type="button"
+            :disabled="loadingOfficialProviderOptions"
+            @click="openOfficialProviderModal"
+          >
+            <svg
+              class="source-primary-icon"
+              aria-hidden="true"
+              fill="none"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+            >
+              <path d="M12 5v14" />
+              <path d="M5 12h14" />
+            </svg>
+            {{ t('llmOps.providerManagement.actions.addOfficialSource') }}
+          </button>
+          <button
             class="btn-secondary btn-action-sync"
             type="button"
             :disabled="syncingAllSources || !hasSyncablePriceSources"
@@ -176,22 +197,12 @@
                     })
                   }}
                 </p>
-                <p class="mt-1 text-xs text-slate-400">
-                  {{
-                    t('llmOps.providerManagement.sourcesCount', {
-                      count: provider.source_count
-                    })
-                  }}
-                </p>
               </td>
 
               <td class="table-cell">
                 <span :class="['status-pill', provider.status_tone]">
                   {{ provider.status_label }}
                 </span>
-                <p class="mt-1 text-xs text-slate-400">
-                  {{ provider.status_hint }}
-                </p>
               </td>
 
               <td class="table-cell">
@@ -220,6 +231,136 @@
       @close="showManualImportModal = false"
       @imported="handleManualImported"
     />
+    <div
+      v-if="showOfficialProviderModal"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/30 px-4 py-6"
+      @click.self="closeOfficialProviderModal"
+    >
+      <form
+        class="max-h-[calc(100vh-3rem)] w-full max-w-xl overflow-hidden rounded-xl bg-white shadow-2xl"
+        @submit.prevent="addOfficialProviderSource"
+      >
+        <div class="border-b border-slate-200 px-5 py-4">
+          <div class="flex items-start justify-between gap-4">
+            <div>
+              <p
+                class="text-xs font-semibold uppercase tracking-[0.18em] text-indigo-600"
+              >
+                Official Source
+              </p>
+              <h3 class="mt-2 text-lg font-semibold text-slate-900">
+                {{ t('llmOps.providerManagement.officialSourceModal.title') }}
+              </h3>
+            </div>
+            <button
+              class="btn-secondary btn-action-cancel"
+              type="button"
+              :disabled="addingOfficialProviderSource"
+              @click="closeOfficialProviderModal"
+            >
+              {{ t('llmOps.providerManagement.actions.cancel') }}
+            </button>
+          </div>
+        </div>
+
+        <div class="space-y-4 px-5 py-5">
+          <label class="field-group">
+            <span class="field-label">
+              {{
+                t('llmOps.providerManagement.officialSourceModal.provider')
+              }}
+            </span>
+            <CompactSelect
+              v-model="selectedOfficialProviderCode"
+              :disabled="
+                loadingOfficialProviderOptions ||
+                addingOfficialProviderSource
+              "
+              :options="officialProviderSelectOptions"
+              class-name="w-full"
+              :menu-min-width="360"
+            />
+          </label>
+
+          <div
+            v-if="loadingOfficialProviderOptions"
+            class="official-source-state"
+          >
+            {{ t('common.loading') }}
+          </div>
+          <div
+            v-else-if="selectedOfficialProviderOption"
+            class="official-source-detail"
+          >
+            <div>
+              <span>
+                {{
+                  t('llmOps.providerManagement.officialSourceModal.source')
+                }}
+              </span>
+              <strong>{{ selectedOfficialProviderOption.source_name }}</strong>
+            </div>
+            <div>
+              <span>
+                {{ t('llmOps.providerManagement.officialSourceModal.slug') }}
+              </span>
+              <strong class="font-mono">
+                {{ selectedOfficialProviderOption.source_slug }}
+              </strong>
+            </div>
+            <div>
+              <span>
+                {{
+                  t('llmOps.providerManagement.officialSourceModal.currency')
+                }}
+              </span>
+              <strong>{{ selectedOfficialProviderOption.currency }}</strong>
+            </div>
+            <div class="md:col-span-2">
+              <span>
+                {{ t('llmOps.providerManagement.officialSourceModal.url') }}
+              </span>
+              <strong class="break-all">
+                {{ selectedOfficialProviderOption.source_url }}
+              </strong>
+            </div>
+          </div>
+          <div v-else class="official-source-state">
+            {{ t('llmOps.providerManagement.officialSourceModal.empty') }}
+          </div>
+        </div>
+
+        <div class="modal-footer">
+          <span class="modal-footer-note">
+            {{ officialProviderModalStatus }}
+          </span>
+          <div class="modal-footer-actions">
+            <button
+              class="btn-secondary btn-action-cancel"
+              type="button"
+              :disabled="addingOfficialProviderSource"
+              @click="closeOfficialProviderModal"
+            >
+              {{ t('llmOps.providerManagement.actions.cancel') }}
+            </button>
+            <button
+              class="btn-primary btn-action-save"
+              type="submit"
+              :disabled="officialProviderAddDisabled"
+            >
+              <span class="icon-mark" />
+              {{
+                addingOfficialProviderSource
+                  ? t('llmOps.providerManagement.actions.submitting')
+                  : selectedOfficialProviderOption?.source_exists
+                    ? t('llmOps.providerManagement.actions.added')
+                    : t('llmOps.providerManagement.actions.add')
+              }}
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
     <PriceSourceModal
       :open="showPriceSourceModal || Boolean(editingSource)"
       :source="editingSource"
@@ -275,6 +416,7 @@ import PriceSourceModal from '@/components/llm-ops/PriceSourceModal.vue'
 import ProviderPricingDrawer from '@/components/llm-ops/ProviderPricingDrawer.vue'
 import SourcePriceDrawer from '@/components/llm-ops/SourcePriceDrawer.vue'
 import OperationIconButton from '@/components/llm-ops/OperationIconButton.vue'
+import CompactSelect from '@/components/llm-ops/CompactSelect.vue'
 
 const props = defineProps({
   providers: {
@@ -317,14 +459,17 @@ const editingSource = ref(null)
 const priceEntrySource = ref(null)
 const showPriceSourceModal = ref(false)
 const showManualImportModal = ref(false)
+const showOfficialProviderModal = ref(false)
 const collectingSourceId = ref(null)
 const syncingAllSources = ref(false)
 const deletingSourceId = ref(null)
+const loadingOfficialProviderOptions = ref(false)
+const addingOfficialProviderSource = ref(false)
+const officialProviderOptions = ref([])
+const selectedOfficialProviderCode = ref('')
 const sourceSearch = ref('')
 const sourceCategoryFilter = ref('all')
 const sourceStatusFilter = ref('all')
-
-const supportedPriceSyncProviderCodes = new Set(['aliyun', 'aliyun-wanx'])
 
 const sourceCategoryFilterOptions = computed(() => [
   {
@@ -364,6 +509,46 @@ const sourceStatusFilterOptions = computed(() => [
   }
 ])
 
+const officialProviderSelectOptions = computed(() =>
+  officialProviderOptions.value.map((option) => ({
+    value: option.provider_code,
+    label: option.provider_name,
+    description: option.source_name,
+    badge: option.source_exists
+      ? t('llmOps.providerManagement.officialSourceModal.existsBadge')
+      : option.currency
+  }))
+)
+
+const selectedOfficialProviderOption = computed(() =>
+  officialProviderOptions.value.find(
+    (option) =>
+      String(option.provider_code) === String(selectedOfficialProviderCode.value)
+  )
+)
+
+const officialProviderAddDisabled = computed(
+  () =>
+    loadingOfficialProviderOptions.value ||
+    addingOfficialProviderSource.value ||
+    !selectedOfficialProviderOption.value ||
+    selectedOfficialProviderOption.value.source_exists
+)
+
+const officialProviderModalStatus = computed(() => {
+  if (loadingOfficialProviderOptions.value) {
+    return t('llmOps.providerManagement.officialSourceModal.loading')
+  }
+  const option = selectedOfficialProviderOption.value
+  if (!option) {
+    return t('llmOps.providerManagement.officialSourceModal.empty')
+  }
+  if (option.source_exists) {
+    return t('llmOps.providerManagement.officialSourceModal.exists')
+  }
+  return t('llmOps.providerManagement.officialSourceModal.ready')
+})
+
 const sourceRows = computed(() =>
   props.sources
     .map((source) => buildSourceRow(source))
@@ -374,6 +559,8 @@ const sourceRows = computed(() =>
       return String(left.name).localeCompare(String(right.name))
     })
 )
+
+const entrySourceRows = computed(() => sourceRows.value.filter(isEntrySource))
 
 const providerRows = computed(() =>
   props.providers
@@ -397,7 +584,7 @@ const unboundSourceRows = computed(() => {
 })
 
 const unboundProviderRow = computed(() => {
-  const sources = unboundSourceRows.value
+  const sources = unboundSourceRows.value.filter(isEntrySource)
   if (!sources.length) return null
 
   const provider = {
@@ -424,7 +611,6 @@ const unboundProviderRow = computed(() => {
     source_ids: sources.map((source) => String(source.id)),
     status_label: status.label,
     status_tone: status.tone,
-    status_hint: status.hint,
     filter_is_active: status.filterActive,
     search_text: [
       provider.name,
@@ -449,13 +635,13 @@ const sourceMetrics = computed(() => {
     provider.meta_model_ids.forEach((id) => coveredMetaModelIds.add(id))
   })
 
-  const official = sourceRows.value.filter(
+  const official = entrySourceRows.value.filter(
     (source) => source.business_source_category === 'official_provider'
   ).length
-  const supplier = sourceRows.value.filter(
+  const supplier = entrySourceRows.value.filter(
     (source) => source.business_source_category === 'supplier'
   ).length
-  const manual = sourceRows.value.filter(
+  const manual = entrySourceRows.value.filter(
     (source) => source.business_source_category === 'manual'
   ).length
 
@@ -543,13 +729,14 @@ function buildProviderRow(provider) {
   const models = modelsForProvider(provider)
   const priceItems = priceItemsForProvider(provider)
   const sources = sourcesForProvider(provider, priceItems)
+  const entrySources = sources.filter(isEntrySource)
   const metaModelIds = metaModelIdsForProvider(models, priceItems)
   const categoryKeys = sourceCategoryKeysForProvider(
     provider,
-    sources,
+    entrySources,
     priceItems
   )
-  const status = providerStatus(provider, sources)
+  const status = providerStatus(provider, entrySources)
 
   return {
     ...provider,
@@ -561,46 +748,56 @@ function buildProviderRow(provider) {
     covered_model_count: metaModelIds.length,
     meta_model_ids: metaModelIds,
     price_item_count: priceItems.length,
-    source_count: sources.length,
+    output_source_count: Math.max(sources.length - entrySources.length, 0),
+    source_count: entrySources.length,
     source_ids: sources.map((source) => String(source.id)),
     status_label: status.label,
     status_tone: status.tone,
-    status_hint: status.hint,
     filter_is_active: status.filterActive,
     search_text: buildProviderSearchText(provider, models, sources, priceItems)
   }
 }
 
 function modelsForProvider(provider) {
-  return props.models.filter((model) =>
-    recordMatchesModelVendor(model, provider)
+  const providerSourceIds = sourceIdsForProvider(provider)
+  const pricedModelIds = new Set(
+    props.priceItems
+      .filter(
+        (item) =>
+          item.is_current !== false &&
+          providerSourceIds.has(String(item.source || ''))
+      )
+      .map((item) => String(item.model || ''))
+      .filter(Boolean)
+  )
+  return props.models.filter(
+    (model) =>
+      sourceMatchesProvider(sourceForRecord(model), provider) ||
+      pricedModelIds.has(String(model.id))
   )
 }
 
 function priceItemsForProvider(provider) {
-  const modelIds = new Set(
-    modelsForProvider(provider).map((model) => String(model.id))
-  )
+  const providerSourceIds = sourceIdsForProvider(provider)
   return props.priceItems.filter(
     (item) =>
       item.is_current !== false &&
-      (modelIds.has(String(item.model)) ||
-        recordMatchesModelVendor(item, provider))
+      providerSourceIds.has(String(item.source || ''))
   )
 }
 
-function recordMatchesModelVendor(record, provider) {
-  const vendorId = String(record.meta_model_vendor || '')
-  const vendorCode = String(record.meta_model_vendor_code || '')
-  if (vendorId || vendorCode) {
-    return (
-      vendorId === String(provider.id) ||
-      vendorCode === String(provider.code)
-    )
-  }
-  return (
-    String(record.provider || '') === String(provider.id) ||
-    String(record.provider_code || '') === String(provider.code)
+function sourceIdsForProvider(provider) {
+  return new Set(
+    sourceRows.value
+      .filter((source) => sourceMatchesProvider(source, provider))
+      .map((source) => String(source.id))
+  )
+}
+
+function sourceForRecord(record) {
+  if (!record?.source) return null
+  return sourceRows.value.find(
+    (source) => String(source.id) === String(record.source || '')
   )
 }
 
@@ -615,6 +812,7 @@ function sourcesForProvider(provider, priceItems) {
 }
 
 function sourceMatchesProvider(source, provider) {
+  if (!source || !provider) return false
   return (
     String(source.provider || '') === String(provider.id) ||
     String(source.provider_code || '') === String(provider.code)
@@ -654,7 +852,6 @@ function providerStatus(provider, sources) {
     return {
       label: t('llmOps.providerManagement.sourceStatus.inactive.label'),
       tone: 'muted',
-      hint: t('llmOps.providerManagement.sourceStatus.inactive.hint'),
       filterActive: false
     }
   }
@@ -662,16 +859,12 @@ function providerStatus(provider, sources) {
     return {
       label: t('llmOps.providerManagement.sourceStatus.pending.label'),
       tone: 'warn',
-      hint: t('llmOps.providerManagement.sourcesCount', { count: 0 }),
       filterActive: true
     }
   }
   return {
     label: t('llmOps.providerManagement.sourceStatus.active.label'),
     tone: 'ok',
-    hint: t('llmOps.providerManagement.sourcesCount', {
-      count: sources.length
-    }),
     filterActive: true
   }
 }
@@ -803,6 +996,75 @@ function handleManualImported() {
   emit('refresh')
 }
 
+async function openOfficialProviderModal() {
+  showOfficialProviderModal.value = true
+  await loadOfficialProviderOptions()
+}
+
+function closeOfficialProviderModal() {
+  if (addingOfficialProviderSource.value) return
+  showOfficialProviderModal.value = false
+}
+
+async function loadOfficialProviderOptions() {
+  loadingOfficialProviderOptions.value = true
+  try {
+    const response = await llmOpsApi.listOfficialProviderSourceOptions()
+    const payload = response?.data?.data || response?.data || {}
+    const options = Array.isArray(payload.results) ? payload.results : []
+    officialProviderOptions.value = options
+    const current = options.find(
+      (option) =>
+        String(option.provider_code) ===
+        String(selectedOfficialProviderCode.value)
+    )
+    const preferred = options.find((option) => !option.source_exists)
+    const selected =
+      current && !current.source_exists ? current : preferred || current
+    selectedOfficialProviderCode.value =
+      selected?.provider_code || options[0]?.provider_code || ''
+  } catch (error) {
+    showError(
+      errorMessage(
+        error,
+        t('llmOps.providerManagement.errors.loadOfficialSourcesFailed')
+      )
+    )
+  } finally {
+    loadingOfficialProviderOptions.value = false
+  }
+}
+
+async function addOfficialProviderSource() {
+  const option = selectedOfficialProviderOption.value
+  if (!option || option.source_exists) return
+
+  addingOfficialProviderSource.value = true
+  try {
+    const response = await llmOpsApi.ensureOfficialProviderSource(
+      option.provider_code
+    )
+    const payload = response?.data?.data || response?.data || {}
+    const sourceName = payload.source?.name || option.source_name
+    showSuccess(
+      t('llmOps.providerManagement.messages.officialSourceAdded', {
+        name: sourceName
+      })
+    )
+    showOfficialProviderModal.value = false
+    emit('refresh')
+  } catch (error) {
+    showError(
+      errorMessage(
+        error,
+        t('llmOps.providerManagement.errors.addOfficialSourceFailed')
+      )
+    )
+  } finally {
+    addingOfficialProviderSource.value = false
+  }
+}
+
 function closePriceSourceModal() {
   showPriceSourceModal.value = false
   editingSource.value = null
@@ -843,7 +1105,8 @@ async function collectSource(source) {
   collectingSourceId.value = source.id
   try {
     const response = await llmOpsApi.collectCollectionSource(source.id)
-    const taskId = response?.data?.task_id
+    const payload = apiPayload(response)
+    const taskId = payload.task_id
     showSuccess(
       t('llmOps.providerManagement.messages.syncSubmitted', {
         name: source.name,
@@ -867,11 +1130,10 @@ async function syncAllPriceSources() {
   syncingAllSources.value = true
   try {
     const response = await llmOpsApi.syncAllCollectionSources()
-    const taskId = response?.data?.task_id
-    const count = response?.data?.source_count || 0
+    const payload = apiPayload(response)
+    const taskId = payload.task_id
     showSuccess(
       t('llmOps.providerManagement.messages.syncAllSubmitted', {
-        count,
         taskId: taskId
           ? t('llmOps.providerManagement.messages.taskId', { taskId })
           : ''
@@ -1047,12 +1309,18 @@ function sourceStatus(source, latestRun) {
 }
 
 function canCollectSource(source) {
-  const providerCode = source.provider_code || source.provider?.code || ''
   return Boolean(
-    source.provider &&
+    source.can_collect_prices &&
       source.source_category === 'official_provider' &&
-      supportedPriceSyncProviderCodes.has(providerCode)
+      source.updates_model_prices
   )
+}
+
+function isEntrySource(source) {
+  if (source?.source_category === 'official_provider') {
+    return canCollectSource(source)
+  }
+  return canManualEntrySource(source)
 }
 
 function canManualEntrySource(source) {
@@ -1110,6 +1378,10 @@ function errorMessage(error, fallback) {
     error?.message ||
     fallback
   )
+}
+
+function apiPayload(response) {
+  return response?.data?.data || response?.data || {}
 }
 </script>
 
@@ -1192,6 +1464,38 @@ function errorMessage(error, fallback) {
 
 .field-input {
   @apply w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 outline-none transition placeholder:text-slate-400 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-100;
+}
+
+.field-group {
+  @apply flex min-w-0 flex-col gap-1.5;
+}
+
+.field-label {
+  @apply text-xs font-medium text-slate-500;
+}
+
+.official-source-detail {
+  @apply grid gap-3 rounded-lg border border-slate-200 bg-slate-50 p-4 md:grid-cols-2;
+}
+
+.official-source-detail div {
+  @apply min-w-0;
+}
+
+.official-source-detail span {
+  @apply block text-xs font-medium text-slate-500;
+}
+
+.official-source-detail strong {
+  @apply mt-1 block truncate text-sm font-semibold text-slate-900;
+}
+
+.official-source-detail strong.break-all {
+  @apply whitespace-normal;
+}
+
+.official-source-state {
+  @apply rounded-lg border border-dashed border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-500;
 }
 
 .btn-primary {

--- a/frontend/src/components/llm-ops/ProviderPricingDrawer.vue
+++ b/frontend/src/components/llm-ops/ProviderPricingDrawer.vue
@@ -189,92 +189,6 @@
           </div>
         </div>
 
-        <div v-if="sources.length" class="panel space-y-3">
-          <div class="flex items-center justify-between gap-3">
-            <div>
-              <h3 class="panel-title">价格源概览</h3>
-              <p class="mt-1 text-xs text-slate-500">
-                这里保留该厂商下的原厂、供货商和人工价格源，便于继续录价和维护。
-              </p>
-            </div>
-          </div>
-          <div class="grid gap-3 md:grid-cols-2">
-            <div
-              v-for="source in sources"
-              :key="source.id"
-              class="rounded-lg border border-slate-200 px-3 py-2"
-            >
-              <div class="flex items-start justify-between gap-3">
-                <div class="min-w-0">
-                  <p class="truncate text-sm font-medium text-slate-900">
-                    {{ source.name }}
-                  </p>
-                  <p class="mt-1 text-xs text-slate-500">
-                    {{ sourceCategoryLabel(businessSourceCategory(source)) }}
-                    <span v-if="source.channel_name">
-                      / {{ source.channel_name }}
-                    </span>
-                  </p>
-                  <a
-                    v-if="source.endpoint_url"
-                    class="mt-1 block truncate text-xs text-indigo-600 hover:text-indigo-700 hover:underline"
-                    :href="source.endpoint_url"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                    :title="source.endpoint_url"
-                  >
-                    {{ source.endpoint_url }}
-                  </a>
-                  <p v-else class="mt-1 text-xs text-slate-400">-</p>
-                </div>
-                <span :class="source.is_enabled ? 'badge-ok' : 'badge-muted'">
-                  {{ source.is_enabled ? '启用' : '停用' }}
-                </span>
-              </div>
-              <div class="mt-3 flex flex-wrap gap-2">
-                <OperationIconButton
-                  icon="price"
-                  label="价格明细"
-                  @click="$emit('view-source', source)"
-                />
-                <OperationIconButton
-                  v-if="source.can_manual_entry"
-                  icon="manual"
-                  label="手工录价"
-                  tone="success"
-                  @click="$emit('manual-entry-source', source)"
-                />
-                <OperationIconButton
-                  icon="edit"
-                  label="编辑"
-                  @click="$emit('edit-source', source)"
-                />
-                <OperationIconButton
-                  :icon="source.is_enabled ? 'toggleOff' : 'toggleOn'"
-                  :label="source.is_enabled ? '停用' : '启用'"
-                  :tone="source.is_enabled ? 'warn' : 'success'"
-                  @click="$emit('toggle-source', source)"
-                />
-                <OperationIconButton
-                  v-if="source.can_collect"
-                  icon="collect"
-                  :label="source.collect_action_label || '采集价格'"
-                  tone="primary"
-                  :disabled="
-                    String(collectingSourceId || '') === String(source.id)
-                  "
-                  @click="$emit('collect-source', source)"
-                />
-                <OperationIconButton
-                  icon="delete"
-                  label="删除"
-                  tone="danger"
-                  @click="$emit('delete-source', source)"
-                />
-              </div>
-            </div>
-          </div>
-        </div>
       </div>
     </aside>
   </div>
@@ -282,17 +196,8 @@
 
 <script setup>
 import { computed, ref } from 'vue'
-import OperationIconButton from '@/components/llm-ops/OperationIconButton.vue'
 
-defineEmits([
-  'close',
-  'view-source',
-  'manual-entry-source',
-  'edit-source',
-  'toggle-source',
-  'collect-source',
-  'delete-source'
-])
+defineEmits(['close'])
 
 const props = defineProps({
   provider: {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -771,6 +771,10 @@
         "label": "Model Price Sources",
         "description": "Review supplier price sources and meta-model prices."
       },
+      "taskLogs": {
+        "label": "Collection Task Logs",
+        "description": "Review model price collection status, write results, errors, and metadata."
+      },
       "channels": {
         "label": "Forwarding Channels",
         "description": "Maintain channels and manage enabled provider models and pricing policies inside each channel."
@@ -1322,10 +1326,13 @@
     "providerManagement": {
       "title": "Provider Model Prices",
       "modelsCount": "{count} meta models",
-      "sourcesCount": "{count} price sources",
       "empty": "No providers match the current filters.",
       "actions": {
+        "add": "Add",
+        "addOfficialSource": "Add official source",
+        "added": "Added",
         "bulkImport": "Bulk import",
+        "cancel": "Cancel",
         "createSource": "New price source",
         "delete": "Delete",
         "deleting": "Deleting",
@@ -1333,7 +1340,7 @@
         "manualPricing": "Manual pricing",
         "notSupported": "Not supported",
         "submitting": "Submitting",
-        "syncAllPrices": "Sync all prices",
+        "syncAllPrices": "Sync price collection",
         "syncPrice": "Sync prices",
         "viewModels": "View meta models"
       },
@@ -1419,6 +1426,19 @@
           "label": "Syncing"
         }
       },
+      "officialSourceModal": {
+        "currency": "Currency",
+        "empty": "No official price source presets are available.",
+        "exists": "This official source has already been added.",
+        "existsBadge": "Added",
+        "loading": "Loading official sources.",
+        "provider": "Provider",
+        "ready": "Confirm to create the official price source.",
+        "slug": "System slug",
+        "source": "Price source",
+        "title": "Add Official Price Source",
+        "url": "Price URL"
+      },
       "collectMode": {
         "autoCollect": "Auto collect",
         "dedicatedCollector": "Dedicated collector",
@@ -1430,12 +1450,15 @@
       },
       "messages": {
         "deleted": "Model price source deleted",
-        "syncAllSubmitted": "{count} price source sync tasks submitted{taskId}",
+        "officialSourceAdded": "Official price source \"{name}\" added",
+        "syncAllSubmitted": "Price collection task submitted{taskId}",
         "syncSubmitted": "{name} sync task submitted{taskId}",
         "taskId": " ({taskId})"
       },
       "errors": {
+        "addOfficialSourceFailed": "Failed to add official price source",
         "deleteFailed": "Failed to delete model price source",
+        "loadOfficialSourcesFailed": "Failed to load official price sources",
         "saveFailed": "Failed to save model price source",
         "syncAllFailed": "Failed to submit model price source sync task",
         "syncFailed": "Failed to submit price sync task"
@@ -1969,6 +1992,86 @@
         "directOfflineFailed": "Direct offline failed",
         "operationFailed": "Operation failed",
         "transitionFailed": "Status transition failed"
+      }
+    },
+    "taskLogs": {
+      "title": "Collection Task Logs",
+      "description": "Records price collection task status, write counts, errors, and metadata.",
+      "deletedSource": "Deleted price source",
+      "actions": {
+        "refresh": "Refresh",
+        "showDetails": "Details",
+        "hideDetails": "Collapse",
+        "noDetails": "No details"
+      },
+      "filters": {
+        "keyword": "Keyword",
+        "keywordPlaceholder": "Search source, provider, or error",
+        "status": "Status",
+        "category": "Source type"
+      },
+      "metrics": {
+        "total": "Total tasks",
+        "running": "Running",
+        "succeeded": "Succeeded",
+        "failed": "Failed"
+      },
+      "status": {
+        "all": "All statuses",
+        "failed": "Failed",
+        "running": "Running",
+        "succeeded": "Succeeded",
+        "unknown": "Unknown"
+      },
+      "categories": {
+        "all": "All types",
+        "officialProvider": "Official",
+        "supplier": "Supplier",
+        "manual": "Manual",
+        "unknown": "Other"
+      },
+      "table": {
+        "status": "Status",
+        "source": "Price source",
+        "category": "Type",
+        "startedAt": "Started at",
+        "duration": "Duration",
+        "result": "Result",
+        "detail": "Detail"
+      },
+      "counts": {
+        "collected": "Collected",
+        "created": "Created",
+        "updated": "Updated",
+        "skipped": "Skipped"
+      },
+      "detail": {
+        "error": "Error",
+        "metadata": "Collection metadata"
+      },
+      "metadata": {
+        "changedCount": "Changed",
+        "collectedModelCodes": "Collected models",
+        "currency": "Currency",
+        "fallbackModelIds": "Fallback models",
+        "missingModelIds": "Missing models",
+        "skippedModelCodes": "Skipped models",
+        "sourceParseFallbackModelIds": "Parse fallback models",
+        "sourceParseMissingModelIds": "Parse missing models",
+        "sourceUrl": "Source URL",
+        "unchangedCount": "Unchanged"
+      },
+      "empty": {
+        "title": "No collection tasks",
+        "description": "After adding a price source and running sync, each collection result appears here."
+      },
+      "pagination": {
+        "emptyRange": "0 records",
+        "range": "{start}-{end} of {count}",
+        "pageSize": "Per page",
+        "pageSizeOption": "{size} rows",
+        "previous": "Previous",
+        "next": "Next"
       }
     },
     "auditLog": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -781,6 +781,10 @@
         "label": "模型价格源",
         "description": "查看供货商价格源与元模型价格。"
       },
+      "taskLogs": {
+        "label": "采集任务日志",
+        "description": "查看模型价格采集任务的状态、写入结果、错误和采集元数据。"
+      },
       "channels": {
         "label": "转发渠道",
         "description": "维护渠道，并在渠道内管理可启用转发的服务商模型和价格策略。"
@@ -1328,14 +1332,17 @@
         "channelRequired": "请选择账单归属的转发渠道。",
         "modelRequired": "请选择本次用量对应的调用模型。"
       }
-    },
+      },
     "providerManagement": {
       "title": "厂商模型价格",
       "modelsCount": "{count} 个元模型",
-      "sourcesCount": "{count} 个价格源",
       "empty": "暂无匹配的厂商。",
       "actions": {
+        "add": "添加",
+        "addOfficialSource": "添加原厂源",
+        "added": "已添加",
         "bulkImport": "批量导入",
+        "cancel": "取消",
         "createSource": "新建价格源",
         "delete": "删除",
         "deleting": "删除中",
@@ -1343,7 +1350,7 @@
         "manualPricing": "手工录价",
         "notSupported": "暂不支持",
         "submitting": "提交中",
-        "syncAllPrices": "同步全部价格源",
+        "syncAllPrices": "同步全部价格采集",
         "syncPrice": "同步价格",
         "viewModels": "查看元模型"
       },
@@ -1429,6 +1436,19 @@
           "label": "同步中"
         }
       },
+      "officialSourceModal": {
+        "currency": "币种",
+        "empty": "暂无可添加的原厂价格源。",
+        "exists": "当前原厂源已经添加。",
+        "existsBadge": "已添加",
+        "loading": "正在加载原厂源。",
+        "provider": "厂商",
+        "ready": "确认后会创建原厂价格源。",
+        "slug": "系统标识",
+        "source": "价格源",
+        "title": "添加原厂价格源",
+        "url": "价格地址"
+      },
       "collectMode": {
         "autoCollect": "自动采集",
         "dedicatedCollector": "专用采集器",
@@ -1440,12 +1460,15 @@
       },
       "messages": {
         "deleted": "模型价格源已删除",
-        "syncAllSubmitted": "{count} 个价格源同步任务已提交{taskId}",
+        "officialSourceAdded": "原厂价格源「{name}」已添加",
+        "syncAllSubmitted": "价格采集任务已提交{taskId}",
         "syncSubmitted": "{name} 同步任务已提交{taskId}",
         "taskId": "（{taskId}）"
       },
       "errors": {
+        "addOfficialSourceFailed": "添加原厂价格源失败",
         "deleteFailed": "删除模型价格源失败",
+        "loadOfficialSourcesFailed": "加载原厂价格源失败",
         "saveFailed": "保存模型价格源失败",
         "syncAllFailed": "提交全部价格源同步任务失败",
         "syncFailed": "提交价格同步任务失败"
@@ -1979,6 +2002,86 @@
         "directOfflineFailed": "直接下架失败",
         "operationFailed": "操作失败",
         "transitionFailed": "状态流转失败"
+      }
+    },
+    "taskLogs": {
+      "title": "采集任务日志",
+      "description": "记录价格采集任务的运行状态、写入数量、错误和采集元数据。",
+      "deletedSource": "已删除价格源",
+      "actions": {
+        "refresh": "刷新",
+        "showDetails": "详情",
+        "hideDetails": "收起",
+        "noDetails": "无详情"
+      },
+      "filters": {
+        "keyword": "关键字",
+        "keywordPlaceholder": "搜索价格源、厂商或错误信息",
+        "status": "状态",
+        "category": "来源类型"
+      },
+      "metrics": {
+        "total": "任务总数",
+        "running": "运行中",
+        "succeeded": "成功",
+        "failed": "失败"
+      },
+      "status": {
+        "all": "全部状态",
+        "failed": "失败",
+        "running": "运行中",
+        "succeeded": "成功",
+        "unknown": "未知"
+      },
+      "categories": {
+        "all": "全部类型",
+        "officialProvider": "原厂",
+        "supplier": "供货商",
+        "manual": "人工",
+        "unknown": "其他"
+      },
+      "table": {
+        "status": "状态",
+        "source": "价格源",
+        "category": "类型",
+        "startedAt": "开始时间",
+        "duration": "耗时",
+        "result": "结果",
+        "detail": "详情"
+      },
+      "counts": {
+        "collected": "采集",
+        "created": "新增",
+        "updated": "更新",
+        "skipped": "跳过"
+      },
+      "detail": {
+        "error": "错误信息",
+        "metadata": "采集元数据"
+      },
+      "metadata": {
+        "changedCount": "变化数",
+        "collectedModelCodes": "采集模型",
+        "currency": "币种",
+        "fallbackModelIds": "兜底模型",
+        "missingModelIds": "缺失模型",
+        "skippedModelCodes": "跳过模型",
+        "sourceParseFallbackModelIds": "解析兜底模型",
+        "sourceParseMissingModelIds": "解析缺失模型",
+        "sourceUrl": "采集地址",
+        "unchangedCount": "未变化数"
+      },
+      "empty": {
+        "title": "暂无采集任务",
+        "description": "添加价格源并执行同步后，这里会显示每次采集的结果。"
+      },
+      "pagination": {
+        "emptyRange": "0 条记录",
+        "range": "第 {start}-{end} 条，共 {count} 条",
+        "pageSize": "每页",
+        "pageSizeOption": "{size} 条",
+        "previous": "上一页",
+        "next": "下一页"
       }
     },
     "auditLog": {

--- a/frontend/src/pages/LLMOps.vue
+++ b/frontend/src/pages/LLMOps.vue
@@ -579,6 +579,13 @@
               @saved="refreshLight"
             />
 
+            <CollectionRunLogPanel
+              v-else-if="activeSection === 'taskLogs'"
+              :runs="collectionRuns"
+              :sources="sources"
+              @refresh="refreshCollectionRuns"
+            />
+
             <ProviderManagement
               v-else-if="activeSection === 'providers'"
               :providers="providers"
@@ -670,6 +677,7 @@ import BaseLoading from '@/components/ui/BaseLoading.vue'
 import AgioneListingStatusBoard from '@/components/llm-ops/AgioneListingStatusBoard.vue'
 import AuditLogPanel from '@/components/llm-ops/AuditLogPanel.vue'
 import ChannelManagement from '@/components/llm-ops/ChannelManagement.vue'
+import CollectionRunLogPanel from '@/components/llm-ops/CollectionRunLogPanel.vue'
 import GlobalConfigPanel from '@/components/llm-ops/GlobalConfigPanel.vue'
 import MetaModelManagement from '@/components/llm-ops/MetaModelManagement.vue'
 import ProviderManagement from '@/components/llm-ops/ProviderManagement.vue'
@@ -687,6 +695,7 @@ const sectionKeys = new Set([
   'monitor',
   'metaModels',
   'providers',
+  'taskLogs',
   'channels',
   'globalConfig',
   'reseller',
@@ -769,6 +778,7 @@ const navIcons = {
     'M14 17h1'
   ],
   reseller: ['M6 8h12l-1 12H7L6 8Z', 'M9 8a3 3 0 0 1 6 0'],
+  taskLogs: ['M5 4h14v16H5Z', 'M8 8h8', 'M8 12h8', 'M8 16h5'],
   workflow: [
     'M4 6h7',
     'M13 6h7',
@@ -802,6 +812,13 @@ const navItems = computed(() => [
     eyebrow: 'Sources',
     description: t('llmOps.nav.providers.description'),
     icon: navIcons.providers
+  },
+  {
+    key: 'taskLogs',
+    label: t('llmOps.nav.taskLogs.label'),
+    eyebrow: 'Task Logs',
+    description: t('llmOps.nav.taskLogs.description'),
+    icon: navIcons.taskLogs
   },
   {
     key: 'channels',
@@ -864,7 +881,8 @@ const navGroups = computed(() =>
     createNavGroup('overview', 'llmOps.navGroups.overview', ['monitor']),
     createNavGroup('catalog', 'llmOps.navGroups.catalog', [
       'metaModels',
-      'providers'
+      'providers',
+      'taskLogs'
     ]),
     createNavGroup('distribution', 'llmOps.navGroups.distribution', [
       'channels',
@@ -1204,7 +1222,7 @@ const actionItems = computed(() => [
       : t('llmOps.queue.checkPriceSource.empty'),
     value: collectionAttentionCount.value,
     tone: collectionAttentionCount.value ? 'danger' : 'good',
-    section: 'providers'
+    section: 'taskLogs'
   },
   {
     label: t('llmOps.queue.handleReconciliation.label'),
@@ -1408,6 +1426,15 @@ async function refreshLight() {
   listings.value = extract(listingRes)
   records.value = extract(recordRes)
   summary.value = extract(summaryRes)
+}
+
+async function refreshCollectionRuns() {
+  const [sourceRes, runRes] = await Promise.all([
+    llmOpsApi.listCollectionSources(FULL_LIST_PARAMS),
+    llmOpsApi.listCollectionRuns(FULL_LIST_PARAMS)
+  ])
+  sources.value = extract(sourceRes)
+  collectionRuns.value = extract(runRes)
 }
 
 async function loadResaleWorkflowConfig(


### PR DESCRIPTION
## Summary
- Add provider-selected official price source creation and sync controls for LLM Ops.
- Add standard vendor price catalog skills and full-catalog official sync for Aliyun, Baidu, and Volcengine sources.
- Add collection run logs so users can inspect price sync results and errors.
- Remove frontend hard-coded provider sync allowlist in favor of backend `can_collect_prices` capability.

## Test plan
- [x] `docker exec -w /opt/backend backend-api-dev python -m py_compile ...`
- [x] `docker exec backend-api-dev python manage.py test llm_ops.tests.test_skill_runner llm_ops.tests.test_official_collector llm_ops.tests.test_source_collectors llm_ops.tests.test_views --keepdb`
- [x] `docker exec backend-api-dev python manage.py test llm_ops.tests --keepdb`
- [x] `git diff --cached --check`
- [ ] `cd frontend && npm run build` blocked locally because `vite` is not installed in the current frontend checkout.

Made with [Orca](https://github.com/stablyai/orca) 🐋
