### PR TITLE
Handle tiered source prices for channel models

### DIFF
--- a/backend/llm_ops/services.py
+++ b/backend/llm_ops/services.py
@@ -1154,7 +1154,7 @@ def source_unit_prices_for_channel_model(
     *,
     override: ChannelModelPrice | None,
 ) -> UnitPrices | None:
-    """Resolve flat unit prices from the selected procurement source."""
+    """Resolve unit prices from the selected procurement source."""
     if not override:
         return None
 
@@ -1164,17 +1164,20 @@ def source_unit_prices_for_channel_model(
         override=override,
     )
     values = {}
+    grouped_items = {}
     for item in current_model_price_items_for_channel_price(override):
-        if item.tier_type != ModelPriceItem.TIER_FLAT:
+        grouped_items.setdefault(item.dimension, []).append(item)
+
+    for dimension, items in grouped_items.items():
+        item = selected_price_item_for_channel_model(items)
+        if item is None:
             continue
         unit_price = convert_currency_between(
             item.unit_price,
             item.currency,
             target_currency,
         )
-        values[item.dimension] = unit_price or decimal_or_zero(
-            item.unit_price
-        )
+        values[dimension] = unit_price or decimal_or_zero(item.unit_price)
 
     if not values:
         return None
@@ -1213,6 +1216,39 @@ def source_unit_prices_for_channel_model(
             ZERO,
         ),
     )
+
+
+def selected_price_item_for_channel_model(
+    items: list[ModelPriceItem],
+) -> ModelPriceItem | None:
+    """Select a flat item or the highest tiered unit price."""
+    if not items:
+        return None
+
+    flat_items = [
+        item for item in items if item.tier_type == ModelPriceItem.TIER_FLAT
+    ]
+    if flat_items:
+        return sorted(flat_items, key=lambda item: item.id)[0]
+
+    tiered_items = [
+        item
+        for item in items
+        if item.tier_type
+        in (ModelPriceItem.TIER_USAGE_RANGE, ModelPriceItem.TIER_VOLUME)
+    ]
+    if not tiered_items:
+        return None
+
+    return sorted(
+        tiered_items,
+        key=lambda item: (
+            decimal_or_zero(item.unit_price),
+            decimal_or_zero(item.tier_start),
+            item.id,
+        ),
+        reverse=True,
+    )[0]
 
 
 def calculate_usage_cost(

--- a/backend/llm_ops/tests/test_services.py
+++ b/backend/llm_ops/tests/test_services.py
@@ -550,6 +550,81 @@ class LLMOpsPricingServiceTests(TestCase):
             {Decimal("1.000000"), Decimal("2.000000")},
         )
 
+    def test_channel_source_uses_highest_usage_range_price(self):
+        source = PriceCollectionSource.objects.create(
+            name="Aliyun Tiered Official",
+            slug="aliyun-tiered-official",
+            provider=self.provider,
+            source_category=(
+                PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
+            ),
+            currency="CNY",
+        )
+        self.model.currency = "CNY"
+        self.model.save(update_fields=["currency"])
+        self.channel.currency = "CNY"
+        self.channel.save(update_fields=["currency"])
+        price_specs = [
+            (
+                "range-input-low",
+                ModelPriceItem.DIMENSION_TEXT_INPUT,
+                "0.2",
+                "0",
+                "128000",
+            ),
+            (
+                "range-input-high",
+                ModelPriceItem.DIMENSION_TEXT_INPUT,
+                "1.2",
+                "128000",
+                "256000",
+            ),
+            (
+                "range-output-low",
+                ModelPriceItem.DIMENSION_TEXT_OUTPUT,
+                "2",
+                "0",
+                "128000",
+            ),
+            (
+                "range-output-high",
+                ModelPriceItem.DIMENSION_TEXT_OUTPUT,
+                "12",
+                "128000",
+                "256000",
+            ),
+        ]
+        for fingerprint, dimension, unit_price, start, end in price_specs:
+            ModelPriceItem.objects.create(
+                provider=self.provider,
+                model=self.model,
+                meta_model=self.model.meta_model,
+                source=source,
+                dimension=dimension,
+                billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
+                currency="CNY",
+                unit_price=Decimal(unit_price),
+                tier_type=ModelPriceItem.TIER_USAGE_RANGE,
+                tier_start=Decimal(start),
+                tier_end=Decimal(end),
+                price_fingerprint=fingerprint,
+                is_current=True,
+            )
+        price = ChannelModelPrice.objects.create(
+            channel=self.channel,
+            model=self.model,
+            price_source=source,
+        )
+
+        unit_prices = resolve_channel_model_price(
+            self.channel,
+            self.model,
+            override=price,
+        )
+
+        self.assertEqual(unit_prices.input_per_million, Decimal("0.960000"))
+        self.assertEqual(unit_prices.output_per_million, Decimal("9.600000"))
+
     def test_marks_channel_item_comparison_unknown_for_currency_mismatch(self):
         ModelPriceItem.objects.create(
             provider=self.provider,

--- a/frontend/src/components/llm-ops/agioneListingStatusBoard.css
+++ b/frontend/src/components/llm-ops/agioneListingStatusBoard.css
@@ -712,7 +712,9 @@
 }
 
 .agione-listing-status-board .listing-table .table-head,
-.agione-listing-status-board .listing-table .table-cell {
+.agione-listing-status-board .listing-table .table-cell,
+.agione-listing-status-board .listing-table th,
+.agione-listing-status-board .listing-table td {
   text-align: center;
   vertical-align: middle;
 }
@@ -720,6 +722,7 @@
 .agione-listing-status-board .listing-table .table-cell > p {
   margin-left: auto;
   margin-right: auto;
+  text-align: center;
 }
 
 .agione-listing-status-board .listing-table .row-checkbox {
@@ -792,7 +795,10 @@
   gap: 0.25rem;
   margin-left: auto;
   margin-right: auto;
-  max-width: 9.25rem;
+  width: 100%;
+  max-width: none;
+  justify-items: center;
+  text-align: center;
   font-family:
     ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
     'Courier New', monospace;
@@ -801,15 +807,17 @@
 
 .agione-listing-status-board .metric-line {
   display: grid;
-  grid-template-columns: 3rem minmax(0, 1fr);
+  grid-template-columns: max-content minmax(3.75rem, max-content);
   align-items: baseline;
-  column-gap: 0.25rem;
+  justify-content: center;
+  column-gap: 0.5rem;
   min-height: 1.375rem;
   color: #475569;
 }
 
 .agione-listing-status-board .metric-line-value {
   grid-template-columns: minmax(0, 1fr);
+  justify-items: center;
 }
 
 .agione-listing-status-board .metric-label {
@@ -817,7 +825,7 @@
   font-size: 10px;
   font-weight: 700;
   letter-spacing: 0;
-  text-align: right;
+  text-align: left;
   text-transform: uppercase;
 }
 


### PR DESCRIPTION
## Summary
- Resolve channel model source unit prices from flat items when available.
- Fall back to the highest current usage-range or volume tier per price dimension.
- Add regression coverage for official tiered source prices and keep listing table price metrics centered.

No linked open Issue found for this follow-up.

## Test plan
- [x] `.venv/bin/python -m py_compile backend/llm_ops/services.py backend/llm_ops/tests/test_services.py`
- [x] `npx eslint src/components/llm-ops/AgioneListingStatusBoard.vue --ext .vue --ignore-path ../.gitignore`
- [x] `git diff --check HEAD~1 HEAD`
- [ ] Targeted Django tests not run: local `.venv` has no pytest module.