### PR TITLE
Improve LLM Ops source management

### DIFF
--- a/frontend/src/components/llm-ops/ProviderManagement.vue
+++ b/frontend/src/components/llm-ops/ProviderManagement.vue
@@ -197,7 +197,9 @@
                     icon="edit"
                     label="编辑价格源"
                     :disabled="!provider.primary_source"
-                    @click.stop="editSourceFromProvider(provider.primary_source)"
+                    @click.stop="
+                      editSourceFromProvider(provider.primary_source)
+                    "
                   />
                   <OperationIconButton
                     v-if="provider.primary_source?.can_manual_entry"
@@ -212,7 +214,8 @@
                     v-if="provider.primary_source?.can_collect"
                     icon="collect"
                     :label="
-                      provider.primary_source?.collect_action_label || '同步价格'
+                      provider.primary_source?.collect_action_label ||
+                      '同步价格'
                     "
                     :disabled="
                       !provider.primary_source.is_enabled ||
@@ -220,6 +223,17 @@
                         String(provider.primary_source.id)
                     "
                     @click.stop="collectSource(provider.primary_source)"
+                  />
+                  <OperationIconButton
+                    icon="delete"
+                    label="删除价格源"
+                    tone="danger"
+                    :disabled="
+                      !provider.primary_source ||
+                      String(deletingSourceId || '') ===
+                        String(provider.primary_source.id)
+                    "
+                    @click.stop="deleteSource(provider.primary_source)"
                   />
                 </div>
               </td>

--- a/frontend/src/components/llm-ops/ProviderPricingDrawer.vue
+++ b/frontend/src/components/llm-ops/ProviderPricingDrawer.vue
@@ -61,10 +61,7 @@
           </div>
           <div class="rounded-lg bg-slate-50 px-3 py-2">
             <p class="text-xs text-slate-500">价格来源</p>
-            <div
-              v-if="primarySource"
-              class="mt-1 min-w-0"
-            >
+            <div v-if="primarySource" class="mt-1 min-w-0">
               <div class="min-w-0">
                 <p class="truncate text-sm font-medium text-slate-900">
                   {{ primarySource.name }}
@@ -85,6 +82,119 @@
               </div>
             </div>
             <p v-else class="mt-1 font-mono text-sm text-slate-800">0</p>
+          </div>
+        </div>
+
+        <div class="panel overflow-hidden p-0">
+          <div class="table-toolbar">
+            <div>
+              <h3 class="panel-title">模型价格源</h3>
+              <p class="mt-1 text-xs text-slate-500">
+                维护该厂商下的原厂、供货商和人工价格来源。
+              </p>
+            </div>
+          </div>
+          <div class="overflow-x-auto">
+            <table class="data-table provider-source-table">
+              <colgroup>
+                <col class="source-name-col" />
+                <col class="source-type-col" />
+                <col class="source-status-col" />
+                <col class="source-action-col" />
+              </colgroup>
+              <thead>
+                <tr>
+                  <th class="table-head">价格源</th>
+                  <th class="table-head">类型</th>
+                  <th class="table-head">状态</th>
+                  <th class="table-head">操作</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="source in managementSourceRows" :key="source.id">
+                  <td class="table-cell">
+                    <div class="min-w-0">
+                      <p class="truncate font-medium text-slate-900">
+                        {{ source.name }}
+                      </p>
+                      <p class="mt-1 truncate font-mono text-xs text-slate-400">
+                        {{ source.slug }}
+                      </p>
+                      <a
+                        v-if="source.endpoint_url"
+                        class="source-link mt-1"
+                        :href="source.endpoint_url"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                        :title="source.endpoint_url"
+                      >
+                        {{ source.endpoint_url }}
+                      </a>
+                    </div>
+                  </td>
+                  <td class="table-cell text-center">
+                    <span :class="['source-badge', source.category_tone]">
+                      {{ source.category_label }}
+                    </span>
+                  </td>
+                  <td class="table-cell text-center">
+                    <span
+                      :class="[source.is_enabled ? 'badge-ok' : 'badge-muted']"
+                    >
+                      {{ source.is_enabled ? '已启用' : '已停用' }}
+                    </span>
+                    <p class="mt-1 text-xs text-slate-400">
+                      {{ source.price_item_count }} 个价格项
+                    </p>
+                  </td>
+                  <td class="table-cell">
+                    <div class="source-actions">
+                      <OperationIconButton
+                        icon="edit"
+                        label="编辑价格源"
+                        @click.stop="$emit('edit-source', source)"
+                      />
+                      <OperationIconButton
+                        icon="powerOff"
+                        :label="source.is_enabled ? '停用价格源' : '启用价格源'"
+                        @click.stop="$emit('toggle-source', source)"
+                      />
+                      <OperationIconButton
+                        v-if="source.can_manual_entry"
+                        icon="manual"
+                        label="配置模型价格"
+                        tone="primary"
+                        @click.stop="$emit('manual-entry-source', source)"
+                      />
+                      <OperationIconButton
+                        v-if="source.can_collect"
+                        icon="collect"
+                        :label="source.collect_action_label || '同步价格'"
+                        :disabled="
+                          !source.is_enabled ||
+                          String(collectingSourceId || '') === String(source.id)
+                        "
+                        @click.stop="$emit('collect-source', source)"
+                      />
+                      <OperationIconButton
+                        icon="delete"
+                        label="删除价格源"
+                        tone="danger"
+                        :disabled="
+                          String(deletingSourceId || '') === String(source.id)
+                        "
+                        @click.stop="$emit('delete-source', source)"
+                      />
+                    </div>
+                  </td>
+                </tr>
+                <tr v-if="!managementSourceRows.length">
+                  <td class="table-cell text-slate-500" colspan="4">
+                    当前厂商还没有模型价格源。
+                  </td>
+                </tr>
+              </tbody>
+            </table>
           </div>
         </div>
 
@@ -191,6 +301,7 @@
 
 <script setup>
 import { computed, ref } from 'vue'
+import OperationIconButton from '@/components/llm-ops/OperationIconButton.vue'
 
 defineEmits([
   'close',
@@ -264,6 +375,17 @@ const categoryFilterOptions = computed(() => {
 
 const sourceRows = computed(() =>
   aggregatePriceSources(props.sources, props.priceItems)
+)
+
+const managementSourceRows = computed(() =>
+  props.sources
+    .map((source) => buildManagementSourceRow(source))
+    .sort((left, right) => {
+      const leftRank = categoryRank(businessSourceCategory(left))
+      const rightRank = categoryRank(businessSourceCategory(right))
+      if (leftRank !== rightRank) return leftRank - rightRank
+      return String(left.name || '').localeCompare(String(right.name || ''))
+    })
 )
 
 const primarySource = computed(() => preferredPriceSource(sourceRows.value))
@@ -514,6 +636,8 @@ function buildAggregateSource(group, priceItems) {
     slug: aggregateSourceSlug(primary),
     endpoint_url: endpointUrl,
     is_enabled: sorted.some((source) => source.is_enabled),
+    category_label: sourceCategoryLabel(businessSourceCategory(primary)),
+    category_tone: sourceTone(businessSourceCategory(primary)),
     source_group_key: priceSourceGroupKey(primary),
     source_group_ids: sourceIds,
     source_count: sorted.length,
@@ -526,6 +650,20 @@ function buildAggregateSource(group, priceItems) {
     price_item_count: priceItems.filter(
       (item) =>
         sourceIds.includes(String(item.source || '')) &&
+        item.is_current !== false
+    ).length
+  }
+}
+
+function buildManagementSourceRow(source) {
+  const category = businessSourceCategory(source)
+  return {
+    ...source,
+    category_label: sourceCategoryLabel(category),
+    category_tone: sourceTone(category),
+    price_item_count: props.priceItems.filter(
+      (item) =>
+        String(item.source || '') === String(source.id) &&
         item.is_current !== false
     ).length
   }

--- a/frontend/src/pages/LLMOps.vue
+++ b/frontend/src/pages/LLMOps.vue
@@ -692,6 +692,13 @@ import { llmOpsApi } from '@/api/llmOps'
 import { DEFAULT_WORKFLOW_POLICIES } from '@/constants/llmOpsWorkflow'
 
 const FULL_LIST_PARAMS = { page_size: 10000 }
+const DATA_HEAVY_SECTIONS = new Set([
+  'channels',
+  'metaModels',
+  'providers',
+  'reconciler',
+  'reseller'
+])
 const sectionKeys = new Set([
   'monitor',
   'metaModels',
@@ -706,6 +713,9 @@ const sectionKeys = new Set([
 ])
 const activeSection = ref(initialActiveSection())
 const loading = ref(false)
+const backgroundLoading = ref(false)
+const secondaryDataLoaded = ref(false)
+const secondaryRefreshQueued = ref(false)
 
 const sources = ref([])
 const collectionRuns = ref([])
@@ -1346,6 +1356,15 @@ function extract(response) {
   return Array.isArray(data.results) ? data.results : data
 }
 
+function errorMessage(error, fallback) {
+  return (
+    error?.response?.data?.detail ||
+    error?.response?.data?.message ||
+    error?.message ||
+    fallback
+  )
+}
+
 function monitorModelSubtitle(row) {
   const name = String(row.model_name || '').trim()
   const code = String(row.model_code || '').trim()
@@ -1355,59 +1374,131 @@ function monitorModelSubtitle(row) {
 
 async function refreshAll() {
   loading.value = true
+  const section = activeSection.value
   try {
-    const [
-      sourceRes,
-      runRes,
-      providerRes,
-      metaModelRes,
-      modelRes,
-      channelRes,
-      priceRes,
-      channelPriceItemRes,
-      priceItemRes,
-      platformRes,
-      listingRes,
-      recordRes,
-      summaryRes
-    ] = await Promise.all([
-      llmOpsApi.listCollectionSources(FULL_LIST_PARAMS),
-      llmOpsApi.listCollectionRuns(FULL_LIST_PARAMS),
-      llmOpsApi.listProviders(FULL_LIST_PARAMS),
-      llmOpsApi.listMetaModels(FULL_LIST_PARAMS),
-      llmOpsApi.listModels(FULL_LIST_PARAMS),
-      llmOpsApi.listChannels(FULL_LIST_PARAMS),
-      llmOpsApi.listChannelModelPrices(FULL_LIST_PARAMS),
-      llmOpsApi.listChannelPriceItems({
-        ...FULL_LIST_PARAMS,
-        is_current: 'true'
-      }),
-      llmOpsApi.listModelPriceItems({
-        ...FULL_LIST_PARAMS,
-        is_current: 'true'
-      }),
-      llmOpsApi.listResalePlatforms(FULL_LIST_PARAMS),
-      llmOpsApi.listResaleListings(FULL_LIST_PARAMS),
-      llmOpsApi.listReconciliationRecords(FULL_LIST_PARAMS),
-      llmOpsApi.getSummary(summaryParams())
-    ])
-    sources.value = extract(sourceRes)
-    collectionRuns.value = extract(runRes)
-    providers.value = extract(providerRes)
-    metaModels.value = extract(metaModelRes)
-    models.value = extract(modelRes)
-    channels.value = extract(channelRes)
-    channelPrices.value = extract(priceRes)
-    channelPriceItems.value = extract(channelPriceItemRes)
-    modelPriceItems.value = extract(priceItemRes)
-    resalePlatforms.value = extract(platformRes)
-    listings.value = extract(listingRes)
-    records.value = extract(recordRes)
-    summary.value = extract(summaryRes)
-    await loadResaleWorkflowConfig()
+    await refreshCoreData()
+    await refreshSectionData(section)
   } finally {
     loading.value = false
   }
+
+  refreshSecondaryData({ force: true, silent: true })
+}
+
+async function refreshCoreData() {
+  const [
+    sourceRes,
+    runRes,
+    providerRes,
+    modelRes,
+    channelRes,
+    platformRes,
+    summaryRes
+  ] = await Promise.all([
+    llmOpsApi.listCollectionSources(FULL_LIST_PARAMS),
+    llmOpsApi.listCollectionRuns(FULL_LIST_PARAMS),
+    llmOpsApi.listProviders(FULL_LIST_PARAMS),
+    llmOpsApi.listModels(FULL_LIST_PARAMS),
+    llmOpsApi.listChannels(FULL_LIST_PARAMS),
+    llmOpsApi.listResalePlatforms(FULL_LIST_PARAMS),
+    llmOpsApi.getSummary(summaryParams())
+  ])
+  sources.value = extract(sourceRes)
+  collectionRuns.value = extract(runRes)
+  providers.value = extract(providerRes)
+  models.value = extract(modelRes)
+  channels.value = extract(channelRes)
+  resalePlatforms.value = extract(platformRes)
+  summary.value = extract(summaryRes)
+  await loadResaleWorkflowConfig()
+}
+
+async function refreshSecondaryData({ force = false, silent = false } = {}) {
+  if (backgroundLoading.value) {
+    if (force) {
+      secondaryDataLoaded.value = false
+      secondaryRefreshQueued.value = true
+    }
+    return
+  }
+  if (force) {
+    secondaryDataLoaded.value = false
+  }
+  backgroundLoading.value = true
+  try {
+    await Promise.all([
+      refreshMetaModels(),
+      refreshChannelPricingData(),
+      refreshModelPriceItems(),
+      refreshResaleListings(),
+      refreshReconciliationRecords()
+    ])
+    secondaryDataLoaded.value = true
+  } catch (error) {
+    if (!silent) {
+      showError(errorMessage(error, '加载 LLM Ops 扩展数据失败。'))
+    }
+  } finally {
+    backgroundLoading.value = false
+    if (secondaryRefreshQueued.value) {
+      secondaryRefreshQueued.value = false
+      refreshSecondaryData({ force: true, silent: true })
+    }
+  }
+}
+
+async function refreshSectionData(section) {
+  if (!DATA_HEAVY_SECTIONS.has(section)) return
+  if (section === 'providers' || section === 'metaModels') {
+    await Promise.all([refreshMetaModels(), refreshModelPriceItems()])
+    return
+  }
+  if (section === 'channels') {
+    await Promise.all([refreshChannelPricingData(), refreshModelPriceItems()])
+    return
+  }
+  if (section === 'reseller') {
+    await Promise.all([refreshModelPriceItems(), refreshResaleListings()])
+    return
+  }
+  if (section === 'reconciler') {
+    await refreshReconciliationRecords()
+  }
+}
+
+async function refreshMetaModels() {
+  const response = await llmOpsApi.listMetaModels(FULL_LIST_PARAMS)
+  metaModels.value = extract(response)
+}
+
+async function refreshChannelPricingData() {
+  const [priceRes, itemRes] = await Promise.all([
+    llmOpsApi.listChannelModelPrices(FULL_LIST_PARAMS),
+    llmOpsApi.listChannelPriceItems({
+      ...FULL_LIST_PARAMS,
+      is_current: 'true'
+    })
+  ])
+  channelPrices.value = extract(priceRes)
+  channelPriceItems.value = extract(itemRes)
+}
+
+async function refreshModelPriceItems() {
+  const response = await llmOpsApi.listModelPriceItems({
+    ...FULL_LIST_PARAMS,
+    is_current: 'true'
+  })
+  modelPriceItems.value = extract(response)
+}
+
+async function refreshResaleListings() {
+  const response = await llmOpsApi.listResaleListings(FULL_LIST_PARAMS)
+  listings.value = extract(response)
+}
+
+async function refreshReconciliationRecords() {
+  const response = await llmOpsApi.listReconciliationRecords(FULL_LIST_PARAMS)
+  records.value = extract(response)
 }
 
 async function refreshLight() {
@@ -1564,6 +1655,15 @@ watch(activeSection, (section) => {
   const url = new URL(window.location.href)
   url.searchParams.set('section', section)
   window.history.replaceState({}, '', `${url.pathname}${url.search}`)
+  if (
+    DATA_HEAVY_SECTIONS.has(section) &&
+    !secondaryDataLoaded.value &&
+    !loading.value
+  ) {
+    refreshSectionData(section).catch((error) => {
+      showError(errorMessage(error, '加载当前页面数据失败。'))
+    })
+  }
 })
 
 watch(selectedResalePlatformId, (platformId) => {


### PR DESCRIPTION
## Summary
- Add source management actions to provider rows and pricing drawer source tables
- Show source category, status, endpoint, and current price item counts in the provider pricing drawer
- Split LLM Ops page loading into core, section-specific, and background secondary refreshes to reduce initial heavy requests

## Test plan
- [x] npx eslint src/components/llm-ops/ProviderManagement.vue src/components/llm-ops/ProviderPricingDrawer.vue src/pages/LLMOps.vue --ext .vue,.js,.jsx,.cjs,.mjs --fix --ignore-path ../.gitignore
- [x] npm run build

## Notes
- Full npm run lint is currently blocked by existing repository-wide ESLint errors outside this change.

Made with [Orca](https://github.com/stablyai/orca) 🐋
