### PR TITLE
Refine LLM Ops page styling

### DIFF
--- a/frontend/src/components/llm-ops/llmOpsButtons.css
+++ b/frontend/src/components/llm-ops/llmOpsButtons.css
@@ -3,7 +3,7 @@ body.llm-ops-theme .icon-mark {
   height: 0.875rem !important;
   width: 0.875rem !important;
   flex-shrink: 0 !important;
-  border-radius: 0.25rem !important;
+  border-radius: 4px !important;
   background-color: currentColor !important;
 }
 
@@ -14,29 +14,27 @@ body.llm-ops-theme .add-listing-button {
   align-items: center !important;
   justify-content: center !important;
   gap: 0.5rem !important;
-  border-radius: 0.75rem !important;
-  border: 1px solid #4f46e5 !important;
-  background: linear-gradient(135deg, #5b4bdb, #4338ca) !important;
+  border-radius: var(--ui-radius-control, 8px) !important;
+  border: 1px solid var(--ui-color-primary, #5f4ecf) !important;
+  background: var(--ui-color-primary, #5f4ecf) !important;
   padding: 0.5rem 0.875rem !important;
   font-size: 0.875rem !important;
   font-weight: 600 !important;
   line-height: 1.25rem !important;
-  color: #ffffff !important;
-  box-shadow: 0 8px 20px rgba(79, 70, 229, 0.18) !important;
+  color: var(--ui-text-on-brand, #ffffff) !important;
+  box-shadow: var(--ui-shadow-xs, 0 1px 2px rgba(24, 24, 27, 0.04)) !important;
   transition:
     background-color 150ms ease,
     border-color 150ms ease,
     box-shadow 150ms ease,
-    color 150ms ease,
-    transform 150ms ease !important;
+    color 150ms ease !important;
 }
 
 body.llm-ops-theme .btn-primary:hover:not(:disabled),
 body.llm-ops-theme .add-listing-button:hover:not(:disabled) {
-  border-color: #4338ca !important;
-  background: linear-gradient(135deg, #4f46e5, #3730a3) !important;
-  box-shadow: 0 10px 24px rgba(79, 70, 229, 0.24) !important;
-  transform: translateY(-1px) !important;
+  border-color: var(--ui-color-primary-hover, #5140bd) !important;
+  background: var(--ui-color-primary-hover, #5140bd) !important;
+  box-shadow: var(--ui-shadow-xs, 0 1px 2px rgba(24, 24, 27, 0.04)) !important;
 }
 
 body.llm-ops-theme .btn-secondary,
@@ -47,89 +45,87 @@ body.llm-ops-theme .batch-action {
   align-items: center !important;
   justify-content: center !important;
   gap: 0.5rem !important;
-  border-radius: 0.75rem !important;
-  border: 1px solid #dbe4f0 !important;
-  background: #ffffff !important;
+  border-radius: var(--ui-radius-control, 8px) !important;
+  border: 1px solid var(--ui-border-default, #e4e4e7) !important;
+  background: var(--ui-bg-card, #ffffff) !important;
   padding: 0.5rem 0.875rem !important;
   font-size: 0.875rem !important;
   font-weight: 600 !important;
   line-height: 1.25rem !important;
-  color: #334155 !important;
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04) !important;
+  color: var(--ui-text-secondary, #3f3f46) !important;
+  box-shadow: var(--ui-shadow-xs, 0 1px 2px rgba(24, 24, 27, 0.04)) !important;
   transition:
     background-color 150ms ease,
     border-color 150ms ease,
     box-shadow 150ms ease,
-    color 150ms ease,
-    transform 150ms ease !important;
+    color 150ms ease !important;
 }
 
 body.llm-ops-theme .btn-secondary:hover:not(:disabled),
 body.llm-ops-theme .header-back:hover:not(:disabled),
 body.llm-ops-theme .batch-action:hover:not(:disabled) {
-  border-color: #cbd5e1 !important;
-  background: #f8fafc !important;
-  color: #0f172a !important;
-  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08) !important;
-  transform: translateY(-1px) !important;
+  border-color: var(--ui-border-interactive, #8f8f8f) !important;
+  background: var(--ui-bg-muted, #f4f5f8) !important;
+  color: var(--ui-text-primary, #18181b) !important;
+  box-shadow: var(--ui-shadow-xs, 0 1px 2px rgba(24, 24, 27, 0.04)) !important;
 }
 
 body.llm-ops-theme .refresh-action-button {
   min-width: 5.5rem !important;
-  border-color: #cbd5e1 !important;
-  background: #ffffff !important;
-  color: #334155 !important;
+  border-color: var(--ui-border-default, #e4e4e7) !important;
+  background: var(--ui-bg-card, #ffffff) !important;
+  color: var(--ui-text-secondary, #3f3f46) !important;
   font-weight: 700 !important;
 }
 
 body.llm-ops-theme .refresh-action-button:hover:not(:disabled) {
-  border-color: #a5b4fc !important;
-  background: #eef2ff !important;
-  color: #4338ca !important;
-  box-shadow: 0 8px 18px rgba(79, 70, 229, 0.12) !important;
+  border-color: var(--ui-color-primary, #5f4ecf) !important;
+  background: var(--ui-color-primary-subtle, #f0eefb) !important;
+  color: var(--ui-color-primary-hover, #5140bd) !important;
+  box-shadow: var(--ui-shadow-xs, 0 1px 2px rgba(24, 24, 27, 0.04)) !important;
 }
 
 body.llm-ops-theme .refresh-action-button:disabled {
   cursor: wait !important;
-  border-color: #e2e8f0 !important;
-  background: #f8fafc !important;
-  color: #94a3b8 !important;
+  border-color: var(--ui-border-default, #e4e4e7) !important;
+  background: var(--ui-bg-muted, #f4f5f8) !important;
+  color: var(--ui-text-muted, #71717a) !important;
 }
 
 body.llm-ops-theme .btn-action-create,
 body.llm-ops-theme .btn-action-save,
 body.llm-ops-theme .btn-action-submit,
 body.llm-ops-theme .btn-action-confirm {
-  border-color: #4f46e5 !important;
-  background: linear-gradient(135deg, #5b4bdb, #4338ca) !important;
-  color: #ffffff !important;
-  box-shadow: 0 8px 20px rgba(79, 70, 229, 0.18) !important;
+  border-color: var(--ui-color-primary, #5f4ecf) !important;
+  background: var(--ui-color-primary, #5f4ecf) !important;
+  color: var(--ui-text-on-brand, #ffffff) !important;
+  box-shadow: var(--ui-shadow-xs, 0 1px 2px rgba(24, 24, 27, 0.04)) !important;
 }
 
 body.llm-ops-theme .btn-action-create:hover:not(:disabled),
 body.llm-ops-theme .btn-action-save:hover:not(:disabled),
 body.llm-ops-theme .btn-action-submit:hover:not(:disabled),
 body.llm-ops-theme .btn-action-confirm:hover:not(:disabled) {
-  border-color: #4338ca !important;
-  background: linear-gradient(135deg, #4f46e5, #3730a3) !important;
-  color: #ffffff !important;
-  box-shadow: 0 10px 24px rgba(79, 70, 229, 0.24) !important;
+  border-color: var(--ui-color-primary-hover, #5140bd) !important;
+  background: var(--ui-color-primary-hover, #5140bd) !important;
+  color: var(--ui-text-on-brand, #ffffff) !important;
+  box-shadow: var(--ui-shadow-xs, 0 1px 2px rgba(24, 24, 27, 0.04)) !important;
 }
 
 body.llm-ops-theme .btn-action-refresh,
 body.llm-ops-theme .btn-action-sync {
-  border-color: #bfdbfe !important;
-  background: #eff6ff !important;
-  color: #1d4ed8 !important;
-  box-shadow: 0 1px 2px rgba(37, 99, 235, 0.06) !important;
+  border-color: var(--ui-border-default, #e4e4e7) !important;
+  background: var(--ui-color-info-subtle, #eff6ff) !important;
+  color: var(--ui-color-info, #2563eb) !important;
+  box-shadow: var(--ui-shadow-xs, 0 1px 2px rgba(24, 24, 27, 0.04)) !important;
 }
 
 body.llm-ops-theme .btn-action-refresh:hover:not(:disabled),
 body.llm-ops-theme .btn-action-sync:hover:not(:disabled) {
-  border-color: #93c5fd !important;
-  background: #dbeafe !important;
-  color: #1e40af !important;
-  box-shadow: 0 8px 18px rgba(37, 99, 235, 0.12) !important;
+  border-color: var(--ui-color-info, #2563eb) !important;
+  background: var(--ui-color-info-subtle, #eff6ff) !important;
+  color: var(--ui-color-info, #2563eb) !important;
+  box-shadow: var(--ui-shadow-xs, 0 1px 2px rgba(24, 24, 27, 0.04)) !important;
 }
 
 body.llm-ops-theme .btn-action-import,
@@ -153,10 +149,10 @@ body.llm-ops-theme .btn-action-edit,
 body.llm-ops-theme .btn-action-view,
 body.llm-ops-theme .btn-action-neutral,
 body.llm-ops-theme .btn-action-cancel {
-  border-color: #dbe4f0 !important;
-  background: #ffffff !important;
-  color: #334155 !important;
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04) !important;
+  border-color: var(--ui-border-default, #e4e4e7) !important;
+  background: var(--ui-bg-card, #ffffff) !important;
+  color: var(--ui-text-secondary, #3f3f46) !important;
+  box-shadow: var(--ui-shadow-xs, 0 1px 2px rgba(24, 24, 27, 0.04)) !important;
 }
 
 body.llm-ops-theme .btn-action-config:hover:not(:disabled),
@@ -164,10 +160,10 @@ body.llm-ops-theme .btn-action-edit:hover:not(:disabled),
 body.llm-ops-theme .btn-action-view:hover:not(:disabled),
 body.llm-ops-theme .btn-action-neutral:hover:not(:disabled),
 body.llm-ops-theme .btn-action-cancel:hover:not(:disabled) {
-  border-color: #cbd5e1 !important;
-  background: #f8fafc !important;
-  color: #0f172a !important;
-  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08) !important;
+  border-color: var(--ui-border-interactive, #8f8f8f) !important;
+  background: var(--ui-bg-muted, #f4f5f8) !important;
+  color: var(--ui-text-primary, #18181b) !important;
+  box-shadow: var(--ui-shadow-xs, 0 1px 2px rgba(24, 24, 27, 0.04)) !important;
 }
 
 body.llm-ops-theme .btn-action-warning {
@@ -208,10 +204,10 @@ body.llm-ops-theme .batch-action {
 }
 
 body.llm-ops-theme .batch-action-primary {
-  border-color: #4f46e5 !important;
-  background: linear-gradient(135deg, #5b4bdb, #4338ca) !important;
-  color: #ffffff !important;
-  box-shadow: 0 8px 20px rgba(79, 70, 229, 0.16) !important;
+  border-color: var(--ui-color-primary, #5f4ecf) !important;
+  background: var(--ui-color-primary, #5f4ecf) !important;
+  color: var(--ui-text-on-brand, #ffffff) !important;
+  box-shadow: var(--ui-shadow-xs, 0 1px 2px rgba(24, 24, 27, 0.04)) !important;
 }
 
 body.llm-ops-theme .batch-action-success {
@@ -256,7 +252,7 @@ body.llm-ops-theme .btn-danger:hover:not(:disabled) {
   background: #ffe4e6 !important;
   color: #9f1239 !important;
   box-shadow: 0 4px 12px rgba(190, 24, 93, 0.1) !important;
-  transform: translateY(-1px) !important;
+  transform: none !important;
 }
 
 body.llm-ops-theme .btn-ghost {
@@ -339,7 +335,7 @@ body.llm-ops-theme .operation-icon-button {
 }
 
 body.llm-ops-theme .operation-icon-button:hover:not(:disabled) {
-  transform: translateY(-1px) !important;
+  transform: none !important;
 }
 
 body.llm-ops-theme .operation-icon {
@@ -437,4 +433,120 @@ body.llm-ops-theme .link-btn:disabled,
 body.llm-ops-theme .danger-link-btn:disabled {
   background: transparent !important;
   color: #94a3b8 !important;
+}
+
+body.llm-ops-theme .btn-primary,
+body.llm-ops-theme .add-listing-button,
+body.llm-ops-theme .btn-action-create,
+body.llm-ops-theme .btn-action-save,
+body.llm-ops-theme .btn-action-submit,
+body.llm-ops-theme .btn-action-confirm,
+body.llm-ops-theme .batch-action-primary {
+  border-color: var(--ui-color-primary, #5f4ecf) !important;
+  background: var(--ui-color-primary, #5f4ecf) !important;
+  color: var(--ui-text-on-brand, #ffffff) !important;
+  box-shadow: var(--ui-shadow-xs, 0 1px 2px rgba(24, 24, 27, 0.04)) !important;
+}
+
+body.llm-ops-theme .btn-primary:hover:not(:disabled),
+body.llm-ops-theme .add-listing-button:hover:not(:disabled),
+body.llm-ops-theme .btn-action-create:hover:not(:disabled),
+body.llm-ops-theme .btn-action-save:hover:not(:disabled),
+body.llm-ops-theme .btn-action-submit:hover:not(:disabled),
+body.llm-ops-theme .btn-action-confirm:hover:not(:disabled),
+body.llm-ops-theme .batch-action-primary:hover:not(:disabled) {
+  border-color: var(--ui-color-primary-hover, #5140bd) !important;
+  background: var(--ui-color-primary-hover, #5140bd) !important;
+  color: var(--ui-text-on-brand, #ffffff) !important;
+  box-shadow: var(--ui-shadow-xs, 0 1px 2px rgba(24, 24, 27, 0.04)) !important;
+  transform: none !important;
+}
+
+body.llm-ops-theme .btn-secondary,
+body.llm-ops-theme .header-back,
+body.llm-ops-theme .batch-action,
+body.llm-ops-theme .btn-action-config,
+body.llm-ops-theme .btn-action-edit,
+body.llm-ops-theme .btn-action-view,
+body.llm-ops-theme .btn-action-neutral,
+body.llm-ops-theme .btn-action-cancel {
+  border-color: var(--ui-border-default, #e4e4e7) !important;
+  background: var(--ui-bg-card, #ffffff) !important;
+  color: var(--ui-text-secondary, #3f3f46) !important;
+  box-shadow: var(--ui-shadow-xs, 0 1px 2px rgba(24, 24, 27, 0.04)) !important;
+}
+
+body.llm-ops-theme .btn-secondary:hover:not(:disabled),
+body.llm-ops-theme .header-back:hover:not(:disabled),
+body.llm-ops-theme .batch-action:hover:not(:disabled),
+body.llm-ops-theme .btn-action-config:hover:not(:disabled),
+body.llm-ops-theme .btn-action-edit:hover:not(:disabled),
+body.llm-ops-theme .btn-action-view:hover:not(:disabled),
+body.llm-ops-theme .btn-action-neutral:hover:not(:disabled),
+body.llm-ops-theme .btn-action-cancel:hover:not(:disabled) {
+  border-color: var(--ui-border-interactive, #8f8f8f) !important;
+  background: var(--ui-bg-muted, #f4f5f8) !important;
+  color: var(--ui-text-primary, #18181b) !important;
+  box-shadow: var(--ui-shadow-xs, 0 1px 2px rgba(24, 24, 27, 0.04)) !important;
+  transform: none !important;
+}
+
+body.llm-ops-theme .btn-action-warning,
+body.llm-ops-theme .batch-action-warn {
+  border-color: color-mix(
+    in srgb,
+    var(--ui-color-warning, #d97706) 28%,
+    var(--ui-border-default, #e4e4e7)
+  ) !important;
+  background: var(--ui-color-warning-subtle, #fffbeb) !important;
+  color: var(--ui-color-warning, #d97706) !important;
+}
+
+body.llm-ops-theme .btn-action-danger,
+body.llm-ops-theme .batch-action-danger,
+body.llm-ops-theme .btn-danger,
+body.llm-ops-theme .btn-text-danger,
+body.llm-ops-theme .danger-link-btn {
+  border-color: color-mix(
+    in srgb,
+    var(--ui-color-destructive, #e11d48) 24%,
+    var(--ui-border-default, #e4e4e7)
+  ) !important;
+  background: var(--ui-color-destructive-subtle, #fff1f2) !important;
+  color: var(--ui-color-destructive, #e11d48) !important;
+  box-shadow: var(--ui-shadow-xs, 0 1px 2px rgba(24, 24, 27, 0.04)) !important;
+}
+
+body.llm-ops-theme .btn-action-refresh,
+body.llm-ops-theme .btn-action-sync,
+body.llm-ops-theme .link-btn {
+  border-color: var(--ui-border-default, #e4e4e7) !important;
+  background: var(--ui-color-info-subtle, #eff6ff) !important;
+  color: var(--ui-color-info, #2563eb) !important;
+  box-shadow: var(--ui-shadow-xs, 0 1px 2px rgba(24, 24, 27, 0.04)) !important;
+}
+
+body.llm-ops-theme .operation-icon-button:hover:not(:disabled) {
+  transform: none !important;
+}
+
+body.llm-ops-theme .btn-primary:disabled,
+body.llm-ops-theme .add-listing-button:disabled {
+  border-color: var(--ui-border-default, #e4e4e7) !important;
+  background: var(--ui-bg-muted, #f4f5f8) !important;
+  color: var(--ui-text-muted, #71717a) !important;
+}
+
+body.llm-ops-theme .btn-secondary:disabled,
+body.llm-ops-theme .btn-danger:disabled,
+body.llm-ops-theme .btn-ghost:disabled,
+body.llm-ops-theme .btn-text-danger:disabled,
+body.llm-ops-theme .batch-action:disabled,
+body.llm-ops-theme .header-back:disabled,
+body.llm-ops-theme .link-btn:disabled,
+body.llm-ops-theme .danger-link-btn:disabled {
+  border-color: var(--ui-border-default, #e4e4e7) !important;
+  background: var(--ui-bg-muted, #f4f5f8) !important;
+  color: var(--ui-text-muted, #71717a) !important;
+  box-shadow: none !important;
 }

--- a/frontend/src/components/llm-ops/llmOpsModals.css
+++ b/frontend/src/components/llm-ops/llmOpsModals.css
@@ -3,10 +3,10 @@ body.llm-ops-theme .modal-footer {
   flex-direction: column !important;
   align-items: stretch !important;
   gap: 1rem !important;
-  border-top: 1px solid #e2e8f0 !important;
-  background: linear-gradient(180deg, #fcfdff, #f8fafc) !important;
+  border-top: 1px solid var(--ui-border-default, #e4e4e7) !important;
+  background: var(--ui-bg-subtle, #fafbfc) !important;
   padding: 1rem 1.5rem 1.5rem !important;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.9) !important;
+  box-shadow: none !important;
 }
 
 body.llm-ops-theme .modal-footer-status {
@@ -25,7 +25,7 @@ body.llm-ops-theme .modal-footer-note {
   display: block !important;
   font-size: 0.75rem !important;
   line-height: 1.25rem !important;
-  color: #64748b !important;
+  color: var(--ui-text-muted, #71717a) !important;
 }
 
 body.llm-ops-theme .modal-footer-actions {
@@ -51,16 +51,20 @@ body.llm-ops-theme .status-inline {
   min-height: 2.75rem !important;
   align-items: center !important;
   gap: 0.75rem !important;
-  border: 1px solid #dbe4f0 !important;
-  border-radius: 0.875rem !important;
-  background: #ffffff !important;
+  border: 1px solid var(--ui-border-default, #e4e4e7) !important;
+  border-radius: var(--ui-radius-card, 12px) !important;
+  background: var(--ui-bg-card, #ffffff) !important;
   padding: 0.625rem 0.875rem !important;
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04) !important;
+  box-shadow: var(--ui-shadow-xs, 0 1px 2px rgba(24, 24, 27, 0.04)) !important;
 }
 
 body.llm-ops-theme .status-inline.active {
-  border-color: #bbf7d0 !important;
-  background: #f0fdf4 !important;
+  border-color: color-mix(
+    in srgb,
+    var(--ui-color-success, #059669) 28%,
+    var(--ui-border-default, #e4e4e7)
+  ) !important;
+  background: var(--ui-color-success-subtle, #ecfdf5) !important;
 }
 
 body.llm-ops-theme .status-switch {
@@ -69,21 +73,21 @@ body.llm-ops-theme .status-switch {
   width: 2.5rem !important;
   align-items: center !important;
   border-radius: 9999px !important;
-  background: #cbd5e1 !important;
+  background: var(--ui-border-interactive, #8f8f8f) !important;
   padding: 0.125rem !important;
   transition: background-color 150ms ease !important;
 }
 
 body.llm-ops-theme .status-inline.active .status-switch {
-  background: #22c55e !important;
+  background: var(--ui-color-success, #059669) !important;
 }
 
 body.llm-ops-theme .status-switch-dot {
   height: 1.125rem !important;
   width: 1.125rem !important;
   border-radius: 9999px !important;
-  background: #ffffff !important;
-  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.16) !important;
+  background: var(--ui-bg-card, #ffffff) !important;
+  box-shadow: var(--ui-shadow-xs, 0 1px 2px rgba(24, 24, 27, 0.04)) !important;
   transition: transform 150ms ease !important;
 }
 

--- a/frontend/src/components/llm-ops/llmOpsSelects.css
+++ b/frontend/src/components/llm-ops/llmOpsSelects.css
@@ -1,0 +1,228 @@
+body.llm-ops-theme {
+  --llm-select-height: 2.5rem;
+  --llm-select-height-sm: 2rem;
+  --llm-select-bg: var(--ui-bg-card, #ffffff);
+  --llm-select-bg-hover: var(--ui-bg-subtle, #fafafa);
+  --llm-select-border: var(--ui-border-default, #dedee3);
+  --llm-select-border-hover: var(--ui-border-interactive, #8f8f8f);
+  --llm-select-ring: color-mix(
+    in srgb,
+    var(--ui-color-primary, #5f4ecf) 16%,
+    transparent
+  );
+}
+
+body.llm-ops-theme .compact-select {
+  min-width: 0 !important;
+}
+
+body.llm-ops-theme .compact-select-trigger,
+body.llm-ops-theme .searchable-trigger,
+body.llm-ops-theme .field-select,
+body.llm-ops-theme .workflow-node-select,
+body.llm-ops-theme .pagination-select,
+body.llm-ops-theme .export-format-select,
+body.llm-ops-theme .config-field select,
+body.llm-ops-theme select.field-input {
+  min-height: var(--llm-select-height) !important;
+  border: 1px solid var(--llm-select-border) !important;
+  border-radius: var(--ui-radius-control, 8px) !important;
+  background-color: var(--llm-select-bg) !important;
+  color: var(--ui-text-secondary, #3f3f46) !important;
+  font-family: var(--ui-font-body, Inter, system-ui, sans-serif) !important;
+  font-size: 0.8125rem !important;
+  font-weight: 600 !important;
+  letter-spacing: 0 !important;
+  line-height: 1.25rem !important;
+  box-shadow: var(--ui-shadow-xs, 0 1px 2px rgba(24, 24, 27, 0.04)) !important;
+  transition:
+    background-color var(--ui-duration-fast, 150ms) var(--ui-ease-out, ease),
+    border-color var(--ui-duration-fast, 150ms) var(--ui-ease-out, ease),
+    box-shadow var(--ui-duration-fast, 150ms) var(--ui-ease-out, ease),
+    color var(--ui-duration-fast, 150ms) var(--ui-ease-out, ease) !important;
+}
+
+body.llm-ops-theme .compact-select-trigger,
+body.llm-ops-theme .searchable-trigger {
+  align-items: center !important;
+  justify-content: space-between !important;
+  gap: var(--ui-space-inline, 8px) !important;
+  padding: 0.5rem 0.75rem !important;
+}
+
+body.llm-ops-theme .field-select,
+body.llm-ops-theme .workflow-node-select,
+body.llm-ops-theme .pagination-select,
+body.llm-ops-theme .export-format-select,
+body.llm-ops-theme .config-field select,
+body.llm-ops-theme select.field-input {
+  appearance: none !important;
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M4 6L8 10L12 6' stroke='%237a7a85' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E") !important;
+  background-position: right 0.625rem center !important;
+  background-repeat: no-repeat !important;
+  background-size: 1rem 1rem !important;
+  padding-left: 0.75rem !important;
+  padding-right: 2rem !important;
+}
+
+body.llm-ops-theme .compact-select-sm {
+  min-height: var(--llm-select-height-sm) !important;
+  padding: 0.375rem 0.625rem !important;
+  font-size: 0.75rem !important;
+  line-height: 1rem !important;
+}
+
+body.llm-ops-theme .compact-select-trigger:hover:not(:disabled),
+body.llm-ops-theme .searchable-trigger:hover:not(:disabled),
+body.llm-ops-theme .field-select:hover:not(:disabled),
+body.llm-ops-theme .workflow-node-select:hover:not(:disabled),
+body.llm-ops-theme .pagination-select:hover:not(:disabled),
+body.llm-ops-theme .export-format-select:hover:not(:disabled),
+body.llm-ops-theme .config-field select:hover:not(:disabled),
+body.llm-ops-theme select.field-input:hover:not(:disabled) {
+  border-color: var(--llm-select-border-hover) !important;
+  background-color: var(--llm-select-bg-hover) !important;
+  color: var(--ui-text-primary, #18181b) !important;
+}
+
+body.llm-ops-theme .compact-select-trigger:focus,
+body.llm-ops-theme .compact-select-trigger:focus-visible,
+body.llm-ops-theme .searchable-trigger:focus,
+body.llm-ops-theme .searchable-trigger:focus-visible,
+body.llm-ops-theme .field-select:focus,
+body.llm-ops-theme .workflow-node-select:focus,
+body.llm-ops-theme .pagination-select:focus,
+body.llm-ops-theme .export-format-select:focus,
+body.llm-ops-theme .config-field select:focus,
+body.llm-ops-theme select.field-input:focus {
+  border-color: var(--ui-color-primary, #5f4ecf) !important;
+  background-color: var(--llm-select-bg) !important;
+  color: var(--ui-text-primary, #18181b) !important;
+  outline: none !important;
+  box-shadow: 0 0 0 3px var(--llm-select-ring) !important;
+}
+
+body.llm-ops-theme .compact-select-disabled,
+body.llm-ops-theme .compact-select-trigger:disabled,
+body.llm-ops-theme .searchable-trigger:disabled,
+body.llm-ops-theme .field-select:disabled,
+body.llm-ops-theme .workflow-node-select:disabled,
+body.llm-ops-theme .pagination-select:disabled,
+body.llm-ops-theme .export-format-select:disabled,
+body.llm-ops-theme .config-field select:disabled,
+body.llm-ops-theme select.field-input:disabled {
+  cursor: not-allowed !important;
+  border-color: var(--ui-border-soft, #ededf0) !important;
+  background-color: var(--ui-bg-muted, #f5f5f6) !important;
+  color: var(--ui-text-muted, #7a7a85) !important;
+  box-shadow: none !important;
+}
+
+body.llm-ops-theme .compact-select-caret,
+body.llm-ops-theme .dropdown-caret {
+  color: var(--ui-text-muted, #7a7a85) !important;
+  font-size: 0.75rem !important;
+  line-height: 1 !important;
+}
+
+body.llm-ops-theme .compact-select-menu,
+body.llm-ops-theme .searchable-menu {
+  z-index: 70 !important;
+  overflow: hidden !important;
+  border: 1px solid var(--ui-border-default, #dedee3) !important;
+  border-radius: var(--ui-radius-card, 12px) !important;
+  background-color: var(--ui-bg-card, #ffffff) !important;
+  padding: 0.375rem !important;
+  box-shadow: var(--ui-shadow-card, 0 1px 2px rgba(24, 24, 27, 0.04)) !important;
+}
+
+body.llm-ops-theme .compact-select-menu {
+  overflow-y: auto !important;
+}
+
+body.llm-ops-theme .searchable-list {
+  border-top-color: var(--ui-border-soft, #ededf0) !important;
+  padding: 0.25rem !important;
+}
+
+body.llm-ops-theme .compact-select-search,
+body.llm-ops-theme .searchable-input {
+  min-height: var(--llm-select-height-sm) !important;
+  border: 1px solid var(--ui-border-default, #dedee3) !important;
+  border-radius: var(--ui-radius-control, 8px) !important;
+  background-color: var(--ui-bg-subtle, #fafafa) !important;
+  color: var(--ui-text-primary, #18181b) !important;
+  font-size: 0.8125rem !important;
+  line-height: 1.25rem !important;
+  outline: none !important;
+  box-shadow: none !important;
+}
+
+body.llm-ops-theme .compact-select-search:focus,
+body.llm-ops-theme .searchable-input:focus {
+  border-color: var(--ui-color-primary, #5f4ecf) !important;
+  background-color: var(--ui-bg-card, #ffffff) !important;
+  box-shadow: 0 0 0 3px var(--llm-select-ring) !important;
+}
+
+body.llm-ops-theme .compact-select-option,
+body.llm-ops-theme .searchable-option {
+  min-height: 2rem !important;
+  border-radius: var(--ui-radius-control, 8px) !important;
+  padding: 0.5rem 0.625rem !important;
+  color: var(--ui-text-secondary, #3f3f46) !important;
+  font-size: 0.8125rem !important;
+  font-weight: 600 !important;
+  line-height: 1.25rem !important;
+}
+
+body.llm-ops-theme .compact-select-option:hover:not(:disabled),
+body.llm-ops-theme .searchable-option:hover {
+  background-color: var(--ui-bg-subtle, #fafafa) !important;
+  color: var(--ui-text-primary, #18181b) !important;
+}
+
+body.llm-ops-theme .compact-select-option-active,
+body.llm-ops-theme .searchable-option-active {
+  background-color: var(--ui-color-primary-subtle, #f0eefb) !important;
+  color: var(--ui-color-primary-hover, #5140bd) !important;
+}
+
+body.llm-ops-theme .compact-select-option-disabled {
+  color: var(--ui-text-muted, #7a7a85) !important;
+}
+
+body.llm-ops-theme .compact-select-option-group {
+  min-height: auto !important;
+  background: transparent !important;
+  padding: 0.5rem 0.625rem 0.25rem !important;
+}
+
+body.llm-ops-theme .compact-select-group-label,
+body.llm-ops-theme .searchable-meta {
+  color: var(--ui-text-muted, #7a7a85) !important;
+  font-size: 0.6875rem !important;
+  font-weight: 700 !important;
+  letter-spacing: 0.08em !important;
+}
+
+body.llm-ops-theme .compact-select-check,
+body.llm-ops-theme .searchable-meta-actions button {
+  color: var(--ui-color-primary, #5f4ecf) !important;
+}
+
+body.llm-ops-theme .compact-select-badge,
+body.llm-ops-theme .option-provider {
+  border: 1px solid var(--ui-border-default, #dedee3) !important;
+  border-radius: var(--ui-radius-pill, 9999px) !important;
+  background-color: var(--ui-bg-muted, #f5f5f6) !important;
+  color: var(--ui-text-muted, #7a7a85) !important;
+  font-size: 0.6875rem !important;
+  font-weight: 600 !important;
+}
+
+body.llm-ops-theme .compact-select-empty,
+body.llm-ops-theme .searchable-empty {
+  color: var(--ui-text-muted, #7a7a85) !important;
+  font-size: 0.75rem !important;
+}

--- a/frontend/src/components/llm-ops/llmOpsTables.css
+++ b/frontend/src/components/llm-ops/llmOpsTables.css
@@ -1,45 +1,45 @@
 body.llm-ops-theme .data-table,
 body.llm-ops-theme .preview-table {
   width: 100%;
-  border-collapse: separate;
+  border-collapse: collapse;
   border-spacing: 0;
-  color: #475569;
+  color: var(--ui-text-secondary, #3f3f46);
   font-size: 13px;
   line-height: 1.45;
 }
 
 body.llm-ops-theme .data-table thead,
 body.llm-ops-theme .preview-table thead {
-  background: #f8fafc;
+  background: var(--ui-bg-subtle, #fafbfc);
 }
 
 body.llm-ops-theme .data-table tbody,
 body.llm-ops-theme .preview-table tbody {
-  background: #ffffff;
+  background: var(--ui-bg-card, #ffffff);
 }
 
 body.llm-ops-theme .data-table tbody tr,
 body.llm-ops-theme .preview-table tbody tr {
-  background: #ffffff;
+  background: var(--ui-bg-card, #ffffff);
   transition: background-color 0.14s ease;
 }
 
 body.llm-ops-theme .data-table tbody tr:hover,
 body.llm-ops-theme .preview-table tbody tr:hover {
-  background: #f8fafc;
+  background: var(--ui-bg-subtle, #fafbfc);
 }
 
 body.llm-ops-theme .data-table th,
 body.llm-ops-theme .data-table .table-head,
 body.llm-ops-theme .preview-table th {
   height: 40px;
-  border-bottom: 1px solid #e2e8f0;
-  background: #f8fafc;
-  color: #64748b;
+  border-bottom: 1px solid var(--ui-border-default, #e4e4e7);
+  background: var(--ui-bg-subtle, #fafbfc);
+  color: var(--ui-text-muted, #71717a);
   font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.025em;
-  line-height: 1.2;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  line-height: 1.4;
   padding: 0.625rem 1rem;
   text-align: center;
   text-transform: uppercase;
@@ -49,8 +49,8 @@ body.llm-ops-theme .preview-table th {
 body.llm-ops-theme .data-table td,
 body.llm-ops-theme .data-table .table-cell,
 body.llm-ops-theme .preview-table td {
-  border-bottom: 1px solid #f1f5f9;
-  color: #475569;
+  border-bottom: 1px solid var(--ui-border-soft, #f0f0f2);
+  color: var(--ui-text-secondary, #3f3f46);
   font-size: 13px;
   font-weight: 400;
   line-height: 1.45;
@@ -79,30 +79,30 @@ body.llm-ops-theme .data-table .font-mono,
 body.llm-ops-theme .preview-table .font-mono,
 body.llm-ops-theme .model-code,
 body.llm-ops-theme .sku-code {
-  color: #64748b;
+  color: var(--ui-text-muted, #71717a);
   font-family:
-    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
-    "Courier New", monospace;
+    var(--ui-font-mono, "IBM Plex Mono"), ui-monospace, SFMono-Regular, Menlo,
+    Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   font-size: 12px;
   letter-spacing: 0;
 }
 
 body.llm-ops-theme .data-table .font-medium,
 body.llm-ops-theme .preview-table .font-medium {
-  color: #0f172a;
+  color: var(--ui-text-primary, #18181b);
   font-weight: 600;
 }
 
 body.llm-ops-theme .data-table td[colspan],
 body.llm-ops-theme .preview-table td[colspan] {
-  color: #94a3b8;
+  color: var(--ui-text-muted, #71717a);
   font-size: 13px;
   padding: 1.5rem 1rem;
   text-align: center;
 }
 
 body.llm-ops-theme .data-table .detail-cell {
-  background: #f8fafc;
+  background: var(--ui-bg-subtle, #fafbfc);
   padding: 0.875rem 1rem;
 }
 

--- a/frontend/src/pages/LLMOps.vue
+++ b/frontend/src/pages/LLMOps.vue
@@ -1,11 +1,11 @@
 <template>
   <AppLayout :show-sidebar="false" :full-bleed="true">
-    <div class="h-full min-h-[calc(100vh-4rem)] bg-slate-50">
+    <div class="llm-ops-page h-full min-h-[calc(100vh-4rem)] bg-slate-50">
       <div class="flex h-full min-h-[calc(100vh-4rem)] w-full gap-0">
         <aside
-          class="fixed bottom-0 left-0 top-16 z-20 hidden w-72 flex-col overflow-hidden bg-slate-950 text-white shadow-sm lg:flex"
+          class="llm-ops-sidebar fixed bottom-0 left-0 top-16 z-20 hidden w-72 flex-col overflow-hidden text-white lg:flex"
         >
-          <div class="border-b border-slate-800 px-5 py-5">
+          <div class="llm-ops-sidebar-brand px-5 py-5">
             <p
               class="text-[11px] font-bold uppercase tracking-[0.18em] text-agione-300"
             >
@@ -31,12 +31,8 @@
                   v-for="item in group.items"
                   :key="item.key"
                   type="button"
-                  class="flex w-full items-center gap-2.5 rounded-lg px-3 py-2.5 text-left text-sm font-medium transition"
-                  :class="
-                    activeSection === item.key
-                      ? 'bg-agione-600 text-white shadow-sm'
-                      : 'text-slate-400 hover:bg-slate-900 hover:text-white'
-                  "
+                  class="llm-nav-item flex w-full items-center gap-2.5 px-3 py-2.5 text-left text-sm font-medium"
+                  :class="{ 'is-active': activeSection === item.key }"
                   @click="activeSection = item.key"
                 >
                   <svg
@@ -59,9 +55,9 @@
         </aside>
 
         <main
-          class="min-w-0 flex-1 border-l border-slate-200 bg-white shadow-sm lg:ml-72"
+          class="llm-ops-content min-w-0 flex-1 lg:ml-72"
         >
-          <header class="border-b border-slate-200 px-5 py-3 lg:px-7">
+          <header class="llm-ops-header px-5 py-3 lg:px-7">
             <div class="page-hero">
               <div class="page-hero-copy">
                 <div class="space-y-3 lg:hidden">
@@ -76,12 +72,8 @@
                         v-for="item in group.items"
                         :key="item.key"
                         type="button"
-                        class="rounded-lg px-3 py-2 text-xs font-semibold"
-                        :class="
-                          activeSection === item.key
-                            ? 'bg-agione-600 text-white'
-                            : 'bg-slate-100 text-slate-600'
-                        "
+                        class="llm-mobile-nav-item px-3 py-2 text-xs font-semibold"
+                        :class="{ 'is-active': activeSection === item.key }"
                         @click="activeSection = item.key"
                       >
                         {{ item.label }}
@@ -180,7 +172,7 @@
           <div
             v-else
             :class="[
-              'px-5 py-5 lg:px-7',
+              'llm-ops-body px-5 py-5 lg:px-7',
               activeSection === 'audit'
                 ? 'flex h-[calc(100vh-10.75rem)] min-h-0 flex-col'
                 : 'space-y-6'
@@ -198,7 +190,7 @@
                       <p class="text-xs font-medium text-slate-500">
                         {{ item.label }}
                       </p>
-                      <p class="mt-2 text-2xl font-semibold text-slate-900">
+                      <p class="kpi-value mt-2 text-2xl font-semibold">
                         {{ item.value }}
                       </p>
                     </div>
@@ -669,6 +661,7 @@
 <script setup>
 import '@/components/llm-ops/llmOpsButtons.css'
 import '@/components/llm-ops/llmOpsModals.css'
+import '@/components/llm-ops/llmOpsSelects.css'
 import '@/components/llm-ops/llmOpsTables.css'
 
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
@@ -2039,6 +2032,50 @@ onBeforeUnmount(() => {
 
 <style scoped>
 :global(body.llm-ops-theme) {
+  --ui-bg-page: #ffffff;
+  --ui-bg-card: #ffffff;
+  --ui-bg-muted: #f5f5f6;
+  --ui-bg-subtle: #fafafa;
+  --ui-sidebar-bg: #020617;
+  --ui-sidebar-border: #1e293b;
+  --ui-sidebar-active-bg: #5f4ecf;
+  --ui-sidebar-hover-bg: #0f172a;
+  --ui-sidebar-text: #94a3b8;
+  --ui-sidebar-text-active: #ffffff;
+  --ui-sidebar-text-muted: #64748b;
+  --ui-text-primary: #18181b;
+  --ui-text-secondary: #3f3f46;
+  --ui-text-muted: #7a7a85;
+  --ui-text-on-brand: #ffffff;
+  --ui-color-primary: #5f4ecf;
+  --ui-color-primary-hover: #5140bd;
+  --ui-color-primary-subtle: #f0eefb;
+  --ui-color-info: #2563eb;
+  --ui-color-info-subtle: #eff6ff;
+  --ui-color-success: #059669;
+  --ui-color-success-subtle: #ecfdf5;
+  --ui-color-warning: #d97706;
+  --ui-color-warning-subtle: #fffbeb;
+  --ui-color-destructive: #e11d48;
+  --ui-color-destructive-subtle: #fff1f2;
+  --ui-border-default: #dedee3;
+  --ui-border-soft: #ededf0;
+  --ui-border-interactive: #8f8f8f;
+  --ui-radius-control: 8px;
+  --ui-radius-card: 12px;
+  --ui-radius-pill: 9999px;
+  --ui-space-inline: 8px;
+  --ui-space-control: 12px;
+  --ui-space-card: 20px;
+  --ui-space-section: 24px;
+  --ui-shadow-xs: 0 1px 2px rgba(24, 24, 27, 0.04);
+  --ui-shadow-card: 0 1px 2px rgba(24, 24, 27, 0.04);
+  --ui-duration-fast: 150ms;
+  --ui-ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --ui-font-heading: Manrope, Inter, system-ui, sans-serif;
+  --ui-font-body: Inter, "Noto Sans SC", system-ui, sans-serif;
+  --ui-font-mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo,
+    monospace;
   padding: 0 !important;
 }
 
@@ -2494,11 +2531,10 @@ onBeforeUnmount(() => {
 }
 
 .refresh-action-button:hover:not(:disabled) {
-  border-color: #a5b4fc;
-  background-color: #eef2ff;
-  color: #4338ca;
-  box-shadow: 0 8px 18px rgba(79, 70, 229, 0.12);
-  transform: translateY(-1px);
+  border-color: var(--ui-color-primary);
+  background-color: var(--ui-color-primary-subtle);
+  color: var(--ui-color-primary-hover);
+  box-shadow: var(--ui-shadow-xs);
 }
 
 .refresh-action-button:disabled {
@@ -2853,8 +2889,8 @@ onBeforeUnmount(() => {
 }
 
 .status-pill.info {
-  background-color: #000;
-  color: #000;
+  background-color: var(--ui-color-info-subtle);
+  color: var(--ui-color-info);
 }
 
 .status-pill.warn {
@@ -2865,5 +2901,304 @@ onBeforeUnmount(() => {
 .status-pill.danger {
   background-color: #fff1f2;
   color: #be123c;
+}
+
+.llm-ops-page {
+  background: var(--ui-bg-page);
+  color: var(--ui-text-primary);
+  font-family: var(--ui-font-body);
+}
+
+.llm-ops-sidebar {
+  background: var(--ui-sidebar-bg);
+  border-right: 1px solid var(--ui-sidebar-border);
+  box-shadow: var(--ui-shadow-xs);
+  color: var(--ui-sidebar-text-active);
+}
+
+.llm-ops-sidebar-brand {
+  border-bottom: 1px solid var(--ui-sidebar-border);
+  padding-bottom: var(--ui-space-card);
+}
+
+.llm-ops-sidebar-brand p:first-child {
+  color: #8b7dd1;
+  letter-spacing: 0.18em;
+}
+
+.llm-ops-sidebar-brand h1 {
+  color: var(--ui-sidebar-text-active);
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: 0;
+}
+
+.llm-ops-sidebar-brand p:last-child {
+  color: var(--ui-sidebar-text);
+}
+
+.llm-nav-item,
+.llm-mobile-nav-item {
+  border-radius: var(--ui-radius-control);
+  color: var(--ui-sidebar-text);
+  transition:
+    background-color var(--ui-duration-fast) var(--ui-ease-out),
+    color var(--ui-duration-fast) var(--ui-ease-out),
+    box-shadow var(--ui-duration-fast) var(--ui-ease-out);
+}
+
+.llm-nav-item:hover,
+.llm-mobile-nav-item:hover {
+  background: var(--ui-sidebar-hover-bg);
+  color: var(--ui-sidebar-text-active);
+}
+
+.llm-nav-item.is-active,
+.llm-mobile-nav-item.is-active {
+  background: var(--ui-sidebar-active-bg);
+  color: var(--ui-sidebar-text-active);
+  box-shadow: var(--ui-shadow-xs);
+}
+
+.llm-mobile-nav-item {
+  background: var(--ui-bg-muted);
+  color: var(--ui-text-secondary);
+}
+
+.llm-ops-content {
+  background: var(--ui-bg-page);
+  border-left: 0;
+}
+
+.llm-ops-header {
+  background: var(--ui-bg-card);
+  border-bottom: 1px solid var(--ui-border-default);
+}
+
+.llm-ops-body {
+  background: var(--ui-bg-page);
+}
+
+.page-hero {
+  gap: var(--ui-space-control);
+  min-height: 7.5rem;
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+}
+
+.page-hero-eyebrow {
+  display: none;
+}
+
+.page-hero-title {
+  color: var(--ui-text-primary);
+  font-family: var(--ui-font-heading);
+  font-size: 24px;
+  font-weight: 800;
+  letter-spacing: 0;
+  line-height: 1.25;
+}
+
+.page-hero-description {
+  color: var(--ui-text-muted);
+  font-size: 13px;
+  line-height: 1.5;
+  max-width: 36rem;
+  white-space: normal;
+}
+
+.panel,
+.kpi-card,
+.coverage-row,
+.provider-card {
+  background: var(--ui-bg-card);
+  border: 1px solid var(--ui-border-default);
+  border-radius: var(--ui-radius-card);
+  box-shadow: none;
+}
+
+.panel {
+  padding: var(--ui-space-card);
+}
+
+.kpi-card {
+  min-height: 8.75rem;
+  padding: var(--ui-space-card);
+}
+
+.kpi-value {
+  color: var(--ui-text-primary);
+  font-family: var(--ui-font-mono);
+  font-size: 28px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.kpi-tone,
+.badge-ok,
+.badge-muted,
+.status-pill {
+  border-radius: var(--ui-radius-pill);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.35;
+}
+
+.kpi-tone.good,
+.badge-ok,
+.status-pill.success {
+  background: var(--ui-color-success-subtle);
+  color: var(--ui-color-success);
+}
+
+.kpi-tone.warn,
+.status-pill.warn {
+  background: var(--ui-color-warning-subtle);
+  color: var(--ui-color-warning);
+}
+
+.kpi-tone.danger,
+.status-pill.danger {
+  background: var(--ui-color-destructive-subtle);
+  color: var(--ui-color-destructive);
+}
+
+.badge-muted {
+  background: var(--ui-bg-muted);
+  border-color: var(--ui-border-default);
+  color: var(--ui-text-muted);
+}
+
+.status-pill.info {
+  background: var(--ui-color-info-subtle);
+  color: var(--ui-color-info);
+}
+
+.table-toolbar {
+  background: var(--ui-bg-card);
+  border-bottom-color: var(--ui-border-default);
+  padding: var(--ui-space-control) var(--ui-space-card);
+}
+
+.panel-title {
+  color: var(--ui-text-primary);
+  font-family: var(--ui-font-heading);
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 1.4;
+}
+
+.data-table {
+  background: var(--ui-bg-card);
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.data-table tr {
+  background: var(--ui-bg-card);
+}
+
+.table-head {
+  background: var(--ui-bg-subtle);
+  border-bottom: 1px solid var(--ui-border-default);
+  color: var(--ui-text-muted);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  line-height: 1.4;
+}
+
+.table-cell {
+  border-bottom: 1px solid var(--ui-border-soft);
+  color: var(--ui-text-secondary);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.currency-control,
+.field-sm,
+.page-toolbar-chip {
+  background: var(--ui-bg-card);
+  border: 1px solid var(--ui-border-interactive);
+  border-radius: var(--ui-radius-control);
+  color: var(--ui-text-muted);
+}
+
+.currency-control select,
+.metric-line strong {
+  color: var(--ui-text-primary);
+  font-family: var(--ui-font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.action-row {
+  background: var(--ui-bg-card);
+  border: 1px solid var(--ui-border-default);
+  border-radius: var(--ui-radius-card);
+}
+
+.action-row:hover {
+  background: var(--ui-bg-subtle);
+  border-color: var(--ui-border-interactive);
+}
+
+.metric-line {
+  color: var(--ui-text-muted);
+  font-size: 13px;
+}
+
+.icon-mark {
+  border-radius: 4px;
+}
+
+.llm-ops-sidebar nav p {
+  color: var(--ui-sidebar-text-muted);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.llm-ops-sidebar .nav-icon {
+  color: currentColor;
+}
+
+.llm-nav-item.is-active .nav-icon {
+  color: var(--ui-sidebar-text-active);
+}
+
+.llm-ops-body {
+  padding-top: var(--ui-space-section);
+}
+
+.llm-ops-body .grid:first-child {
+  gap: var(--ui-space-card);
+}
+
+.llm-ops-body .panel .text-agione-600 {
+  color: var(--ui-text-muted);
+  font-size: 12px;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.llm-ops-body .panel h3 {
+  color: var(--ui-text-primary);
+  font-size: 20px;
+  font-weight: 800;
+  letter-spacing: 0;
+}
+
+.coverage-row,
+.provider-card {
+  background: var(--ui-bg-card);
+  padding: var(--ui-space-card);
+}
+
+.page-toolbar-control,
+.page-toolbar-button,
+.page-toolbar-chip {
+  min-height: 44px;
 }
 </style>


### PR DESCRIPTION
## Summary
- Refresh LLM Ops page shell, cards, tables, buttons, and modal styling with scoped UI tokens
- Add unified dropdown/select styling for LLM Ops controls
- Keep global header and LLM Ops sidebar colors aligned with main branch behavior

## Test plan
- [x] npm run build
- [x] git diff --check
- [x] Playwright smoke test for /llm-ops dropdown rendering