### PR TITLE
Improve LLM Ops price source management

### DIFF
--- a/backend/llm_ops/models.py
+++ b/backend/llm_ops/models.py
@@ -22,6 +22,13 @@ def _ensure_meta_model_from_model(instance, kwargs):
 class PriceCollectionSource(models.Model):
     """Pricing source for official, supplier, or manual price catalogs."""
 
+    CLOUD_PROVIDER_OFFICIAL_CODES = {
+        "aliyun",
+        "aliyun-wanx",
+        "baidu",
+        "volcengine",
+    }
+
     SOURCE_TYPE_AGIONE = "agione"
     SOURCE_TYPE_YUNCE = "yunce"
     SOURCE_TYPE_CUSTOM = "custom"
@@ -122,6 +129,46 @@ class PriceCollectionSource(models.Model):
 
     def __str__(self) -> str:
         return f"{self.name} ({self.slug})"
+
+    def save(self, *args, **kwargs):
+        """Normalize required source classification fields before saving."""
+        self._fill_required_classification_fields()
+        update_fields = kwargs.get("update_fields")
+        if update_fields is not None:
+            update_fields = set(update_fields)
+            update_fields.update({"source_owner_type", "collection_method"})
+            kwargs["update_fields"] = list(update_fields)
+        super().save(*args, **kwargs)
+
+    def _fill_required_classification_fields(self):
+        """Apply source classification defaults for legacy creation paths."""
+        if not self.source_owner_type:
+            self.source_owner_type = self._default_source_owner_type()
+        if not self.collection_method:
+            self.collection_method = self._default_collection_method()
+
+    def _default_source_owner_type(self):
+        if self.source_category == self.SOURCE_CATEGORY_OFFICIAL_PROVIDER:
+            provider_code = str(getattr(self.provider, "code", "")).lower()
+            if provider_code in self.CLOUD_PROVIDER_OFFICIAL_CODES:
+                return self.SOURCE_OWNER_CLOUD_PROVIDER_OFFICIAL
+            return self.SOURCE_OWNER_MODEL_PROVIDER_OFFICIAL
+        if self.source_category == self.SOURCE_CATEGORY_SUPPLIER:
+            return self.SOURCE_OWNER_SUPPLIER
+        if self.source_category == self.SOURCE_CATEGORY_MANUAL:
+            return self.SOURCE_OWNER_INTERNAL
+        return self.SOURCE_OWNER_UNKNOWN
+
+    def _default_collection_method(self):
+        if self.source_category == self.SOURCE_CATEGORY_OFFICIAL_PROVIDER:
+            return self.COLLECTION_METHOD_AUTO_COLLECT
+        if self.source_category == self.SOURCE_CATEGORY_SUPPLIER:
+            if self.source_type == self.SOURCE_TYPE_YUNCE:
+                return self.COLLECTION_METHOD_API_SYNC
+            return self.COLLECTION_METHOD_UNKNOWN
+        if self.source_category == self.SOURCE_CATEGORY_MANUAL:
+            return self.COLLECTION_METHOD_MANUAL_ENTRY
+        return self.COLLECTION_METHOD_UNKNOWN
 
 
 class LLMOpsGlobalConfig(models.Model):

--- a/backend/llm_ops/serializers.py
+++ b/backend/llm_ops/serializers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from decimal import Decimal
 
 from django.utils.text import slugify
@@ -68,7 +70,11 @@ class PriceCollectionSourceSerializer(serializers.ModelSerializer):
     )
     business_source_category = serializers.SerializerMethodField()
     business_source_category_label = serializers.SerializerMethodField()
+    capabilities = serializers.SerializerMethodField()
     can_collect_prices = serializers.SerializerMethodField()
+    latest_run_status = serializers.SerializerMethodField()
+    model_count = serializers.SerializerMethodField()
+    price_item_count = serializers.SerializerMethodField()
 
     class Meta:
         model = PriceCollectionSource
@@ -82,31 +88,19 @@ class PriceCollectionSourceSerializer(serializers.ModelSerializer):
         category = self.get_business_source_category(instance)
         return price_role_label(category)
 
+    def get_capabilities(self, instance):
+        can_collect_prices = self.get_can_collect_prices(instance)
+        return {
+            "can_collect_prices": can_collect_prices,
+            "updates_model_prices": bool(instance.updates_model_prices),
+            "has_endpoint": bool(instance.endpoint_url),
+        }
+
     def to_representation(self, instance):
         data = super().to_representation(instance)
         data["source_owner_type"] = source_owner_type_for_source(instance)
         data["collection_method"] = collection_method_for_source(instance)
         return data
-
-    def validate(self, attrs):
-        source_owner_type = attrs.get("source_owner_type")
-        if source_owner_type and not attrs.get("source_category"):
-            attrs["source_category"] = legacy_category_for_source_owner_type(
-                source_owner_type
-            )
-        collection_method = attrs.get("collection_method")
-        if (
-            collection_method
-            in (
-                PriceCollectionSource.COLLECTION_METHOD_MANUAL_ENTRY,
-                PriceCollectionSource.COLLECTION_METHOD_MANUAL_IMPORT,
-            )
-            and not attrs.get("source_owner_type")
-        ):
-            attrs["source_owner_type"] = (
-                PriceCollectionSource.SOURCE_OWNER_INTERNAL
-            )
-        return attrs
 
     def get_can_collect_prices(self, instance):
         from .source_collectors import source_supports_code_collection
@@ -116,8 +110,22 @@ class PriceCollectionSourceSerializer(serializers.ModelSerializer):
             and source_supports_code_collection(instance)
         )
 
+    def get_latest_run_status(self, instance):
+        return (
+            instance.collection_runs.order_by("-started_at", "-id")
+            .values_list("status", flat=True)
+            .first()
+        )
+
+    def get_model_count(self, instance):
+        return instance.models.count()
+
+    def get_price_item_count(self, instance):
+        return instance.model_price_items.count()
+
     def validate(self, attrs):
         attrs = super().validate(attrs)
+        self._apply_classification_defaults(attrs)
         requested_slug = attrs.get("slug")
         if self.instance and "slug" not in self.initial_data:
             return attrs
@@ -131,6 +139,67 @@ class PriceCollectionSourceSerializer(serializers.ModelSerializer):
             instance_id=getattr(self.instance, "id", None),
         )
         return attrs
+
+    def _apply_classification_defaults(self, attrs):
+        source_owner_type = attrs.get("source_owner_type")
+        source_category = attrs.get("source_category")
+        if (
+            source_owner_type
+            and source_owner_type != PriceCollectionSource.SOURCE_OWNER_UNKNOWN
+            and (
+                not source_category
+                or source_category
+                == PriceCollectionSource.SOURCE_CATEGORY_UNKNOWN
+            )
+        ):
+            attrs["source_category"] = legacy_category_for_source_owner_type(
+                source_owner_type
+            )
+
+        collection_method = attrs.get("collection_method")
+        if collection_method in (
+            PriceCollectionSource.COLLECTION_METHOD_MANUAL_ENTRY,
+            PriceCollectionSource.COLLECTION_METHOD_MANUAL_IMPORT,
+        ):
+            owner_type = self._effective_value(attrs, "source_owner_type")
+            if (
+                not owner_type
+                or owner_type == PriceCollectionSource.SOURCE_OWNER_UNKNOWN
+            ):
+                attrs["source_owner_type"] = (
+                    PriceCollectionSource.SOURCE_OWNER_INTERNAL
+                )
+
+        owner_type = self._effective_value(attrs, "source_owner_type")
+        if (
+            not owner_type
+            or owner_type == PriceCollectionSource.SOURCE_OWNER_UNKNOWN
+        ):
+            source_category = self._effective_value(attrs, "source_category")
+            provider = self._effective_value(attrs, "provider")
+            attrs["source_owner_type"] = default_source_owner_type_for_values(
+                source_category,
+                provider,
+            )
+
+        collection_method = self._effective_value(
+            attrs,
+            "collection_method",
+        )
+        if (
+            not collection_method
+            or collection_method
+            == PriceCollectionSource.COLLECTION_METHOD_UNKNOWN
+        ):
+            attrs["collection_method"] = default_collection_method_for_values(
+                self._effective_value(attrs, "source_category"),
+                self._effective_value(attrs, "source_type"),
+            )
+
+    def _effective_value(self, attrs, field_name):
+        if field_name in attrs:
+            return attrs[field_name]
+        return getattr(self.instance, field_name, None)
 
 
 def unique_price_source_slug(
@@ -1016,6 +1085,37 @@ def legacy_category_for_source_owner_type(source_owner_type):
     return PriceCollectionSource.SOURCE_CATEGORY_UNKNOWN
 
 
+def default_source_owner_type_for_values(source_category, provider):
+    """Return the default publisher type for serializer-created sources."""
+    if source_category == PriceCollectionSource.SOURCE_CATEGORY_MANUAL:
+        return PriceCollectionSource.SOURCE_OWNER_INTERNAL
+    if source_category == PriceCollectionSource.SOURCE_CATEGORY_SUPPLIER:
+        return PriceCollectionSource.SOURCE_OWNER_SUPPLIER
+    if (
+        source_category
+        == PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
+    ):
+        provider_code = str(getattr(provider, "code", "") or "").lower()
+        return source_owner_type_for_provider_code(provider_code)
+    return PriceCollectionSource.SOURCE_OWNER_UNKNOWN
+
+
+def default_collection_method_for_values(source_category, source_type):
+    """Return the default maintenance method for serializer-created sources."""
+    if (
+        source_category
+        == PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
+    ):
+        return PriceCollectionSource.COLLECTION_METHOD_AUTO_COLLECT
+    if source_category == PriceCollectionSource.SOURCE_CATEGORY_SUPPLIER:
+        if source_type == PriceCollectionSource.SOURCE_TYPE_YUNCE:
+            return PriceCollectionSource.COLLECTION_METHOD_API_SYNC
+        return PriceCollectionSource.COLLECTION_METHOD_UNKNOWN
+    if source_category == PriceCollectionSource.SOURCE_CATEGORY_MANUAL:
+        return PriceCollectionSource.COLLECTION_METHOD_MANUAL_ENTRY
+    return PriceCollectionSource.COLLECTION_METHOD_UNKNOWN
+
+
 def source_owner_type_for_provider_code(provider_code):
     """Return the default source owner type for official provider configs."""
     if str(provider_code or "").lower() in {
@@ -1634,6 +1734,11 @@ class ManualPriceImportRowSerializer(serializers.Serializer):
 
     model_code = serializers.CharField(max_length=150)
     model_name = serializers.CharField(max_length=255, required=False)
+    provider = serializers.CharField(required=False, allow_blank=True)
+    provider_code = serializers.CharField(required=False, allow_blank=True)
+    provider_name = serializers.CharField(required=False, allow_blank=True)
+    model_provider = serializers.CharField(required=False, allow_blank=True)
+    model_source = serializers.CharField(required=False, allow_blank=True)
     modality = serializers.ChoiceField(
         choices=LLMModel.MODALITY_CHOICES,
         required=False,
@@ -1744,15 +1849,6 @@ class ManualPriceImportRequestSerializer(serializers.Serializer):
         if source is not None:
             if source.provider_id and provider is None:
                 attrs["provider"] = source.provider
-            if not source.provider_id and provider is None:
-                raise serializers.ValidationError(
-                    {
-                        "source": (
-                            "Selected price source must be bound to a "
-                            "provider, or provider must be provided."
-                        )
-                    }
-                )
             attrs.setdefault("source_name", source.name)
             attrs.setdefault("source_url", source.endpoint_url)
             if not self.initial_data.get("currency"):

--- a/backend/llm_ops/services.py
+++ b/backend/llm_ops/services.py
@@ -15,6 +15,7 @@ from .models import (
     ChannelModelPriceHistory,
     ChannelPriceItem,
     LLMModel,
+    LLMProvider,
     MetaModel,
     ModelPriceItem,
     PriceCollectionSource,
@@ -564,7 +565,7 @@ def can_convert_currency(
 def import_manual_model_prices(
     *,
     source: PriceCollectionSource,
-    provider,
+    provider=None,
     rows: list[dict],
     default_currency: str,
     updates_model_prices: bool,
@@ -589,15 +590,20 @@ def import_manual_model_prices(
             skipped_count += 1
             continue
 
+        row_provider = resolve_manual_import_provider(
+            row,
+            default_provider=provider,
+            model_code=model_code,
+        )
         meta_model = ensure_meta_model(
             code=model_code,
             name=row.get("model_name") or model_code,
-            provider=provider,
+            provider=row_provider,
             modality=row.get("modality") or LLMModel.MODALITY_TEXT,
         )
         if effective_updates_model_prices:
             model, created = LLMModel.objects.get_or_create(
-                provider=provider,
+                provider=row_provider,
                 source=source,
                 code=model_code,
                 defaults={
@@ -621,7 +627,7 @@ def import_manual_model_prices(
             )
         else:
             model = find_aggregated_model(
-                provider=provider,
+                provider=row_provider,
                 code=model_code,
                 meta_model=meta_model,
                 source=source,
@@ -629,7 +635,7 @@ def import_manual_model_prices(
             created = model is None
             if model is None:
                 model = LLMModel.objects.create(
-                    provider=provider,
+                    provider=row_provider,
                     meta_model=meta_model,
                     name=row.get("model_name") or model_code,
                     code=model_code,
@@ -663,7 +669,7 @@ def import_manual_model_prices(
 
         price_item_count += sync_manual_model_price_items(
             source=source,
-            provider=provider,
+            provider=row_provider,
             model=model,
             row=row,
             row_index=index,
@@ -702,6 +708,79 @@ def import_manual_model_prices(
         "skipped_count": skipped_count,
         "price_item_count": price_item_count,
     }
+
+
+def resolve_manual_import_provider(
+    row: dict,
+    *,
+    default_provider: LLMProvider | None,
+    model_code: str,
+) -> LLMProvider:
+    """Resolve the model owner for one manually imported price row."""
+
+    if default_provider is not None:
+        return default_provider
+
+    matched = match_manual_import_provider(row)
+    if matched is not None:
+        return matched
+
+    model_matches = list(
+        LLMModel.objects.filter(code=model_code)
+        .select_related("provider")
+        .order_by("id")
+    )
+    provider_ids = {
+        model.provider_id for model in model_matches if model.provider_id
+    }
+    if len(provider_ids) == 1:
+        return model_matches[0].provider
+
+    meta_model = (
+        MetaModel.objects.filter(code=model_code)
+        .select_related("vendor")
+        .first()
+    )
+    if meta_model and meta_model.vendor_id:
+        return meta_model.vendor
+
+    raise ValueError(
+        "Cannot resolve model provider for manual price row "
+        f"{model_code}. Add provider_code or select an existing model."
+    )
+
+
+def match_manual_import_provider(row: dict) -> LLMProvider | None:
+    """Match row-level provider fields to an existing model provider."""
+
+    labels = {
+        normalize_provider_match_label(row.get(field))
+        for field in (
+            "provider",
+            "provider_code",
+            "provider_name",
+            "model_provider",
+            "model_source",
+        )
+        if normalize_provider_match_label(row.get(field))
+    }
+    if not labels:
+        return None
+
+    for provider in LLMProvider.objects.filter(is_active=True).order_by("id"):
+        provider_labels = {
+            normalize_provider_match_label(provider.code),
+            normalize_provider_match_label(provider.name),
+        }
+        if labels & provider_labels:
+            return provider
+    return None
+
+
+def normalize_provider_match_label(value: str | None) -> str:
+    """Normalize provider labels for manual import matching."""
+
+    return re.sub(r"[\s_\-]+", "", str(value or "").strip().lower())
 
 
 def update_model_from_manual_row(

--- a/backend/llm_ops/skills/model-price-sync/scripts/vendor_pricing_aliyun.py
+++ b/backend/llm_ops/skills/model-price-sync/scripts/vendor_pricing_aliyun.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from decimal import Decimal, InvalidOperation
 import re
 from html import unescape
 from typing import Any
@@ -342,11 +343,20 @@ def _price_row(
     row = {
         "input_price_per_million": input_price,
         "output_price_per_million": output_price,
+        "cache_hit_price_per_million": _cache_hit_price(input_price),
     }
     if token_range:
         row["input_token_range"] = token_range
         row["output_token_range"] = token_range
     return row
+
+
+def _cache_hit_price(input_price: str) -> str:
+    try:
+        price = Decimal(str(input_price)) * Decimal("0.1")
+    except (InvalidOperation, ValueError):
+        return ""
+    return format(price.normalize(), "f")
 
 
 def _normalize_token_range(text: str) -> str:

--- a/backend/llm_ops/source_collectors/base.py
+++ b/backend/llm_ops/source_collectors/base.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from typing import Protocol
+from typing import List, Protocol, Union
 
 from llm_ops.models import PriceCollectionSource
 
 
-CollectorResult = dict[str, int | list[str]]
+CollectorResult = dict[str, Union[int, List[str]]]
 
 
 class PriceSourceCollector(Protocol):

--- a/backend/llm_ops/tests/test_official_collector.py
+++ b/backend/llm_ops/tests/test_official_collector.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from django.test import TestCase
 
 from llm_ops.collection_services import (
+    ensure_official_model_source,
     ensure_official_source,
     official_model_source_slug as build_official_model_source_slug,
     sync_configured_official_model_prices,
@@ -1098,6 +1099,54 @@ class OfficialCollectionSyncTests(TestCase):
         self.assertEqual(
             ensured.endpoint_url,
             "https://help.aliyun.com/zh/model-studio/model-pricing",
+        )
+
+    def test_ensure_official_model_source_sets_classification_fields(self):
+        provider = LLMProvider.objects.get(code="aliyun")
+
+        source = ensure_official_model_source(
+            provider=provider,
+            model_code="deepseek-r1",
+            display_name="DeepSeek R1",
+            source_url=OFFICIAL_PROVIDER_CONFIGS["aliyun"].source_url,
+            currency="CNY",
+        )
+
+        self.assertEqual(
+            source.source_owner_type,
+            PriceCollectionSource.SOURCE_OWNER_CLOUD_PROVIDER_OFFICIAL,
+        )
+        self.assertEqual(
+            source.collection_method,
+            PriceCollectionSource.COLLECTION_METHOD_AUTO_COLLECT,
+        )
+
+    def test_price_source_save_fills_missing_classification_fields(self):
+        provider = LLMProvider.objects.get(code="aliyun")
+
+        source = PriceCollectionSource.objects.create(
+            provider=provider,
+            name="阿里云 / DeepSeek R1 官方价格",
+            slug="aliyun-deepseek-r1-official-test",
+            source_type=PriceCollectionSource.SOURCE_TYPE_CUSTOM,
+            source_category=(
+                PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
+            ),
+            source_owner_type=None,
+            collection_method=None,
+            endpoint_url=OFFICIAL_PROVIDER_CONFIGS["aliyun"].source_url,
+            currency="CNY",
+            is_enabled=True,
+            updates_model_prices=True,
+        )
+
+        self.assertEqual(
+            source.source_owner_type,
+            PriceCollectionSource.SOURCE_OWNER_CLOUD_PROVIDER_OFFICIAL,
+        )
+        self.assertEqual(
+            source.collection_method,
+            PriceCollectionSource.COLLECTION_METHOD_AUTO_COLLECT,
         )
 
     def test_sync_volcengine_official_prices_keeps_cny_currency(self):

--- a/backend/llm_ops/tests/test_serializers.py
+++ b/backend/llm_ops/tests/test_serializers.py
@@ -7,6 +7,7 @@ from llm_ops.models import (
     LLMProvider,
     MetaModel,
     ModelPriceItem,
+    PriceCollectionRun,
     PriceCollectionSource,
     ProcurementChannel,
     ResalePlatform,
@@ -282,6 +283,58 @@ class PriceCollectionSourceSerializerTests(TestCase):
         source = serializer.save()
         self.assertEqual(source.slug, "price-source-2")
 
+    def test_create_maps_owner_type_and_keeps_slug_unique(self):
+        PriceCollectionSource.objects.create(
+            name="Existing Supplier",
+            slug="supplier-api",
+            source_category=PriceCollectionSource.SOURCE_CATEGORY_SUPPLIER,
+        )
+        serializer = PriceCollectionSourceSerializer(
+            data={
+                "name": "Supplier API",
+                "slug": "supplier-api",
+                "source_type": PriceCollectionSource.SOURCE_TYPE_CUSTOM,
+                "source_owner_type": (
+                    PriceCollectionSource.SOURCE_OWNER_SUPPLIER
+                ),
+                "currency": "USD",
+                "is_enabled": True,
+                "updates_model_prices": True,
+            }
+        )
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        source = serializer.save()
+        self.assertEqual(
+            source.source_category,
+            PriceCollectionSource.SOURCE_CATEGORY_SUPPLIER,
+        )
+        self.assertEqual(source.slug, "supplier-api-2")
+
+    def test_manual_import_method_defaults_owner_type(self):
+        serializer = PriceCollectionSourceSerializer(
+            data={
+                "name": "Manual Import",
+                "source_type": PriceCollectionSource.SOURCE_TYPE_CUSTOM,
+                "source_category": (
+                    PriceCollectionSource.SOURCE_CATEGORY_MANUAL
+                ),
+                "collection_method": (
+                    PriceCollectionSource.COLLECTION_METHOD_MANUAL_IMPORT
+                ),
+                "currency": "CNY",
+                "is_enabled": True,
+                "updates_model_prices": False,
+            }
+        )
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        source = serializer.save()
+        self.assertEqual(
+            source.source_owner_type,
+            PriceCollectionSource.SOURCE_OWNER_INTERNAL,
+        )
+
     def test_create_generates_slug_for_chinese_name(self):
         serializer = PriceCollectionSourceSerializer(
             data={
@@ -349,6 +402,48 @@ class PriceCollectionSourceSerializerTests(TestCase):
         self.assertEqual(data["source_owner_type"], "cloud_provider_official")
         self.assertEqual(data["collection_method"], "unknown")
         self.assertEqual(data["business_source_category"], "cloud_hosted")
+
+    def test_source_representation_includes_stable_summary_fields(self):
+        provider = LLMProvider.objects.create(name="OpenAI", code="openai")
+        source = PriceCollectionSource.objects.create(
+            name="OpenAI Official",
+            slug="openai-official",
+            provider=provider,
+            source_category=(
+                PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
+            ),
+            endpoint_url="https://openai.com/api/pricing/",
+            updates_model_prices=True,
+        )
+        model = LLMModel.objects.create(
+            provider=provider,
+            source=source,
+            name="GPT-4o mini",
+            code="gpt-4o-mini",
+        )
+        ModelPriceItem.objects.create(
+            provider=provider,
+            model=model,
+            meta_model=model.meta_model,
+            source=source,
+            dimension=ModelPriceItem.DIMENSION_TEXT_INPUT,
+            billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
+            currency="USD",
+            unit_price=Decimal("0.150000"),
+            price_fingerprint="openai-input",
+        )
+        PriceCollectionRun.objects.create(
+            source=source,
+            status=PriceCollectionRun.STATUS_SUCCEEDED,
+        )
+
+        data = PriceCollectionSourceSerializer(source).data
+
+        self.assertEqual(data["model_count"], 1)
+        self.assertEqual(data["price_item_count"], 1)
+        self.assertEqual(data["latest_run_status"], "succeeded")
+        self.assertTrue(data["capabilities"]["can_collect_prices"])
+        self.assertTrue(data["capabilities"]["updates_model_prices"])
 
 
 class LLMModelSerializerTests(TestCase):
@@ -428,6 +523,33 @@ class ManualPriceImportRequestSerializerTests(TestCase):
             serializer.validated_data["provider"],
             model_provider,
         )
+        self.assertFalse(serializer.validated_data["updates_model_prices"])
+
+    def test_accepts_existing_source_without_bound_provider(self):
+        source = PriceCollectionSource.objects.create(
+            name="Agione Manual Sheet",
+            slug="agione-manual-sheet",
+            source_type=PriceCollectionSource.SOURCE_TYPE_CUSTOM,
+            source_category=PriceCollectionSource.SOURCE_CATEGORY_MANUAL,
+            currency="CNY",
+        )
+
+        serializer = ManualPriceImportRequestSerializer(
+            data={
+                "source": source.id,
+                "rows": [
+                    {
+                        "model_code": "deepseek-r1",
+                        "model_name": "DeepSeek R1",
+                        "provider_code": "deepseek",
+                        "input_price_per_million": "4.000000",
+                    }
+                ],
+            }
+        )
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        self.assertIsNone(serializer.validated_data.get("provider"))
         self.assertFalse(serializer.validated_data["updates_model_prices"])
 
     def test_new_manual_source_import_never_promotes_model_prices(self):

--- a/backend/llm_ops/tests/test_services.py
+++ b/backend/llm_ops/tests/test_services.py
@@ -433,6 +433,34 @@ class LLMOpsPricingServiceTests(TestCase):
         item = ModelPriceItem.objects.get(source=source)
         self.assertEqual(item.model, self.model)
 
+    def test_manual_import_without_source_provider_uses_model_owner(self):
+        source = PriceCollectionSource.objects.create(
+            name="Agione Sheet",
+            slug="agione-sheet",
+            source_category=PriceCollectionSource.SOURCE_CATEGORY_SUPPLIER,
+            currency="USD",
+            updates_model_prices=False,
+        )
+
+        import_manual_model_prices(
+            source=source,
+            provider=None,
+            rows=[
+                {
+                    "model_code": "gpt-4o",
+                    "model_name": "GPT-4o",
+                    "currency": "USD",
+                    "input_price_per_million": Decimal("1.5"),
+                }
+            ],
+            default_currency="USD",
+            updates_model_prices=False,
+        )
+
+        item = ModelPriceItem.objects.get(source=source)
+        self.assertEqual(item.provider, self.provider)
+        self.assertEqual(item.model, self.model)
+
     def test_manual_source_import_never_promotes_model_prices(self):
         aliyun = LLMProvider.objects.create(name="阿里云", code="aliyun")
         deepseek = LLMProvider.objects.create(

--- a/backend/llm_ops/tests/test_skill_runner.py
+++ b/backend/llm_ops/tests/test_skill_runner.py
@@ -199,6 +199,12 @@ class ModelPriceSkillRunnerTests(SimpleTestCase):
             payload["models"][0]["price_rows"][0]["values"]["output_price"],
             "7",
         )
+        self.assertEqual(
+            payload["models"][0]["price_rows"][0]["values"][
+                "cache_hit_input_price"
+            ],
+            "0.35",
+        )
 
     def test_aliyun_vendor_skill_extracts_seven_column_qwen_rows(self):
         payload = run_vendor_pricing_skill(
@@ -237,11 +243,13 @@ class ModelPriceSkillRunnerTests(SimpleTestCase):
         self.assertEqual(len(rows), 2)
         self.assertEqual(rows[0]["values"]["input_token_range"], "0-128000")
         self.assertEqual(rows[0]["values"]["input_price"], "9")
+        self.assertEqual(rows[0]["values"]["cache_hit_input_price"], "0.9")
         self.assertEqual(
             rows[1]["values"]["input_token_range"],
             "128000-256000",
         )
         self.assertEqual(rows[1]["values"]["output_price"], "90")
+        self.assertEqual(rows[1]["values"]["cache_hit_input_price"], "1.5")
 
     def test_aliyun_vendor_skill_filters_non_model_rows(self):
         payload = run_vendor_pricing_skill(

--- a/backend/llm_ops/tests/test_views.py
+++ b/backend/llm_ops/tests/test_views.py
@@ -518,6 +518,48 @@ class LLMOpsViewTests(TestCase):
             1,
         )
 
+    @patch("llm_ops.views.import_manual_model_prices")
+    def test_manual_price_import_accepts_source_without_provider(
+        self,
+        mock_import,
+    ):
+        source = PriceCollectionSource.objects.create(
+            name="Agione Manual Sheet",
+            slug="agione-manual-sheet",
+            source_type=PriceCollectionSource.SOURCE_TYPE_CUSTOM,
+            source_category=PriceCollectionSource.SOURCE_CATEGORY_MANUAL,
+            currency="CNY",
+        )
+        mock_import.return_value = {
+            "created_models": 0,
+            "updated_models": 1,
+            "created_price_items": 1,
+        }
+
+        response = self.client.post(
+            reverse("llm-ops-manual-price-import"),
+            {
+                "source": source.id,
+                "rows": [
+                    {
+                        "model_code": "deepseek-r1",
+                        "model_name": "DeepSeek R1",
+                        "provider_code": "deepseek",
+                        "input_price_per_million": "1.000000",
+                    }
+                ],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        mock_import.assert_called_once()
+        _, kwargs = mock_import.call_args
+        self.assertEqual(kwargs["source"], source)
+        self.assertIsNone(kwargs["provider"])
+        audit = AuditLog.objects.get(target_id=str(source.id))
+        self.assertIsNone(audit.metadata["provider_id"])
+
     def test_collection_source_can_be_deleted(self):
         source = PriceCollectionSource.objects.create(
             name="Manual Source",
@@ -837,7 +879,7 @@ class LLMOpsViewTests(TestCase):
         self.assertEqual(response.status_code, 409)
         self.assertTrue(MetaModel.objects.filter(id=meta.id).exists())
 
-    @patch("llm_ops.views.collect_price_source_prices.delay")
+    @patch("llm_ops.views.run_model_price_sync_agent.delay")
     def test_collection_source_collects_official_provider(self, mock_delay):
         provider = LLMProvider.objects.create(name="阿里云", code="aliyun")
         source = PriceCollectionSource.objects.create(
@@ -867,7 +909,7 @@ class LLMOpsViewTests(TestCase):
         self.assertEqual(response.data["provider_code"], "aliyun")
         self.assertEqual(response.data["source_id"], source.id)
         mock_delay.assert_called_once_with(
-            source_id=source.id,
+            source_ids=[source.id],
             verify_source=True,
         )
         audit = AuditLog.objects.get(target_id=str(source.id))
@@ -981,12 +1023,24 @@ class LLMOpsViewTests(TestCase):
         self.assertEqual(response.data["source"]["slug"], "aliyun-official")
         self.assertEqual(response.data["source"]["provider_code"], "aliyun")
         self.assertEqual(response.data["source"]["currency"], "CNY")
+        self.assertEqual(
+            response.data["source"]["collection_method"],
+            PriceCollectionSource.COLLECTION_METHOD_AUTO_COLLECT,
+        )
         provider = LLMProvider.objects.get(code="aliyun")
         source = PriceCollectionSource.objects.get(slug="aliyun-official")
         self.assertEqual(source.provider, provider)
         self.assertEqual(
             source.source_category,
             PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER,
+        )
+        self.assertEqual(
+            source.source_owner_type,
+            PriceCollectionSource.SOURCE_OWNER_CLOUD_PROVIDER_OFFICIAL,
+        )
+        self.assertEqual(
+            source.collection_method,
+            PriceCollectionSource.COLLECTION_METHOD_AUTO_COLLECT,
         )
         self.assertTrue(source.updates_model_prices)
         audit = AuditLog.objects.get(target_id=str(source.id))
@@ -1021,7 +1075,7 @@ class LLMOpsViewTests(TestCase):
             1,
         )
 
-    @patch("llm_ops.views.collect_price_source_prices.delay")
+    @patch("llm_ops.views.run_model_price_sync_agent.delay")
     def test_collection_source_collect_rejects_disabled_source(
         self,
         mock_delay,
@@ -1052,7 +1106,7 @@ class LLMOpsViewTests(TestCase):
         )
         mock_delay.assert_not_called()
 
-    @patch("llm_ops.views.collect_price_source_prices.delay")
+    @patch("llm_ops.views.run_model_price_sync_agent.delay")
     def test_collection_source_collect_rejects_unsupported_source(
         self,
         mock_delay,
@@ -1086,7 +1140,7 @@ class LLMOpsViewTests(TestCase):
         mock_delay.assert_not_called()
 
     @patch("llm_ops.views.source_supports_code_collection")
-    @patch("llm_ops.views.collect_price_source_prices.delay")
+    @patch("llm_ops.views.run_model_price_sync_agent.delay")
     def test_collection_source_collect_does_not_require_provider(
         self,
         mock_delay,
@@ -1115,7 +1169,7 @@ class LLMOpsViewTests(TestCase):
         self.assertEqual(response.data["provider_code"], "")
         self.assertEqual(response.data["source_id"], source.id)
         mock_delay.assert_called_once_with(
-            source_id=source.id,
+            source_ids=[source.id],
             verify_source=True,
         )
 

--- a/backend/llm_ops/views.py
+++ b/backend/llm_ops/views.py
@@ -86,7 +86,7 @@ from .services import (
     sync_channel_price_items,
 )
 from .source_collectors import source_supports_code_collection
-from .tasks import collect_price_source_prices, run_model_price_sync_agent
+from .tasks import run_model_price_sync_agent
 from .workflow_config import (
     merge_resale_workflow_config,
     validate_resale_workflow_config,
@@ -313,8 +313,8 @@ class PriceCollectionSourceViewSet(
                 status=status.HTTP_400_BAD_REQUEST,
             )
         if source_supports_code_collection(source):
-            task = collect_price_source_prices.delay(
-                source_id=source.id,
+            task = run_model_price_sync_agent.delay(
+                source_ids=[source.id],
                 verify_source=True,
             )
             record_audit_log(
@@ -2909,7 +2909,7 @@ class ManualPriceImportAPIView(LLMOpsPermissionMixin, APIView):
         serializer = ManualPriceImportRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        provider = data["provider"]
+        provider = data.get("provider")
         source = data.get("source")
         source_before = snapshot_instance(source)
         if source is None:
@@ -2943,13 +2943,19 @@ class ManualPriceImportAPIView(LLMOpsPermissionMixin, APIView):
                     "updates_model_prices": data["updates_model_prices"],
                 },
             )
-        result = import_manual_model_prices(
-            source=source,
-            provider=provider,
-            rows=data["rows"],
-            default_currency=data["currency"],
-            updates_model_prices=data["updates_model_prices"],
-        )
+        try:
+            result = import_manual_model_prices(
+                source=source,
+                provider=provider,
+                rows=data["rows"],
+                default_currency=data["currency"],
+                updates_model_prices=data["updates_model_prices"],
+            )
+        except ValueError as exc:
+            return Response(
+                {"detail": str(exc)},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         record_audit_log(
             request=request,
             action=AuditLog.ACTION_IMPORT,
@@ -2959,7 +2965,7 @@ class ManualPriceImportAPIView(LLMOpsPermissionMixin, APIView):
             before=source_before,
             after=snapshot_instance(source),
             metadata={
-                "provider_id": provider.id,
+                "provider_id": provider.id if provider else None,
                 "row_count": len(data["rows"]),
                 "updates_model_prices": data["updates_model_prices"],
                 "result": result,

--- a/frontend/src/components/llm-ops/ManualPriceEntryModal.vue
+++ b/frontend/src/components/llm-ops/ManualPriceEntryModal.vue
@@ -447,12 +447,6 @@ watch(
     if (open) {
       modelMode.value = isManualSource.value ? 'custom' : 'existing'
       form.value = defaults()
-      if (!form.value.model_id && props.models.length) {
-        const matched = props.models.find(
-          (model) => String(model.provider) === String(props.source?.provider)
-        )
-        form.value.model_id = matched?.id || ''
-      }
     }
   }
 )
@@ -560,7 +554,6 @@ function clearInactivePrices() {
 }
 
 function buildModelOptions() {
-  const sourceProvider = props.source?.provider
   const sortedModels = props.models.slice().sort((left, right) => {
     const providerCompare = String(left.provider_name || '').localeCompare(
       String(right.provider_name || '')
@@ -568,29 +561,7 @@ function buildModelOptions() {
     if (providerCompare !== 0) return providerCompare
     return String(left.name || '').localeCompare(String(right.name || ''))
   })
-  const preferred = sortedModels.filter(
-    (model) => String(model.provider) === String(sourceProvider)
-  )
-  const others = sortedModels.filter(
-    (model) => String(model.provider) !== String(sourceProvider)
-  )
-  if (!sourceProvider || !preferred.length) {
-    return sortedModels.map(modelOption)
-  }
-  return [
-    {
-      label: t('llmOps.manualPriceEntry.groups.currentProvider'),
-      value: '__group_preferred',
-      type: 'group'
-    },
-    ...preferred.map(modelOption),
-    {
-      label: t('llmOps.manualPriceEntry.groups.otherModels'),
-      value: '__group_others',
-      type: 'group'
-    },
-    ...others.map(modelOption)
-  ]
+  return sortedModels.map(modelOption)
 }
 
 function resolveModelProviderId(model) {
@@ -600,8 +571,7 @@ function resolveModelProviderId(model) {
 }
 
 function buildMetaModelOptions() {
-  const sourceProvider = props.source?.provider
-  const rows = props.metaModels
+  return props.metaModels
     .map((model) => {
       const vendor = resolveCanonicalMetaVendor(model, props.providers)
       return {
@@ -619,29 +589,7 @@ function buildMetaModelOptions() {
         String(right.name || right.code || '')
       )
     })
-  const preferred = rows.filter(
-    (model) => String(model.resolved_vendor) === String(sourceProvider)
-  )
-  const others = rows.filter(
-    (model) => String(model.resolved_vendor) !== String(sourceProvider)
-  )
-  if (!sourceProvider || !preferred.length) {
-    return rows.map(metaModelOption)
-  }
-  return [
-    {
-      label: t('llmOps.manualPriceEntry.groups.currentProvider'),
-      value: '__group_preferred_meta',
-      type: 'group'
-    },
-    ...preferred.map(metaModelOption),
-    {
-      label: t('llmOps.manualPriceEntry.groups.otherModels'),
-      value: '__group_other_meta',
-      type: 'group'
-    },
-    ...others.map(metaModelOption)
-  ]
+    .map(metaModelOption)
 }
 
 function modelOption(model) {

--- a/frontend/src/components/llm-ops/ManualPriceImportModal.vue
+++ b/frontend/src/components/llm-ops/ManualPriceImportModal.vue
@@ -41,7 +41,9 @@
             </span>
           </label>
           <div class="source-context">
-            <span>{{ t('llmOps.manualPriceImport.fields.provider') }}</span>
+            <span>
+              {{ t('llmOps.manualPriceImport.fields.defaultProvider') }}
+            </span>
             <strong>
               {{ selectedSourceProvider?.name || '-' }}
             </strong>
@@ -85,6 +87,7 @@
               </p>
               <p class="mt-2 text-xs leading-5 text-slate-500">
                 model_code、model_name、modality、currency、source_url、
+                provider_code、provider_name、
                 input_price_per_million、output_price_per_million、
                 cache_input_price_per_million、image_output_price_per_image、
                 audio_input_price_per_second、audio_output_price_per_second、
@@ -273,7 +276,11 @@ const sourceOptions = computed(() => [
     .map((source) => ({
       label: source.name,
       value: source.id,
-      description: source.provider_name || source.relation_name || '',
+      description:
+        source.channel_name ||
+        source.relation_name ||
+        source.provider_name ||
+        '',
       badge: source.category_label || source.source_category || ''
     }))
 ])
@@ -300,7 +307,7 @@ const sourceStatusText = computed(() => {
     return t('llmOps.manualPriceImport.validation.sourceRequired')
   }
   if (!selectedSourceProvider.value) {
-    return t('llmOps.manualPriceImport.validation.sourceProviderRequired')
+    return t('llmOps.manualPriceImport.validation.sourceProviderOptional')
   }
   return t('llmOps.manualPriceImport.validation.sourceReady', {
     name: selectedSource.value.name
@@ -311,10 +318,7 @@ const parsedRows = computed(() => parsed.value.rows)
 const parseErrors = computed(() => parsed.value.errors)
 const canSubmit = computed(
   () =>
-    form.value.source &&
-    selectedSourceProvider.value &&
-    parsedRows.value.length &&
-    !parseErrors.value.length
+    form.value.source && parsedRows.value.length && !parseErrors.value.length
 )
 
 watch(
@@ -343,8 +347,7 @@ function defaultForm() {
 }
 
 function firstImportSourceId() {
-  const source = props.sources.find((item) => item.provider)
-  return source?.id || props.sources[0]?.id || ''
+  return props.sources[0]?.id || ''
 }
 
 function close() {
@@ -356,14 +359,17 @@ async function submit() {
   if (!canSubmit.value) return
   saving.value = true
   try {
-    await llmOpsApi.importManualPrices({
+    const payload = {
       ...form.value,
-      provider: selectedSourceProvider.value.id,
       source_name: selectedSource.value.name,
       source_url: selectedSource.value.endpoint_url || '',
       updates_model_prices: false,
       rows: parsedRows.value.map((row) => cleanRow(row))
-    })
+    }
+    if (selectedSourceProvider.value?.id) {
+      payload.provider = selectedSourceProvider.value.id
+    }
+    await llmOpsApi.importManualPrices(payload)
     emit('imported')
   } finally {
     saving.value = false
@@ -426,8 +432,16 @@ function normalizeHeader(header) {
   const aliases = {
     code: 'model_code',
     model: 'model_code',
+    provider: 'provider',
+    provider_code: 'provider_code',
+    provider_name: 'provider_name',
+    model_provider: 'model_provider',
+    model_source: 'model_source',
     '\u6a21\u578b\u7f16\u7801': 'model_code',
     '\u6a21\u578b\u540d\u79f0': 'model_name',
+    '\u6a21\u578b\u5382\u5546': 'provider_name',
+    '\u5382\u5546': 'provider_name',
+    '\u5382\u5546\u7f16\u7801': 'provider_code',
     '\u7c7b\u578b': 'modality',
     '\u5e01\u79cd': 'currency',
     '\u8f93\u5165\u4ef7\u683c': 'input_price_per_million',

--- a/frontend/src/components/llm-ops/PriceSourceModal.vue
+++ b/frontend/src/components/llm-ops/PriceSourceModal.vue
@@ -50,16 +50,6 @@
             <h4>{{ t('llmOps.priceSourceModal.sections.basic') }}</h4>
             <p>{{ t('llmOps.priceSourceModal.sections.basicHint') }}</p>
           </div>
-          <div class="source-meta-strip">
-            <div class="source-meta-item">
-              <span>{{ t('llmOps.priceSourceModal.fields.slug') }}</span>
-              <strong>{{ internalSlugLabel }}</strong>
-            </div>
-            <div class="source-meta-item">
-              <span>{{ t('llmOps.priceSourceModal.fields.sourceType') }}</span>
-              <strong>{{ sourceTypeLabel }}</strong>
-            </div>
-          </div>
           <div class="grid gap-4 md:grid-cols-2">
             <label class="field-group">
               <span class="field-label">
@@ -71,12 +61,21 @@
                 :placeholder="t('llmOps.priceSourceModal.placeholders.name')"
                 required
               />
-              <span v-if="!isEditing" class="field-help">
-                {{
-                  t('llmOps.priceSourceModal.help.autoSlug', {
-                    slug: internalSlugLabel
-                  })
-                }}
+            </label>
+            <label class="field-group">
+              <span class="field-label">
+                {{ t('llmOps.priceSourceModal.fields.slug') }}
+              </span>
+              <input
+                v-model="form.slug"
+                class="field font-mono"
+                :disabled="!canEditSlug"
+                maxlength="100"
+                :placeholder="sourceSlugLabel"
+                @blur="normalizeSlugField"
+              />
+              <span class="field-help">
+                {{ slugHelpText }}
               </span>
             </label>
             <label class="field-group">
@@ -84,7 +83,7 @@
                 {{ t('llmOps.priceSourceModal.fields.sourceOwnerType') }}
               </span>
               <CompactSelect
-                v-model="form.source_owner_type"
+                v-model="sourceOwnerTypeSelection"
                 :options="sourceOwnerTypeOptions"
               />
             </label>
@@ -98,60 +97,29 @@
               />
             </label>
             <label
-              v-if="shouldUseOfficialPreset"
-              class="field-group md:col-span-2"
+              class="field-group"
             >
               <span class="field-label">
                 {{ t('llmOps.priceSourceModal.fields.officialProvider') }}
               </span>
               <CompactSelect
                 v-model="selectedOfficialProviderCode"
-                :disabled="loadingOfficialProviderOptions || saving"
+                :disabled="
+                  !shouldUseOfficialPreset ||
+                  loadingOfficialProviderOptions ||
+                  saving
+                "
                 :options="officialProviderSelectOptions"
                 class-name="w-full"
                 :menu-min-width="360"
+                :placeholder="
+                  t('llmOps.priceSourceModal.officialPreset.selectProvider')
+                "
               />
               <span class="field-help">
-                {{ officialProviderStatus }}
+                {{ officialProviderHelpText }}
               </span>
             </label>
-            <div
-              v-if="shouldUseOfficialPreset && selectedOfficialProviderOption"
-              class="official-source-detail md:col-span-2"
-            >
-              <div>
-                <span>
-                  {{ t('llmOps.priceSourceModal.officialPreset.source') }}
-                </span>
-                <strong>
-                  {{ selectedOfficialProviderOption.source_name }}
-                </strong>
-              </div>
-              <div>
-                <span>
-                  {{ t('llmOps.priceSourceModal.officialPreset.slug') }}
-                </span>
-                <strong class="font-mono">
-                  {{ selectedOfficialProviderOption.source_slug }}
-                </strong>
-              </div>
-              <div>
-                <span>
-                  {{ t('llmOps.priceSourceModal.officialPreset.currency') }}
-                </span>
-                <strong>
-                  {{ selectedOfficialProviderOption.currency }}
-                </strong>
-              </div>
-              <div>
-                <span>
-                  {{ t('llmOps.priceSourceModal.officialPreset.url') }}
-                </span>
-                <strong class="break-all">
-                  {{ selectedOfficialProviderOption.source_url || '-' }}
-                </strong>
-              </div>
-            </div>
             <label class="field-group">
               <span class="field-label">
                 {{ t('llmOps.priceSourceModal.fields.currency') }}
@@ -264,41 +232,58 @@ const form = ref(defaults())
 const officialProviderOptions = ref([])
 const selectedOfficialProviderCode = ref('')
 const loadingOfficialProviderOptions = ref(false)
+const officialSourceOwnerTypes = [
+  'model_provider_official',
+  'cloud_provider_official'
+]
+const visibleSourceOwnerTypes = ['supplier', 'internal']
+const sourceOwnerOfficialOption = 'official'
 const isEditing = computed(() => Boolean(props.source?.id))
 const shouldUseOfficialPreset = computed(
   () =>
     !isEditing.value &&
-    ['model_provider_official', 'cloud_provider_official'].includes(
-      form.value.source_owner_type
-    )
+    officialSourceOwnerTypes.includes(form.value.source_owner_type)
 )
-const internalSlugLabel = computed(() =>
-  isEditing.value ? form.value.slug || '-' : sourceSlugLabel.value
+const canEditSlug = computed(
+  () => !shouldUseOfficialPreset.value && !isStableOfficialSource.value
 )
+const isStableOfficialSource = computed(() => {
+  if (!isEditing.value) return false
+  const source = props.source || {}
+  const providerCode = String(source.provider_code || '').trim()
+  if (!providerCode) return false
+  return (
+    source.source_category === 'official_provider' &&
+    String(source.slug || '') === `${providerCode}-official`
+  )
+})
+const slugHelpText = computed(() => {
+  if (shouldUseOfficialPreset.value && !selectedOfficialProviderOption.value) {
+    return t('llmOps.priceSourceModal.help.officialSlugPreset')
+  }
+  if (isStableOfficialSource.value) {
+    return t('llmOps.priceSourceModal.help.officialSlugLocked')
+  }
+  if (shouldUseOfficialPreset.value) {
+    return t('llmOps.priceSourceModal.help.officialSlugLocked')
+  }
+  if (isEditing.value) {
+    return t('llmOps.priceSourceModal.help.slug')
+  }
+  return t('llmOps.priceSourceModal.help.autoSlug', {
+    slug: sourceSlugLabel.value
+  })
+})
 const sourceSlugLabel = computed(() => {
   if (shouldUseOfficialPreset.value && selectedOfficialProviderOption.value) {
     return selectedOfficialProviderOption.value.source_slug || '-'
   }
   return autoSlug(form.value.name || '')
 })
-const sourceTypeLabel = computed(() => {
-  const type = props.source?.source_type || 'custom'
-  const labels = {
-    agione: 'Agione',
-    yunce: 'Yunce',
-    custom: t('llmOps.priceSourceModal.sourceTypes.custom')
-  }
-  return labels[type] || type || '-'
-})
-
 const sourceOwnerTypeOptions = computed(() => [
   {
-    label: t('llmOps.priceSourceModal.sourceOwnerTypes.modelProvider'),
-    value: 'model_provider_official'
-  },
-  {
-    label: t('llmOps.priceSourceModal.sourceOwnerTypes.cloudProvider'),
-    value: 'cloud_provider_official'
+    label: t('llmOps.priceSourceModal.sourceOwnerTypes.official'),
+    value: sourceOwnerOfficialOption
   },
   {
     label: t('llmOps.priceSourceModal.sourceOwnerTypes.supplier'),
@@ -307,12 +292,35 @@ const sourceOwnerTypeOptions = computed(() => [
   {
     label: t('llmOps.priceSourceModal.sourceOwnerTypes.internal'),
     value: 'internal'
-  },
-  {
-    label: t('llmOps.priceSourceModal.sourceOwnerTypes.unknown'),
-    value: 'unknown'
   }
 ])
+
+const sourceOwnerTypeSelection = computed({
+  get() {
+    if (officialSourceOwnerTypes.includes(form.value.source_owner_type)) {
+      return sourceOwnerOfficialOption
+    }
+    if (visibleSourceOwnerTypes.includes(form.value.source_owner_type)) {
+      return form.value.source_owner_type
+    }
+    return 'internal'
+  },
+  set(value) {
+    if (value === sourceOwnerOfficialOption) {
+      selectedOfficialProviderCode.value = ''
+      form.value.source_owner_type = sourceOwnerTypeForOfficialProvider(
+        { provider_code: selectedOfficialProviderCode.value }
+      )
+      form.value.collection_method = 'auto_collect'
+      return
+    }
+    selectedOfficialProviderCode.value = ''
+    form.value.source_owner_type = value
+    if (['supplier', 'internal'].includes(value)) {
+      form.value.collection_method = 'manual_entry'
+    }
+  }
+})
 
 const collectionMethodOptions = computed(() => [
   {
@@ -366,11 +374,21 @@ const officialProviderStatus = computed(() => {
     return t('llmOps.priceSourceModal.officialPreset.loading')
   }
   const option = selectedOfficialProviderOption.value
+  if (!option && officialProviderOptions.value.length) {
+    return t('llmOps.priceSourceModal.officialPreset.selectProvider')
+  }
   if (!option) return t('llmOps.priceSourceModal.officialPreset.empty')
   if (option.source_exists) {
     return t('llmOps.priceSourceModal.officialPreset.exists')
   }
   return t('llmOps.priceSourceModal.officialPreset.ready')
+})
+
+const officialProviderHelpText = computed(() => {
+  if (!shouldUseOfficialPreset.value) {
+    return t('llmOps.priceSourceModal.officialPreset.onlyOfficial')
+  }
+  return officialProviderStatus.value
 })
 
 const saveDisabled = computed(
@@ -406,8 +424,8 @@ function defaults() {
   return {
     name: '',
     slug: '',
-    source_owner_type: 'supplier',
-    collection_method: 'manual_entry',
+    source_owner_type: 'model_provider_official',
+    collection_method: 'auto_collect',
     endpoint_url: '',
     currency: 'CNY',
     is_enabled: true,
@@ -444,11 +462,12 @@ async function save() {
       await saveOfficialProviderSource()
       return
     }
+    const submittedSlug = canEditSlug.value
+      ? normalizeSlug(form.value.slug) || autoSlug(form.value.name)
+      : props.source?.slug || form.value.slug || autoSlug(form.value.name)
     const payload = {
       ...form.value,
-      slug: isEditing.value
-        ? props.source?.slug || form.value.slug || autoSlug(form.value.name)
-        : form.value.slug || autoSlug(form.value.name),
+      slug: submittedSlug,
       source_type: props.source?.source_type || 'custom'
     }
     payload.source_category = legacyCategoryForSourceOwnerType(
@@ -499,12 +518,8 @@ async function loadOfficialProviderOptions() {
         String(option.provider_code) ===
         String(selectedOfficialProviderCode.value)
     )
-    const preferred = options.find((option) => !option.source_exists)
-    const selected =
-      current && !current.source_exists ? current : preferred || current
-    selectedOfficialProviderCode.value =
-      selected?.provider_code || options[0]?.provider_code || ''
-    if (selected) applyOfficialProviderOption(selected)
+    selectedOfficialProviderCode.value = current?.provider_code || ''
+    if (current) applyOfficialProviderOption(current)
   } catch (error) {
     showError(
       errorMessage(
@@ -531,7 +546,7 @@ function applyOfficialProviderOption(option) {
 }
 
 function legacyCategoryForSourceOwnerType(value) {
-  if (['model_provider_official', 'cloud_provider_official'].includes(value)) {
+  if (officialSourceOwnerTypes.includes(value)) {
     return 'official_provider'
   }
   if (value === 'supplier') return 'supplier'
@@ -563,13 +578,21 @@ function errorMessage(error, fallback) {
   )
 }
 
+function normalizeSlugField() {
+  if (!canEditSlug.value) return
+  form.value.slug = normalizeSlug(form.value.slug)
+}
+
 function autoSlug(value) {
-  const normalized = String(value || '')
+  return normalizeSlug(value) || 'price-source'
+}
+
+function normalizeSlug(value) {
+  return String(value || '')
     .trim()
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
-  return normalized || 'price-source'
 }
 </script>
 
@@ -603,23 +626,7 @@ function autoSlug(value) {
 }
 
 .field {
-  @apply h-10 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm text-slate-800 outline-none transition placeholder:text-slate-400 focus:border-indigo-300 focus:ring-2 focus:ring-indigo-100;
-}
-
-.source-meta-strip {
-  @apply mb-4 grid gap-3 sm:grid-cols-2;
-}
-
-.source-meta-item {
-  @apply rounded-lg border border-slate-200 bg-white px-3 py-2;
-}
-
-.source-meta-item span {
-  @apply block text-xs text-slate-500;
-}
-
-.source-meta-item strong {
-  @apply mt-1 block truncate font-mono text-sm text-slate-800;
+  @apply h-10 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm text-slate-800 outline-none transition placeholder:text-slate-400 focus:border-indigo-300 focus:ring-2 focus:ring-indigo-100 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-500;
 }
 
 .status-inline {

--- a/frontend/src/components/llm-ops/ProviderManagement.vue
+++ b/frontend/src/components/llm-ops/ProviderManagement.vue
@@ -149,7 +149,7 @@
           </thead>
           <tbody>
             <tr
-              v-for="provider in filteredProviderRows"
+              v-for="provider in filteredSourceProviderRows"
               :key="provider.id"
               class="cursor-pointer"
               @click="selectedProvider = provider"
@@ -238,7 +238,7 @@
                 </div>
               </td>
             </tr>
-            <tr v-if="!filteredProviderRows.length">
+            <tr v-if="!filteredSourceProviderRows.length">
               <td class="table-cell text-slate-500" colspan="5">
                 {{ t('llmOps.providerManagement.empty') }}
               </td>
@@ -390,6 +390,17 @@ import ManualPriceEntryModal from '@/components/llm-ops/ManualPriceEntryModal.vu
 import PriceSourceModal from '@/components/llm-ops/PriceSourceModal.vue'
 import ProviderPricingDrawer from '@/components/llm-ops/ProviderPricingDrawer.vue'
 import OperationIconButton from '@/components/llm-ops/OperationIconButton.vue'
+import {
+  canApiSyncPriceSource as canApiSyncSource,
+  canCollectPriceSource as canCollectSource,
+  canManualEntryPriceSource as canManualEntrySource,
+  isEntryPriceSource as isEntrySource,
+  isModelsDevPriceSource as isModelsDevSource,
+  normalizePriceSourceCategory as businessSourceCategory,
+  priceSourceCategory,
+  priceSourceCategoryRank as categoryRank,
+  priceSourceCollectionMethod as sourceCollectionMethod
+} from '@/utils/llmOpsPriceSources'
 
 const props = defineProps({
   providers: {
@@ -430,6 +441,7 @@ const emit = defineEmits(['refresh'])
 const { showSuccess, showError } = useToast()
 const { t } = useI18n()
 
+// Workspace state
 const selectedProvider = ref(null)
 const editingSource = ref(null)
 const priceEntrySource = ref(null)
@@ -489,6 +501,7 @@ const sourceStatusFilterOptions = computed(() => [
   }
 ])
 
+// Source rows
 const sourceRows = computed(() =>
   props.sources
     .map((source) => buildSourceRow(source))
@@ -502,78 +515,15 @@ const sourceRows = computed(() =>
 
 const entrySourceRows = computed(() => sourceRows.value.filter(isEntrySource))
 
-const providerRows = computed(() =>
-  props.providers
-    .map((provider) => buildProviderRow(provider))
-    .filter(
-      (provider) =>
-        provider.covered_model_count > 0 ||
-        provider.source_count > 0 ||
-        provider.price_item_count > 0
-    )
-    .sort((left, right) => String(left.name).localeCompare(String(right.name)))
+const sourceProviderRows = computed(() =>
+  entrySourceRows.value.map((source) => buildSourceProviderRow(source))
 )
 
-const unboundSourceRows = computed(() => {
-  const assignedSourceIds = new Set(
-    providerRows.value.flatMap((provider) => provider.source_ids)
-  )
-  return sourceRows.value.filter(
-    (source) => !assignedSourceIds.has(String(source.id))
-  )
-})
-
-const unboundProviderRow = computed(() => {
-  const sources = unboundSourceRows.value.filter(isEntrySource)
-  if (!sources.length) return null
-
-  const provider = {
-    id: '__unbound_price_sources__',
-    code: 'unbound-price-sources',
-    name: t('llmOps.providerManagement.unboundSources.name'),
-    is_active: sources.some((source) => source.is_enabled),
-    is_unbound_sources: true
-  }
-  const categoryKeys = sourceCategoryKeysForProvider(provider, sources, [])
-  const status = providerStatus(provider, sources)
-
-  return {
-    ...provider,
-    category_badges: categoryKeys.map((key) => ({
-      key,
-      ...sourceCategory(key)
-    })),
-    category_keys: categoryKeys,
-    covered_model_count: 0,
-    meta_model_ids: [],
-    price_item_count: 0,
-    primary_source: primaryProviderSource(sources),
-    source_count: sources.length,
-    source_ids: sources.map((source) => String(source.id)),
-    status_label: status.label,
-    status_tone: status.tone,
-    filter_is_active: status.filterActive,
-    search_text: [
-      provider.name,
-      provider.code,
-      t('llmOps.providerManagement.unboundSources.hint'),
-      ...sources.map((source) => source.search_text)
-    ]
-      .filter(Boolean)
-      .join(' ')
-      .toLowerCase()
-  }
-})
-
-const tableProviderRows = computed(() => [
-  ...providerRows.value,
-  ...(unboundProviderRow.value ? [unboundProviderRow.value] : [])
-])
-
+// Metrics
 const sourceMetrics = computed(() => {
   const coveredMetaModelIds = new Set()
-  providerRows.value.forEach((provider) => {
-    provider.meta_model_ids.forEach((id) => coveredMetaModelIds.add(id))
+  entrySourceRows.value.forEach((source) => {
+    source.meta_model_ids.forEach((id) => coveredMetaModelIds.add(id))
   })
 
   const official = entrySourceRows.value.filter(
@@ -592,7 +542,7 @@ const sourceMetrics = computed(() => {
   return [
     {
       label: t('llmOps.providerManagement.metrics.sources.label'),
-      value: providerRows.value.length,
+      value: entrySourceRows.value.length,
       hint: t('llmOps.providerManagement.metrics.sources.hint')
     },
     {
@@ -617,9 +567,10 @@ const sourceMetrics = computed(() => {
   ]
 })
 
-const filteredProviderRows = computed(() => {
+// Filters
+const filteredSourceProviderRows = computed(() => {
   const keyword = sourceSearch.value.trim().toLowerCase()
-  return tableProviderRows.value.filter((provider) => {
+  return sourceProviderRows.value.filter((provider) => {
     if (sourceStatusFilter.value === 'active' && !provider.filter_is_active) {
       return false
     }
@@ -641,6 +592,7 @@ const hasSyncablePriceSources = computed(() =>
   sourceRows.value.some((source) => source.can_collect && source.is_enabled)
 )
 
+// Official reset state
 const officialResetProviderOptions = computed(() =>
   sourceRows.value
     .filter(
@@ -678,243 +630,71 @@ const officialResetLegacySources = computed(
   () => officialResetPreview.value?.stats?.legacy_source_slugs || []
 )
 
+// Drawer selection
 const selectedProviderModels = computed(() => {
   if (!selectedProvider.value) return []
-  if (selectedProvider.value.is_unbound_sources) return []
-  return modelsForProvider(selectedProvider.value)
+  return modelsForSourceIds(selectedProviderSourceIds.value)
 })
 
 const selectedProviderPriceItems = computed(() => {
   if (!selectedProvider.value) return []
-  if (selectedProvider.value.is_unbound_sources) return []
-  return priceItemsForProvider(selectedProvider.value)
+  return priceItemsForSourceIds(selectedProviderSourceIds.value)
 })
 
 const selectedProviderSources = computed(() => {
   if (!selectedProvider.value) return []
-  if (selectedProvider.value.is_unbound_sources) {
-    return unboundSourceRows.value
-  }
-  const sourceIds = new Set(
-    selectedProviderPriceItems.value
-      .map((item) => String(item.source || ''))
-      .filter(Boolean)
-  )
-  return sourceRows.value.filter(
-    (source) =>
-      sourceMatchesProvider(source, selectedProvider.value) ||
-      sourceIds.has(String(source.id))
-  )
+  const sourceIds = selectedProviderSourceIds.value
+  return sourceRows.value.filter((source) => sourceIds.has(String(source.id)))
 })
 
-function buildProviderRow(provider) {
-  const models = modelsForProvider(provider)
-  const priceItems = priceItemsForProvider(provider)
-  const sources = sourcesForProvider(provider, priceItems)
-  const entrySources = sources.filter(isEntrySource)
-  const metaModelIds = metaModelIdsForProvider(models, priceItems)
-  const categoryKeys = sourceCategoryKeysForProvider(
-    provider,
-    entrySources,
-    priceItems
-  )
-  const status = providerStatus(provider, entrySources)
+const selectedProviderSourceIds = computed(
+  () => new Set(selectedProvider.value?.source_ids || [])
+)
 
+function buildSourceProviderRow(source) {
   return {
-    ...provider,
-    category_badges: categoryKeys.map((key) => ({
-      key,
-      ...sourceCategory(key)
-    })),
-    category_keys: categoryKeys,
-    covered_model_count: metaModelIds.length,
-    meta_model_ids: metaModelIds,
-    price_item_count: priceItems.length,
-    primary_source: primaryProviderSource(entrySources),
-    output_source_count: Math.max(sources.length - entrySources.length, 0),
-    source_count: entrySources.length,
-    source_ids: sources.map((source) => String(source.id)),
-    status_label: status.label,
-    status_tone: status.tone,
-    filter_is_active: status.filterActive,
-    search_text: buildProviderSearchText(provider, models, sources, priceItems)
+    id: `source-${source.id}`,
+    name: source.name,
+    code: source.slug,
+    category_badges: [
+      {
+        key: source.business_source_category,
+        label: source.category_label,
+        tone: source.category_tone
+      }
+    ],
+    category_keys: [source.business_source_category],
+    covered_model_count: source.covered_model_count,
+    meta_model_ids: source.meta_model_ids,
+    price_item_count: source.price_item_count,
+    primary_source: source,
+    source_count: 1,
+    source_ids: [String(source.id)],
+    status_label: source.status_label,
+    status_tone: source.status_tone,
+    filter_is_active: source.is_enabled,
+    search_text: source.search_text
   }
 }
 
-function primaryProviderSource(sources) {
-  return (
-    sources.find(
-      (source) =>
-        source.business_source_category === 'official_provider' &&
-        source.can_collect &&
-        String(source.slug || '') === `${source.provider_code}-official`
-    ) ||
-    sources.find(
-      (source) =>
-        source.business_source_category === 'official_provider' &&
-        source.can_collect
-    ) ||
-    sources.find((source) => source.can_collect) ||
-    sources.find((source) => source.can_manual_entry && source.is_enabled) ||
-    sources.find((source) => source.can_manual_entry) ||
-    sources.find((source) => source.is_enabled) ||
-    sources[0] ||
-    null
-  )
-}
-
-function modelsForProvider(provider) {
-  const providerSourceIds = sourceIdsForProvider(provider)
+function modelsForSourceIds(sourceIds) {
   const pricedModelIds = new Set(
-    props.priceItems
-      .filter(
-        (item) =>
-          item.is_current !== false &&
-          priceItemMatchesProvider(item, provider, providerSourceIds)
-      )
+    priceItemsForSourceIds(sourceIds)
       .map((item) => String(item.model || ''))
       .filter(Boolean)
   )
   return props.models.filter(
     (model) =>
-      sourceMatchesProvider(sourceForRecord(model), provider) ||
+      sourceIds.has(String(model.source || '')) ||
       pricedModelIds.has(String(model.id))
   )
 }
 
-function priceItemsForProvider(provider) {
-  const providerSourceIds = sourceIdsForProvider(provider)
+function priceItemsForSourceIds(sourceIds) {
   return props.priceItems.filter(
     (item) =>
-      item.is_current !== false &&
-      priceItemMatchesProvider(item, provider, providerSourceIds)
+      item.is_current !== false && sourceIds.has(String(item.source || ''))
   )
-}
-
-function priceItemMatchesProvider(item, provider, providerSourceIds = null) {
-  if (!item || !provider) return false
-  if (String(item.provider || '') === String(provider.id)) return true
-  const sourceIds = providerSourceIds || sourceIdsForProvider(provider)
-  return sourceIds.has(String(item.source || ''))
-}
-
-function sourceIdsForProvider(provider) {
-  return new Set(
-    sourceRows.value
-      .filter((source) => sourceMatchesProvider(source, provider))
-      .map((source) => String(source.id))
-  )
-}
-
-function sourceForRecord(record) {
-  if (!record?.source) return null
-  return sourceRows.value.find(
-    (source) => String(source.id) === String(record.source || '')
-  )
-}
-
-function sourcesForProvider(provider, priceItems) {
-  const sourceIds = new Set(
-    priceItems.map((item) => String(item.source || '')).filter(Boolean)
-  )
-  return sourceRows.value.filter(
-    (source) =>
-      sourceMatchesProvider(source, provider) ||
-      sourceIds.has(String(source.id))
-  )
-}
-
-function sourceMatchesProvider(source, provider) {
-  if (!source || !provider) return false
-  return (
-    String(source.provider || '') === String(provider.id) ||
-    String(source.provider_code || '') === String(provider.code)
-  )
-}
-
-function metaModelIdsForProvider(models, priceItems) {
-  const ids = [
-    ...models.map((model) => model.meta_model || model.meta_model_code),
-    ...priceItems.map((item) => item.meta_model || item.meta_model_code)
-  ]
-    .map((id) => String(id || ''))
-    .filter(Boolean)
-  return Array.from(new Set(ids))
-}
-
-function sourceCategoryKeysForProvider(provider, sources, priceItems) {
-  const sourceKeys = sources
-    .filter(
-      (source) =>
-        provider?.is_unbound_sources || sourceMatchesProvider(source, provider)
-    )
-    .map((source) => source.business_source_category)
-  const keys = [
-    ...sourceKeys,
-    ...priceItems.map((item) => businessSourceCategory(item))
-  ].filter(Boolean)
-  const uniqueKeys = Array.from(new Set(keys))
-  return uniqueKeys.length
-    ? uniqueKeys.sort((left, right) => categoryRank(left) - categoryRank(right))
-    : ['unknown']
-}
-
-function providerStatus(provider, sources) {
-  const hasEnabledSource = sources.some((source) => source.is_enabled)
-  if (!provider.is_active || (sources.length > 0 && !hasEnabledSource)) {
-    return {
-      label: t('llmOps.providerManagement.sourceStatus.inactive.label'),
-      tone: 'muted',
-      filterActive: false
-    }
-  }
-  if (!sources.length) {
-    return {
-      label: t('llmOps.providerManagement.sourceStatus.pending.label'),
-      tone: 'warn',
-      filterActive: true
-    }
-  }
-  return {
-    label: t('llmOps.providerManagement.sourceStatus.active.label'),
-    tone: 'ok',
-    filterActive: true
-  }
-}
-
-function buildProviderSearchText(provider, models, sources, priceItems) {
-  return [
-    provider.name,
-    provider.code,
-    provider.website,
-    ...sources.map((source) => source.search_text),
-    ...models.map((model) =>
-      [
-        model.name,
-        model.code,
-        model.meta_model_name,
-        model.meta_model_code,
-        model.provider_name,
-        model.meta_model_vendor_name
-      ]
-        .filter(Boolean)
-        .join(' ')
-    ),
-    ...priceItems.map((item) =>
-      [
-        item.meta_model_name,
-        item.meta_model_code,
-        item.source_name,
-        item.source_channel_name,
-        item.source_provider_name
-      ]
-        .filter(Boolean)
-        .join(' ')
-    )
-  ]
-    .filter(Boolean)
-    .join(' ')
-    .toLowerCase()
 }
 
 function buildSourceRow(source) {
@@ -1004,6 +784,7 @@ function dimensionCount(items) {
   return new Set(dimensions).size
 }
 
+// Actions
 function handleManualImported() {
   showManualImportModal.value = false
   emit('refresh')
@@ -1185,60 +966,27 @@ async function deleteSource(source) {
   }
 }
 
-function businessSourceCategory(source) {
-  return (
-    source?.business_source_category || source?.source_category || 'unknown'
-  )
-}
-
 function sourceCategory(category) {
-  const labels = {
-    official_provider: {
-      label: t('llmOps.providerManagement.category.officialProvider'),
-      tone: 'official'
-    },
-    supplier: {
-      label: t('llmOps.providerManagement.category.supplier'),
-      tone: 'supplier'
-    },
-    manual: {
-      label: t('llmOps.providerManagement.category.internal'),
-      tone: 'manual'
-    },
-    cloud_hosted: {
-      label: t('llmOps.providerManagement.category.cloudHosted'),
-      tone: 'cloud'
-    },
-    unknown: {
-      label: t('llmOps.providerManagement.category.unknown'),
-      tone: 'unknown'
-    }
-  }
-  return labels[category] || labels.unknown
-}
-
-function categoryRank(category) {
-  const ranks = {
-    official_provider: 1,
-    cloud_hosted: 2,
-    supplier: 3,
-    manual: 4,
-    unknown: 4
-  }
-  return ranks[category] || 9
+  return priceSourceCategory(category, {
+    official_provider: t('llmOps.providerManagement.category.officialProvider'),
+    supplier: t('llmOps.providerManagement.category.supplier'),
+    manual: t('llmOps.providerManagement.category.internal'),
+    cloud_hosted: t('llmOps.providerManagement.category.cloudHosted'),
+    unknown: t('llmOps.providerManagement.category.unknown')
+  })
 }
 
 function sourceRelation(source) {
-  if (source.provider_name) {
-    return {
-      name: source.provider_name,
-      hint: t('llmOps.providerManagement.relation.metaProvider')
-    }
-  }
   if (source.channel_name) {
     return {
       name: source.channel_name,
       hint: t('llmOps.providerManagement.relation.forwardingChannel')
+    }
+  }
+  if (source.provider_name) {
+    return {
+      name: source.provider_name,
+      hint: t('llmOps.providerManagement.relation.metaProvider')
     }
   }
   return {
@@ -1333,32 +1081,6 @@ function sourceStatus(source, latestRun) {
   }
 }
 
-function canCollectSource(source) {
-  return Boolean(
-    source.can_collect_prices &&
-      sourceCollectionMethod(source) === 'auto_collect' &&
-      source.updates_model_prices
-  )
-}
-
-function isEntrySource(source) {
-  return (
-    canCollectSource(source) ||
-    canManualEntrySource(source) ||
-    canApiSyncSource(source)
-  )
-}
-
-function canApiSyncSource(source) {
-  return sourceCollectionMethod(source) === 'api_sync'
-}
-
-function canManualEntrySource(source) {
-  return ['manual_entry', 'manual_import', 'unknown'].includes(
-    sourceCollectionMethod(source)
-  )
-}
-
 function collectActionLabel(source) {
   if (canCollectSource(source)) {
     return t('llmOps.providerManagement.actions.syncPrice')
@@ -1380,26 +1102,6 @@ function collectModeLabel(source) {
     return t('llmOps.providerManagement.collectMode.dedicatedCollector')
   }
   return t('llmOps.providerManagement.collectMode.pending')
-}
-
-function sourceCollectionMethod(source) {
-  const method = source?.collection_method
-  if (method && method !== 'unknown') return method
-  if (source?.source_type === 'yunce') return 'api_sync'
-  if (
-    source?.source_category === 'official_provider' &&
-    source?.updates_model_prices
-  ) {
-    return 'auto_collect'
-  }
-  if (source?.source_category === 'manual') return 'manual_entry'
-  return method || 'unknown'
-}
-
-function isModelsDevSource(source) {
-  return String(source?.endpoint_url || '')
-    .toLowerCase()
-    .includes('models.dev/api.json')
 }
 
 function latestRunForSource(sourceId) {

--- a/frontend/src/components/llm-ops/ProviderPricingDrawer.vue
+++ b/frontend/src/components/llm-ops/ProviderPricingDrawer.vue
@@ -88,120 +88,7 @@
         <div class="panel overflow-hidden p-0">
           <div class="table-toolbar">
             <div>
-              <h3 class="panel-title">模型价格源</h3>
-              <p class="mt-1 text-xs text-slate-500">
-                维护该厂商下的原厂、供货商和人工价格来源。
-              </p>
-            </div>
-          </div>
-          <div class="overflow-x-auto">
-            <table class="data-table provider-source-table">
-              <colgroup>
-                <col class="source-name-col" />
-                <col class="source-type-col" />
-                <col class="source-status-col" />
-                <col class="source-action-col" />
-              </colgroup>
-              <thead>
-                <tr>
-                  <th class="table-head">价格源</th>
-                  <th class="table-head">类型</th>
-                  <th class="table-head">状态</th>
-                  <th class="table-head">操作</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr v-for="source in managementSourceRows" :key="source.id">
-                  <td class="table-cell">
-                    <div class="min-w-0">
-                      <p class="truncate font-medium text-slate-900">
-                        {{ source.name }}
-                      </p>
-                      <p class="mt-1 truncate font-mono text-xs text-slate-400">
-                        {{ source.slug }}
-                      </p>
-                      <a
-                        v-if="source.endpoint_url"
-                        class="source-link mt-1"
-                        :href="source.endpoint_url"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                        :title="source.endpoint_url"
-                      >
-                        {{ source.endpoint_url }}
-                      </a>
-                    </div>
-                  </td>
-                  <td class="table-cell text-center">
-                    <span :class="['source-badge', source.category_tone]">
-                      {{ source.category_label }}
-                    </span>
-                  </td>
-                  <td class="table-cell text-center">
-                    <span
-                      :class="[source.is_enabled ? 'badge-ok' : 'badge-muted']"
-                    >
-                      {{ source.is_enabled ? '已启用' : '已停用' }}
-                    </span>
-                    <p class="mt-1 text-xs text-slate-400">
-                      {{ source.price_item_count }} 个价格项
-                    </p>
-                  </td>
-                  <td class="table-cell">
-                    <div class="source-actions">
-                      <OperationIconButton
-                        icon="edit"
-                        label="编辑价格源"
-                        @click.stop="$emit('edit-source', source)"
-                      />
-                      <OperationIconButton
-                        icon="powerOff"
-                        :label="source.is_enabled ? '停用价格源' : '启用价格源'"
-                        @click.stop="$emit('toggle-source', source)"
-                      />
-                      <OperationIconButton
-                        v-if="source.can_manual_entry"
-                        icon="manual"
-                        label="配置模型价格"
-                        tone="primary"
-                        @click.stop="$emit('manual-entry-source', source)"
-                      />
-                      <OperationIconButton
-                        v-if="source.can_collect"
-                        icon="collect"
-                        :label="source.collect_action_label || '同步价格'"
-                        :disabled="
-                          !source.is_enabled ||
-                          String(collectingSourceId || '') === String(source.id)
-                        "
-                        @click.stop="$emit('collect-source', source)"
-                      />
-                      <OperationIconButton
-                        icon="delete"
-                        label="删除价格源"
-                        tone="danger"
-                        :disabled="
-                          String(deletingSourceId || '') === String(source.id)
-                        "
-                        @click.stop="$emit('delete-source', source)"
-                      />
-                    </div>
-                  </td>
-                </tr>
-                <tr v-if="!managementSourceRows.length">
-                  <td class="table-cell text-slate-500" colspan="4">
-                    当前厂商还没有模型价格源。
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div>
-
-        <div class="panel overflow-hidden p-0">
-          <div class="table-toolbar">
-            <div>
-              <h3 class="panel-title">厂商模型价格</h3>
+              <h3 class="panel-title">服务商模型价格</h3>
               <p class="mt-1 text-xs text-slate-500">
                 按模型汇总输入、输出、缓存等核心价格，减少逐维度展开带来的噪音。
               </p>
@@ -301,16 +188,21 @@
 
 <script setup>
 import { computed, ref } from 'vue'
-import OperationIconButton from '@/components/llm-ops/OperationIconButton.vue'
+import {
+  canCollectPriceSource,
+  canManualEntryPriceSource,
+  isLegacyOfficialModelSource as baseIsLegacyOfficialModelSource,
+  isProviderOfficialPriceSource as baseIsProviderOfficialPriceSource,
+  normalizePriceSourceCategory as businessSourceCategory,
+  officialProviderCodeFromSlug as baseOfficialProviderCodeFromSlug,
+  preferredPriceSource,
+  priceSourceCategoryLabel as sourceCategoryLabel,
+  priceSourceCategoryRank as categoryRank,
+  priceSourceGroupKey as basePriceSourceGroupKey,
+  priceSourceTone as sourceTone
+} from '@/utils/llmOpsPriceSources'
 
-defineEmits([
-  'close',
-  'manual-entry-source',
-  'edit-source',
-  'toggle-source',
-  'collect-source',
-  'delete-source'
-])
+defineEmits(['close'])
 
 const props = defineProps({
   provider: {
@@ -375,17 +267,6 @@ const categoryFilterOptions = computed(() => {
 
 const sourceRows = computed(() =>
   aggregatePriceSources(props.sources, props.priceItems)
-)
-
-const managementSourceRows = computed(() =>
-  props.sources
-    .map((source) => buildManagementSourceRow(source))
-    .sort((left, right) => {
-      const leftRank = categoryRank(businessSourceCategory(left))
-      const rightRank = categoryRank(businessSourceCategory(right))
-      if (leftRank !== rightRank) return leftRank - rightRank
-      return String(left.name || '').localeCompare(String(right.name || ''))
-    })
 )
 
 const primarySource = computed(() => preferredPriceSource(sourceRows.value))
@@ -642,10 +523,10 @@ function buildAggregateSource(group, priceItems) {
     source_group_ids: sourceIds,
     source_count: sorted.length,
     updated_at: latestUpdate || primary.updated_at,
-    can_collect: Boolean(
-      sorted.find((source) => source.can_collect)?.can_collect
+    can_collect: sorted.some((source) => canCollectPriceSource(source)),
+    can_manual_entry: sorted.some((source) =>
+      canManualEntryPriceSource(source)
     ),
-    can_manual_entry: sorted.some((source) => source.can_manual_entry),
     collect_action_label: primary.collect_action_label,
     price_item_count: priceItems.filter(
       (item) =>
@@ -655,52 +536,16 @@ function buildAggregateSource(group, priceItems) {
   }
 }
 
-function buildManagementSourceRow(source) {
-  const category = businessSourceCategory(source)
-  return {
-    ...source,
-    category_label: sourceCategoryLabel(category),
-    category_tone: sourceTone(category),
-    price_item_count: props.priceItems.filter(
-      (item) =>
-        String(item.source || '') === String(source.id) &&
-        item.is_current !== false
-    ).length
-  }
-}
-
 function priceSourceGroupKey(source) {
-  const providerCode = String(source?.provider_code || '').trim()
-  const drawerProviderCode = String(props.provider?.code || '').trim()
-  if (businessSourceCategory(source) === 'official_provider') {
-    return `official:${
-      providerCode || drawerProviderCode || officialProviderCodeFromSlug(source)
-    }`
-  }
-  return `source:${source?.id || source?.slug || 'unknown'}`
+  return basePriceSourceGroupKey(source, props.provider?.code || '')
 }
 
 function isLegacyOfficialModelSource(source) {
-  if (businessSourceCategory(source) !== 'official_provider') return false
-  const providerCode = String(
-    source?.provider_code ||
-      props.provider?.code ||
-      officialProviderCodeFromSlug(source)
-  ).trim()
-  if (!providerCode) return false
-  const slug = String(source?.slug || '')
-  return slug !== `${providerCode}-official` && slug.endsWith('-official')
+  return baseIsLegacyOfficialModelSource(source, props.provider?.code || '')
 }
 
 function isProviderOfficialSource(source) {
-  const providerCode = String(source?.provider_code || '').trim()
-  const drawerProviderCode = String(props.provider?.code || '').trim()
-  const expectedCode = providerCode || drawerProviderCode
-  return (
-    expectedCode &&
-    businessSourceCategory(source) === 'official_provider' &&
-    String(source?.slug || '') === `${expectedCode}-official`
-  )
+  return baseIsProviderOfficialPriceSource(source, props.provider?.code || '')
 }
 
 function aggregateSourceName(source) {
@@ -723,13 +568,7 @@ function aggregateSourceSlug(source) {
 }
 
 function officialProviderCodeFromSlug(source) {
-  const slug = String(source?.slug || '')
-  if (!slug.endsWith('-official')) return ''
-  const providerCode = String(props.provider?.code || '').trim()
-  if (providerCode && slug.startsWith(`${providerCode}-`)) {
-    return providerCode
-  }
-  return ''
+  return baseOfficialProviderCodeFromSlug(source, props.provider?.code || '')
 }
 
 function dimensionLabel(dimension) {
@@ -944,65 +783,6 @@ function formatDateTime(value) {
   if (!value) return '-'
   return new Date(value).toLocaleString()
 }
-
-function preferredPriceSource(sources) {
-  return (
-    sources.find(
-      (source) => businessSourceCategory(source) === 'official_provider'
-    ) ||
-    sources.find((source) => String(source.slug || '').endsWith('-official')) ||
-    sources.find((source) => source.updates_model_prices) ||
-    sources.find((source) => source.endpoint_url) ||
-    null
-  )
-}
-
-function businessSourceCategory(item, model = {}, source = null) {
-  return (
-    item?.business_source_category ||
-    item?.price_role ||
-    model?.business_source_category ||
-    model?.price_role ||
-    source?.business_source_category ||
-    item?.source_category ||
-    model?.source_category ||
-    source?.source_category ||
-    'unknown'
-  )
-}
-
-function sourceCategoryLabel(category) {
-  const labels = {
-    official_provider: '原厂',
-    cloud_hosted: '云托管',
-    supplier: '供货商',
-    manual: '内部维护',
-    unknown: '其他'
-  }
-  return labels[category] || '其他'
-}
-
-function sourceTone(category) {
-  const tones = {
-    official_provider: 'official',
-    cloud_hosted: 'cloud',
-    supplier: 'supplier',
-    manual: 'manual',
-    unknown: 'unknown'
-  }
-  return tones[category] || 'unknown'
-}
-
-function categoryRank(category) {
-  const ranks = {
-    official_provider: 1,
-    cloud_hosted: 2,
-    supplier: 3,
-    manual: 4,
-    unknown: 5
-  }
-  return ranks[category] || 9
-}
 </script>
 
 <style scoped>
@@ -1053,30 +833,6 @@ function categoryRank(category) {
 
 .pricing-source-table .time-col {
   width: 18%;
-}
-
-.provider-source-table .source-name-col {
-  width: 38%;
-}
-
-.provider-source-table .source-type-col {
-  width: 18%;
-}
-
-.provider-source-table .source-status-col {
-  width: 14%;
-}
-
-.provider-source-table .source-action-col {
-  width: 30%;
-}
-
-.source-actions {
-  display: flex;
-  min-width: 0;
-  align-items: center;
-  justify-content: center;
-  gap: 0.25rem;
 }
 
 .field-input {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1324,9 +1324,9 @@
       }
     },
     "providerManagement": {
-      "title": "Provider Model Prices",
+      "title": "Service Price Sources",
       "modelsCount": "{count} meta models",
-      "empty": "No providers match the current filters.",
+      "empty": "No price sources match the current filters.",
       "actions": {
         "add": "Add",
         "addOfficialSource": "Add official source",
@@ -1349,12 +1349,12 @@
         "allStatuses": "All statuses",
         "allTypes": "All types",
         "inactiveOnly": "Inactive only",
-        "searchPlaceholder": "Search provider, model, price source, or URL"
+        "searchPlaceholder": "Search service, model, price source, or URL"
       },
       "table": {
         "actions": "Actions",
         "metaModels": "Linked meta models",
-        "source": "Provider",
+        "source": "Service / price source",
         "status": "Status",
         "type": "Price source"
       },
@@ -1364,12 +1364,12 @@
           "label": "Covered meta models"
         },
         "official": {
-          "hint": "Published directly by meta model providers",
+          "hint": "Published directly by official services",
           "label": "Official sources"
         },
         "sources": {
-          "hint": "Meta model providers with price data",
-          "label": "Providers"
+          "hint": "Service price sources with model prices",
+          "label": "Price sources"
         },
         "supplierManual": {
           "hint": "Cloud hosted {cloudHosted} · supplier {supplier} · internal {internal}",
@@ -1386,12 +1386,12 @@
       },
       "relation": {
         "forwardingChannel": "Forwarding channel",
-        "metaProvider": "Meta model provider",
+        "metaProvider": "Linked meta model provider",
         "needsOwner": "Ownership needs completion",
         "unbound": "Unbound source"
       },
       "unboundSources": {
-        "hint": "Price sources not yet linked to a provider, model, or price item",
+        "hint": "Price sources not yet linked to models or price items",
         "name": "Unbound price sources"
       },
       "sourceMode": {
@@ -1402,7 +1402,7 @@
         "dedicatedCollect": "Dedicated collection",
         "manualImport": "Manual import",
         "manualMaintenance": "Manual maintenance",
-        "pending": "Pending adapter",
+        "pending": "Collection not configured",
         "supplierMaintenance": "Supplier maintained"
       },
       "sourceStatus": {
@@ -1423,7 +1423,7 @@
           "label": "Manual maintenance"
         },
         "pending": {
-          "label": "Pending adapter"
+          "label": "Collection not configured"
         },
         "syncing": {
           "hint": "Refresh again later",
@@ -1436,7 +1436,7 @@
         "exists": "This official source has already been added.",
         "existsBadge": "Added",
         "loading": "Loading official sources.",
-        "provider": "Provider",
+        "provider": "Official provider",
         "ready": "Confirm to create the official price source.",
         "slug": "System slug",
         "source": "Price source",
@@ -1500,7 +1500,10 @@
       },
       "help": {
         "autoSlug": "The system slug will be generated after creation: {slug}",
-        "endpointUrl": "Official pricing page, supplier price API, or manual price source URL."
+        "endpointUrl": "Official pricing page, supplier price API, or manual price source URL.",
+        "officialSlugLocked": "Official collection source slugs are used by collectors and cannot be changed.",
+        "officialSlugPreset": "The system slug is filled after selecting an official provider.",
+        "slug": "Use lowercase letters, numbers, and hyphens only. It is normalized on save."
       },
       "actions": {
         "cancel": "Cancel",
@@ -1520,6 +1523,7 @@
         "cloudProvider": "Cloud provider official",
         "internal": "Internal",
         "modelProvider": "Model provider official",
+        "official": "Official pricing",
         "supplier": "Supplier",
         "unknown": "Unknown"
       },
@@ -1546,7 +1550,9 @@
         "exists": "This official source has already been added.",
         "existsBadge": "Added",
         "loading": "Loading official sources.",
+        "onlyOfficial": "Only official pricing requires an official provider.",
         "ready": "Confirm to create the official price source.",
+        "selectProvider": "Select an official provider.",
         "slug": "System slug",
         "source": "Price source",
         "url": "Price URL"
@@ -1642,7 +1648,7 @@
         "dedicatedCollect": "Dedicated collection",
         "manualImport": "Manual import",
         "manualMaintenance": "Manual maintenance",
-        "pending": "Pending adapter",
+        "pending": "Collection not configured",
         "supplierMaintenance": "Supplier maintained"
       }
     },
@@ -1755,7 +1761,7 @@
         "selectMetaModel": "Select a meta model."
       },
       "groups": {
-        "currentProvider": "Current price source provider",
+        "currentProvider": "Default model provider",
         "otherModels": "Other models"
       },
       "fallback": {
@@ -1776,6 +1782,7 @@
       "emptyPreview": "Paste a price table with headers to show the preview.",
       "fields": {
         "currency": "Default currency",
+        "defaultProvider": "Default model provider",
         "provider": "Model provider",
         "source": "Model price source",
         "sourceCategory": "Pricing scope",
@@ -1818,7 +1825,8 @@
         "video": "Video"
       },
       "validation": {
-        "sourceProviderRequired": "This price source is not bound to a model provider and cannot be imported in bulk.",
+        "sourceProviderOptional": "No default model provider is set; rows will be matched by provider_code / provider_name or existing models.",
+        "sourceProviderRequired": "This price source has no default model provider.",
         "sourceReady": "Prices will be imported into \"{name}\".",
         "sourceRequired": "Select an existing model price source."
       },

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1334,9 +1334,9 @@
       }
       },
     "providerManagement": {
-      "title": "厂商模型价格",
+      "title": "服务商价格源",
       "modelsCount": "{count} 个元模型",
-      "empty": "暂无匹配的厂商。",
+      "empty": "暂无匹配的价格源。",
       "actions": {
         "add": "添加",
         "addOfficialSource": "添加原厂源",
@@ -1359,12 +1359,12 @@
         "allStatuses": "全部状态",
         "allTypes": "全部类型",
         "inactiveOnly": "仅停用",
-        "searchPlaceholder": "搜索厂商、模型、价格源或地址"
+        "searchPlaceholder": "搜索服务商、模型、价格源或地址"
       },
       "table": {
         "actions": "操作",
         "metaModels": "关联元模型",
-        "source": "厂商",
+        "source": "服务商 / 价格源",
         "status": "状态",
         "type": "价格来源"
       },
@@ -1374,12 +1374,12 @@
           "label": "覆盖元模型"
         },
         "official": {
-          "hint": "由元模型厂商直接发布",
+          "hint": "由官方服务商直接发布",
           "label": "原厂源"
         },
         "sources": {
-          "hint": "已接入模型价格的元模型厂商",
-          "label": "厂商"
+          "hint": "已接入模型价格的服务商价格源",
+          "label": "价格源"
         },
         "supplierManual": {
           "hint": "云托管 {cloudHosted} · 供货商 {supplier} · 内部 {internal}",
@@ -1396,12 +1396,12 @@
       },
       "relation": {
         "forwardingChannel": "转发渠道",
-        "metaProvider": "元模型厂商",
+        "metaProvider": "关联元模型厂商",
         "needsOwner": "待补充归属",
         "unbound": "未绑定来源"
       },
       "unboundSources": {
-        "hint": "尚未绑定厂商、模型或价格项的价格源",
+        "hint": "尚未关联模型或价格项的价格源",
         "name": "未绑定价格源"
       },
       "sourceMode": {
@@ -1412,7 +1412,7 @@
         "dedicatedCollect": "专用采集",
         "manualImport": "批量导入",
         "manualMaintenance": "手动维护",
-        "pending": "待适配",
+        "pending": "未配置采集",
         "supplierMaintenance": "供货商维护"
       },
       "sourceStatus": {
@@ -1433,7 +1433,7 @@
           "label": "手动维护"
         },
         "pending": {
-          "label": "待适配"
+          "label": "未配置采集"
         },
         "syncing": {
           "hint": "请稍后刷新",
@@ -1446,7 +1446,7 @@
         "exists": "当前原厂源已经添加。",
         "existsBadge": "已添加",
         "loading": "正在加载原厂源。",
-        "provider": "厂商",
+        "provider": "官方厂商",
         "ready": "确认后会创建原厂价格源。",
         "slug": "系统标识",
         "source": "价格源",
@@ -1510,7 +1510,10 @@
       },
       "help": {
         "autoSlug": "创建后系统标识将自动生成：{slug}",
-        "endpointUrl": "官方价格页、供货商价格接口或人工价格来源地址。"
+        "endpointUrl": "官方价格页、供货商价格接口或人工价格来源地址。",
+        "officialSlugLocked": "官方采集源的系统标识用于匹配采集器，不能修改。",
+        "officialSlugPreset": "选择原厂厂商后会自动填充系统标识。",
+        "slug": "仅支持小写字母、数字和短横线；保存时会自动规范化。"
       },
       "actions": {
         "cancel": "取消",
@@ -1530,6 +1533,7 @@
         "cloudProvider": "云厂商官方",
         "internal": "内部维护",
         "modelProvider": "模型厂商官方",
+        "official": "官方价格",
         "supplier": "供货商",
         "unknown": "未知"
       },
@@ -1556,7 +1560,9 @@
         "exists": "当前原厂源已经添加。",
         "existsBadge": "已添加",
         "loading": "正在加载原厂源。",
+        "onlyOfficial": "仅官方价格需要选择原厂厂商。",
         "ready": "确认后会创建原厂价格源。",
+        "selectProvider": "请选择原厂厂商。",
         "slug": "系统标识",
         "source": "价格源",
         "url": "价格地址"
@@ -1652,7 +1658,7 @@
         "dedicatedCollect": "专用采集",
         "manualImport": "批量导入",
         "manualMaintenance": "手动维护",
-        "pending": "待适配",
+        "pending": "未配置采集",
         "supplierMaintenance": "供货商维护"
       }
     },
@@ -1765,7 +1771,7 @@
         "selectMetaModel": "请选择一个元模型。"
       },
       "groups": {
-        "currentProvider": "当前价格源关联厂商",
+        "currentProvider": "默认模型厂商",
         "otherModels": "其他模型"
       },
       "fallback": {
@@ -1786,6 +1792,7 @@
       "emptyPreview": "粘贴带表头的价格表后会显示预览。",
       "fields": {
         "currency": "默认币种",
+        "defaultProvider": "默认模型厂商",
         "provider": "模型厂商",
         "source": "模型价格源",
         "sourceCategory": "价格口径",
@@ -1828,7 +1835,8 @@
         "video": "视频"
       },
       "validation": {
-        "sourceProviderRequired": "该价格源尚未绑定模型厂商，无法批量导入。",
+        "sourceProviderOptional": "未设置默认模型厂商；将按行内 provider_code / provider_name 或已有模型匹配。",
+        "sourceProviderRequired": "该价格源未设置默认模型厂商。",
         "sourceReady": "将导入到价格源「{name}」。",
         "sourceRequired": "请选择一个已有模型价格源。"
       },

--- a/frontend/src/pages/LLMOps.vue
+++ b/frontend/src/pages/LLMOps.vue
@@ -691,7 +691,8 @@ import { useToast } from '@/composables/useToast'
 import { llmOpsApi } from '@/api/llmOps'
 import { DEFAULT_WORKFLOW_POLICIES } from '@/constants/llmOpsWorkflow'
 
-const FULL_LIST_PARAMS = { page_size: 10000 }
+const LIST_PAGE_SIZE = 200
+const LIST_PARAMS = { page_size: LIST_PAGE_SIZE }
 const DATA_HEAVY_SECTIONS = new Set([
   'channels',
   'metaModels',
@@ -1352,8 +1353,44 @@ const monitorTableRows = computed(() => {
 })
 
 function extract(response) {
+  if (Array.isArray(response)) return response
   const data = response?.data?.data || response?.data || []
   return Array.isArray(data.results) ? data.results : data
+}
+
+function paginationPayload(response) {
+  return response?.data?.data || response?.data || []
+}
+
+function paginationResults(payload) {
+  if (Array.isArray(payload?.results)) return payload.results
+  return Array.isArray(payload) ? payload : []
+}
+
+async function fetchList(request, params = {}) {
+  const firstResponse = await request({
+    ...LIST_PARAMS,
+    ...params,
+    page: 1
+  })
+  const firstPayload = paginationPayload(firstResponse)
+  const results = paginationResults(firstPayload)
+  const total = Number(firstPayload?.count || results.length)
+  const totalPages = Math.max(1, Math.ceil(total / LIST_PAGE_SIZE))
+
+  if (!firstPayload?.results || totalPages <= 1) {
+    return results
+  }
+
+  const pageRequests = []
+  for (let page = 2; page <= totalPages; page += 1) {
+    pageRequests.push(request({ ...LIST_PARAMS, ...params, page }))
+  }
+  const pageResponses = await Promise.all(pageRequests)
+  pageResponses.forEach((response) => {
+    results.push(...paginationResults(paginationPayload(response)))
+  })
+  return results
 }
 
 function errorMessage(error, fallback) {
@@ -1395,12 +1432,12 @@ async function refreshCoreData() {
     platformRes,
     summaryRes
   ] = await Promise.all([
-    llmOpsApi.listCollectionSources(FULL_LIST_PARAMS),
-    llmOpsApi.listCollectionRuns(FULL_LIST_PARAMS),
-    llmOpsApi.listProviders(FULL_LIST_PARAMS),
-    llmOpsApi.listModels(FULL_LIST_PARAMS),
-    llmOpsApi.listChannels(FULL_LIST_PARAMS),
-    llmOpsApi.listResalePlatforms(FULL_LIST_PARAMS),
+    fetchList(llmOpsApi.listCollectionSources),
+    fetchList(llmOpsApi.listCollectionRuns),
+    fetchList(llmOpsApi.listProviders),
+    fetchList(llmOpsApi.listModels),
+    fetchList(llmOpsApi.listChannels),
+    fetchList(llmOpsApi.listResalePlatforms),
     llmOpsApi.getSummary(summaryParams())
   ])
   sources.value = extract(sourceRes)
@@ -1467,66 +1504,59 @@ async function refreshSectionData(section) {
 }
 
 async function refreshMetaModels() {
-  const response = await llmOpsApi.listMetaModels(FULL_LIST_PARAMS)
-  metaModels.value = extract(response)
+  metaModels.value = await fetchList(llmOpsApi.listMetaModels)
 }
 
 async function refreshChannelPricingData() {
-  const [priceRes, itemRes] = await Promise.all([
-    llmOpsApi.listChannelModelPrices(FULL_LIST_PARAMS),
-    llmOpsApi.listChannelPriceItems({
-      ...FULL_LIST_PARAMS,
+  const [prices, items] = await Promise.all([
+    fetchList(llmOpsApi.listChannelModelPrices),
+    fetchList(llmOpsApi.listChannelPriceItems, {
       is_current: 'true'
     })
   ])
-  channelPrices.value = extract(priceRes)
-  channelPriceItems.value = extract(itemRes)
+  channelPrices.value = prices
+  channelPriceItems.value = items
 }
 
 async function refreshModelPriceItems() {
-  const response = await llmOpsApi.listModelPriceItems({
-    ...FULL_LIST_PARAMS,
+  modelPriceItems.value = await fetchList(llmOpsApi.listModelPriceItems, {
     is_current: 'true'
   })
-  modelPriceItems.value = extract(response)
 }
 
 async function refreshResaleListings() {
-  const response = await llmOpsApi.listResaleListings(FULL_LIST_PARAMS)
-  listings.value = extract(response)
+  listings.value = await fetchList(llmOpsApi.listResaleListings)
 }
 
 async function refreshReconciliationRecords() {
-  const response = await llmOpsApi.listReconciliationRecords(FULL_LIST_PARAMS)
-  records.value = extract(response)
+  records.value = await fetchList(llmOpsApi.listReconciliationRecords)
 }
 
 async function refreshLight() {
-  const [priceRes, channelPriceItemRes, listingRes, recordRes, summaryRes] =
+  const [prices, channelPriceItemsData, listingData, recordData, summaryRes] =
     await Promise.all([
-      llmOpsApi.listChannelModelPrices(FULL_LIST_PARAMS),
-      llmOpsApi.listChannelPriceItems({
-        ...FULL_LIST_PARAMS,
+      fetchList(llmOpsApi.listChannelModelPrices),
+      fetchList(llmOpsApi.listChannelPriceItems, {
         is_current: 'true'
       }),
-      llmOpsApi.listResaleListings(FULL_LIST_PARAMS),
-      llmOpsApi.listReconciliationRecords(FULL_LIST_PARAMS),
+      fetchList(llmOpsApi.listResaleListings),
+      fetchList(llmOpsApi.listReconciliationRecords),
       llmOpsApi.getSummary(summaryParams())
     ])
-  channelPrices.value = extract(priceRes)
-  channelPriceItems.value = extract(channelPriceItemRes)
-  listings.value = extract(listingRes)
-  records.value = extract(recordRes)
+  channelPrices.value = prices
+  channelPriceItems.value = channelPriceItemsData
+  listings.value = listingData
+  records.value = recordData
   summary.value = extract(summaryRes)
 }
 
 async function refreshCollectionRuns() {
-  const [sourceRes, runRes] = await Promise.all([
-    llmOpsApi.listCollectionSources(FULL_LIST_PARAMS),
-    llmOpsApi.listCollectionRuns(FULL_LIST_PARAMS)
+  const [sourceData, runData] = await Promise.all([
+    fetchList(llmOpsApi.listCollectionSources),
+    fetchList(llmOpsApi.listCollectionRuns)
   ])
-  sources.value = extract(sourceRes)
-  collectionRuns.value = extract(runRes)
+  sources.value = sourceData
+  collectionRuns.value = runData
 }
 
 async function loadResaleWorkflowConfig(

--- a/frontend/src/utils/llmOpsPriceSources.js
+++ b/frontend/src/utils/llmOpsPriceSources.js
@@ -1,0 +1,187 @@
+const DEFAULT_CATEGORY_LABELS = {
+  official_provider: '原厂',
+  cloud_hosted: '云托管',
+  supplier: '供货商',
+  manual: '内部维护',
+  unknown: '其他'
+}
+
+const CATEGORY_TONES = {
+  official_provider: 'official',
+  cloud_hosted: 'cloud',
+  supplier: 'supplier',
+  manual: 'manual',
+  unknown: 'unknown'
+}
+
+const CATEGORY_RANKS = {
+  official_provider: 1,
+  cloud_hosted: 2,
+  supplier: 3,
+  manual: 4,
+  unknown: 5
+}
+
+export function normalizePriceSourceCategory(item, model = {}, source = null) {
+  return (
+    item?.business_source_category ||
+    item?.price_role ||
+    model?.business_source_category ||
+    model?.price_role ||
+    source?.business_source_category ||
+    item?.source_category ||
+    model?.source_category ||
+    source?.source_category ||
+    'unknown'
+  )
+}
+
+export function priceSourceCategoryLabel(category, labels = {}) {
+  const key = category || 'unknown'
+  return (
+    labels[key] ||
+    DEFAULT_CATEGORY_LABELS[key] ||
+    labels.unknown ||
+    DEFAULT_CATEGORY_LABELS.unknown
+  )
+}
+
+export function priceSourceTone(category) {
+  return CATEGORY_TONES[category || 'unknown'] || CATEGORY_TONES.unknown
+}
+
+export function priceSourceCategory(category, labels = {}) {
+  return {
+    label: priceSourceCategoryLabel(category, labels),
+    tone: priceSourceTone(category)
+  }
+}
+
+export function priceSourceCategoryRank(category) {
+  return CATEGORY_RANKS[category || 'unknown'] || 9
+}
+
+export function comparePriceSources(left, right) {
+  const leftRank = priceSourceCategoryRank(normalizePriceSourceCategory(left))
+  const rightRank = priceSourceCategoryRank(normalizePriceSourceCategory(right))
+  if (leftRank !== rightRank) return leftRank - rightRank
+  return String(left?.name || '').localeCompare(String(right?.name || ''))
+}
+
+export function priceSourceCollectionMethod(source) {
+  const method = source?.collection_method
+  if (method && method !== 'unknown') return method
+
+  if (source?.source_type === 'yunce') return 'api_sync'
+  if (
+    normalizePriceSourceCategory(source) === 'official_provider' &&
+    source?.updates_model_prices
+  ) {
+    return 'auto_collect'
+  }
+  if (normalizePriceSourceCategory(source) === 'manual') {
+    return 'manual_entry'
+  }
+  return method || 'unknown'
+}
+
+export function canCollectPriceSource(source) {
+  if (!source) return false
+  if (source.can_collect === true) return true
+  return Boolean(
+    source.can_collect_prices &&
+      priceSourceCollectionMethod(source) === 'auto_collect' &&
+      source.updates_model_prices
+  )
+}
+
+export function canApiSyncPriceSource(source) {
+  return priceSourceCollectionMethod(source) === 'api_sync'
+}
+
+export function canManualEntryPriceSource(source) {
+  if (!source) return false
+  if (source.can_manual_entry === true) return true
+  return ['manual_entry', 'manual_import', 'unknown'].includes(
+    priceSourceCollectionMethod(source)
+  )
+}
+
+export function isEntryPriceSource(source) {
+  return (
+    canCollectPriceSource(source) ||
+    canManualEntryPriceSource(source) ||
+    canApiSyncPriceSource(source)
+  )
+}
+
+export function isModelsDevPriceSource(source) {
+  return String(source?.endpoint_url || '')
+    .toLowerCase()
+    .includes('models.dev/api.json')
+}
+
+export function officialProviderCodeFromSlug(
+  source,
+  fallbackProviderCode = ''
+) {
+  const slug = String(source?.slug || '')
+  if (!slug.endsWith('-official')) return ''
+  const providerCode = String(fallbackProviderCode || '').trim()
+  if (providerCode && slug.startsWith(`${providerCode}-`)) {
+    return providerCode
+  }
+  return ''
+}
+
+export function priceSourceGroupKey(source, fallbackProviderCode = '') {
+  const providerCode = String(source?.provider_code || '').trim()
+  const resolvedProviderCode =
+    providerCode ||
+    String(fallbackProviderCode || '').trim() ||
+    officialProviderCodeFromSlug(source, fallbackProviderCode)
+
+  if (normalizePriceSourceCategory(source) === 'official_provider') {
+    return `official:${resolvedProviderCode}`
+  }
+  return `source:${source?.id || source?.slug || 'unknown'}`
+}
+
+export function isLegacyOfficialModelSource(source, fallbackProviderCode = '') {
+  if (normalizePriceSourceCategory(source) !== 'official_provider') {
+    return false
+  }
+  const providerCode = String(
+    source?.provider_code ||
+      fallbackProviderCode ||
+      officialProviderCodeFromSlug(source, fallbackProviderCode)
+  ).trim()
+  if (!providerCode) return false
+  const slug = String(source?.slug || '')
+  return slug !== `${providerCode}-official` && slug.endsWith('-official')
+}
+
+export function isProviderOfficialPriceSource(
+  source,
+  fallbackProviderCode = ''
+) {
+  const providerCode = String(source?.provider_code || '').trim()
+  const expectedCode = providerCode || String(fallbackProviderCode || '').trim()
+  return Boolean(
+    expectedCode &&
+      normalizePriceSourceCategory(source) === 'official_provider' &&
+      String(source?.slug || '') === `${expectedCode}-official`
+  )
+}
+
+export function preferredPriceSource(sources) {
+  return (
+    sources.find(
+      (source) => normalizePriceSourceCategory(source) === 'official_provider'
+    ) ||
+    sources.find((source) => String(source.slug || '').endsWith('-official')) ||
+    sources.find((source) => source.updates_model_prices) ||
+    sources.find((source) => source.endpoint_url) ||
+    null
+  )
+}


### PR DESCRIPTION
## Summary
- Add stable classification defaults and summary/capability fields for LLM Ops price sources.
- Resolve manual import model providers from row-level provider fields, existing models, or meta model vendors when a source has no default provider.
- Rework the LLM Ops management UI around service price sources and share source classification helpers across components.
- Include Aliyun cache-hit pricing in official parser output.

## Test plan
- [x] python3 -m pytest backend/llm_ops/tests/test_official_collector.py backend/llm_ops/tests/test_serializers.py backend/llm_ops/tests/test_services.py backend/llm_ops/tests/test_skill_runner.py
- [x] npm run build
- [ ] python3 -m pytest backend/llm_ops/tests/test_views.py (blocked locally: system Python lacks drf_spectacular and uses Django 4.2/DRF 3.16 instead of project Django 5.1/DRF 3.15; uv resolution is blocked by pyproject requires-python >=3.8 conflicting with deepagents==0.4.9 requiring Python >=3.11)

No open GitHub issue was available to close for this change.

Made with [Orca](https://github.com/stablyai/orca) 🐋
