### PR TITLE
Fix LLM Ops price source and refresh flows

### DIFF
--- a/backend/llm_ops/services.py
+++ b/backend/llm_ops/services.py
@@ -1270,7 +1270,7 @@ def sync_channel_price_items(
     price: ChannelModelPrice,
 ) -> list[ChannelPriceItem]:
     """Sync normalized channel price items from one channel/model config."""
-    source = ensure_channel_price_source(price.channel)
+    source = price.price_source
     payloads = channel_price_item_payloads(price, source=source)
     now = timezone.now()
     ChannelPriceItem.objects.filter(
@@ -1315,36 +1315,10 @@ def sync_channel_price_items(
     return items
 
 
-def ensure_channel_price_source(
-    channel: ProcurementChannel,
-) -> PriceCollectionSource:
-    """Ensure a supplier price source exists for one procurement channel."""
-    source, _ = PriceCollectionSource.objects.update_or_create(
-        slug=f"{channel.code}-supplier",
-        defaults={
-            "name": f"{channel.name} 供应商价格",
-            "source_type": PriceCollectionSource.SOURCE_TYPE_CUSTOM,
-            "source_category": (
-                PriceCollectionSource.SOURCE_CATEGORY_SUPPLIER
-            ),
-            "source_owner_type": PriceCollectionSource.SOURCE_OWNER_SUPPLIER,
-            "collection_method": (
-                PriceCollectionSource.COLLECTION_METHOD_API_SYNC
-            ),
-            "channel": channel,
-            "endpoint_url": channel.api_endpoint,
-            "currency": normalize_currency(channel.currency) or "USD",
-            "is_enabled": channel.is_active,
-            "updates_model_prices": False,
-        },
-    )
-    return source
-
-
 def channel_price_item_payloads(
     price: ChannelModelPrice,
     *,
-    source: PriceCollectionSource,
+    source: PriceCollectionSource | None,
 ) -> list[dict]:
     """Build normalized channel price item payloads for a model config."""
     channel = price.channel

--- a/backend/llm_ops/tests/test_services.py
+++ b/backend/llm_ops/tests/test_services.py
@@ -255,8 +255,8 @@ class LLMOpsPricingServiceTests(TestCase):
         self.assertEqual(item.comparison_status, "below_official")
         self.assertEqual(item.delta_amount, Decimal("-0.500000"))
         self.assertEqual(item.delta_percent, Decimal("-20.0000"))
-        self.assertEqual(item.source.source_category, "supplier")
-        self.assertEqual(item.source.channel, self.channel)
+        self.assertIsNone(item.source)
+        self.assertFalse(PriceCollectionSource.objects.exists())
 
     def test_sync_uses_selected_procurement_price_source(self):
         official_source = PriceCollectionSource.objects.create(

--- a/frontend/src/components/llm-ops/ChannelModelDrawer.vue
+++ b/frontend/src/components/llm-ops/ChannelModelDrawer.vue
@@ -955,7 +955,7 @@ const availableModelGroups = computed(() => {
       if (model.modality) {
         group.modalities.add(model.modality)
       }
-      group.providerCount = group.models.length
+      group.providerCount = uniqueProviderModelsForGroup(group).length
       groups.set(key, group)
     })
   return Array.from(groups.values())
@@ -1418,7 +1418,7 @@ function handleVendorChange() {
 
 function providerOptionsForModelGroup(group) {
   if (!group) return []
-  return group.models
+  return uniqueProviderModelsForGroup(group)
     .slice()
     .sort((left, right) =>
       purchaseSourceLabel(left).localeCompare(purchaseSourceLabel(right))
@@ -1436,6 +1436,29 @@ function providerOptionsForModelGroup(group) {
         model.currency
       ].join(' ')
     }))
+}
+
+function uniqueProviderModelsForGroup(group) {
+  if (!group?.models?.length) return []
+  const modelsByUpstream = new Map()
+  group.models.forEach((model) => {
+    const key = providerOptionIdentityKey(model)
+    const current = modelsByUpstream.get(key)
+    if (!current || providerOptionScore(model) > providerOptionScore(current)) {
+      modelsByUpstream.set(key, model)
+    }
+  })
+  return Array.from(modelsByUpstream.values())
+}
+
+function providerOptionIdentityKey(model) {
+  const sourceId = String(model?.source || '').trim()
+  if (sourceId) return `source:${sourceId}`
+  return `model:${model?.id || model?.code || model?.name || ''}`
+}
+
+function providerOptionScore(model) {
+  return providerPriceSummary(model).length
 }
 
 function isModelSelected(key) {
@@ -1470,8 +1493,9 @@ function clearSelectedModels() {
 
 function ensureDefaultProvider(group) {
   if (selectedProviderByModelKey.value[group.key]) return
-  if (group.models.length !== 1) return
-  selectBatchPriceSourceModel(group.key, group.models[0].id)
+  const options = uniqueProviderModelsForGroup(group)
+  if (options.length !== 1) return
+  selectBatchPriceSourceModel(group.key, options[0].id)
 }
 
 function removeSelectedProvider(key) {

--- a/frontend/src/components/llm-ops/ManualPriceEntryModal.vue
+++ b/frontend/src/components/llm-ops/ManualPriceEntryModal.vue
@@ -127,11 +127,7 @@
               <span>
                 {{ t('llmOps.manualPriceEntry.fields.provider') }}
               </span>
-              <strong>
-                {{
-                  selectedSourceProvider?.name || source?.provider_name || '-'
-                }}
-              </strong>
+              <strong>{{ selectedMetaModelProviderName }}</strong>
             </div>
             <div class="readonly-field">
               <span>
@@ -344,11 +340,31 @@ const selectedMetaModel = computed(() =>
   )
 )
 
-const selectedSourceProvider = computed(() => {
-  const sourceProviderId = sourceProviderIdValue()
-  if (!sourceProviderId) return null
-  return props.providers.find(
-    (provider) => String(provider.id) === String(sourceProviderId)
+const selectedMetaModelOwner = computed(() => {
+  if (!selectedMetaModel.value) {
+    return { providerId: '', code: '', name: '' }
+  }
+  const owner = resolveCanonicalMetaOwner(
+    selectedMetaModel.value,
+    props.providers
+  )
+  const provider = props.providers.find(
+    (item) =>
+      String(item.code || '').toLowerCase() ===
+      String(owner.code || '').toLowerCase()
+  )
+  return {
+    providerId: provider?.id || '',
+    code: owner.code || selectedMetaModel.value.owner_code || '',
+    name: owner.name || selectedMetaModel.value.owner_name || ''
+  }
+})
+
+const selectedMetaModelProviderName = computed(() => {
+  return (
+    selectedMetaModelOwner.value.name ||
+    selectedMetaModelOwner.value.code ||
+    '-'
   )
 })
 
@@ -429,7 +445,11 @@ const validationMessage = computed(() => {
     if (!selectedMetaModel.value) {
       return t('llmOps.manualPriceEntry.validation.selectMetaModel')
     }
-    if (!sourceProviderIdValue()) {
+    if (
+      !selectedMetaModelOwner.value.providerId &&
+      !selectedMetaModelOwner.value.code &&
+      !selectedMetaModelOwner.value.name
+    ) {
       return t('llmOps.manualPriceEntry.validation.customModelProvider')
     }
   }
@@ -511,13 +531,16 @@ function resolveImportSelection() {
       row: buildImportRow(selectedModel.value)
     }
   }
+  const owner = selectedMetaModelOwner.value
   const model = {
     code: selectedMetaModel.value.code,
     name: selectedMetaModel.value.name || selectedMetaModel.value.code,
-    modality: selectedMetaModel.value.modality || 'text'
+    modality: selectedMetaModel.value.modality || 'text',
+    provider_code: owner.code,
+    provider_name: owner.name
   }
   return {
-    providerId: sourceProviderIdValue(),
+    providerId: owner.providerId,
     row: buildImportRow(model)
   }
 }
@@ -532,6 +555,9 @@ function buildImportRow(model) {
   }
   if (model.provider_code) {
     row.provider_code = model.provider_code
+  }
+  if (model.provider_name) {
+    row.provider_name = model.provider_name
   }
   activePriceFields.value.forEach((field) => {
     const value = normalizePrice(form.value[field.key])
@@ -569,10 +595,6 @@ function buildModelOptions() {
 function resolveModelProviderId(model) {
   if (!model) return ''
   return model.provider || ''
-}
-
-function sourceProviderIdValue() {
-  return props.source?.provider || props.source?.provider_id || ''
 }
 
 function buildMetaModelOptions() {

--- a/frontend/src/components/llm-ops/ResalePublishingWorkspace.vue
+++ b/frontend/src/components/llm-ops/ResalePublishingWorkspace.vue
@@ -1639,43 +1639,66 @@ function priceDiffClass(price, avg) {
 const selectedMetaModelPriceItems = computed(() => {
   const metaModelId = form.value.modelId
   if (!metaModelId) return []
-  return (props.priceItems || []).filter(
-    (item) => String(item.meta_model) === String(metaModelId)
-  )
+  return (props.priceItems || []).filter((item) => {
+    if (String(item.meta_model || '') === String(metaModelId)) return true
+    const model = modelById.value.get(String(item.model || ''))
+    return String(model?.meta_model || '') === String(metaModelId)
+  })
 })
 
 const marketAvg = computed(() => {
-  const refs = selectedMetaModelPriceItems.value
-  if (!refs.length) return { in: 0, out: 0, cacheIn: 0 }
-  let inSum = 0
-  let outSum = 0
-  let cacheInSum = 0
-  let inCount = 0
-  let outCount = 0
-  let cacheInCount = 0
-  refs.forEach((it) => {
-    const value = convertToDisplay(it.unit_price, it.currency)
-    if (value === null) return
-    if (it.dimension === 'text_input') {
-      inSum += value
-      inCount += 1
-    }
-    if (it.dimension === 'text_output') {
-      outSum += value
-      outCount += 1
-    }
-    if (it.dimension === 'cache_input') {
-      cacheInSum += value
-      cacheInCount += 1
-    }
+  const samples = {
+    in: [],
+    out: [],
+    cacheIn: []
+  }
+  selectedMetaModelPriceItems.value.forEach((item) => {
+    const spec = priceSpecForItemDimension(item.dimension)
+    if (!spec || item.is_current === false) return
+    addMarketSample(samples[spec.marketKey], item.unit_price, item.currency)
+  })
+  RESALE_PRICE_DIMENSION_SPECS.forEach((spec) => {
+    if (samples[spec.marketKey].length) return
+    selectedMetaModelProcurements.value.forEach((procurement) => {
+      ;(procurement.options || []).forEach((option) => {
+        const price = channelPriceValue(
+          option,
+          procurement.model_id,
+          spec.itemDimension,
+          option[spec.costField]
+        )
+        addMarketSample(
+          samples[spec.marketKey],
+          price.value,
+          price.currency || option.currency
+        )
+      })
+    })
   })
   return {
-    in: inCount > 0 ? Number((inSum / inCount).toFixed(4)) : 0,
-    out: outCount > 0 ? Number((outSum / outCount).toFixed(4)) : 0,
-    cacheIn:
-      cacheInCount > 0 ? Number((cacheInSum / cacheInCount).toFixed(4)) : 0
+    in: averageMarketSamples(samples.in),
+    out: averageMarketSamples(samples.out),
+    cacheIn: averageMarketSamples(samples.cacheIn)
   }
 })
+
+function priceSpecForItemDimension(dimension) {
+  return RESALE_PRICE_DIMENSION_SPECS.find(
+    (spec) => spec.itemDimension === dimension
+  )
+}
+
+function addMarketSample(samples, value, currency) {
+  const converted = convertToDisplay(value, currency)
+  if (converted === null || converted <= 0) return
+  samples.push(converted)
+}
+
+function averageMarketSamples(samples) {
+  if (!samples.length) return 0
+  const sum = samples.reduce((total, value) => total + value, 0)
+  return Number((sum / samples.length).toFixed(4))
+}
 
 const priceMetricConfigs = Object.fromEntries(
   RESALE_PRICE_DIMENSION_SPECS.map((item) => [

--- a/frontend/src/pages/LLMOps.vue
+++ b/frontend/src/pages/LLMOps.vue
@@ -596,7 +596,7 @@
               :price-items="modelPriceItems"
               :display-currency="displayCurrency"
               :exchange-rate="exchangeRate"
-              @refresh="refreshAll"
+              @refresh="refreshProviderManagementData"
             />
 
             <MetaModelManagement
@@ -605,7 +605,7 @@
               :providers="providers"
               :models="models"
               :price-items="modelPriceItems"
-              @refresh="refreshAll"
+              @refresh="refreshMetaModelManagementData"
             />
 
             <ChannelManagement
@@ -618,7 +618,7 @@
               :price-items="modelPriceItems"
               :display-currency="displayCurrency"
               :exchange-rate="exchangeRate"
-              @refresh="refreshAll"
+              @refresh="refreshChannelManagementData"
             />
 
             <ReconciliationPanel
@@ -893,8 +893,7 @@ const navGroups = computed(() =>
     createNavGroup('overview', 'llmOps.navGroups.overview', ['monitor']),
     createNavGroup('catalog', 'llmOps.navGroups.catalog', [
       'metaModels',
-      'providers',
-      'taskLogs'
+      'providers'
     ]),
     createNavGroup('distribution', 'llmOps.navGroups.distribution', [
       'channels',
@@ -904,7 +903,8 @@ const navGroups = computed(() =>
     createNavGroup('governance', 'llmOps.navGroups.governance', [
       'reconciler',
       'audit',
-      'globalConfig'
+      'globalConfig',
+      'taskLogs'
     ])
   ].filter((group) => group.items.length > 0)
 )
@@ -1559,6 +1559,94 @@ async function refreshCollectionRuns() {
   collectionRuns.value = runData
 }
 
+async function refreshProviderManagementData() {
+  try {
+    const [
+      sourceData,
+      runData,
+      providerData,
+      modelData,
+      metaModelData,
+      priceItemData,
+      summaryRes
+    ] = await Promise.all([
+      fetchList(llmOpsApi.listCollectionSources),
+      fetchList(llmOpsApi.listCollectionRuns),
+      fetchList(llmOpsApi.listProviders),
+      fetchList(llmOpsApi.listModels),
+      fetchList(llmOpsApi.listMetaModels),
+      fetchList(llmOpsApi.listModelPriceItems, {
+        is_current: 'true'
+      }),
+      llmOpsApi.getSummary(summaryParams())
+    ])
+    sources.value = sourceData
+    collectionRuns.value = runData
+    providers.value = providerData
+    models.value = modelData
+    metaModels.value = metaModelData
+    modelPriceItems.value = priceItemData
+    summary.value = extract(summaryRes)
+  } catch (error) {
+    showError(errorMessage(error, '刷新价格源数据失败。'))
+  }
+}
+
+async function refreshMetaModelManagementData() {
+  try {
+    const [providerData, modelData, metaModelData, priceItemData, summaryRes] =
+      await Promise.all([
+        fetchList(llmOpsApi.listProviders),
+        fetchList(llmOpsApi.listModels),
+        fetchList(llmOpsApi.listMetaModels),
+        fetchList(llmOpsApi.listModelPriceItems, {
+          is_current: 'true'
+        }),
+        llmOpsApi.getSummary(summaryParams())
+      ])
+    providers.value = providerData
+    models.value = modelData
+    metaModels.value = metaModelData
+    modelPriceItems.value = priceItemData
+    summary.value = extract(summaryRes)
+  } catch (error) {
+    showError(errorMessage(error, '刷新元模型数据失败。'))
+  }
+}
+
+async function refreshChannelManagementData() {
+  try {
+    const [channelData, summaryRes] = await Promise.all([
+      fetchList(llmOpsApi.listChannels),
+      llmOpsApi.getSummary(summaryParams()),
+      refreshChannelPricingData()
+    ])
+    channels.value = channelData
+    summary.value = extract(summaryRes)
+    refreshResaleListings().catch((error) => {
+      showError(errorMessage(error, '刷新转售列表失败。'))
+    })
+  } catch (error) {
+    showError(errorMessage(error, '刷新渠道数据失败。'))
+  }
+}
+
+async function refreshPlatformData() {
+  try {
+    const [platformData, listingData, summaryRes] = await Promise.all([
+      fetchList(llmOpsApi.listResalePlatforms),
+      fetchList(llmOpsApi.listResaleListings),
+      llmOpsApi.getSummary(summaryParams())
+    ])
+    resalePlatforms.value = platformData
+    listings.value = listingData
+    summary.value = extract(summaryRes)
+    await loadResaleWorkflowConfig()
+  } catch (error) {
+    showError(errorMessage(error, '刷新转售平台数据失败。'))
+  }
+}
+
 async function loadResaleWorkflowConfig(
   platformId = selectedResalePlatformId.value
 ) {
@@ -1756,7 +1844,7 @@ function handleWorkflowConfigSaved(payload) {
 
 function handlePlatformSaved() {
   closePlatformModal()
-  refreshAll()
+  refreshPlatformData()
 }
 
 function mergeResaleListings(updatedItems) {


### PR DESCRIPTION
## Summary
- Stop creating implicit supplier price sources when syncing channel price items without a selected source
- Use canonical meta model ownership when manually entering prices for custom models
- Deduplicate provider options and refresh LLM Ops management data more narrowly after edits
- Improve resale pricing benchmarks by falling back to procurement channel prices when market items are missing

## Test plan
- [x] python3 -m pytest backend/llm_ops/tests/test_services.py
- [x] npx eslint src/components/llm-ops/ChannelModelDrawer.vue src/components/llm-ops/ManualPriceEntryModal.vue src/components/llm-ops/ResalePublishingWorkspace.vue src/pages/LLMOps.vue
- [x] npm run build

No linked GitHub issue was found for this branch.

Made with [Orca](https://github.com/stablyai/orca) 🐋
