### PR TITLE
Optimize model price source presentation

### DIFF
--- a/backend/llm_ops/serializers.py
+++ b/backend/llm_ops/serializers.py
@@ -1512,8 +1512,9 @@ class ManualPriceImportRequestSerializer(serializers.Serializer):
     )
     provider = serializers.PrimaryKeyRelatedField(
         queryset=LLMProvider.objects.filter(is_active=True),
+        required=False,
     )
-    source_name = serializers.CharField(max_length=255)
+    source_name = serializers.CharField(max_length=255, required=False)
     source_slug = serializers.SlugField(
         max_length=100,
         required=False,
@@ -1526,6 +1527,47 @@ class ManualPriceImportRequestSerializer(serializers.Serializer):
 
     def validate_currency(self, value):
         return validate_currency_code(value, required=True)
+
+    def validate(self, attrs):
+        source = attrs.get("source")
+        provider = attrs.get("provider")
+
+        if source is not None:
+            if source.provider_id:
+                if provider and provider.id != source.provider_id:
+                    raise serializers.ValidationError(
+                        {
+                            "provider": (
+                                "Provider must match the selected price "
+                                "source."
+                            )
+                        }
+                    )
+                attrs["provider"] = source.provider
+            elif provider is None:
+                raise serializers.ValidationError(
+                    {
+                        "source": (
+                            "Selected price source must be bound to a "
+                            "provider, or provider must be provided."
+                        )
+                    }
+                )
+            attrs.setdefault("source_name", source.name)
+            attrs.setdefault("source_url", source.endpoint_url)
+            if not self.initial_data.get("currency"):
+                attrs["currency"] = source.currency
+            return attrs
+
+        if provider is None:
+            raise serializers.ValidationError(
+                {"provider": "This field is required."}
+            )
+        if not attrs.get("source_name"):
+            raise serializers.ValidationError(
+                {"source_name": "This field is required."}
+            )
+        return attrs
 
 
 def validate_non_negative_prices(attrs, fields):

--- a/backend/llm_ops/tests/test_views.py
+++ b/backend/llm_ops/tests/test_views.py
@@ -470,6 +470,50 @@ class LLMOpsViewTests(TestCase):
         self.assertEqual(audit.metadata["provider_id"], provider.id)
         self.assertNotIn("rows", audit.metadata)
 
+    @patch("llm_ops.views.import_manual_model_prices")
+    def test_manual_price_import_accepts_existing_source(self, mock_import):
+        provider = LLMProvider.objects.create(name="OpenAI", code="openai")
+        source = PriceCollectionSource.objects.create(
+            name="OpenAI Manual Sheet",
+            slug="openai-manual-sheet",
+            provider=provider,
+            source_type=PriceCollectionSource.SOURCE_TYPE_CUSTOM,
+            source_category=PriceCollectionSource.SOURCE_CATEGORY_MANUAL,
+            currency="CNY",
+        )
+        mock_import.return_value = {
+            "created_models": 0,
+            "updated_models": 1,
+            "created_price_items": 1,
+        }
+
+        response = self.client.post(
+            reverse("llm-ops-manual-price-import"),
+            {
+                "source": source.id,
+                "updates_model_prices": True,
+                "rows": [
+                    {
+                        "model_code": "gpt-5",
+                        "model_name": "GPT-5",
+                        "input_price_per_million": "1.000000",
+                    }
+                ],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        mock_import.assert_called_once()
+        _, kwargs = mock_import.call_args
+        self.assertEqual(kwargs["source"], source)
+        self.assertEqual(kwargs["provider"], provider)
+        self.assertEqual(kwargs["default_currency"], "CNY")
+        self.assertEqual(
+            AuditLog.objects.filter(target_id=str(source.id)).count(),
+            1,
+        )
+
     def test_collection_source_can_be_deleted(self):
         source = PriceCollectionSource.objects.create(
             name="Manual Source",

--- a/frontend/src/components/llm-ops/ManualPriceImportModal.vue
+++ b/frontend/src/components/llm-ops/ManualPriceImportModal.vue
@@ -26,12 +26,32 @@
 
       <div class="modal-body space-y-4">
         <div class="grid gap-3 md:grid-cols-2">
-          <label class="form-field">
+          <label class="form-field md:col-span-2">
             <span class="field-label">
-              {{ t('llmOps.manualPriceImport.fields.provider') }}
+              {{ t('llmOps.manualPriceImport.fields.source') }}
             </span>
-            <CompactSelect v-model="form.provider" :options="providerOptions" />
+            <CompactSelect
+              v-model="form.source"
+              :options="sourceOptions"
+              class-name="w-full"
+              :menu-min-width="360"
+            />
+            <span class="field-help">
+              {{ sourceStatusText }}
+            </span>
           </label>
+          <div class="source-context">
+            <span>{{ t('llmOps.manualPriceImport.fields.provider') }}</span>
+            <strong>
+              {{ selectedSourceProvider?.name || '-' }}
+            </strong>
+          </div>
+          <div class="source-context">
+            <span>{{ t('llmOps.manualPriceImport.fields.sourceUrl') }}</span>
+            <strong class="break-all">
+              {{ selectedSource?.endpoint_url || '-' }}
+            </strong>
+          </div>
           <label class="form-field">
             <span class="field-label">
               {{ t('llmOps.manualPriceImport.fields.currency') }}
@@ -40,27 +60,9 @@
           </label>
           <label class="form-field">
             <span class="field-label">
-              {{ t('llmOps.manualPriceImport.fields.sourceName') }}
+              {{ t('llmOps.manualPriceImport.fields.sourceCategory') }}
             </span>
-            <input
-              v-model="form.source_name"
-              class="field"
-              :placeholder="
-                t('llmOps.manualPriceImport.placeholders.sourceName')
-              "
-            />
-          </label>
-          <label class="form-field">
-            <span class="field-label">
-              {{ t('llmOps.manualPriceImport.fields.sourceUrl') }}
-            </span>
-            <input
-              v-model="form.source_url"
-              class="field"
-              :placeholder="
-                t('llmOps.manualPriceImport.placeholders.sourceUrl')
-              "
-            />
+            <input class="field" :value="sourceCategoryLabel" disabled />
           </label>
         </div>
 
@@ -252,6 +254,10 @@ const props = defineProps({
   providers: {
     type: Array,
     required: true
+  },
+  sources: {
+    type: Array,
+    default: () => []
   }
 })
 
@@ -267,27 +273,57 @@ const currencyOptions = [
   { label: 'CNY', value: 'CNY' }
 ]
 
-const providerOptions = computed(() => [
+const sourceOptions = computed(() => [
   {
-    label: t('llmOps.manualPriceImport.placeholders.selectProvider'),
+    label: t('llmOps.manualPriceImport.placeholders.selectSource'),
     value: ''
   },
-  ...props.providers
+  ...props.sources
     .slice()
-    .sort((left, right) => left.name.localeCompare(right.name))
-    .map((provider) => ({
-      label: provider.name,
-      value: provider.id
+    .sort((left, right) => String(left.name).localeCompare(String(right.name)))
+    .map((source) => ({
+      label: source.name,
+      value: source.id,
+      description: source.provider_name || source.relation_name || '',
+      badge: source.category_label || source.source_category || ''
     }))
 ])
 
+const selectedSource = computed(() =>
+  props.sources.find(
+    (source) => String(source.id) === String(form.value.source)
+  )
+)
+const selectedSourceProvider = computed(() => {
+  const providerId = selectedSource.value?.provider
+  return props.providers.find(
+    (provider) => String(provider.id) === String(providerId || '')
+  )
+})
+const sourceCategoryLabel = computed(
+  () =>
+    selectedSource.value?.category_label ||
+    selectedSource.value?.source_category ||
+    '-'
+)
+const sourceStatusText = computed(() => {
+  if (!selectedSource.value) {
+    return t('llmOps.manualPriceImport.validation.sourceRequired')
+  }
+  if (!selectedSourceProvider.value) {
+    return t('llmOps.manualPriceImport.validation.sourceProviderRequired')
+  }
+  return t('llmOps.manualPriceImport.validation.sourceReady', {
+    name: selectedSource.value.name
+  })
+})
 const parsed = computed(() => parseTable(rawTable.value))
 const parsedRows = computed(() => parsed.value.rows)
 const parseErrors = computed(() => parsed.value.errors)
 const canSubmit = computed(
   () =>
-    form.value.provider &&
-    form.value.source_name.trim() &&
+    form.value.source &&
+    selectedSourceProvider.value &&
     parsedRows.value.length &&
     !parseErrors.value.length
 )
@@ -298,18 +334,28 @@ watch(
     if (open) {
       form.value = defaultForm()
       rawTable.value = ''
+      form.value.source = firstImportSourceId()
     }
   }
 )
 
+watch(selectedSource, (source) => {
+  if (source?.currency) {
+    form.value.currency = source.currency
+  }
+})
+
 function defaultForm() {
   return {
-    provider: '',
-    source_name: '',
-    source_url: '',
+    source: '',
     currency: 'USD',
     updates_model_prices: true
   }
+}
+
+function firstImportSourceId() {
+  const source = props.sources.find((item) => item.provider)
+  return source?.id || props.sources[0]?.id || ''
 }
 
 function close() {
@@ -323,6 +369,9 @@ async function submit() {
   try {
     await llmOpsApi.importManualPrices({
       ...form.value,
+      provider: selectedSourceProvider.value.id,
+      source_name: selectedSource.value.name,
+      source_url: selectedSource.value.endpoint_url || '',
       rows: parsedRows.value.map((row) => cleanRow(row))
     })
     emit('imported')
@@ -548,8 +597,24 @@ function modalityLabel(value) {
   @apply text-xs font-medium text-slate-500;
 }
 
+.field-help {
+  @apply text-xs leading-5 text-slate-400;
+}
+
 .field {
   @apply min-h-9 w-full rounded-lg border border-slate-200 bg-white px-2.5 py-1.5 text-sm text-slate-800 outline-none transition placeholder:text-slate-400 focus:border-indigo-300 focus:ring-4 focus:ring-indigo-50;
+}
+
+.source-context {
+  @apply rounded-lg border border-slate-200 bg-slate-50 px-3 py-2;
+}
+
+.source-context span {
+  @apply block text-xs text-slate-500;
+}
+
+.source-context strong {
+  @apply mt-1 block truncate text-sm font-medium text-slate-800;
 }
 
 .table-input {

--- a/frontend/src/components/llm-ops/PriceSourceModal.vue
+++ b/frontend/src/components/llm-ops/PriceSourceModal.vue
@@ -88,6 +88,61 @@
                 :options="sourceCategoryOptions"
               />
             </label>
+            <label
+              v-if="shouldUseOfficialPreset"
+              class="field-group md:col-span-2"
+            >
+              <span class="field-label">
+                {{ t('llmOps.priceSourceModal.fields.officialProvider') }}
+              </span>
+              <CompactSelect
+                v-model="selectedOfficialProviderCode"
+                :disabled="loadingOfficialProviderOptions || saving"
+                :options="officialProviderSelectOptions"
+                class-name="w-full"
+                :menu-min-width="360"
+              />
+              <span class="field-help">
+                {{ officialProviderStatus }}
+              </span>
+            </label>
+            <div
+              v-if="shouldUseOfficialPreset && selectedOfficialProviderOption"
+              class="official-source-detail md:col-span-2"
+            >
+              <div>
+                <span>
+                  {{ t('llmOps.priceSourceModal.officialPreset.source') }}
+                </span>
+                <strong>
+                  {{ selectedOfficialProviderOption.source_name }}
+                </strong>
+              </div>
+              <div>
+                <span>
+                  {{ t('llmOps.priceSourceModal.officialPreset.slug') }}
+                </span>
+                <strong class="font-mono">
+                  {{ selectedOfficialProviderOption.source_slug }}
+                </strong>
+              </div>
+              <div>
+                <span>
+                  {{ t('llmOps.priceSourceModal.officialPreset.currency') }}
+                </span>
+                <strong>
+                  {{ selectedOfficialProviderOption.currency }}
+                </strong>
+              </div>
+              <div>
+                <span>
+                  {{ t('llmOps.priceSourceModal.officialPreset.url') }}
+                </span>
+                <strong class="break-all">
+                  {{ selectedOfficialProviderOption.source_url || '-' }}
+                </strong>
+              </div>
+            </div>
             <label class="field-group">
               <span class="field-label">
                 {{ t('llmOps.priceSourceModal.fields.currency') }}
@@ -156,7 +211,7 @@
           <button
             class="btn-primary btn-action-save"
             type="submit"
-            :disabled="saving"
+            :disabled="saving || saveDisabled"
           >
             <span class="icon-mark" />
             {{
@@ -197,10 +252,22 @@ const { t } = useI18n()
 
 const saving = ref(false)
 const form = ref(defaults())
+const officialProviderOptions = ref([])
+const selectedOfficialProviderCode = ref('')
+const loadingOfficialProviderOptions = ref(false)
 const isEditing = computed(() => Boolean(props.source?.id))
-const internalSlugLabel = computed(() =>
-  isEditing.value ? form.value.slug || '-' : autoSlug(form.value.name || '')
+const shouldUseOfficialPreset = computed(
+  () => !isEditing.value && form.value.source_category === 'official_provider'
 )
+const internalSlugLabel = computed(() =>
+  isEditing.value ? form.value.slug || '-' : sourceSlugLabel.value
+)
+const sourceSlugLabel = computed(() => {
+  if (shouldUseOfficialPreset.value && selectedOfficialProviderOption.value) {
+    return selectedOfficialProviderOption.value.source_slug || '-'
+  }
+  return autoSlug(form.value.name || '')
+})
 const sourceTypeLabel = computed(() => {
   const type = props.source?.source_type || 'custom'
   const labels = {
@@ -235,6 +302,44 @@ const currencyOptions = computed(() => [
   { label: t('llmOps.priceSourceModal.currencies.usd'), value: 'USD' }
 ])
 
+const officialProviderSelectOptions = computed(() =>
+  officialProviderOptions.value.map((option) => ({
+    value: option.provider_code,
+    label: option.provider_name,
+    description: option.source_name,
+    badge: option.source_exists
+      ? t('llmOps.priceSourceModal.officialPreset.existsBadge')
+      : option.currency
+  }))
+)
+
+const selectedOfficialProviderOption = computed(() =>
+  officialProviderOptions.value.find(
+    (option) =>
+      String(option.provider_code) ===
+      String(selectedOfficialProviderCode.value)
+  )
+)
+
+const officialProviderStatus = computed(() => {
+  if (loadingOfficialProviderOptions.value) {
+    return t('llmOps.priceSourceModal.officialPreset.loading')
+  }
+  const option = selectedOfficialProviderOption.value
+  if (!option) return t('llmOps.priceSourceModal.officialPreset.empty')
+  if (option.source_exists) {
+    return t('llmOps.priceSourceModal.officialPreset.exists')
+  }
+  return t('llmOps.priceSourceModal.officialPreset.ready')
+})
+
+const saveDisabled = computed(
+  () =>
+    shouldUseOfficialPreset.value &&
+    (!selectedOfficialProviderOption.value ||
+      selectedOfficialProviderOption.value.source_exists)
+)
+
 watch(
   () => props.source,
   (source) => {
@@ -242,6 +347,20 @@ watch(
   },
   { immediate: true }
 )
+
+watch(
+  () => [props.open, form.value.source_category, isEditing.value],
+  ([open]) => {
+    if (open && shouldUseOfficialPreset.value) {
+      loadOfficialProviderOptions()
+    }
+  }
+)
+
+watch(selectedOfficialProviderOption, (option) => {
+  if (!shouldUseOfficialPreset.value || !option) return
+  applyOfficialProviderOption(option)
+})
 
 function defaults() {
   return {
@@ -277,6 +396,10 @@ function close() {
 async function save() {
   saving.value = true
   try {
+    if (shouldUseOfficialPreset.value) {
+      await saveOfficialProviderSource()
+      return
+    }
     const payload = {
       ...form.value,
       slug: isEditing.value
@@ -296,6 +419,65 @@ async function save() {
     showError(errorMessage(error, t('llmOps.priceSourceModal.errors.save')))
   } finally {
     saving.value = false
+  }
+}
+
+async function saveOfficialProviderSource() {
+  const option = selectedOfficialProviderOption.value
+  if (!option || option.source_exists) return
+
+  const response = await llmOpsApi.ensureOfficialProviderSource(
+    option.provider_code
+  )
+  const payload = response?.data?.data || response?.data || {}
+  const sourceName = payload.source?.name || option.source_name
+  showSuccess(
+    t('llmOps.priceSourceModal.messages.officialCreated', {
+      name: sourceName
+    })
+  )
+  emit('saved')
+}
+
+async function loadOfficialProviderOptions() {
+  if (loadingOfficialProviderOptions.value) return
+  loadingOfficialProviderOptions.value = true
+  try {
+    const response = await llmOpsApi.listOfficialProviderSourceOptions()
+    const payload = response?.data?.data || response?.data || {}
+    const options = Array.isArray(payload.results) ? payload.results : []
+    officialProviderOptions.value = options
+    const current = options.find(
+      (option) =>
+        String(option.provider_code) ===
+        String(selectedOfficialProviderCode.value)
+    )
+    const preferred = options.find((option) => !option.source_exists)
+    const selected =
+      current && !current.source_exists ? current : preferred || current
+    selectedOfficialProviderCode.value =
+      selected?.provider_code || options[0]?.provider_code || ''
+    if (selected) applyOfficialProviderOption(selected)
+  } catch (error) {
+    showError(
+      errorMessage(
+        error,
+        t('llmOps.priceSourceModal.errors.loadOfficialSources')
+      )
+    )
+  } finally {
+    loadingOfficialProviderOptions.value = false
+  }
+}
+
+function applyOfficialProviderOption(option) {
+  form.value = {
+    ...form.value,
+    name: option.source_name || option.provider_name || form.value.name,
+    slug: option.source_slug || form.value.slug,
+    currency: option.currency || form.value.currency,
+    endpoint_url: option.source_url || form.value.endpoint_url,
+    updates_model_prices: true
   }
 }
 

--- a/frontend/src/components/llm-ops/ProviderManagement.vue
+++ b/frontend/src/components/llm-ops/ProviderManagement.vue
@@ -25,27 +25,6 @@
         </div>
         <div class="provider-toolbar-actions">
           <button
-            class="btn-secondary btn-action-create"
-            type="button"
-            :disabled="loadingOfficialProviderOptions"
-            @click="openOfficialProviderModal"
-          >
-            <svg
-              class="source-primary-icon"
-              aria-hidden="true"
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-            >
-              <path d="M12 5v14" />
-              <path d="M5 12h14" />
-            </svg>
-            {{ t('llmOps.providerManagement.actions.addOfficialSource') }}
-          </button>
-          <button
             class="btn-secondary btn-action-sync"
             type="button"
             :disabled="syncingAllSources || !hasSyncablePriceSources"
@@ -228,139 +207,10 @@
     <ManualPriceImportModal
       :open="showManualImportModal"
       :providers="providers"
+      :sources="entrySourceRows"
       @close="showManualImportModal = false"
       @imported="handleManualImported"
     />
-    <div
-      v-if="showOfficialProviderModal"
-      class="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/30 px-4 py-6"
-      @click.self="closeOfficialProviderModal"
-    >
-      <form
-        class="max-h-[calc(100vh-3rem)] w-full max-w-xl overflow-hidden rounded-xl bg-white shadow-2xl"
-        @submit.prevent="addOfficialProviderSource"
-      >
-        <div class="border-b border-slate-200 px-5 py-4">
-          <div class="flex items-start justify-between gap-4">
-            <div>
-              <p
-                class="text-xs font-semibold uppercase tracking-[0.18em] text-indigo-600"
-              >
-                Official Source
-              </p>
-              <h3 class="mt-2 text-lg font-semibold text-slate-900">
-                {{ t('llmOps.providerManagement.officialSourceModal.title') }}
-              </h3>
-            </div>
-            <button
-              class="btn-secondary btn-action-cancel"
-              type="button"
-              :disabled="addingOfficialProviderSource"
-              @click="closeOfficialProviderModal"
-            >
-              {{ t('llmOps.providerManagement.actions.cancel') }}
-            </button>
-          </div>
-        </div>
-
-        <div class="space-y-4 px-5 py-5">
-          <label class="field-group">
-            <span class="field-label">
-              {{
-                t('llmOps.providerManagement.officialSourceModal.provider')
-              }}
-            </span>
-            <CompactSelect
-              v-model="selectedOfficialProviderCode"
-              :disabled="
-                loadingOfficialProviderOptions ||
-                addingOfficialProviderSource
-              "
-              :options="officialProviderSelectOptions"
-              class-name="w-full"
-              :menu-min-width="360"
-            />
-          </label>
-
-          <div
-            v-if="loadingOfficialProviderOptions"
-            class="official-source-state"
-          >
-            {{ t('common.loading') }}
-          </div>
-          <div
-            v-else-if="selectedOfficialProviderOption"
-            class="official-source-detail"
-          >
-            <div>
-              <span>
-                {{
-                  t('llmOps.providerManagement.officialSourceModal.source')
-                }}
-              </span>
-              <strong>{{ selectedOfficialProviderOption.source_name }}</strong>
-            </div>
-            <div>
-              <span>
-                {{ t('llmOps.providerManagement.officialSourceModal.slug') }}
-              </span>
-              <strong class="font-mono">
-                {{ selectedOfficialProviderOption.source_slug }}
-              </strong>
-            </div>
-            <div>
-              <span>
-                {{
-                  t('llmOps.providerManagement.officialSourceModal.currency')
-                }}
-              </span>
-              <strong>{{ selectedOfficialProviderOption.currency }}</strong>
-            </div>
-            <div class="md:col-span-2">
-              <span>
-                {{ t('llmOps.providerManagement.officialSourceModal.url') }}
-              </span>
-              <strong class="break-all">
-                {{ selectedOfficialProviderOption.source_url }}
-              </strong>
-            </div>
-          </div>
-          <div v-else class="official-source-state">
-            {{ t('llmOps.providerManagement.officialSourceModal.empty') }}
-          </div>
-        </div>
-
-        <div class="modal-footer">
-          <span class="modal-footer-note">
-            {{ officialProviderModalStatus }}
-          </span>
-          <div class="modal-footer-actions">
-            <button
-              class="btn-secondary btn-action-cancel"
-              type="button"
-              :disabled="addingOfficialProviderSource"
-              @click="closeOfficialProviderModal"
-            >
-              {{ t('llmOps.providerManagement.actions.cancel') }}
-            </button>
-            <button
-              class="btn-primary btn-action-save"
-              type="submit"
-              :disabled="officialProviderAddDisabled"
-            >
-              <span class="icon-mark" />
-              {{
-                addingOfficialProviderSource
-                  ? t('llmOps.providerManagement.actions.submitting')
-                  : selectedOfficialProviderOption?.source_exists
-                    ? t('llmOps.providerManagement.actions.added')
-                    : t('llmOps.providerManagement.actions.add')
-              }}
-            </button>
-          </div>
-        </div>
-      </form>
-    </div>
     <PriceSourceModal
       :open="showPriceSourceModal || Boolean(editingSource)"
       :source="editingSource"
@@ -416,7 +266,6 @@ import PriceSourceModal from '@/components/llm-ops/PriceSourceModal.vue'
 import ProviderPricingDrawer from '@/components/llm-ops/ProviderPricingDrawer.vue'
 import SourcePriceDrawer from '@/components/llm-ops/SourcePriceDrawer.vue'
 import OperationIconButton from '@/components/llm-ops/OperationIconButton.vue'
-import CompactSelect from '@/components/llm-ops/CompactSelect.vue'
 
 const props = defineProps({
   providers: {
@@ -459,14 +308,9 @@ const editingSource = ref(null)
 const priceEntrySource = ref(null)
 const showPriceSourceModal = ref(false)
 const showManualImportModal = ref(false)
-const showOfficialProviderModal = ref(false)
 const collectingSourceId = ref(null)
 const syncingAllSources = ref(false)
 const deletingSourceId = ref(null)
-const loadingOfficialProviderOptions = ref(false)
-const addingOfficialProviderSource = ref(false)
-const officialProviderOptions = ref([])
-const selectedOfficialProviderCode = ref('')
 const sourceSearch = ref('')
 const sourceCategoryFilter = ref('all')
 const sourceStatusFilter = ref('all')
@@ -508,46 +352,6 @@ const sourceStatusFilterOptions = computed(() => [
     label: t('llmOps.providerManagement.filters.inactiveOnly')
   }
 ])
-
-const officialProviderSelectOptions = computed(() =>
-  officialProviderOptions.value.map((option) => ({
-    value: option.provider_code,
-    label: option.provider_name,
-    description: option.source_name,
-    badge: option.source_exists
-      ? t('llmOps.providerManagement.officialSourceModal.existsBadge')
-      : option.currency
-  }))
-)
-
-const selectedOfficialProviderOption = computed(() =>
-  officialProviderOptions.value.find(
-    (option) =>
-      String(option.provider_code) === String(selectedOfficialProviderCode.value)
-  )
-)
-
-const officialProviderAddDisabled = computed(
-  () =>
-    loadingOfficialProviderOptions.value ||
-    addingOfficialProviderSource.value ||
-    !selectedOfficialProviderOption.value ||
-    selectedOfficialProviderOption.value.source_exists
-)
-
-const officialProviderModalStatus = computed(() => {
-  if (loadingOfficialProviderOptions.value) {
-    return t('llmOps.providerManagement.officialSourceModal.loading')
-  }
-  const option = selectedOfficialProviderOption.value
-  if (!option) {
-    return t('llmOps.providerManagement.officialSourceModal.empty')
-  }
-  if (option.source_exists) {
-    return t('llmOps.providerManagement.officialSourceModal.exists')
-  }
-  return t('llmOps.providerManagement.officialSourceModal.ready')
-})
 
 const sourceRows = computed(() =>
   props.sources
@@ -807,7 +611,8 @@ function sourcesForProvider(provider, priceItems) {
   )
   return sourceRows.value.filter(
     (source) =>
-      sourceMatchesProvider(source, provider) || sourceIds.has(String(source.id))
+      sourceMatchesProvider(source, provider) ||
+      sourceIds.has(String(source.id))
   )
 }
 
@@ -994,75 +799,6 @@ function dimensionCount(items) {
 function handleManualImported() {
   showManualImportModal.value = false
   emit('refresh')
-}
-
-async function openOfficialProviderModal() {
-  showOfficialProviderModal.value = true
-  await loadOfficialProviderOptions()
-}
-
-function closeOfficialProviderModal() {
-  if (addingOfficialProviderSource.value) return
-  showOfficialProviderModal.value = false
-}
-
-async function loadOfficialProviderOptions() {
-  loadingOfficialProviderOptions.value = true
-  try {
-    const response = await llmOpsApi.listOfficialProviderSourceOptions()
-    const payload = response?.data?.data || response?.data || {}
-    const options = Array.isArray(payload.results) ? payload.results : []
-    officialProviderOptions.value = options
-    const current = options.find(
-      (option) =>
-        String(option.provider_code) ===
-        String(selectedOfficialProviderCode.value)
-    )
-    const preferred = options.find((option) => !option.source_exists)
-    const selected =
-      current && !current.source_exists ? current : preferred || current
-    selectedOfficialProviderCode.value =
-      selected?.provider_code || options[0]?.provider_code || ''
-  } catch (error) {
-    showError(
-      errorMessage(
-        error,
-        t('llmOps.providerManagement.errors.loadOfficialSourcesFailed')
-      )
-    )
-  } finally {
-    loadingOfficialProviderOptions.value = false
-  }
-}
-
-async function addOfficialProviderSource() {
-  const option = selectedOfficialProviderOption.value
-  if (!option || option.source_exists) return
-
-  addingOfficialProviderSource.value = true
-  try {
-    const response = await llmOpsApi.ensureOfficialProviderSource(
-      option.provider_code
-    )
-    const payload = response?.data?.data || response?.data || {}
-    const sourceName = payload.source?.name || option.source_name
-    showSuccess(
-      t('llmOps.providerManagement.messages.officialSourceAdded', {
-        name: sourceName
-      })
-    )
-    showOfficialProviderModal.value = false
-    emit('refresh')
-  } catch (error) {
-    showError(
-      errorMessage(
-        error,
-        t('llmOps.providerManagement.errors.addOfficialSourceFailed')
-      )
-    )
-  } finally {
-    addingOfficialProviderSource.value = false
-  }
 }
 
 function closePriceSourceModal() {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1484,6 +1484,7 @@
         "currency": "Default currency",
         "endpointUrl": "Price URL",
         "name": "Price source name",
+        "officialProvider": "Official provider",
         "slug": "System slug",
         "sourceType": "Source mode"
       },
@@ -1519,11 +1520,24 @@
         "cny": "CNY",
         "usd": "USD"
       },
+      "officialPreset": {
+        "currency": "Currency",
+        "empty": "No official price source presets are available.",
+        "exists": "This official source has already been added.",
+        "existsBadge": "Added",
+        "loading": "Loading official sources.",
+        "ready": "Confirm to create the official price source.",
+        "slug": "System slug",
+        "source": "Price source",
+        "url": "Price URL"
+      },
       "messages": {
         "created": "Model price source created",
+        "officialCreated": "Official price source \"{name}\" added",
         "updated": "Model price source updated"
       },
       "errors": {
+        "loadOfficialSources": "Failed to load official price sources",
         "save": "Failed to save model price source"
       }
     },
@@ -1728,12 +1742,15 @@
       "fields": {
         "currency": "Default currency",
         "provider": "Model provider",
+        "source": "Model price source",
+        "sourceCategory": "Pricing scope",
         "sourceName": "Model price source name",
         "sourceUrl": "Model price source URL",
         "tableContent": "Excel / CSV content"
       },
       "placeholders": {
         "selectProvider": "Select model owner",
+        "selectSource": "Select an existing model price source",
         "sourceName": "Example: OpenAI 2026-06 manual price sheet",
         "sourceUrl": "Optional, official site or internal spreadsheet link"
       },
@@ -1764,6 +1781,11 @@
         "multimodal": "Multimodal",
         "text": "Text",
         "video": "Video"
+      },
+      "validation": {
+        "sourceProviderRequired": "This price source is not bound to a model provider and cannot be imported in bulk.",
+        "sourceReady": "Prices will be imported into \"{name}\".",
+        "sourceRequired": "Select an existing model price source."
       },
       "parseErrors": {
         "invalidNumber": "Line {line}: {field} is not a valid non-negative number.",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1494,6 +1494,7 @@
         "currency": "默认币种",
         "endpointUrl": "价格地址",
         "name": "价格源名称",
+        "officialProvider": "原厂厂商",
         "slug": "系统标识",
         "sourceType": "来源方式"
       },
@@ -1529,11 +1530,24 @@
         "cny": "CNY",
         "usd": "USD"
       },
+      "officialPreset": {
+        "currency": "币种",
+        "empty": "暂无可添加的原厂价格源。",
+        "exists": "当前原厂源已经添加。",
+        "existsBadge": "已添加",
+        "loading": "正在加载原厂源。",
+        "ready": "确认后会创建原厂价格源。",
+        "slug": "系统标识",
+        "source": "价格源",
+        "url": "价格地址"
+      },
       "messages": {
         "created": "模型价格源已创建",
+        "officialCreated": "原厂价格源「{name}」已添加",
         "updated": "模型价格源已更新"
       },
       "errors": {
+        "loadOfficialSources": "加载原厂价格源失败",
         "save": "保存模型价格源失败"
       }
     },
@@ -1738,12 +1752,15 @@
       "fields": {
         "currency": "默认币种",
         "provider": "模型厂商",
+        "source": "模型价格源",
+        "sourceCategory": "价格口径",
         "sourceName": "模型价格源名称",
         "sourceUrl": "模型价格源地址",
         "tableContent": "Excel / CSV 内容"
       },
       "placeholders": {
         "selectProvider": "选择模型归属方",
+        "selectSource": "选择已有模型价格源",
         "sourceName": "例如 OpenAI 2026-06 手动价格表",
         "sourceUrl": "可选，官网或内部表格链接"
       },
@@ -1774,6 +1791,11 @@
         "multimodal": "多模态",
         "text": "文本",
         "video": "视频"
+      },
+      "validation": {
+        "sourceProviderRequired": "该价格源尚未绑定模型厂商，无法批量导入。",
+        "sourceReady": "将导入到价格源「{name}」。",
+        "sourceRequired": "请选择一个已有模型价格源。"
       },
       "parseErrors": {
         "invalidNumber": "第 {line} 行 {field} 不是有效的非负数字。",


### PR DESCRIPTION
## Summary
- Move official provider source creation into the price source modal preset flow
- Require manual price import to target an existing price source and infer provider/source metadata
- Allow backend manual imports to accept an existing source and validate provider consistency
- Add localized copy for the new source selection and official source preset states

## Test plan
- [x] `npm run build`
- [x] `npx eslint src/components/llm-ops/ManualPriceImportModal.vue src/components/llm-ops/PriceSourceModal.vue src/components/llm-ops/ProviderManagement.vue --ext .vue,.js,.jsx,.cjs,.mjs --fix --ignore-path ../.gitignore`
- [x] `git diff --check`
- [ ] `pytest backend/llm_ops/tests/test_views.py -k manual_price_import` could not run: `pytest` is not installed in PATH
- [ ] `UV_DEFAULT_INDEX=https://pypi.org/simple uv run pytest backend/llm_ops/tests/test_views.py -k manual_price_import` was stopped after hanging without output during dependency setup; default uv mirror also failed with TLS errors fetching django-allauth

Made with [Orca](https://github.com/stablyai/orca) 🐋
