### PR TITLE
Protect LLM Ops reset from deleting linked records

### DIFF
--- a/backend/llm_ops/catalog_maintenance.py
+++ b/backend/llm_ops/catalog_maintenance.py
@@ -1,4 +1,5 @@
 """Maintenance helpers for LLM Ops catalog normalization and cleanup."""
+
 from __future__ import annotations
 
 from django.db.models import Q
@@ -28,7 +29,6 @@ from .models import (
     UsageReconciliationRecord,
 )
 from .services import stable_fingerprint
-
 
 REAL_RESOURCE_CHANNEL_CODE = "real-resource-platform"
 YUNCE_SUPPLIER_CHANNEL_CODE = "yunce-supplier-platform"
@@ -88,6 +88,8 @@ def clean_legacy_llm_ops_demo_data() -> dict[str, int]:
         "channel_price_items": 0,
         "channel_model_prices": 0,
         "channel_model_histories": 0,
+        "resale_listings": 0,
+        "resale_listing_histories": 0,
         "sources": 0,
         "channels": 0,
     }
@@ -107,13 +109,19 @@ def clean_legacy_llm_ops_demo_data() -> dict[str, int]:
         | Q(channel__code__startswith="test-")
         | Q(channel__name__startswith="测试")
     )
+    test_channel_ids = list(
+        ProcurementChannel.objects.filter(
+            Q(code=REAL_RESOURCE_CHANNEL_CODE)
+            | Q(code__in=MOCK_SUPPLIER_CHANNEL_CODES)
+            | Q(code__startswith="test-")
+        ).values_list("id", flat=True)
+    )
     PriceCollectionSource.objects.filter(
         channel__code=REAL_RESOURCE_CHANNEL_CODE,
     ).update(channel=None)
     stats["model_price_items"] += _delete_count(
         ModelPriceItem.objects.filter(
-            Q(source_id__in=source_ids)
-            | Q(spec__mock_source="yunce_supplier")
+            Q(source_id__in=source_ids) | Q(spec__mock_source="yunce_supplier")
         )
     )
     stats["channel_price_items"] += _delete_count(
@@ -130,6 +138,14 @@ def clean_legacy_llm_ops_demo_data() -> dict[str, int]:
         ChannelModelPriceHistory.objects.filter(
             price_fingerprint__in=trend_demo_history_fingerprints(),
         )
+    )
+    stats["resale_listing_histories"] += _delete_count(
+        ResaleListingPriceHistory.objects.filter(
+            channel_id__in=test_channel_ids,
+        )
+    )
+    stats["resale_listings"] += _delete_count(
+        ResaleListing.objects.filter(channel_id__in=test_channel_ids)
     )
     stats["sources"] += _delete_count(
         PriceCollectionSource.objects.filter(id__in=source_ids)
@@ -225,12 +241,16 @@ def normalize_model_linked_meta_models() -> int:
     )
     for model in LLMModel.objects.select_related("meta_model").all():
         for model_type in model_linked_types:
-            total += model_type.objects.filter(
-                model=model,
-            ).exclude(
-                meta_model=model.meta_model,
-            ).update(
-                meta_model=model.meta_model,
+            total += (
+                model_type.objects.filter(
+                    model=model,
+                )
+                .exclude(
+                    meta_model=model.meta_model,
+                )
+                .update(
+                    meta_model=model.meta_model,
+                )
             )
     return total
 
@@ -282,6 +302,14 @@ def merge_meta_model_rows(
 
 def cleanup_orphan_meta_models() -> dict[str, int]:
     """Remove meta models that no canonical price row references."""
+    return cleanup_orphan_meta_models_for_reset(dry_run=False)
+
+
+def cleanup_orphan_meta_models_for_reset(
+    *,
+    dry_run: bool = False,
+) -> dict[str, int]:
+    """Remove or preview meta models that no canonical model references."""
     stats = {
         "meta_models_rehomed": 0,
         "meta_models_deleted": 0,
@@ -291,20 +319,95 @@ def cleanup_orphan_meta_models() -> dict[str, int]:
         spec = canonical_vendor_for_model_code(meta.code)
         canonical = None
         if spec:
-            canonical = ensure_canonical_vendor_row(spec)
+            if dry_run:
+                if is_canonical_vendor_code(spec["code"]):
+                    canonical = LLMProvider.objects.filter(
+                        code=spec["code"],
+                    ).first()
+            else:
+                canonical = ensure_canonical_vendor_row(spec)
         elif meta.vendor_id and is_canonical_vendor_code(meta.vendor.code):
             canonical = meta.vendor
         if canonical and meta.vendor_id and canonical.id != meta.vendor_id:
-            meta.vendor = canonical
-            meta.save(update_fields=["vendor", "updated_at"])
+            if not dry_run:
+                meta.vendor = canonical
+                meta.save(update_fields=["vendor", "updated_at"])
             stats["meta_models_rehomed"] += 1
         if not meta.provider_prices.exists():
             orphan_ids.append(meta.id)
     if orphan_ids:
-        stats["meta_models_deleted"] = MetaModel.objects.filter(
-            id__in=orphan_ids,
-        ).delete()[0]
+        if dry_run:
+            stats["meta_models_deleted"] = len(orphan_ids)
+        else:
+            stats["meta_models_deleted"] = MetaModel.objects.filter(
+                id__in=orphan_ids,
+            ).delete()[0]
     return stats
+
+
+MODEL_BUSINESS_LINK_MODELS = (
+    ("channel_model_prices", ChannelModelPrice),
+    ("channel_price_items", ChannelPriceItem),
+    ("channel_model_histories", ChannelModelPriceHistory),
+    ("resale_listings", ResaleListing),
+    ("resale_listing_exclusions", ResaleListingExclusion),
+    ("resale_listing_histories", ResaleListingPriceHistory),
+    ("usage_reconciliation_records", UsageReconciliationRecord),
+)
+
+
+def model_business_link_counts(model_ids: list[int]) -> dict[str, int]:
+    """Return downstream business references for model ids."""
+    if not model_ids:
+        return {}
+    counts = {}
+    for key, model_type in MODEL_BUSINESS_LINK_MODELS:
+        count = model_type.objects.filter(model_id__in=model_ids).count()
+        if count:
+            counts[key] = count
+    return counts
+
+
+def model_ids_with_business_links(model_ids: list[int]) -> set[int]:
+    """Return model ids referenced by downstream business rows."""
+    linked_ids: set[int] = set()
+    if not model_ids:
+        return linked_ids
+    for _, model_type in MODEL_BUSINESS_LINK_MODELS:
+        linked_ids.update(
+            model_type.objects.filter(model_id__in=model_ids)
+            .values_list("model_id", flat=True)
+            .distinct()
+        )
+    return linked_ids
+
+
+def model_delete_dependency_counts(model: LLMModel) -> dict[str, int]:
+    """Return dependencies that make direct model deletion unsafe."""
+    counts = model_business_link_counts([model.id])
+    price_items = ModelPriceItem.objects.filter(model=model).count()
+    if price_items:
+        counts["model_price_items"] = price_items
+    return counts
+
+
+def meta_model_dependency_counts(meta_model: MetaModel) -> dict[str, int]:
+    """Return dependencies that make direct meta-model deletion unsafe."""
+    counts = {}
+    for relation in MetaModel._meta.related_objects:
+        if relation.related_model is MetaModel:
+            continue
+        count = relation.related_model.objects.filter(
+            **{relation.field.name: meta_model},
+        ).count()
+        if count:
+            counts[relation.get_accessor_name()] = count
+    return counts
+
+
+def meta_model_has_business_links(meta_model: MetaModel) -> bool:
+    """Return whether a meta model is still referenced by another table."""
+    return bool(meta_model_dependency_counts(meta_model))
 
 
 def reset_meta_models_canonical() -> dict[str, int]:
@@ -314,20 +417,12 @@ def reset_meta_models_canonical() -> dict[str, int]:
         "supplier_sources_kept": 0,
         "meta_models_deleted": 0,
     }
-    stats["manual_sources_kept"] = (
-        PriceCollectionSource.objects.filter(
-            source_category=(
-                PriceCollectionSource.SOURCE_CATEGORY_MANUAL
-            ),
-        ).count()
-    )
-    stats["supplier_sources_kept"] = (
-        PriceCollectionSource.objects.filter(
-            source_category=(
-                PriceCollectionSource.SOURCE_CATEGORY_SUPPLIER
-            ),
-        ).count()
-    )
+    stats["manual_sources_kept"] = PriceCollectionSource.objects.filter(
+        source_category=(PriceCollectionSource.SOURCE_CATEGORY_MANUAL),
+    ).count()
+    stats["supplier_sources_kept"] = PriceCollectionSource.objects.filter(
+        source_category=(PriceCollectionSource.SOURCE_CATEGORY_SUPPLIER),
+    ).count()
     PriceCollectionSource.objects.filter(
         channel__code=REAL_RESOURCE_CHANNEL_CODE,
     ).delete()

--- a/backend/llm_ops/collection_services.py
+++ b/backend/llm_ops/collection_services.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from decimal import Decimal, InvalidOperation
 import hashlib
 import json
 import re
+from decimal import Decimal, InvalidOperation
 
 from django.db import transaction
 from django.utils import timezone
@@ -22,8 +22,8 @@ from .constants import canonical_meta_model_identity
 from .models import (
     CollectedModelPriceHistory,
     CollectedModelPriceSnapshot,
-    LLMOpsGlobalConfig,
     LLMModel,
+    LLMOpsGlobalConfig,
     LLMProvider,
     MetaModel,
     ModelPriceItem,
@@ -114,6 +114,7 @@ def source_owner_type_for_provider(provider: LLMProvider) -> str:
     if str(provider.code or "").lower() in CLOUD_PROVIDER_OFFICIAL_CODES:
         return PriceCollectionSource.SOURCE_OWNER_CLOUD_PROVIDER_OFFICIAL
     return PriceCollectionSource.SOURCE_OWNER_MODEL_PROVIDER_OFFICIAL
+
 
 CACHE_INPUT_PRICE_KEYS = (
     "cache_input_price",
@@ -592,8 +593,8 @@ def sync_configured_official_model_prices(
     verify_source: bool = True,
 ) -> dict[str, dict[str, int | str | list[str]]]:
     """Collect official prices for configured supported providers."""
-    selected_provider_codes = (
-        provider_codes or list(DEFAULT_OFFICIAL_PRICE_SYNC_PROVIDER_CODES)
+    selected_provider_codes = provider_codes or list(
+        DEFAULT_OFFICIAL_PRICE_SYNC_PROVIDER_CODES
     )
     selected_provider_codes = [
         code
@@ -730,10 +731,11 @@ def reset_official_price_catalog(
     dry_run: bool = False,
 ) -> dict[str, int | list[str]]:
     """Clear official price data while preserving provider-level sources."""
-    codes = tuple(provider_codes or SUPPORTED_OFFICIAL_PRICE_SYNC_PROVIDER_CODES)
+    codes = tuple(
+        provider_codes or SUPPORTED_OFFICIAL_PRICE_SYNC_PROVIDER_CODES
+    )
     provider_source_slugs = {
-        official_provider_source_slug(provider_code)
-        for provider_code in codes
+        official_provider_source_slug(provider_code) for provider_code in codes
     }
     matched_sources = [
         source
@@ -767,20 +769,24 @@ def reset_official_price_catalog(
         if source.slug not in provider_source_slugs
     ]
     legacy_sources = [
-        source
-        for source in matched_sources
-        if source.id in legacy_source_ids
+        source for source in matched_sources if source.id in legacy_source_ids
     ]
     legacy_source_slugs = sorted(
         source.slug
         for source in matched_sources
         if source.id in legacy_source_ids
     )
+    legacy_models_deduplicated = count_legacy_model_source_collisions(
+        legacy_sources=legacy_sources,
+        provider_source_ids=provider_source_ids,
+        provider_sources_by_provider_id=provider_sources_by_provider_id,
+    )
 
     stats: dict[str, int | list[str]] = {
         "sources_matched": len(source_ids),
         "provider_sources_kept": len(provider_source_ids),
         "legacy_sources_deleted": len(legacy_source_ids),
+        "legacy_models_deduplicated": legacy_models_deduplicated,
         "models_reset": LLMModel.objects.filter(
             source_id__in=source_ids,
         ).count(),
@@ -837,15 +843,82 @@ def reset_official_price_catalog(
                     updated_at=now,
                 )
                 continue
-            queryset.update(
-                source_id=provider_source.id,
-                source_url=provider_source.endpoint_url or "",
-                updated_at=now,
+            migrate_legacy_models_to_provider_source(
+                queryset=queryset,
+                provider_source=provider_source,
+                now=now,
             )
         prune_global_config_price_sources(legacy_source_ids)
         PriceCollectionSource.objects.filter(id__in=legacy_source_ids).delete()
 
     return stats
+
+
+def count_legacy_model_source_collisions(
+    *,
+    legacy_sources: list[PriceCollectionSource],
+    provider_source_ids: list[int],
+    provider_sources_by_provider_id: dict[int, PriceCollectionSource],
+) -> int:
+    """Count legacy model rows that would collide on provider source move."""
+    if not legacy_sources:
+        return 0
+
+    target_keys = set(
+        LLMModel.objects.filter(source_id__in=provider_source_ids).values_list(
+            "provider_id", "source_id", "code"
+        )
+    )
+    collisions = 0
+    for legacy_source in legacy_sources:
+        provider_source = provider_sources_by_provider_id.get(
+            legacy_source.provider_id
+        )
+        if provider_source is None:
+            continue
+        legacy_models = LLMModel.objects.filter(
+            source=legacy_source,
+        ).values_list("provider_id", "code")
+        for provider_id, code in legacy_models:
+            key = (provider_id, provider_source.id, code)
+            if key in target_keys:
+                collisions += 1
+                continue
+            target_keys.add(key)
+    return collisions
+
+
+def migrate_legacy_models_to_provider_source(
+    *,
+    queryset,
+    provider_source: PriceCollectionSource,
+    now,
+) -> None:
+    """Move legacy official models without violating provider/source/code."""
+    source_url = provider_source.endpoint_url or ""
+    for model in queryset.order_by("id").only("id", "provider_id", "code"):
+        duplicate_exists = (
+            LLMModel.objects.filter(
+                provider_id=model.provider_id,
+                source_id=provider_source.id,
+                code=model.code,
+            )
+            .exclude(id=model.id)
+            .exists()
+        )
+        if duplicate_exists:
+            LLMModel.objects.filter(id=model.id).update(
+                source=None,
+                source_url="",
+                price_role=LLMModel.PRICE_ROLE_UNKNOWN,
+                updated_at=now,
+            )
+            continue
+        LLMModel.objects.filter(id=model.id).update(
+            source_id=provider_source.id,
+            source_url=source_url,
+            updated_at=now,
+        )
 
 
 def official_source_matches_provider_codes(
@@ -881,7 +954,9 @@ def official_source_matches_provider_codes(
         )
     )
     for model_code in model_codes:
-        if source.slug == official_model_source_slug(provider_code, model_code):
+        if source.slug == official_model_source_slug(
+            provider_code, model_code
+        ):
             return True
     return False
 
@@ -895,14 +970,14 @@ def prune_global_config_price_sources(source_ids: list[int]) -> int:
     for config in LLMOpsGlobalConfig.objects.all():
         raw_ids = list(config.price_collection_source_ids or [])
         kept_ids = [
-            source_id
-            for source_id in raw_ids
-            if str(source_id) not in deleted
+            source_id for source_id in raw_ids if str(source_id) not in deleted
         ]
         if kept_ids == raw_ids:
             continue
         config.price_collection_source_ids = kept_ids
-        config.save(update_fields=["price_collection_source_ids", "updated_at"])
+        config.save(
+            update_fields=["price_collection_source_ids", "updated_at"]
+        )
         changed += 1
     return changed
 
@@ -939,10 +1014,7 @@ def ensure_official_model_source(
             "currency": currency or "USD",
             "is_enabled": True,
             "updates_model_prices": True,
-            "notes": (
-                "官方公开价格采集源；"
-                "该来源只对应一个模型。"
-            ),
+            "notes": ("官方公开价格采集源；" "该来源只对应一个模型。"),
         },
     )
     if created:
@@ -963,9 +1035,7 @@ def ensure_official_model_source(
         ),
         "currency": currency or source.currency or "USD",
         "updates_model_prices": True,
-        "notes": (
-            "官方公开价格采集源；该来源只对应一个模型。"
-        ),
+        "notes": ("官方公开价格采集源；该来源只对应一个模型。"),
     }
     if not source.endpoint_url:
         desired_fields["endpoint_url"] = source_url
@@ -1201,9 +1271,11 @@ def update_meta_model_numbers(
 def merge_meta_model_json(meta_model: MetaModel, defaults: dict) -> list[str]:
     """Merge aliases, capabilities and source metadata."""
     changed_fields = []
-    aliases = list(dict.fromkeys(
-        list(meta_model.aliases or []) + list(defaults["aliases"])
-    ))
+    aliases = list(
+        dict.fromkeys(
+            list(meta_model.aliases or []) + list(defaults["aliases"])
+        )
+    )
     if aliases != (meta_model.aliases or []):
         meta_model.aliases = aliases
         changed_fields.append("aliases")
@@ -1267,7 +1339,7 @@ def models_dev_limit(model_payload: dict, key: str) -> int:
     """Return an integer token limit from models.dev."""
     try:
         return int((model_payload.get("limit") or {}).get(key) or 0)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return 0
 
 
@@ -1577,10 +1649,7 @@ def upsert_collected_snapshot(
         source=source,
         source_platform_id=str(item.platform_id),
     ).first()
-    changed = (
-        existing is None
-        or existing.price_fingerprint != fingerprint
-    )
+    changed = existing is None or existing.price_fingerprint != fingerprint
     if changed:
         create_collected_price_history(
             payload,
@@ -1819,15 +1888,19 @@ def price_item_payloads_from_row(
         spec = {}
         if values.get("image_size"):
             spec["size"] = values.get("image_size")
-        return [
-            price_item_payload(
-                common,
-                dimension=ModelPriceItem.DIMENSION_IMAGE_OUTPUT,
-                billing_unit=ModelPriceItem.UNIT_PER_IMAGE,
-                unit_price=price,
-                spec=spec,
-            )
-        ] if price is not None else []
+        return (
+            [
+                price_item_payload(
+                    common,
+                    dimension=ModelPriceItem.DIMENSION_IMAGE_OUTPUT,
+                    billing_unit=ModelPriceItem.UNIT_PER_IMAGE,
+                    unit_price=price,
+                    spec=spec,
+                )
+            ]
+            if price is not None
+            else []
+        )
     if row.kind == "video_resolution_input":
         return video_resolution_input_payloads(values, common)
     if row.kind == "video_resolution_output":
@@ -1836,14 +1909,18 @@ def price_item_payloads_from_row(
         return video_inference_payloads(values, common)
     if row.kind == "video_unit":
         price = first_decimal_from_row(values, "unit_price", "price")
-        return [
-            price_item_payload(
-                common,
-                dimension=ModelPriceItem.DIMENSION_VIDEO_OUTPUT,
-                billing_unit=ModelPriceItem.UNIT_PER_SECOND,
-                unit_price=price,
-            )
-        ] if price is not None else []
+        return (
+            [
+                price_item_payload(
+                    common,
+                    dimension=ModelPriceItem.DIMENSION_VIDEO_OUTPUT,
+                    billing_unit=ModelPriceItem.UNIT_PER_SECOND,
+                    unit_price=price,
+                )
+            ]
+            if price is not None
+            else []
+        )
     return []
 
 
@@ -2140,12 +2217,8 @@ def model_defaults_from_collected_item(
         "cache_input_price_per_million": prices[
             "cache_input_price_per_million"
         ],
-        "image_output_price_per_image": prices[
-            "image_output_price_per_image"
-        ],
-        "video_input_price_per_second": prices[
-            "video_input_price_per_second"
-        ],
+        "image_output_price_per_image": prices["image_output_price_per_image"],
+        "video_input_price_per_second": prices["video_input_price_per_second"],
         "video_output_price_per_second": prices[
             "video_output_price_per_second"
         ],
@@ -2277,8 +2350,7 @@ def ensure_official_source(*, provider: LLMProvider):
             "is_enabled": True,
             "updates_model_prices": True,
             "notes": (
-                "官方公开价格采集源；价格按官方币种入库，"
-                "不做跨币种换算。"
+                "官方公开价格采集源；价格按官方币种入库，" "不做跨币种换算。"
             ),
         },
     )
@@ -2300,8 +2372,7 @@ def ensure_official_source(*, provider: LLMProvider):
         "currency": config.currency,
         "updates_model_prices": True,
         "notes": (
-            "官方公开价格采集源；价格按官方币种入库，"
-            "不做跨币种换算。"
+            "官方公开价格采集源；价格按官方币种入库，" "不做跨币种换算。"
         ),
     }
     if not source.endpoint_url or is_legacy_aliyun_pricing_url(
@@ -2438,8 +2509,7 @@ def first_decimal_from_row(
 ) -> Decimal | None:
     """Return the first decimal value from a row dictionary."""
     normalized_values = {
-        normalize_price_key(key): value
-        for key, value in values.items()
+        normalize_price_key(key): value for key, value in values.items()
     }
     for key in keys:
         value = to_decimal(values.get(key))
@@ -2477,7 +2547,7 @@ def to_decimal(value) -> Decimal | None:
         return None
     try:
         return Decimal(str(value))
-    except (InvalidOperation, TypeError, ValueError):
+    except InvalidOperation, TypeError, ValueError:
         return None
 
 

--- a/backend/llm_ops/llm_config.py
+++ b/backend/llm_ops/llm_config.py
@@ -1,4 +1,5 @@
 """LLM configuration helpers for LLM Ops runtime agents."""
+
 from __future__ import annotations
 
 from typing import Any
@@ -8,7 +9,7 @@ from django.db.utils import OperationalError, ProgrammingError
 
 try:
     from agentcore_metering.adapters.django.models import LLMConfig
-except ImportError:
+except ImportError, RuntimeError:
     LLMConfig = None
 
 
@@ -41,7 +42,7 @@ def get_llm_config_reference(config_uuid: str | None) -> dict[str, str]:
             .order_by("-is_active", "-is_default", "created_at", "id")
             .first()
         )
-    except (OperationalError, ProgrammingError):
+    except OperationalError, ProgrammingError:
         row = None
     if row is None:
         return {"uuid": str(config_uuid), "label": str(config_uuid)}
@@ -62,7 +63,7 @@ def _get_default_llm_row() -> Any | None:
             .order_by("-is_default", "created_at", "id")
             .first()
         )
-    except (OperationalError, ProgrammingError):
+    except OperationalError, ProgrammingError:
         return None
 
 
@@ -84,7 +85,7 @@ def resolve_price_sync_llm_settings(
                 .order_by("-is_default", "created_at", "id")
                 .first()
             )
-        except (OperationalError, ProgrammingError):
+        except OperationalError, ProgrammingError:
             selected_row = None
         if selected_row is not None:
             source = "selected"

--- a/backend/llm_ops/management/commands/cleanup_llm_ops_seed_prices.py
+++ b/backend/llm_ops/management/commands/cleanup_llm_ops_seed_prices.py
@@ -1,4 +1,5 @@
 """Clean legacy LLM Ops seed and unintended official provider data."""
+
 from __future__ import annotations
 
 from django.core.management.base import BaseCommand, CommandError
@@ -9,6 +10,8 @@ from llm_ops.catalog_maintenance import (
     LEGACY_TEST_SOURCE_SLUGS,
     TREND_DEMO_SOURCE_SLUGS,
     UNCONFIRMED_PRICE_SOURCE_SLUGS,
+    meta_model_has_business_links,
+    model_ids_with_business_links,
 )
 from llm_ops.collection_services import prune_global_config_price_sources
 from llm_ops.models import (
@@ -24,7 +27,6 @@ from llm_ops.models import (
     PriceCollectionSource,
     ResaleListing,
 )
-
 
 DEFAULT_PROVIDER_CODES = ("aliyun-wanx", "baidu")
 
@@ -87,6 +89,8 @@ class Command(BaseCommand):
                 f"providers={stats['providers']}, "
                 f"sources={stats['sources']}, "
                 f"models={stats['models']}, "
+                f"models_deleted={stats['models_deleted']}, "
+                f"models_detached={stats['models_detached']}, "
                 f"model_price_items={stats['model_price_items']}, "
                 f"snapshots={stats['snapshots']}, "
                 f"history={stats['history']}, "
@@ -117,7 +121,9 @@ def normalize_provider_codes(values) -> tuple[str, ...]:
     return tuple(codes)
 
 
-def build_cleanup_plan(provider_codes: tuple[str, ...]) -> dict[str, list[int]]:
+def build_cleanup_plan(
+    provider_codes: tuple[str, ...],
+) -> dict[str, list[int]]:
     """Collect row ids that belong to unwanted provider data."""
     provider_scope_ids = list(
         LLMProvider.objects.filter(code__in=provider_codes)
@@ -214,10 +220,13 @@ def plan_stats(plan: dict[str, list[int]]) -> dict[str, int]:
     source_ids = plan["source_ids"]
     model_ids = plan["model_ids"]
     provider_ids = plan["provider_ids"]
+    linked_model_ids = model_ids_with_business_links(model_ids)
     return {
         "providers": len(provider_ids),
         "sources": len(source_ids),
         "models": len(model_ids),
+        "models_deleted": len(model_ids) - len(linked_model_ids),
+        "models_detached": len(linked_model_ids),
         "model_price_items": ModelPriceItem.objects.filter(
             Q(model_id__in=model_ids) | Q(source_id__in=source_ids)
         ).count(),
@@ -243,31 +252,66 @@ def plan_stats(plan: dict[str, list[int]]) -> dict[str, int]:
 def execute_cleanup(plan: dict[str, list[int]]) -> dict[str, int]:
     """Delete planned rows and prune now-unreferenced meta models."""
     stats = {}
+    model_ids = plan["model_ids"]
+    linked_model_ids = model_ids_with_business_links(model_ids)
+    deletable_model_ids = [
+        model_id for model_id in model_ids if model_id not in linked_model_ids
+    ]
     with transaction.atomic():
         PriceCollectionRun.objects.filter(id__in=plan["run_ids"]).delete()
         CollectedModelPriceSnapshot.objects.filter(
-            cleanup_relation_query(plan),
+            cleanup_relation_query(plan, deletable_model_ids),
         ).delete()
         CollectedModelPriceHistory.objects.filter(
-            cleanup_relation_query(plan),
+            cleanup_relation_query(plan, deletable_model_ids),
         ).delete()
-        ModelPriceItem.objects.filter(cleanup_relation_query(plan)).delete()
-        LLMModel.objects.filter(id__in=plan["model_ids"]).delete()
+        ModelPriceItem.objects.filter(
+            cleanup_relation_query(plan, deletable_model_ids),
+        ).delete()
+        LLMModel.objects.filter(id__in=deletable_model_ids).delete()
+        detach_count = detach_cleanup_models(linked_model_ids)
         prune_count = prune_global_config_price_sources(plan["source_ids"])
         PriceCollectionSource.objects.filter(
             id__in=plan["source_ids"],
         ).delete()
         orphan_count = delete_orphan_meta_models(plan["meta_model_ids"])
+        stats["models_deleted"] = len(deletable_model_ids)
+        stats["models_detached"] = detach_count
         stats["global_configs_pruned"] = prune_count
         stats["orphan_meta_models_deleted"] = orphan_count
     return stats
 
 
-def cleanup_relation_query(plan: dict[str, list[int]]) -> Q:
+def cleanup_relation_query(
+    plan: dict[str, list[int]],
+    deletable_model_ids: list[int] | None = None,
+) -> Q:
     """Return relation filters shared by cleanup-owned rows."""
-    return (
-        Q(source_id__in=plan["source_ids"])
-        | Q(model_id__in=plan["model_ids"])
+    if deletable_model_ids is None:
+        model_ids = plan["model_ids"]
+    else:
+        model_ids = deletable_model_ids
+    return Q(source_id__in=plan["source_ids"]) | Q(model_id__in=model_ids)
+
+
+def detach_cleanup_models(model_ids: set[int]) -> int:
+    """Detach legacy cleanup models that have downstream business rows."""
+    if not model_ids:
+        return 0
+    return LLMModel.objects.filter(id__in=model_ids).update(
+        source=None,
+        source_url="",
+        price_role=LLMModel.PRICE_ROLE_UNKNOWN,
+        input_price_per_million=0,
+        output_price_per_million=0,
+        cache_input_price_per_million=None,
+        image_output_price_per_image=None,
+        audio_input_price_per_second=None,
+        audio_output_price_per_second=None,
+        video_input_price_per_second=None,
+        video_output_price_per_second=None,
+        video_resolution_prices={},
+        last_price_updated_at=None,
     )
 
 
@@ -280,15 +324,3 @@ def delete_orphan_meta_models(meta_model_ids: list[int]) -> int:
         meta_model.delete()
         deleted += 1
     return deleted
-
-
-def meta_model_has_business_links(meta_model: MetaModel) -> bool:
-    """Return whether a meta model is still referenced by another table."""
-    for relation in MetaModel._meta.related_objects:
-        if relation.related_model is MetaModel:
-            continue
-        if relation.related_model.objects.filter(
-            **{relation.field.name: meta_model},
-        ).exists():
-            return True
-    return False

--- a/backend/llm_ops/management/commands/reset_llm_ops_meta_models.py
+++ b/backend/llm_ops/management/commands/reset_llm_ops_meta_models.py
@@ -9,12 +9,13 @@ operators should run the Agent sync or add records manually afterwards.
 Use ``--yes`` to confirm. The command refuses to run interactively
 to avoid accidental data loss.
 """
+
 from __future__ import annotations
 
 from django.core.management.base import BaseCommand, CommandError
 
 from llm_ops.catalog_maintenance import (
-    cleanup_orphan_meta_models,
+    cleanup_orphan_meta_models_for_reset,
     reset_meta_models_canonical,
 )
 
@@ -48,7 +49,7 @@ class Command(BaseCommand):
                 "preview the operation."
             )
         if options.get("dry_run"):
-            orphan_stats = cleanup_orphan_meta_models()
+            orphan_stats = cleanup_orphan_meta_models_for_reset(dry_run=True)
             self.stdout.write(
                 self.style.WARNING(
                     "[dry-run] Would reset meta-model catalogue. "

--- a/backend/llm_ops/management/commands/reset_llm_ops_official_prices.py
+++ b/backend/llm_ops/management/commands/reset_llm_ops_official_prices.py
@@ -1,4 +1,5 @@
 """Reset official LLM Ops price data without deleting business config."""
+
 from __future__ import annotations
 
 from django.core.management.base import BaseCommand, CommandError
@@ -87,6 +88,8 @@ class Command(BaseCommand):
                 f"sources_matched={stats['sources_matched']}, "
                 f"provider_sources_kept={stats['provider_sources_kept']}, "
                 f"legacy_sources_deleted={stats['legacy_sources_deleted']}, "
+                f"legacy_models_deduplicated="
+                f"{stats['legacy_models_deduplicated']}, "
                 f"models_reset={stats['models_reset']}, "
                 f"price_items_deleted={stats['price_items_deleted']}, "
                 f"snapshots_deleted={stats['snapshots_deleted']}, "

--- a/backend/llm_ops/tests/test_ops_bootstrap.py
+++ b/backend/llm_ops/tests/test_ops_bootstrap.py
@@ -1,4 +1,5 @@
 """Tests for LLM Ops catalog maintenance without seed bootstrap."""
+
 from __future__ import annotations
 
 from decimal import Decimal
@@ -25,6 +26,7 @@ from llm_ops.management.commands.cleanup_llm_ops_seed_prices import (
     execute_cleanup,
 )
 from llm_ops.models import (
+    ChannelModelPrice,
     LLMModel,
     LLMProvider,
     MetaModel,
@@ -32,6 +34,9 @@ from llm_ops.models import (
     PriceCollectionRun,
     PriceCollectionSource,
     ProcurementChannel,
+    ResaleListing,
+    ResaleListingPriceHistory,
+    ResalePlatform,
 )
 from llm_ops.periodic_tasks import register_periodic_tasks
 
@@ -134,6 +139,21 @@ class LLMOpsCatalogMaintenanceTests(TestCase):
         self.assertFalse(MetaModel.objects.exists())
         self.assertFalse(LLMModel.objects.exists())
 
+    def test_meta_model_reset_dry_run_does_not_delete_orphans(self):
+        meta = MetaModel.objects.create(
+            name="Orphan GPT",
+            code="gpt-orphan",
+        )
+
+        call_command(
+            "reset_llm_ops_meta_models",
+            "--dry-run",
+            stdout=StringIO(),
+        )
+
+        self.assertTrue(MetaModel.objects.filter(id=meta.id).exists())
+        self.assertFalse(LLMProvider.objects.filter(code="openai").exists())
+
     def test_clean_legacy_demo_data_removes_test_rows(self):
         PriceCollectionSource.objects.create(
             name="测试价格源",
@@ -145,6 +165,78 @@ class LLMOpsCatalogMaintenanceTests(TestCase):
 
         self.assertEqual(stats["sources"], 1)
         self.assertFalse(PriceCollectionSource.objects.exists())
+
+    def test_clean_legacy_demo_data_removes_channel_listings_first(self):
+        provider = LLMProvider.objects.create(name="OpenAI", code="openai")
+        model = LLMModel.objects.create(
+            provider=provider,
+            name="GPT Demo",
+            code="gpt-demo",
+        )
+        channel = ProcurementChannel.objects.create(
+            name="Demo Baseline",
+            code="demo-baseline-supplier",
+        )
+        platform = ResalePlatform.objects.create(
+            name="Demo Platform",
+            code="demo-platform",
+        )
+        auto_listing = ResaleListing.objects.create(
+            platform=platform,
+            model=model,
+            channel=None,
+            retail_input_price_per_million=Decimal("1.000000"),
+            retail_output_price_per_million=Decimal("2.000000"),
+        )
+        channel_listing = ResaleListing.objects.create(
+            platform=platform,
+            model=model,
+            channel=channel,
+            retail_input_price_per_million=Decimal("1.100000"),
+            retail_output_price_per_million=Decimal("2.100000"),
+        )
+        auto_history = ResaleListingPriceHistory.objects.create(
+            platform=platform,
+            model=model,
+            channel=None,
+            retail_input_price_per_million=Decimal("1.000000"),
+            retail_output_price_per_million=Decimal("2.000000"),
+            price_fingerprint="same-price",
+            effective_from="2026-01-01T00:00:00Z",
+        )
+        channel_history = ResaleListingPriceHistory.objects.create(
+            platform=platform,
+            model=model,
+            channel=channel,
+            retail_input_price_per_million=Decimal("1.000000"),
+            retail_output_price_per_million=Decimal("2.000000"),
+            price_fingerprint="same-price",
+            effective_from="2026-01-01T00:00:00Z",
+        )
+
+        stats = clean_legacy_llm_ops_demo_data()
+
+        self.assertEqual(stats["resale_listings"], 1)
+        self.assertEqual(stats["resale_listing_histories"], 1)
+        self.assertFalse(
+            ProcurementChannel.objects.filter(id=channel.id).exists()
+        )
+        self.assertTrue(
+            ResaleListing.objects.filter(id=auto_listing.id).exists()
+        )
+        self.assertFalse(
+            ResaleListing.objects.filter(id=channel_listing.id).exists()
+        )
+        self.assertTrue(
+            ResaleListingPriceHistory.objects.filter(
+                id=auto_history.id
+            ).exists()
+        )
+        self.assertFalse(
+            ResaleListingPriceHistory.objects.filter(
+                id=channel_history.id
+            ).exists()
+        )
 
 
 class LLMOpsOfficialProviderOptionTests(TestCase):
@@ -260,6 +352,74 @@ class LLMOpsOfficialPriceResetCommandTests(TestCase):
             PriceCollectionSource.objects.filter(id=legacy_source.id).exists()
         )
 
+    def test_reset_deduplicates_legacy_model_before_source_migration(self):
+        provider = LLMProvider.objects.create(name="OpenAI", code="openai")
+        meta = MetaModel.objects.create(
+            name="GPT-4.1 mini",
+            code="gpt-4.1-mini",
+            vendor=provider,
+        )
+        provider_source = PriceCollectionSource.objects.create(
+            name="OpenAI 官方价格",
+            slug="openai-official",
+            provider=provider,
+            source_category=(
+                PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
+            ),
+            endpoint_url="https://openai.com/api/pricing/",
+            updates_model_prices=True,
+        )
+        legacy_source = PriceCollectionSource.objects.create(
+            name="OpenAI / GPT-4.1 mini 官方价格",
+            slug="openai-gpt-4-1-mini-official",
+            provider=provider,
+            source_category=(
+                PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
+            ),
+            updates_model_prices=True,
+        )
+        provider_model = LLMModel.objects.create(
+            provider=provider,
+            meta_model=meta,
+            source=provider_source,
+            name="GPT-4.1 mini",
+            code="gpt-4.1-mini",
+            price_role=LLMModel.PRICE_ROLE_OFFICIAL,
+            input_price_per_million=Decimal("0.400000"),
+            output_price_per_million=Decimal("1.600000"),
+        )
+        legacy_model = LLMModel.objects.create(
+            provider=provider,
+            meta_model=meta,
+            source=legacy_source,
+            name="GPT-4.1 mini",
+            code="gpt-4.1-mini",
+            price_role=LLMModel.PRICE_ROLE_OFFICIAL,
+            input_price_per_million=Decimal("0.400000"),
+            output_price_per_million=Decimal("1.600000"),
+        )
+
+        stats = reset_official_price_catalog(provider_codes=["openai"])
+
+        provider_model.refresh_from_db()
+        legacy_model.refresh_from_db()
+        self.assertEqual(stats["models_reset"], 2)
+        self.assertEqual(stats["legacy_models_deduplicated"], 1)
+        self.assertIsNone(legacy_model.source_id)
+        self.assertEqual(legacy_model.price_role, LLMModel.PRICE_ROLE_UNKNOWN)
+        self.assertEqual(
+            LLMModel.objects.filter(
+                provider=provider,
+                source=provider_source,
+                code="gpt-4.1-mini",
+            ).count(),
+            1,
+        )
+        self.assertEqual(provider_model.input_price_per_million, Decimal("0"))
+        self.assertFalse(
+            PriceCollectionSource.objects.filter(id=legacy_source.id).exists()
+        )
+
     def test_reset_keeps_non_legacy_official_source_for_same_provider(self):
         provider = LLMProvider.objects.create(name="OpenAI", code="openai")
         meta = MetaModel.objects.create(
@@ -328,6 +488,7 @@ class LLMOpsOfficialPriceResetCommandTests(TestCase):
             "sources_matched": 0,
             "provider_sources_kept": 0,
             "legacy_sources_deleted": 0,
+            "legacy_models_deduplicated": 0,
             "models_reset": 0,
             "price_items_deleted": 0,
             "snapshots_deleted": 0,
@@ -430,6 +591,58 @@ class LLMOpsSeedCleanupCommandTests(TestCase):
         )
         self.assertFalse(LLMModel.objects.filter(code="ernie-4.0").exists())
 
+    def test_cleanup_detaches_legacy_model_with_business_links(self):
+        provider = LLMProvider.objects.create(name="百度", code="baidu")
+        meta = MetaModel.objects.create(
+            name="ERNIE 4.0",
+            code="ernie-4.0",
+            vendor=provider,
+        )
+        channel = ProcurementChannel.objects.create(
+            name="Real Channel",
+            code="real-channel",
+        )
+        legacy_source = PriceCollectionSource.objects.create(
+            name="百度 / ERNIE 4.0 官方价格",
+            slug="baidu-ernie-4-0-official",
+            provider=provider,
+            source_category=(
+                PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
+            ),
+            updates_model_prices=True,
+        )
+        model = LLMModel.objects.create(
+            provider=provider,
+            meta_model=meta,
+            source=legacy_source,
+            name="ERNIE 4.0",
+            code="ernie-4.0",
+            price_role=LLMModel.PRICE_ROLE_OFFICIAL,
+            input_price_per_million=Decimal("1.000000"),
+            output_price_per_million=Decimal("2.000000"),
+        )
+        channel_price = ChannelModelPrice.objects.create(
+            channel=channel,
+            model=model,
+            meta_model=meta,
+            currency="CNY",
+        )
+
+        plan = build_cleanup_plan(("baidu",))
+        stats = execute_cleanup(plan)
+
+        model.refresh_from_db()
+        self.assertEqual(stats["models_detached"], 1)
+        self.assertIsNone(model.source_id)
+        self.assertEqual(model.price_role, LLMModel.PRICE_ROLE_UNKNOWN)
+        self.assertEqual(model.input_price_per_million, Decimal("0"))
+        self.assertTrue(
+            ChannelModelPrice.objects.filter(id=channel_price.id).exists()
+        )
+        self.assertFalse(
+            PriceCollectionSource.objects.filter(id=legacy_source.id).exists()
+        )
+
 
 class LLMOpsPeriodicTasksTests(TestCase):
     """The Celery task and periodic entry are wired up correctly."""
@@ -447,9 +660,7 @@ class LLMOpsPeriodicTasksTests(TestCase):
                 "llm_ops_meta_models_dev_sync",
             ],
         )
-        price_entry = TASK_REGISTRY._entries[
-            "llm_ops_model_price_sync_agent"
-        ]
+        price_entry = TASK_REGISTRY._entries["llm_ops_model_price_sync_agent"]
         self.assertEqual(
             price_entry["task"],
             "llm_ops.tasks.run_model_price_sync_agent",

--- a/backend/llm_ops/tests/test_views.py
+++ b/backend/llm_ops/tests/test_views.py
@@ -12,9 +12,10 @@ from llm_ops.models import (
     ChannelModelPriceHistory,
     ChannelPriceItem,
     CollectedModelPriceSnapshot,
-    LLMOpsGlobalConfig,
     LLMModel,
+    LLMOpsGlobalConfig,
     LLMProvider,
+    MetaModel,
     ModelPriceItem,
     PriceCollectionRun,
     PriceCollectionSource,
@@ -341,9 +342,7 @@ class LLMOpsViewTests(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        legacy_task = PeriodicTask.objects.get(
-            name="llm_ops_official_collect"
-        )
+        legacy_task = PeriodicTask.objects.get(name="llm_ops_official_collect")
         self.assertFalse(legacy_task.enabled)
         self.assertEqual(legacy_task.crontab_id, legacy_crontab.id)
 
@@ -414,9 +413,7 @@ class LLMOpsViewTests(TestCase):
         )
         self.assertFalse(
             PeriodicTask.objects.filter(
-                name=(
-                    f"llm_ops_price_source_collect_{obsolete_source.id}"
-                )
+                name=(f"llm_ops_price_source_collect_{obsolete_source.id}")
             ).exists()
         )
         self.assertFalse(
@@ -796,6 +793,49 @@ class LLMOpsViewTests(TestCase):
 
         self.assertEqual(response.status_code, 204)
         self.assertFalse(ModelPriceItem.objects.filter(id=item.id).exists())
+
+    def test_model_with_business_links_cannot_be_deleted(self):
+        provider = LLMProvider.objects.create(name="OpenAI", code="openai")
+        model = LLMModel.objects.create(
+            provider=provider,
+            name="GPT-4o mini",
+            code="gpt-4o-mini",
+        )
+        channel = ProcurementChannel.objects.create(
+            name="Default Channel",
+            code="default-channel-delete-block",
+        )
+        channel_price = ChannelModelPrice.objects.create(
+            channel=channel,
+            model=model,
+            meta_model=model.meta_model,
+            currency="USD",
+        )
+
+        response = self.client.delete(
+            reverse("model-detail", args=[model.id]),
+        )
+
+        self.assertEqual(response.status_code, 409)
+        self.assertTrue(LLMModel.objects.filter(id=model.id).exists())
+        self.assertTrue(
+            ChannelModelPrice.objects.filter(id=channel_price.id).exists()
+        )
+
+    def test_meta_model_with_provider_prices_cannot_be_deleted(self):
+        provider = LLMProvider.objects.create(name="OpenAI", code="openai")
+        meta = LLMModel.objects.create(
+            provider=provider,
+            name="GPT-4o mini",
+            code="gpt-4o-mini",
+        ).meta_model
+
+        response = self.client.delete(
+            reverse("meta-model-detail", args=[meta.id]),
+        )
+
+        self.assertEqual(response.status_code, 409)
+        self.assertTrue(MetaModel.objects.filter(id=meta.id).exists())
 
     @patch("llm_ops.views.collect_price_source_prices.delay")
     def test_collection_source_collects_official_provider(self, mock_delay):
@@ -1224,9 +1264,7 @@ class LLMOpsViewTests(TestCase):
             2.5,
         )
         self.assertEqual(
-            row["best_channel"][
-                "input_price_per_million_settlement_ratio"
-            ],
+            row["best_channel"]["input_price_per_million_settlement_ratio"],
             0.8,
         )
         self.assertEqual(row["best_channel"]["input_price_per_million"], 2.0)
@@ -1268,7 +1306,9 @@ class LLMOpsViewTests(TestCase):
         self.assertEqual(row["best_channel"]["latency_ms"], 180)
 
     def test_summary_uses_meta_model_price_items_for_zero_sku_price(self):
-        provider = LLMProvider.objects.create(name="Anthropic", code="anthropic")
+        provider = LLMProvider.objects.create(
+            name="Anthropic", code="anthropic"
+        )
         official_model = LLMModel.objects.create(
             provider=provider,
             name="Claude Haiku 4.5",
@@ -1662,7 +1702,9 @@ class LLMOpsViewTests(TestCase):
         )
         self.assertEqual(ResaleListingPriceHistory.objects.count(), 1)
 
-    def test_resale_listing_bulk_upsert_allows_channel_after_auto_listing(self):
+    def test_resale_listing_bulk_upsert_allows_channel_after_auto_listing(
+        self,
+    ):
         provider = LLMProvider.objects.create(name="OpenAI", code="openai")
         model = LLMModel.objects.create(
             provider=provider,
@@ -1813,7 +1855,9 @@ class LLMOpsViewTests(TestCase):
             ).exists()
         )
 
-    def test_resale_listing_bulk_replace_allows_channel_after_auto_listing(self):
+    def test_resale_listing_bulk_replace_allows_channel_after_auto_listing(
+        self,
+    ):
         provider = LLMProvider.objects.create(name="OpenAI", code="openai")
         model = LLMModel.objects.create(
             provider=provider,
@@ -1921,7 +1965,9 @@ class LLMOpsViewTests(TestCase):
         actions = list(
             AuditLog.objects.filter(
                 target_type="llm_ops.ResaleListingExclusion",
-            ).order_by("created_at").values_list("action", flat=True)
+            )
+            .order_by("created_at")
+            .values_list("action", flat=True)
         )
         self.assertEqual(
             actions,
@@ -2088,9 +2134,7 @@ class LLMOpsViewTests(TestCase):
         saved = ResaleWorkflowConfig.objects.get(platform=platform)
         self.assertFalse(saved.config["policies"]["auto_approve_enabled"])
         self.assertFalse(
-            patch_response.data["config"]["policies"][
-                "auto_approve_enabled"
-            ]
+            patch_response.data["config"]["policies"]["auto_approve_enabled"]
         )
         self.assertEqual(patch_response.data["notes"], "disable auto approval")
         self.assertIn("runtime", patch_response.data["config"])
@@ -2642,9 +2686,7 @@ class LLMOpsViewTests(TestCase):
             0.08,
         )
         self.assertEqual(
-            response.data["point_conversion"][
-                "auto_approve_max_margin_rate"
-            ],
+            response.data["point_conversion"]["auto_approve_max_margin_rate"],
             18.0,
         )
         diagnostic = response.data["agione"]["diagnostics"][0]

--- a/backend/llm_ops/views.py
+++ b/backend/llm_ops/views.py
@@ -1,6 +1,5 @@
 from decimal import Decimal
 
-from accounts.permissions import HasRequiredFeature
 from django.db import transaction
 from django.db.models import Count, IntegerField, Q, Value
 from django.utils.text import slugify
@@ -9,6 +8,8 @@ from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.views import APIView
+
+from accounts.permissions import HasRequiredFeature
 
 from .audit import record_audit_log, snapshot_instance
 from .collection_services import (
@@ -33,8 +34,8 @@ from .models import (
     ChannelPriceItem,
     CollectedModelPriceHistory,
     CollectedModelPriceSnapshot,
-    LLMOpsGlobalConfig,
     LLMModel,
+    LLMOpsGlobalConfig,
     LLMProvider,
     MetaModel,
     ModelPriceItem,
@@ -50,13 +51,13 @@ from .models import (
 )
 from .serializers import (
     AuditLogSerializer,
-    ChannelModelPriceSerializer,
     ChannelModelPriceHistorySerializer,
+    ChannelModelPriceSerializer,
     ChannelPriceItemSerializer,
     CollectedModelPriceHistorySerializer,
     CollectedModelPriceSnapshotSerializer,
-    LLMOpsGlobalConfigSerializer,
     LLMModelSerializer,
+    LLMOpsGlobalConfigSerializer,
     LLMProviderSerializer,
     ManualPriceImportRequestSerializer,
     MetaModelSerializer,
@@ -65,14 +66,13 @@ from .serializers import (
     PriceCollectionSourceSerializer,
     ProcurementChannelSerializer,
     ResaleListingExclusionSerializer,
-    ResaleListingSerializer,
     ResaleListingPriceHistorySerializer,
+    ResaleListingSerializer,
     ResalePlatformSerializer,
     ResaleWorkflowConfigSerializer,
     UsageReconciliationRecordSerializer,
     YunceCollectionRequestSerializer,
 )
-from .source_collectors import source_supports_code_collection
 from .services import (
     build_currency_conversion_context,
     calculate_usage_cost,
@@ -85,12 +85,12 @@ from .services import (
     resolve_resale_listing_currency,
     sync_channel_price_items,
 )
+from .source_collectors import source_supports_code_collection
 from .tasks import collect_price_source_prices, run_model_price_sync_agent
 from .workflow_config import (
     merge_resale_workflow_config,
     validate_resale_workflow_config,
 )
-
 
 FEATURE_KEY = "llm_ops"
 DEFAULT_INPUT_TOKENS = 10_000_000
@@ -213,13 +213,19 @@ class PriceCollectionSourceViewSet(
     serializer_class = PriceCollectionSourceSerializer
 
     def get_queryset(self):
-        return PriceCollectionSource.objects.select_related(
-            "provider",
-            "channel",
-        ).prefetch_related(
-            "models__meta_model",
-            "models__meta_model__vendor",
-        ).order_by("source_category", "provider__name", "channel__name", "id")
+        return (
+            PriceCollectionSource.objects.select_related(
+                "provider",
+                "channel",
+            )
+            .prefetch_related(
+                "models__meta_model",
+                "models__meta_model__vendor",
+            )
+            .order_by(
+                "source_category", "provider__name", "channel__name", "id"
+            )
+        )
 
     @action(
         detail=False,
@@ -286,9 +292,7 @@ class PriceCollectionSourceViewSet(
 
         serializer = self.get_serializer(source)
         response_status = (
-            status.HTTP_201_CREATED
-            if source_created
-            else status.HTTP_200_OK
+            status.HTTP_201_CREATED if source_created else status.HTTP_200_OK
         )
         return Response(
             {
@@ -445,7 +449,8 @@ class PriceCollectionSourceViewSet(
         if request.data.get("sync") is not False:
             sync_results = sync_configured_official_model_prices(
                 provider_codes=provider_codes,
-                verify_source=request.data.get("skip_source_check") is not True,
+                verify_source=request.data.get("skip_source_check")
+                is not True,
             )
 
         record_audit_log(
@@ -484,7 +489,9 @@ def official_reset_provider_codes(data) -> list[str]:
     ]
     if data.get("all") is True:
         if provider_codes:
-            raise ValueError("Use either provider_codes or all=true, not both.")
+            raise ValueError(
+                "Use either provider_codes or all=true, not both."
+            )
         return list(SUPPORTED_OFFICIAL_PRICE_SYNC_PROVIDER_CODES)
     if not provider_codes:
         raise ValueError("Select at least one official provider.")
@@ -621,13 +628,10 @@ class PriceCollectionRunViewSet(
         if status_value:
             queryset = queryset.filter(status=status_value)
         if source_category:
-            queryset = queryset.filter(
-                source__source_category=source_category
-            )
+            queryset = queryset.filter(source__source_category=source_category)
         if provider:
-            provider_query = (
-                Q(source__provider__code__icontains=provider)
-                | Q(source__provider__name__icontains=provider)
+            provider_query = Q(source__provider__code__icontains=provider) | Q(
+                source__provider__name__icontains=provider
             )
             if provider.isdigit():
                 provider_query |= Q(source__provider_id=provider)
@@ -712,11 +716,15 @@ class LLMProviderViewSet(
     serializer_class = LLMProviderSerializer
 
     def get_queryset(self):
-        return LLMProvider.objects.annotate(
-            model_count=Count("models"),
-        ).exclude(
-            code__in=SUPPLIER_SOURCE_VENDOR_ALIASES.keys(),
-        ).order_by("name", "id")
+        return (
+            LLMProvider.objects.annotate(
+                model_count=Count("models"),
+            )
+            .exclude(
+                code__in=SUPPLIER_SOURCE_VENDOR_ALIASES.keys(),
+            )
+            .order_by("name", "id")
+        )
 
 
 class MetaModelViewSet(
@@ -736,15 +744,37 @@ class MetaModelViewSet(
     serializer_class = MetaModelSerializer
 
     def get_queryset(self):
-        queryset = MetaModel.objects.select_related("vendor").annotate(
-            provider_price_count=Count("provider_prices"),
-        ).exclude(
-            vendor__code__in=SUPPLIER_SOURCE_VENDOR_ALIASES.keys(),
+        queryset = (
+            MetaModel.objects.select_related("vendor")
+            .annotate(
+                provider_price_count=Count("provider_prices"),
+            )
+            .exclude(
+                vendor__code__in=SUPPLIER_SOURCE_VENDOR_ALIASES.keys(),
+            )
         )
         vendor = self.request.query_params.get("vendor")
         if vendor:
             queryset = queryset.filter(vendor_id=vendor)
         return queryset.order_by("name", "id")
+
+    def destroy(self, request, *args, **kwargs):
+        """Block deleting canonical models that still have dependencies."""
+        instance = self.get_object()
+        from .catalog_maintenance import meta_model_dependency_counts
+
+        dependencies = meta_model_dependency_counts(instance)
+        if dependencies:
+            return Response(
+                {
+                    "detail": (
+                        "Cannot delete meta model with dependent records."
+                    ),
+                    "dependencies": dependencies,
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
+        return super().destroy(request, *args, **kwargs)
 
     def list(self, request, *args, **kwargs):
         from .catalog_maintenance import (
@@ -808,6 +838,22 @@ class LLMModelViewSet(
         if meta_model:
             queryset = queryset.filter(meta_model_id=meta_model)
         return queryset.order_by("meta_model__name", "provider__name", "id")
+
+    def destroy(self, request, *args, **kwargs):
+        """Block deleting models that still have dependent business rows."""
+        instance = self.get_object()
+        from .catalog_maintenance import model_delete_dependency_counts
+
+        dependencies = model_delete_dependency_counts(instance)
+        if dependencies:
+            return Response(
+                {
+                    "detail": "Cannot delete model with dependent records.",
+                    "dependencies": dependencies,
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
+        return super().destroy(request, *args, **kwargs)
 
 
 class ModelPriceItemViewSet(
@@ -1227,9 +1273,7 @@ class ResaleWorkflowConfigViewSet(
 
     def _effective_payload(self, platform, instance):
         saved_config = (
-            instance.config
-            if instance and instance.is_active
-            else None
+            instance.config if instance and instance.is_active else None
         )
         return {
             "id": instance.id if instance else None,
@@ -1691,8 +1735,7 @@ class ResaleListingViewSet(
                 )
             listings = list(queryset)
             before_by_id = {
-                listing.id: snapshot_instance(listing)
-                for listing in listings
+                listing.id: snapshot_instance(listing) for listing in listings
             }
             queryset.update(
                 is_active=False,
@@ -1838,12 +1881,10 @@ class ResaleListingExclusionViewSet(
                     before=before,
                     metadata={"bulk_count": len(model_ids)},
                 )
-            deleted_count, _ = (
-                ResaleListingExclusion.objects.filter(
-                    platform_id=platform_id,
-                    model_id__in=model_ids,
-                ).delete()
-            )
+            deleted_count, _ = ResaleListingExclusion.objects.filter(
+                platform_id=platform_id,
+                model_id__in=model_ids,
+            ).delete()
         return Response(
             {"deleted_count": deleted_count},
             status=status.HTTP_200_OK,
@@ -1922,9 +1963,7 @@ def _listing_submit_status(existing: ResaleListing | None) -> dict:
         ResaleListing.WORKFLOW_UPDATE_DRAFT,
     }
     if existing.workflow_status not in _allowed_submit_workflows:
-        raise ValueError(
-            f"Cannot submit from {existing.workflow_status}."
-        )
+        raise ValueError(f"Cannot submit from {existing.workflow_status}.")
 
     if existing.publish_status == ResaleListing.PUBLISH_ONLINE:
         return {
@@ -1955,9 +1994,7 @@ def _listing_draft_status(existing: ResaleListing | None) -> dict:
         ResaleListing.WORKFLOW_UPDATE_DRAFT,
     }
     if existing.workflow_status not in _allowed_draft_workflows:
-        raise ValueError(
-            f"Cannot save draft from {existing.workflow_status}."
-        )
+        raise ValueError(f"Cannot save draft from {existing.workflow_status}.")
 
     if existing.publish_status == ResaleListing.PUBLISH_ONLINE:
         return {
@@ -1995,39 +2032,90 @@ def _invalid_transition(action_name: str, listing: ResaleListing):
 _RL = ResaleListing
 _LISTING_TRANSITIONS: dict[tuple[str, str], tuple[str, str, bool]] = {
     ("withdraw", _RL.WORKFLOW_PENDING_PUBLISH): (
-        _RL.PUBLISH_NONE, _RL.WORKFLOW_DRAFT, False),
+        _RL.PUBLISH_NONE,
+        _RL.WORKFLOW_DRAFT,
+        False,
+    ),
     ("withdraw", _RL.WORKFLOW_PENDING_UPDATE): (
-        _RL.PUBLISH_ONLINE, _RL.WORKFLOW_UPDATE_DRAFT, True),
+        _RL.PUBLISH_ONLINE,
+        _RL.WORKFLOW_UPDATE_DRAFT,
+        True,
+    ),
     ("withdraw", _RL.WORKFLOW_PENDING_OFFLINE): (
-        _RL.PUBLISH_ONLINE, _RL.WORKFLOW_ONLINE, True),
+        _RL.PUBLISH_ONLINE,
+        _RL.WORKFLOW_ONLINE,
+        True,
+    ),
     ("submit", _RL.WORKFLOW_DRAFT): (
-        _RL.PUBLISH_NONE, _RL.WORKFLOW_PENDING_PUBLISH, False),
+        _RL.PUBLISH_NONE,
+        _RL.WORKFLOW_PENDING_PUBLISH,
+        False,
+    ),
     ("submit", _RL.WORKFLOW_UPDATE_DRAFT): (
-        _RL.PUBLISH_ONLINE, _RL.WORKFLOW_PENDING_UPDATE, True),
+        _RL.PUBLISH_ONLINE,
+        _RL.WORKFLOW_PENDING_UPDATE,
+        True,
+    ),
     ("confirm_publish", _RL.WORKFLOW_PENDING_PUBLISH): (
-        _RL.PUBLISH_ONLINE, _RL.WORKFLOW_ONLINE, True),
+        _RL.PUBLISH_ONLINE,
+        _RL.WORKFLOW_ONLINE,
+        True,
+    ),
     ("start_edit", _RL.WORKFLOW_ONLINE): (
-        _RL.PUBLISH_ONLINE, _RL.WORKFLOW_UPDATE_DRAFT, True),
+        _RL.PUBLISH_ONLINE,
+        _RL.WORKFLOW_UPDATE_DRAFT,
+        True,
+    ),
     ("abandon_update", _RL.WORKFLOW_UPDATE_DRAFT): (
-        _RL.PUBLISH_ONLINE, _RL.WORKFLOW_ONLINE, True),
+        _RL.PUBLISH_ONLINE,
+        _RL.WORKFLOW_ONLINE,
+        True,
+    ),
     ("confirm_update", _RL.WORKFLOW_PENDING_UPDATE): (
-        _RL.PUBLISH_ONLINE, _RL.WORKFLOW_ONLINE, True),
+        _RL.PUBLISH_ONLINE,
+        _RL.WORKFLOW_ONLINE,
+        True,
+    ),
     ("request_offline", _RL.WORKFLOW_ONLINE): (
-        _RL.PUBLISH_ONLINE, _RL.WORKFLOW_PENDING_OFFLINE, True),
+        _RL.PUBLISH_ONLINE,
+        _RL.WORKFLOW_PENDING_OFFLINE,
+        True,
+    ),
     ("confirm_offline", _RL.WORKFLOW_PENDING_OFFLINE): (
-        _RL.PUBLISH_OFFLINE, _RL.WORKFLOW_OFFLINE, False),
+        _RL.PUBLISH_OFFLINE,
+        _RL.WORKFLOW_OFFLINE,
+        False,
+    ),
     ("confirm_offline", _RL.WORKFLOW_OFFLINE_EXCEPTION): (
-        _RL.PUBLISH_OFFLINE, _RL.WORKFLOW_OFFLINE, False),
+        _RL.PUBLISH_OFFLINE,
+        _RL.WORKFLOW_OFFLINE,
+        False,
+    ),
     ("reject_offline", _RL.WORKFLOW_PENDING_OFFLINE): (
-        _RL.PUBLISH_ONLINE, _RL.WORKFLOW_ONLINE, True),
+        _RL.PUBLISH_ONLINE,
+        _RL.WORKFLOW_ONLINE,
+        True,
+    ),
     ("mark_offline_exception", _RL.WORKFLOW_PENDING_OFFLINE): (
-        _RL.PUBLISH_ONLINE, _RL.WORKFLOW_OFFLINE_EXCEPTION, True),
+        _RL.PUBLISH_ONLINE,
+        _RL.WORKFLOW_OFFLINE_EXCEPTION,
+        True,
+    ),
     ("republish", _RL.WORKFLOW_OFFLINE): (
-        _RL.PUBLISH_NONE, _RL.WORKFLOW_PENDING_PUBLISH, False),
+        _RL.PUBLISH_NONE,
+        _RL.WORKFLOW_PENDING_PUBLISH,
+        False,
+    ),
     ("delete", _RL.WORKFLOW_DRAFT): (
-        _RL.PUBLISH_DELETED, _RL.WORKFLOW_DELETED, False),
+        _RL.PUBLISH_DELETED,
+        _RL.WORKFLOW_DELETED,
+        False,
+    ),
     ("delete", _RL.WORKFLOW_OFFLINE): (
-        _RL.PUBLISH_DELETED, _RL.WORKFLOW_DELETED, False),
+        _RL.PUBLISH_DELETED,
+        _RL.WORKFLOW_DELETED,
+        False,
+    ),
 }
 
 
@@ -2142,10 +2230,7 @@ def _selected_resale_platform(value: str | None):
         selected = queryset.filter(code=value).first()
         if selected:
             return selected
-    return (
-        queryset.filter(code="agione").first()
-        or queryset.first()
-    )
+    return queryset.filter(code="agione").first() or queryset.first()
 
 
 def _point_conversion_payload(platform: ResalePlatform | None):
@@ -2407,8 +2492,7 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
                 )
             )
             requires_currency_conversion = any(
-                item.get("requires_currency_conversion")
-                for item in options
+                item.get("requires_currency_conversion") for item in options
             )
             best = _select_best_option(options) if options else None
             procurement_rows.append(
@@ -2569,9 +2653,7 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
                     "model_name": listing.model.name,
                     "model_code": listing.model.code,
                     "channel_id": listing.channel_id,
-                    "channel_name": (
-                        channel.name if channel else "自动最优"
-                    ),
+                    "channel_name": (channel.name if channel else "自动最优"),
                     "currency": (
                         currency_context.display_currency
                         if not requires_currency_conversion


### PR DESCRIPTION
## Summary
- Block direct deletion of LLM/meta-model records that still have dependent business rows
- Detach legacy cleanup models with downstream links instead of deleting them
- Deduplicate legacy official-source models before source migration and report reset stats
- Preserve reset dry-run behavior without creating or deleting canonical provider rows

## Test plan
- [x] .venv/bin/pytest backend/llm_ops/tests/test_ops_bootstrap.py backend/llm_ops/tests/test_views.py
- [x] .venv/bin/black --check --target-version py314 --line-length 79 <changed llm_ops files>
- [x] .venv/bin/isort --check --profile black --line-length 79 --src-path backend <changed llm_ops files>
- [x] .venv/bin/flake8 <changed llm_ops files>
- [x] git diff --check

Made with [Orca](https://github.com/stablyai/orca) 🐋
