### PR TITLE
Optimize LLM Ops operations overview

### DIFF
--- a/backend/llm_ops/tests/test_views.py
+++ b/backend/llm_ops/tests/test_views.py
@@ -2679,6 +2679,16 @@ class LLMOpsViewTests(TestCase):
         self.assertEqual(diagnostic["status"], "low_coverage")
         self.assertTrue(diagnostic["is_agione_listed"])
         self.assertTrue(diagnostic["has_lowest_listing"])
+        self.assertEqual(response.data["kpis"]["active_models"], 1)
+        self.assertEqual(response.data["kpis"]["active_channels"], 1)
+        self.assertEqual(
+            response.data["kpis"]["current_platform_listings"],
+            1,
+        )
+        self.assertEqual(
+            response.data["kpis"]["current_platform_listed_models"],
+            1,
+        )
         self.assertEqual(
             response.data["point_conversion"]["points_per_currency_unit"],
             100.0,
@@ -2746,6 +2756,14 @@ class LLMOpsViewTests(TestCase):
         diagnostic = response.data["agione"]["diagnostics"][0]
         self.assertFalse(diagnostic["is_agione_listed"])
         self.assertEqual(diagnostic["status"], "unlisted")
+        self.assertEqual(
+            response.data["kpis"]["current_platform_listings"],
+            0,
+        )
+        self.assertEqual(
+            response.data["kpis"]["current_platform_listed_models"],
+            0,
+        )
 
     def test_summary_converts_cross_currency_channel_options(self):
         provider = LLMProvider.objects.create(name="OpenAI", code="openai")

--- a/backend/llm_ops/views.py
+++ b/backend/llm_ops/views.py
@@ -2801,6 +2801,12 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
         agione_listed_model_count = len(
             {listing.model_id for listing in selected_platform_listing_rows}
         )
+        selected_platform_listing_count = len(selected_platform_listing_rows)
+        enabled_price_source_count = (
+            PriceCollectionSource.objects.filter(is_enabled=True)
+            .exclude(source_type=PriceCollectionSource.SOURCE_TYPE_AGIONE)
+            .count()
+        )
 
         status_counts = {
             item["status"]: item["count"]
@@ -2815,8 +2821,25 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
                     "models": LLMModel.objects.count(),
                     "channels": ProcurementChannel.objects.count(),
                     "listings": ResaleListing.objects.count(),
+                    "active_providers": LLMProvider.objects.filter(
+                        is_active=True,
+                    ).count(),
                     "active_models": total_models,
+                    "active_channels": len(channels),
+                    "active_resale_platforms": ResalePlatform.objects.filter(
+                        is_active=True,
+                    ).count(),
+                    "active_listings": ResaleListing.objects.filter(
+                        is_active=True,
+                    ).count(),
+                    "enabled_price_sources": enabled_price_source_count,
                     "agione_listed_models": agione_listed_model_count,
+                    "current_platform_listings": (
+                        selected_platform_listing_count
+                    ),
+                    "current_platform_listed_models": (
+                        agione_listed_model_count
+                    ),
                     "ready_models": ready_count,
                     "reconciliation_anomalies": (
                         UsageReconciliationRecord.objects.exclude(

--- a/frontend/src/api/llmOps.js
+++ b/frontend/src/api/llmOps.js
@@ -173,6 +173,13 @@ export const llmOpsApi = {
     return apiClient.get(`${base}/channel-price-items/`, paramsOrEmpty(params))
   },
 
+  listChannelModelPriceHistory(params) {
+    return apiClient.get(
+      `${base}/channel-model-price-history/`,
+      paramsOrEmpty(params)
+    )
+  },
+
   bulkUpsertChannelModelPrices(items) {
     return apiClient.post(`${base}/channel-model-prices/bulk-upsert/`, {
       items
@@ -217,6 +224,13 @@ export const llmOpsApi = {
 
   listResaleListings(params) {
     return apiClient.get(`${base}/resale-listings/`, paramsOrEmpty(params))
+  },
+
+  listResaleListingPriceHistory(params) {
+    return apiClient.get(
+      `${base}/resale-listing-price-history/`,
+      paramsOrEmpty(params)
+    )
   },
 
   bulkUpsertResaleListings(items) {

--- a/frontend/src/components/llm-ops/ChannelPriceMatrixPanel.vue
+++ b/frontend/src/components/llm-ops/ChannelPriceMatrixPanel.vue
@@ -1,0 +1,204 @@
+<template>
+  <section class="space-y-4">
+    <div class="panel">
+      <div
+        class="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between"
+      >
+        <div>
+          <h3 class="panel-title">渠道横向比价矩阵</h3>
+          <p class="mt-1 text-xs text-slate-500">
+            按模型比较各渠道采购价格、最低价命中和覆盖缺口。
+          </p>
+        </div>
+        <div class="flex flex-col gap-2 sm:flex-row">
+          <input
+            v-model="keyword"
+            class="llm-ops-input h-9 w-full sm:w-64"
+            placeholder="搜索模型或厂商"
+            type="search"
+          />
+          <CompactSelect
+            v-model="statusFilter"
+            :options="statusFilterOptions"
+            class-name="w-full sm:w-36"
+            size="sm"
+          />
+        </div>
+      </div>
+    </div>
+
+    <div class="grid gap-4 md:grid-cols-4">
+      <div v-for="item in metrics" :key="item.label" class="kpi-card">
+        <p class="text-xs font-medium text-slate-500">{{ item.label }}</p>
+        <p class="kpi-value mt-2 text-2xl font-semibold">{{ item.value }}</p>
+        <p class="mt-2 text-xs text-slate-500">{{ item.hint }}</p>
+      </div>
+    </div>
+
+    <div class="panel overflow-hidden p-0">
+      <div class="overflow-x-auto">
+        <table class="data-table min-w-[980px]">
+          <thead>
+            <tr>
+              <th class="table-head sticky left-0 z-10 bg-white">模型</th>
+              <th
+                v-for="channel in visibleChannels"
+                :key="channel.id"
+                class="table-head text-right"
+              >
+                {{ channel.name }}
+              </th>
+              <th class="table-head text-right">覆盖</th>
+              <th class="table-head">最低价渠道</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="row in filteredRows" :key="row.model_id">
+              <td class="table-cell sticky left-0 z-10 bg-white">
+                <p class="font-medium text-slate-900">{{ row.model_name }}</p>
+                <p class="mt-1 text-xs text-slate-500">
+                  {{ row.provider_name }}
+                </p>
+              </td>
+              <td
+                v-for="channel in visibleChannels"
+                :key="`${row.model_id}-${channel.id}`"
+                class="table-cell text-right"
+              >
+                <span
+                  v-if="optionFor(row, channel)"
+                  :class="[
+                    'font-mono text-xs',
+                    isBest(row, channel) ? 'text-emerald-700' : 'text-slate-700'
+                  ]"
+                >
+                  {{ priceSummary(optionFor(row, channel)) }}
+                </span>
+                <span v-else class="text-xs text-slate-400">-</span>
+              </td>
+              <td class="table-cell text-right font-mono">
+                {{ row.coverage_count || 0 }} / {{ visibleChannels.length }}
+              </td>
+              <td class="table-cell">
+                <span v-if="row.best_channel" class="status-pill success">
+                  {{ row.best_channel.channel_name }}
+                </span>
+                <span v-else class="status-pill danger">缺渠道价</span>
+              </td>
+            </tr>
+            <tr v-if="!filteredRows.length">
+              <td
+                class="table-cell text-slate-500"
+                :colspan="visibleChannels.length + 3"
+              >
+                当前筛选条件下没有模型。
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue'
+
+import CompactSelect from './CompactSelect.vue'
+
+const props = defineProps({
+  summary: { type: Object, default: () => ({}) },
+  channels: { type: Array, default: () => [] }
+})
+
+const keyword = ref('')
+const statusFilter = ref('all')
+const statusFilterOptions = [
+  { label: '全部状态', value: 'all' },
+  { label: '缺渠道价', value: 'missing' },
+  { label: '单渠道覆盖', value: 'single' },
+  { label: '多渠道覆盖', value: 'ready' }
+]
+
+const rows = computed(() => props.summary.agione?.diagnostics || [])
+const visibleChannels = computed(() =>
+  props.channels.filter((channel) => channel.is_active !== false)
+)
+
+const filteredRows = computed(() => {
+  const query = keyword.value.trim().toLowerCase()
+  return rows.value.filter((row) => {
+    const matchesKeyword =
+      !query ||
+      String(row.model_name || '')
+        .toLowerCase()
+        .includes(query) ||
+      String(row.model_code || '')
+        .toLowerCase()
+        .includes(query) ||
+      String(row.provider_name || '')
+        .toLowerCase()
+        .includes(query)
+    if (!matchesKeyword) return false
+    if (statusFilter.value === 'missing') return !row.best_channel
+    if (statusFilter.value === 'single') return row.coverage_count === 1
+    if (statusFilter.value === 'ready') return row.coverage_count > 1
+    return true
+  })
+})
+
+const metrics = computed(() => {
+  const total = rows.value.length
+  const covered = rows.value.filter((row) => row.best_channel).length
+  const single = rows.value.filter((row) => row.coverage_count === 1).length
+  const missing = rows.value.filter((row) => !row.best_channel).length
+  return [
+    {
+      label: '模型总数',
+      value: total,
+      hint: '参与渠道比价的活跃模型'
+    },
+    {
+      label: '有渠道价',
+      value: covered,
+      hint: `覆盖率 ${percentage(covered, total)}%`
+    },
+    {
+      label: '单渠道风险',
+      value: single,
+      hint: '只有一个采购渠道，缺少备选'
+    },
+    {
+      label: '缺渠道价',
+      value: missing,
+      hint: '无法计算采购成本'
+    }
+  ]
+})
+
+function optionFor(row, channel) {
+  return (row.options || []).find(
+    (option) => String(option.channel_id) === String(channel.id)
+  )
+}
+
+function isBest(row, channel) {
+  return String(row.best_channel?.channel_id) === String(channel.id)
+}
+
+function priceSummary(option) {
+  const input = money(option.input_price_per_million, option.currency)
+  const output = money(option.output_price_per_million, option.currency)
+  return `In ${input} / Out ${output}`
+}
+
+function money(value, currency) {
+  if (value === null || value === undefined || value === '') return '-'
+  return `${currency || ''} ${Number(value).toFixed(4)}`
+}
+
+function percentage(value, total) {
+  if (!total) return 0
+  return Math.round((Number(value || 0) / Number(total)) * 100)
+}
+</script>

--- a/frontend/src/components/llm-ops/CollectionHealthPanel.vue
+++ b/frontend/src/components/llm-ops/CollectionHealthPanel.vue
@@ -1,0 +1,241 @@
+<template>
+  <section class="space-y-4">
+    <div class="grid gap-4 md:grid-cols-4">
+      <div v-for="item in metrics" :key="item.label" class="kpi-card">
+        <p class="text-xs font-medium text-slate-500">{{ item.label }}</p>
+        <div class="mt-2 flex items-end justify-between gap-3">
+          <p class="kpi-value text-2xl font-semibold">{{ item.value }}</p>
+          <span :class="['kpi-tone', item.tone]">{{ item.badge }}</span>
+        </div>
+        <p class="mt-2 text-xs text-slate-500">{{ item.hint }}</p>
+      </div>
+    </div>
+
+    <div class="panel overflow-hidden p-0">
+      <div class="table-toolbar">
+        <div>
+          <h3 class="panel-title">采集健康度看板</h3>
+          <p class="mt-1 text-xs text-slate-500">
+            按价格源查看最近采集、连续失败和数据新鲜度。
+          </p>
+        </div>
+      </div>
+      <div class="overflow-x-auto">
+        <table class="data-table">
+          <thead>
+            <tr>
+              <th class="table-head">价格源</th>
+              <th class="table-head">类型</th>
+              <th class="table-head">最近状态</th>
+              <th class="table-head text-right">成功率</th>
+              <th class="table-head text-right">连续失败</th>
+              <th class="table-head">最近采集</th>
+              <th class="table-head">健康状态</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="row in sourceRows" :key="row.id">
+              <td class="table-cell">
+                <p class="font-medium text-slate-900">{{ row.name }}</p>
+                <p class="mt-1 font-mono text-xs text-slate-500">
+                  {{ row.slug }}
+                </p>
+              </td>
+              <td class="table-cell">{{ sourceCategoryLabel(row) }}</td>
+              <td class="table-cell">
+                <span :class="['status-pill', statusTone(row.latestStatus)]">
+                  {{ statusLabel(row.latestStatus) }}
+                </span>
+              </td>
+              <td class="table-cell text-right font-mono">
+                {{ row.successRate }}%
+              </td>
+              <td class="table-cell text-right font-mono">
+                {{ row.consecutiveFailures }}
+              </td>
+              <td class="table-cell">
+                {{ formatDateTime(row.lastCollectedAt) }}
+              </td>
+              <td class="table-cell">
+                <span :class="['status-pill', row.healthTone]">
+                  {{ row.healthLabel }}
+                </span>
+              </td>
+            </tr>
+            <tr v-if="!sourceRows.length">
+              <td class="table-cell text-slate-500" colspan="7">
+                暂无价格源。
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  sources: { type: Array, default: () => [] },
+  runs: { type: Array, default: () => [] }
+})
+
+const sourceRows = computed(() =>
+  props.sources
+    .filter((source) => source.source_type !== 'agione')
+    .map((source) => {
+      const runs = props.runs
+        .filter((run) => String(run.source) === String(source.id))
+        .sort((left, right) => runTime(right) - runTime(left))
+      const succeeded = runs.filter((run) => run.status === 'succeeded').length
+      const latestRun = runs[0] || null
+      const lastCollectedAt =
+        source.last_collected_at ||
+        latestRun?.finished_at ||
+        latestRun?.started_at ||
+        null
+      const stale = isStale(lastCollectedAt)
+      const failures = consecutiveFailures(runs)
+      const health = healthState({
+        enabled: source.is_enabled !== false,
+        stale,
+        failures,
+        latestStatus: latestRun?.status || ''
+      })
+      return {
+        ...source,
+        latestStatus: latestRun?.status || '',
+        successRate: percentage(succeeded, runs.length),
+        consecutiveFailures: failures,
+        lastCollectedAt,
+        healthLabel: health.label,
+        healthTone: health.tone
+      }
+    })
+    .sort((left, right) => {
+      if (left.healthTone !== right.healthTone) {
+        return healthRank(left.healthTone) - healthRank(right.healthTone)
+      }
+      return String(left.name).localeCompare(String(right.name))
+    })
+)
+
+const metrics = computed(() => {
+  const total = sourceRows.value.length
+  const healthy = sourceRows.value.filter(
+    (row) => row.healthTone === 'success'
+  ).length
+  const failed = sourceRows.value.filter(
+    (row) => row.healthTone === 'danger'
+  ).length
+  const stale = sourceRows.value.filter(
+    (row) => row.healthTone === 'warn'
+  ).length
+  return [
+    {
+      label: '价格源总数',
+      value: total,
+      badge: `${percentage(healthy, total)}%`,
+      hint: '启用的官方、供应商和手工价格源',
+      tone: healthy === total && total ? 'good' : 'warn'
+    },
+    {
+      label: '健康价格源',
+      value: healthy,
+      badge: '正常',
+      hint: '最近一次采集成功且未超过新鲜度窗口',
+      tone: healthy ? 'good' : 'warn'
+    },
+    {
+      label: '采集失败',
+      value: failed,
+      badge: failed ? '需处理' : '正常',
+      hint: '最近任务失败或存在连续失败',
+      tone: failed ? 'danger' : 'good'
+    },
+    {
+      label: '数据过期',
+      value: stale,
+      badge: '7天阈值',
+      hint: '最近采集时间超过 7 天',
+      tone: stale ? 'warn' : 'good'
+    }
+  ]
+})
+
+function runTime(run) {
+  return new Date(
+    run.finished_at || run.started_at || run.created_at || 0
+  ).getTime()
+}
+
+function consecutiveFailures(runs) {
+  let count = 0
+  for (const run of runs) {
+    if (run.status !== 'failed') break
+    count += 1
+  }
+  return count
+}
+
+function isStale(value) {
+  if (!value) return true
+  const ageMs = Date.now() - new Date(value).getTime()
+  return ageMs > 7 * 24 * 60 * 60 * 1000
+}
+
+function healthState({ enabled, stale, failures, latestStatus }) {
+  if (!enabled) return { label: '已停用', tone: 'info' }
+  if (failures > 0 || latestStatus === 'failed') {
+    return { label: '采集失败', tone: 'danger' }
+  }
+  if (stale) return { label: '数据过期', tone: 'warn' }
+  return { label: '健康', tone: 'success' }
+}
+
+function healthRank(tone) {
+  return { danger: 1, warn: 2, info: 3, success: 4 }[tone] || 5
+}
+
+function sourceCategoryLabel(source) {
+  const labels = {
+    official_provider: '官方源',
+    supplier: '供应商',
+    manual: '手工',
+    unknown: '未知'
+  }
+  return labels[source.source_category] || source.source_category || '-'
+}
+
+function statusLabel(status) {
+  return (
+    {
+      succeeded: '成功',
+      failed: '失败',
+      running: '运行中'
+    }[status] || '暂无'
+  )
+}
+
+function statusTone(status) {
+  return (
+    {
+      succeeded: 'success',
+      failed: 'danger',
+      running: 'info'
+    }[status] || 'info'
+  )
+}
+
+function percentage(value, total) {
+  if (!total) return 0
+  return Math.round((Number(value || 0) / Number(total)) * 100)
+}
+
+function formatDateTime(value) {
+  if (!value) return '-'
+  return new Date(value).toLocaleString()
+}
+</script>

--- a/frontend/src/components/llm-ops/ListingRiskPanel.vue
+++ b/frontend/src/components/llm-ops/ListingRiskPanel.vue
@@ -1,0 +1,226 @@
+<template>
+  <section class="space-y-4">
+    <div class="grid gap-4 md:grid-cols-4">
+      <div v-for="item in metrics" :key="item.label" class="kpi-card">
+        <p class="text-xs font-medium text-slate-500">{{ item.label }}</p>
+        <p class="kpi-value mt-2 text-2xl font-semibold">{{ item.value }}</p>
+        <p class="mt-2 text-xs text-slate-500">{{ item.hint }}</p>
+      </div>
+    </div>
+
+    <div class="panel overflow-hidden p-0">
+      <div class="table-toolbar">
+        <div>
+          <h3 class="panel-title">挂售利润风险榜</h3>
+          <p class="mt-1 text-xs text-slate-500">
+            聚合低毛利、非最低采购、未挂售和币种换算风险。
+          </p>
+        </div>
+        <CompactSelect
+          v-model="riskFilter"
+          :options="riskFilterOptions"
+          class-name="w-36"
+          size="sm"
+        />
+      </div>
+      <div class="overflow-x-auto">
+        <table class="data-table">
+          <thead>
+            <tr>
+              <th class="table-head">模型</th>
+              <th class="table-head">风险类型</th>
+              <th class="table-head text-right">Input 毛利</th>
+              <th class="table-head text-right">Output 毛利</th>
+              <th class="table-head">当前渠道</th>
+              <th class="table-head">建议动作</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="row in filteredRows" :key="row.key">
+              <td class="table-cell">
+                <p class="font-medium text-slate-900">{{ row.model_name }}</p>
+                <p class="mt-1 text-xs text-slate-500">
+                  {{ row.provider_name }}
+                </p>
+              </td>
+              <td class="table-cell">
+                <span :class="['status-pill', row.tone]">
+                  {{ row.risk_label }}
+                </span>
+              </td>
+              <td class="table-cell text-right font-mono">
+                {{ percent(row.input_margin) }}
+              </td>
+              <td class="table-cell text-right font-mono">
+                {{ percent(row.output_margin) }}
+              </td>
+              <td class="table-cell">
+                {{ row.channel_name || '-' }}
+              </td>
+              <td class="table-cell text-slate-600">
+                {{ row.action }}
+              </td>
+            </tr>
+            <tr v-if="!filteredRows.length">
+              <td class="table-cell text-slate-500" colspan="6">
+                当前筛选条件下没有风险项。
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue'
+
+import CompactSelect from './CompactSelect.vue'
+
+const props = defineProps({
+  summary: { type: Object, default: () => ({}) }
+})
+
+const riskFilter = ref('all')
+const riskFilterOptions = [
+  { label: '全部风险', value: 'all' },
+  { label: '低毛利', value: 'margin' },
+  { label: '非最低价', value: 'not_lowest' },
+  { label: '未挂售', value: 'unlisted' },
+  { label: '需要汇率', value: 'currency_mismatch' }
+]
+
+const diagnosticRows = computed(() => props.summary.agione?.diagnostics || [])
+const selectedPlatformId = computed(() => props.summary.agione?.platform_id)
+const listingRows = computed(() => {
+  const rows = props.summary.listings || []
+  if (!selectedPlatformId.value) return rows
+  return rows.filter(
+    (listing) =>
+      String(listing.platform_id) === String(selectedPlatformId.value)
+  )
+})
+
+const riskRows = computed(() => {
+  const rows = []
+  diagnosticRows.value.forEach((row) => {
+    if (row.status === 'ready' || row.status === 'low_coverage') return
+    rows.push({
+      key: `diag-${row.model_id}-${row.status}`,
+      model_id: row.model_id,
+      model_name: row.model_name,
+      provider_name: row.provider_name,
+      risk: row.status,
+      risk_label: statusLabel(row.status),
+      tone: statusTone(row.status),
+      input_margin: null,
+      output_margin: null,
+      channel_name: row.best_channel?.channel_name || '',
+      action: actionText(row.status)
+    })
+  })
+  listingRows.value.forEach((listing) => {
+    const inputMargin = listing.input_margin?.margin_rate
+    const outputMargin = listing.output_margin?.margin_rate
+    if (!isLowMargin(inputMargin) && !isLowMargin(outputMargin)) return
+    rows.push({
+      key: `listing-${listing.listing_id}`,
+      model_id: listing.model_id,
+      model_name: listing.model_name,
+      provider_name: listing.platform_name,
+      risk: 'margin',
+      risk_label: '低毛利',
+      tone: 'danger',
+      input_margin: inputMargin,
+      output_margin: outputMargin,
+      channel_name: listing.channel_name,
+      action: '复核售价、服务费率或采购渠道'
+    })
+  })
+  return rows.sort((left, right) => riskRank(left.risk) - riskRank(right.risk))
+})
+
+const filteredRows = computed(() => {
+  if (riskFilter.value === 'all') return riskRows.value
+  return riskRows.value.filter((row) => row.risk === riskFilter.value)
+})
+
+const metrics = computed(() => [
+  {
+    label: '风险总数',
+    value: riskRows.value.length,
+    hint: '当前平台可见的挂售和采购风险'
+  },
+  {
+    label: '低毛利',
+    value: riskRows.value.filter((row) => row.risk === 'margin').length,
+    hint: 'Input 或 Output 毛利低于 10%'
+  },
+  {
+    label: '非最低价',
+    value: riskRows.value.filter((row) => row.risk === 'not_lowest').length,
+    hint: '已挂售但未使用最低采购渠道'
+  },
+  {
+    label: '未挂售',
+    value: riskRows.value.filter((row) => row.risk === 'unlisted').length,
+    hint: '已有供应但未进入当前平台'
+  }
+])
+
+function isLowMargin(value) {
+  if (value === null || value === undefined) return false
+  return Number(value) < 0.1
+}
+
+function statusLabel(status) {
+  return (
+    {
+      currency_mismatch: '需要汇率',
+      missing_channel: '缺渠道价',
+      unlisted: '未挂售',
+      not_lowest: '非最低价'
+    }[status] || status
+  )
+}
+
+function statusTone(status) {
+  return (
+    {
+      currency_mismatch: 'info',
+      missing_channel: 'danger',
+      unlisted: 'warn',
+      not_lowest: 'warn'
+    }[status] || 'info'
+  )
+}
+
+function actionText(status) {
+  return (
+    {
+      currency_mismatch: '补充汇率后重新比较采购价',
+      missing_channel: '先为模型配置至少一个渠道采购价',
+      unlisted: '进入挂售工作台创建平台上架记录',
+      not_lowest: '评估切换到最低采购渠道'
+    }[status] || '复核状态'
+  )
+}
+
+function riskRank(status) {
+  return (
+    {
+      margin: 1,
+      missing_channel: 2,
+      currency_mismatch: 3,
+      not_lowest: 4,
+      unlisted: 5
+    }[status] || 9
+  )
+}
+
+function percent(value) {
+  if (value === null || value === undefined || value === '') return '-'
+  return `${(Number(value) * 100).toFixed(2)}%`
+}
+</script>

--- a/frontend/src/components/llm-ops/ModelWorkbenchPanel.vue
+++ b/frontend/src/components/llm-ops/ModelWorkbenchPanel.vue
@@ -1,0 +1,334 @@
+<template>
+  <section class="space-y-4">
+    <div class="panel">
+      <div class="grid gap-4 lg:grid-cols-[minmax(0,1fr)_320px]">
+        <div>
+          <h3 class="panel-title">模型详情工作台</h3>
+          <p class="mt-1 text-xs text-slate-500">
+            集中查看单个模型的官方价格、渠道采购、挂售状态和对账记录。
+          </p>
+        </div>
+        <CompactSelect
+          v-model="selectedModelId"
+          :options="modelSelectOptions"
+          class-name="w-full lg:w-80"
+          searchable
+          :menu-min-width="360"
+        />
+      </div>
+    </div>
+
+    <div v-if="selectedModel" class="grid gap-4 xl:grid-cols-4">
+      <div class="kpi-card">
+        <p class="text-xs font-medium text-slate-500">元模型</p>
+        <p class="mt-2 text-lg font-semibold text-slate-900">
+          {{ selectedModel.meta_model_name || '-' }}
+        </p>
+        <p class="mt-2 font-mono text-xs text-slate-500">
+          {{ selectedModel.code }}
+        </p>
+      </div>
+      <div class="kpi-card">
+        <p class="text-xs font-medium text-slate-500">渠道覆盖</p>
+        <p class="kpi-value mt-2 text-2xl font-semibold">
+          {{ selectedDiagnostic?.coverage_count || 0 }}
+        </p>
+        <p class="mt-2 text-xs text-slate-500">可用采购渠道数量</p>
+      </div>
+      <div class="kpi-card">
+        <p class="text-xs font-medium text-slate-500">挂售链路</p>
+        <p class="kpi-value mt-2 text-2xl font-semibold">
+          {{ modelListings.length }}
+        </p>
+        <p class="mt-2 text-xs text-slate-500">当前平台及其他平台记录</p>
+      </div>
+      <div class="kpi-card">
+        <p class="text-xs font-medium text-slate-500">对账异常</p>
+        <p class="kpi-value mt-2 text-2xl font-semibold">
+          {{ anomalyRecords.length }}
+        </p>
+        <p class="mt-2 text-xs text-slate-500">非 perfect 的对账记录</p>
+      </div>
+    </div>
+
+    <div class="grid gap-4 xl:grid-cols-2">
+      <div class="panel overflow-hidden p-0">
+        <div class="table-toolbar">
+          <h3 class="panel-title">标准价格项</h3>
+        </div>
+        <MiniTable
+          :columns="['维度', '价格', '来源']"
+          :rows="officialRows"
+          empty-text="暂无标准价格项。"
+        />
+      </div>
+
+      <div class="panel overflow-hidden p-0">
+        <div class="table-toolbar">
+          <h3 class="panel-title">渠道采购价</h3>
+        </div>
+        <MiniTable
+          :columns="['渠道', '维度', '价格']"
+          :rows="channelRows"
+          empty-text="暂无渠道价格项。"
+        />
+      </div>
+    </div>
+
+    <div class="grid gap-4 xl:grid-cols-2">
+      <div class="panel overflow-hidden p-0">
+        <div class="table-toolbar">
+          <h3 class="panel-title">挂售记录</h3>
+        </div>
+        <MiniTable
+          :columns="['平台', '渠道', '状态']"
+          :rows="listingRows"
+          empty-text="暂无挂售记录。"
+        />
+      </div>
+
+      <div class="panel overflow-hidden p-0">
+        <div class="table-toolbar">
+          <h3 class="panel-title">对账记录</h3>
+        </div>
+        <MiniTable
+          :columns="['日期', '渠道', '差异']"
+          :rows="reconciliationRows"
+          empty-text="暂无对账记录。"
+        />
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { computed, defineComponent, h, ref, watch } from 'vue'
+
+import CompactSelect from './CompactSelect.vue'
+
+const MiniTable = defineComponent({
+  props: {
+    columns: { type: Array, default: () => [] },
+    rows: { type: Array, default: () => [] },
+    emptyText: { type: String, default: '暂无数据。' }
+  },
+  setup(props) {
+    return () =>
+      h('div', { class: 'overflow-x-auto' }, [
+        h('table', { class: 'data-table' }, [
+          h('thead', [
+            h(
+              'tr',
+              props.columns.map((column) =>
+                h('th', { class: 'table-head' }, column)
+              )
+            )
+          ]),
+          h('tbody', [
+            ...props.rows.map((row, rowIndex) =>
+              h(
+                'tr',
+                { key: rowIndex },
+                row.map((cell, cellIndex) =>
+                  h(
+                    'td',
+                    {
+                      class:
+                        cellIndex === row.length - 1
+                          ? 'table-cell'
+                          : 'table-cell font-mono text-xs'
+                    },
+                    cell
+                  )
+                )
+              )
+            ),
+            props.rows.length
+              ? null
+              : h('tr', [
+                  h(
+                    'td',
+                    {
+                      class: 'table-cell text-slate-500',
+                      colspan: props.columns.length
+                    },
+                    props.emptyText
+                  )
+                ])
+          ])
+        ])
+      ])
+  }
+})
+
+const props = defineProps({
+  summary: { type: Object, default: () => ({}) },
+  models: { type: Array, default: () => [] },
+  channels: { type: Array, default: () => [] },
+  priceItems: { type: Array, default: () => [] },
+  channelPriceItems: { type: Array, default: () => [] },
+  listings: { type: Array, default: () => [] },
+  records: { type: Array, default: () => [] }
+})
+
+const selectedModelId = ref('')
+
+const diagnostics = computed(() => props.summary.agione?.diagnostics || [])
+const modelOptions = computed(() =>
+  diagnostics.value.map((row) => ({
+    id: row.model_id,
+    name: row.model_name,
+    code: row.model_code,
+    provider_name: row.provider_name,
+    meta_model_name: row.meta_model_name
+  }))
+)
+
+const modelSelectOptions = computed(() =>
+  modelOptions.value.map((model) => ({
+    label: `${model.provider_name} / ${model.name}`,
+    searchText: `${model.provider_name} ${model.name} ${model.code}`,
+    value: String(model.id)
+  }))
+)
+
+watch(
+  modelOptions,
+  (options) => {
+    if (!options.length) {
+      selectedModelId.value = ''
+      return
+    }
+    const exists = options.some(
+      (option) => String(option.id) === String(selectedModelId.value)
+    )
+    if (!exists) selectedModelId.value = String(options[0].id)
+  },
+  { immediate: true }
+)
+
+const selectedModel = computed(() =>
+  modelOptions.value.find(
+    (model) => String(model.id) === String(selectedModelId.value)
+  )
+)
+
+const selectedDiagnostic = computed(() =>
+  diagnostics.value.find(
+    (row) => String(row.model_id) === String(selectedModelId.value)
+  )
+)
+
+const modelListings = computed(() =>
+  props.listings.filter(
+    (listing) => String(listing.model) === String(selectedModelId.value)
+  )
+)
+
+const modelRecords = computed(() =>
+  props.records.filter(
+    (record) => String(record.model) === String(selectedModelId.value)
+  )
+)
+
+const anomalyRecords = computed(() =>
+  modelRecords.value.filter((record) => record.status !== 'perfect')
+)
+
+const officialRows = computed(() =>
+  props.priceItems
+    .filter((item) => String(item.model) === String(selectedModelId.value))
+    .slice(0, 12)
+    .map((item) => [
+      dimensionLabel(item.dimension),
+      money(item.unit_price, item.currency),
+      item.source_name || item.price_role || '-'
+    ])
+)
+
+const channelRows = computed(() =>
+  props.channelPriceItems
+    .filter((item) => String(item.model) === String(selectedModelId.value))
+    .slice(0, 12)
+    .map((item) => [
+      item.channel_name || channelName(item.channel),
+      dimensionLabel(item.dimension),
+      money(item.unit_price, item.currency)
+    ])
+)
+
+const listingRows = computed(() =>
+  modelListings.value.map((listing) => [
+    listing.platform_name || `平台 ${listing.platform}`,
+    listing.channel_name || '自动最优',
+    `${workflowLabel(listing.workflow_status)} / ${publishLabel(
+      listing.publish_status
+    )}`
+  ])
+)
+
+const reconciliationRows = computed(() =>
+  modelRecords.value
+    .slice(0, 12)
+    .map((record) => [
+      record.date,
+      record.channel_name || channelName(record.channel),
+      `${money(record.discrepancy, '')} · ${record.status}`
+    ])
+)
+
+function channelName(channelId) {
+  return (
+    props.channels.find((channel) => String(channel.id) === String(channelId))
+      ?.name || '-'
+  )
+}
+
+function dimensionLabel(value) {
+  return (
+    {
+      text_input: '文本输入',
+      text_output: '文本输出',
+      cache_input: '缓存输入',
+      image_output: '图片输出',
+      audio_input: '音频输入',
+      audio_output: '音频输出',
+      video_input: '视频输入',
+      video_output: '视频输出'
+    }[value] || value
+  )
+}
+
+function workflowLabel(value) {
+  return (
+    {
+      draft: '草稿',
+      pending_publish: '待发布',
+      online: '在线',
+      update_draft: '更新草稿',
+      pending_update: '待更新',
+      pending_offline: '待下架',
+      offline_exception: '下架异常',
+      offline: '已下架',
+      deleted: '已删除'
+    }[value] || value
+  )
+}
+
+function publishLabel(value) {
+  return (
+    {
+      none: '未发布',
+      online: '已发布',
+      offline: '已下架',
+      deleted: '已删除'
+    }[value] || value
+  )
+}
+
+function money(value, currency) {
+  if (value === null || value === undefined || value === '') return '-'
+  const prefix = currency ? `${currency} ` : ''
+  return `${prefix}${Number(value).toFixed(6)}`
+}
+</script>

--- a/frontend/src/components/llm-ops/PriceChangePanel.vue
+++ b/frontend/src/components/llm-ops/PriceChangePanel.vue
@@ -1,0 +1,183 @@
+<template>
+  <section class="space-y-4">
+    <div class="grid gap-4 md:grid-cols-3">
+      <div v-for="item in metrics" :key="item.label" class="kpi-card">
+        <p class="text-xs font-medium text-slate-500">{{ item.label }}</p>
+        <p class="kpi-value mt-2 text-2xl font-semibold">{{ item.value }}</p>
+        <p class="mt-2 text-xs text-slate-500">{{ item.hint }}</p>
+      </div>
+    </div>
+
+    <div class="panel overflow-hidden p-0">
+      <div class="table-toolbar">
+        <div>
+          <h3 class="panel-title">价格变化看板</h3>
+          <p class="mt-1 text-xs text-slate-500">
+            汇总渠道采购价、挂售价和标准价格项的最近变化。
+          </p>
+        </div>
+        <CompactSelect
+          v-model="typeFilter"
+          :options="typeFilterOptions"
+          class-name="w-36"
+          size="sm"
+        />
+      </div>
+      <div class="overflow-x-auto">
+        <table class="data-table">
+          <thead>
+            <tr>
+              <th class="table-head">对象</th>
+              <th class="table-head">类型</th>
+              <th class="table-head text-right">Input</th>
+              <th class="table-head text-right">Output</th>
+              <th class="table-head">币种</th>
+              <th class="table-head">时间</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="row in filteredRows" :key="row.key">
+              <td class="table-cell">
+                <p class="font-medium text-slate-900">{{ row.name }}</p>
+                <p class="mt-1 text-xs text-slate-500">{{ row.context }}</p>
+              </td>
+              <td class="table-cell">
+                <span :class="['status-pill', row.tone]">
+                  {{ row.type_label }}
+                </span>
+              </td>
+              <td class="table-cell text-right font-mono">
+                {{ money(row.input, row.currency) }}
+              </td>
+              <td class="table-cell text-right font-mono">
+                {{ money(row.output, row.currency) }}
+              </td>
+              <td class="table-cell">{{ row.currency || '-' }}</td>
+              <td class="table-cell">{{ formatDateTime(row.time) }}</td>
+            </tr>
+            <tr v-if="!filteredRows.length">
+              <td class="table-cell text-slate-500" colspan="6">
+                暂无价格变化记录。
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue'
+
+import CompactSelect from './CompactSelect.vue'
+
+const props = defineProps({
+  channelHistory: { type: Array, default: () => [] },
+  listingHistory: { type: Array, default: () => [] },
+  priceItems: { type: Array, default: () => [] }
+})
+
+const typeFilter = ref('all')
+const typeFilterOptions = [
+  { label: '全部价格', value: 'all' },
+  { label: '渠道采购价', value: 'channel' },
+  { label: '平台挂售价', value: 'listing' },
+  { label: '标准价格项', value: 'official' }
+]
+
+const changeRows = computed(() => {
+  const channelRows = props.channelHistory.map((item) => ({
+    key: `channel-${item.id}`,
+    type: 'channel',
+    type_label: '渠道采购价',
+    tone: 'info',
+    name: item.model_name || `模型 ${item.model}`,
+    context: item.channel_name || `渠道 ${item.channel}`,
+    input: item.input_price_per_million,
+    output: item.output_price_per_million,
+    currency: item.currency,
+    time: item.effective_from || item.created_at
+  }))
+  const listingRows = props.listingHistory.map((item) => ({
+    key: `listing-${item.id}`,
+    type: 'listing',
+    type_label: '平台挂售价',
+    tone: 'warn',
+    name: item.model_name || `模型 ${item.model}`,
+    context: item.platform_name || `平台 ${item.platform}`,
+    input: item.retail_input_price_per_million,
+    output: item.retail_output_price_per_million,
+    currency: item.currency,
+    time: item.effective_from || item.created_at
+  }))
+  const officialRows = recentOfficialRows()
+  return [...channelRows, ...listingRows, ...officialRows].sort(
+    (left, right) => new Date(right.time || 0) - new Date(left.time || 0)
+  )
+})
+
+const filteredRows = computed(() => {
+  const rows = changeRows.value.slice(0, 120)
+  if (typeFilter.value === 'all') return rows
+  return rows.filter((row) => row.type === typeFilter.value)
+})
+
+const metrics = computed(() => [
+  {
+    label: '渠道价历史',
+    value: props.channelHistory.length,
+    hint: '采购渠道价格版本记录'
+  },
+  {
+    label: '挂售价历史',
+    value: props.listingHistory.length,
+    hint: '平台挂售价格版本记录'
+  },
+  {
+    label: '标准价格项',
+    value: props.priceItems.length,
+    hint: '当前标准价格维度数量'
+  }
+])
+
+function recentOfficialRows() {
+  return props.priceItems.slice(0, 80).map((item) => ({
+    key: `official-${item.id}`,
+    type: 'official',
+    type_label: '标准价格项',
+    tone: 'success',
+    name: item.model_name || `模型 ${item.model}`,
+    context: dimensionLabel(item.dimension),
+    input: item.dimension === 'text_input' ? item.unit_price : null,
+    output: item.dimension === 'text_output' ? item.unit_price : null,
+    currency: item.currency,
+    time: item.effective_from || item.updated_at || item.created_at
+  }))
+}
+
+function dimensionLabel(value) {
+  return (
+    {
+      text_input: '文本输入',
+      text_output: '文本输出',
+      cache_input: '缓存输入',
+      image_output: '图片输出',
+      audio_input: '音频输入',
+      audio_output: '音频输出',
+      video_input: '视频输入',
+      video_output: '视频输出'
+    }[value] || value
+  )
+}
+
+function money(value, currency) {
+  if (value === null || value === undefined || value === '') return '-'
+  return `${currency || ''} ${Number(value).toFixed(6)}`
+}
+
+function formatDateTime(value) {
+  if (!value) return '-'
+  return new Date(value).toLocaleString()
+}
+</script>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -746,7 +746,9 @@
       "displayCurrency": "Display currency",
       "resalePlatform": "Resale platform",
       "platformConfig": "Platform settings",
-      "createPlatform": "New platform"
+      "createPlatform": "New platform",
+      "collapseSidebar": "Collapse sidebar",
+      "expandSidebar": "Expand sidebar"
     },
     "currency": {
       "cny": "CNY",
@@ -756,12 +758,25 @@
       "overview": "Overview",
       "catalog": "Models & Sources",
       "distribution": "Channels & Resale",
+      "dashboards": "Operations Dashboards",
       "governance": "Governance"
     },
     "nav": {
       "monitor": {
         "label": "Operations Overview",
         "description": "Track model pricing, channel coverage, procurement paths, and key operating metrics."
+      },
+      "collectionHealth": {
+        "label": "Collection Health",
+        "description": "Review source freshness, success rate, and collection failures."
+      },
+      "modelWorkbench": {
+        "label": "Model Workbench",
+        "description": "Inspect standard prices, channel prices, listings, and reconciliation by model."
+      },
+      "priceChanges": {
+        "label": "Price Changes",
+        "description": "Track channel procurement, listing, and standard price changes."
       },
       "metaModels": {
         "label": "Meta Models",
@@ -779,9 +794,17 @@
         "label": "Forwarding Channels",
         "description": "Maintain channels and manage enabled provider models and pricing policies inside each channel."
       },
+      "channelMatrix": {
+        "label": "Channel Matrix",
+        "description": "Compare each model across procurement channels and coverage gaps."
+      },
       "reseller": {
         "label": "Resale Platforms",
         "description": "Manage listing prices, credit conversion, and procurement channels."
+      },
+      "listingRisk": {
+        "label": "Listing Risks",
+        "description": "Handle low margin, non-lowest-channel, unlisted, and FX risks."
       },
       "workflow": {
         "label": "Workflow Settings",
@@ -843,7 +866,8 @@
       "providerMatrixTitle": "Provider Model Operations Coverage",
       "modelCount": "{count} models",
       "channelCoverage": "Channel coverage",
-      "agioneListed": "Listed on Agione",
+      "agioneListed": "Listed on current platform",
+      "platformListed": "Listed on {platform}",
       "todo": "To do",
       "focusTableTitle": "Priority Model Operations Table",
       "focusTableSubtitle": "Prioritizes models missing channel prices, listings, lowest-price routing, or coverage.",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -756,7 +756,9 @@
       "displayCurrency": "显示货币",
       "resalePlatform": "挂售平台",
       "platformConfig": "平台配置",
-      "createPlatform": "新建平台"
+      "createPlatform": "新建平台",
+      "collapseSidebar": "折叠侧边栏",
+      "expandSidebar": "展开侧边栏"
     },
     "currency": {
       "cny": "CNY",
@@ -766,12 +768,25 @@
       "overview": "运营概览",
       "catalog": "模型与价格源",
       "distribution": "渠道与挂售",
+      "dashboards": "运营看板",
       "governance": "治理与对账"
     },
     "nav": {
       "monitor": {
         "label": "运营总览",
         "description": "汇总模型价格、渠道覆盖、采购路径和关键运营指标。"
+      },
+      "collectionHealth": {
+        "label": "采集健康度",
+        "description": "查看价格源采集新鲜度、成功率和失败风险。"
+      },
+      "modelWorkbench": {
+        "label": "模型工作台",
+        "description": "按模型汇总标准价、渠道价、挂售与对账记录。"
+      },
+      "priceChanges": {
+        "label": "价格变化",
+        "description": "追踪渠道采购价、挂售价和标准价格项的变化。"
       },
       "metaModels": {
         "label": "元模型库",
@@ -789,9 +804,17 @@
         "label": "转发渠道",
         "description": "维护渠道，并在渠道内管理可启用转发的服务商模型和价格策略。"
       },
+      "channelMatrix": {
+        "label": "渠道比价矩阵",
+        "description": "横向比较每个模型在各采购渠道的价格和覆盖状态。"
+      },
       "reseller": {
         "label": "挂售平台",
         "description": "管理挂售定价、积分换算与供货渠道。"
+      },
+      "listingRisk": {
+        "label": "挂售风险榜",
+        "description": "集中处理低毛利、非最低价、未挂售和汇率风险。"
       },
       "workflow": {
         "label": "流程配置",
@@ -853,7 +876,8 @@
       "providerMatrixTitle": "厂商模型运营覆盖",
       "modelCount": "{count} 个模型",
       "channelCoverage": "渠道覆盖",
-      "agioneListed": "Agione 已挂售",
+      "agioneListed": "当前平台已挂售",
+      "platformListed": "{platform} 已挂售",
       "todo": "待处理",
       "focusTableTitle": "重点模型运营表",
       "focusTableSubtitle": "优先展示缺渠道价、未挂售、非最低价和覆盖偏少的模型",

--- a/frontend/src/pages/LLMOps.vue
+++ b/frontend/src/pages/LLMOps.vue
@@ -3,37 +3,122 @@
     <div class="llm-ops-page h-full min-h-[calc(100vh-4rem)] bg-slate-50">
       <div class="flex h-full min-h-[calc(100vh-4rem)] w-full gap-0">
         <aside
-          class="llm-ops-sidebar fixed bottom-0 left-0 top-16 z-20 hidden w-72 flex-col overflow-hidden text-white lg:flex"
+          :class="[
+            'llm-ops-sidebar fixed bottom-0 left-0 top-16 z-20 hidden',
+            'flex-col overflow-hidden text-white lg:flex',
+            sidebarCollapsed ? 'is-collapsed w-20' : 'w-72'
+          ]"
         >
           <div class="llm-ops-sidebar-brand px-5 py-5">
-            <p
-              class="text-[11px] font-bold uppercase tracking-[0.18em] text-agione-300"
+            <div
+              :class="[
+                'flex gap-3',
+                sidebarCollapsed
+                  ? 'flex-col items-center'
+                  : 'items-start justify-between'
+              ]"
             >
-              LLM OPS
-            </p>
-            <h1 class="mt-2 text-lg font-semibold">
-              {{ t('llmOps.shell.title') }}
-            </h1>
-            <p class="mt-2 text-xs leading-5 text-slate-400">
+              <div :class="['min-w-0', sidebarCollapsed ? 'text-center' : '']">
+                <p
+                  class="text-[11px] font-bold uppercase tracking-[0.18em] text-agione-300"
+                >
+                  {{ sidebarCollapsed ? 'LLM' : 'LLM OPS' }}
+                </p>
+                <h1 v-if="!sidebarCollapsed" class="mt-2 text-lg font-semibold">
+                  {{ t('llmOps.shell.title') }}
+                </h1>
+              </div>
+              <button
+                type="button"
+                class="sidebar-toggle-button"
+                :aria-expanded="!sidebarCollapsed"
+                :aria-label="sidebarToggleLabel"
+                :title="sidebarToggleLabel"
+                @click="toggleSidebar"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    :d="sidebarCollapsed ? 'M9 6l6 6-6 6' : 'M15 6l-6 6 6 6'"
+                  />
+                </svg>
+              </button>
+            </div>
+            <p
+              v-if="!sidebarCollapsed"
+              class="mt-2 text-xs leading-5 text-slate-400"
+            >
               {{ t('llmOps.shell.subtitle') }}
             </p>
           </div>
 
-          <nav class="flex-1 space-y-5 overflow-y-auto px-3 py-4">
+          <nav
+            :class="[
+              'flex-1 overflow-y-auto py-4',
+              sidebarCollapsed ? 'space-y-3 px-2' : 'space-y-5 px-3'
+            ]"
+          >
             <section v-for="group in navGroups" :key="group.key">
-              <p
-                class="px-3 text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500"
+              <button
+                type="button"
+                class="llm-nav-group-button flex w-full items-center gap-2.5 px-3 py-2.5 text-left text-sm font-semibold"
+                :class="{
+                  'is-expanded': isNavGroupExpanded(group.key)
+                }"
+                :aria-expanded="
+                  !sidebarCollapsed && isNavGroupExpanded(group.key)
+                "
+                :title="sidebarCollapsed ? group.label : ''"
+                @click="toggleNavGroup(group.key)"
               >
-                {{ group.label }}
-              </p>
-              <div class="mt-2 space-y-1">
+                <svg
+                  class="nav-icon"
+                  aria-hidden="true"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  viewBox="0 0 24 24"
+                >
+                  <path v-for="path in group.icon" :key="path" :d="path" />
+                </svg>
+                <span v-if="!sidebarCollapsed" class="min-w-0 flex-1 truncate">
+                  {{ group.label }}
+                </span>
+                <svg
+                  v-if="!sidebarCollapsed"
+                  class="nav-group-chevron"
+                  aria-hidden="true"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M9 6l6 6-6 6" />
+                </svg>
+              </button>
+              <div
+                v-if="!sidebarCollapsed && isNavGroupExpanded(group.key)"
+                class="nav-group-items mt-1 space-y-1"
+              >
                 <button
                   v-for="item in group.items"
                   :key="item.key"
                   type="button"
                   class="llm-nav-item flex w-full items-center gap-2.5 px-3 py-2.5 text-left text-sm font-medium"
                   :class="{ 'is-active': activeSection === item.key }"
-                  @click="activeSection = item.key"
+                  :title="sidebarCollapsed ? item.label : ''"
+                  @click="selectNavItem(group.key, item.key)"
                 >
                   <svg
                     class="nav-icon"
@@ -47,7 +132,12 @@
                   >
                     <path v-for="path in item.icon" :key="path" :d="path" />
                   </svg>
-                  <span class="min-w-0 flex-1 truncate">{{ item.label }}</span>
+                  <span
+                    v-if="!sidebarCollapsed"
+                    class="min-w-0 flex-1 truncate"
+                  >
+                    {{ item.label }}
+                  </span>
                 </button>
               </div>
             </section>
@@ -55,7 +145,10 @@
         </aside>
 
         <main
-          class="llm-ops-content min-w-0 flex-1 lg:ml-72"
+          :class="[
+            'llm-ops-content min-w-0 flex-1',
+            sidebarCollapsed ? 'lg:ml-20' : 'lg:ml-72'
+          ]"
         >
           <header class="llm-ops-header px-5 py-3 lg:px-7">
             <div class="page-hero">
@@ -279,7 +372,7 @@
                     <span class="text-sm text-slate-500">
                       {{
                         t('llmOps.monitor.channelCount', {
-                          count: channels.length
+                          count: operationalChannelCount
                         })
                       }}
                     </span>
@@ -451,7 +544,9 @@
                               : t('llmOps.monitor.lowestProcurementChannel')
                           }}
                         </th>
-                        <th class="table-head">Agione</th>
+                        <th class="table-head">
+                          {{ currentPlatformListingLabel }}
+                        </th>
                         <th class="table-head text-right">
                           {{
                             simulation.channel
@@ -486,7 +581,8 @@
                         </td>
                         <td class="table-cell">{{ row.provider_name }}</td>
                         <td class="table-cell text-right font-mono">
-                          {{ row.coverage_count }} / {{ channels.length }}
+                          {{ row.coverage_count }} /
+                          {{ operationalChannelCount }}
                         </td>
                         <td class="table-cell">
                           {{
@@ -556,6 +652,41 @@
               @listings-updated="mergeResaleListings"
               @action="openListingActionDrawer"
               @open-workspace="openResalePublishingWorkspace"
+            />
+
+            <CollectionHealthPanel
+              v-else-if="activeSection === 'collectionHealth'"
+              :sources="providerCollectionSources"
+              :runs="collectionRuns"
+            />
+
+            <ChannelPriceMatrixPanel
+              v-else-if="activeSection === 'channelMatrix'"
+              :summary="summary"
+              :channels="channels"
+            />
+
+            <ModelWorkbenchPanel
+              v-else-if="activeSection === 'modelWorkbench'"
+              :summary="summary"
+              :models="models"
+              :channels="channels"
+              :price-items="modelPriceItems"
+              :channel-price-items="channelPriceItems"
+              :listings="listings"
+              :records="records"
+            />
+
+            <ListingRiskPanel
+              v-else-if="activeSection === 'listingRisk'"
+              :summary="summary"
+            />
+
+            <PriceChangePanel
+              v-else-if="activeSection === 'priceChanges'"
+              :channel-history="channelPriceHistory"
+              :listing-history="listingPriceHistory"
+              :price-items="modelPriceItems"
             />
 
             <ResaleWorkflowConfigPanel
@@ -672,9 +803,14 @@ import BaseLoading from '@/components/ui/BaseLoading.vue'
 import AgioneListingStatusBoard from '@/components/llm-ops/AgioneListingStatusBoard.vue'
 import AuditLogPanel from '@/components/llm-ops/AuditLogPanel.vue'
 import ChannelManagement from '@/components/llm-ops/ChannelManagement.vue'
+import ChannelPriceMatrixPanel from '@/components/llm-ops/ChannelPriceMatrixPanel.vue'
+import CollectionHealthPanel from '@/components/llm-ops/CollectionHealthPanel.vue'
 import CollectionRunLogPanel from '@/components/llm-ops/CollectionRunLogPanel.vue'
 import GlobalConfigPanel from '@/components/llm-ops/GlobalConfigPanel.vue'
+import ListingRiskPanel from '@/components/llm-ops/ListingRiskPanel.vue'
+import ModelWorkbenchPanel from '@/components/llm-ops/ModelWorkbenchPanel.vue'
 import MetaModelManagement from '@/components/llm-ops/MetaModelManagement.vue'
+import PriceChangePanel from '@/components/llm-ops/PriceChangePanel.vue'
 import ProviderManagement from '@/components/llm-ops/ProviderManagement.vue'
 import ReconciliationPanel from '@/components/llm-ops/ReconciliationPanel.vue'
 import ResalePlatformModal from '@/components/llm-ops/ResalePlatformModal.vue'
@@ -687,15 +823,26 @@ import { DEFAULT_WORKFLOW_POLICIES } from '@/constants/llmOpsWorkflow'
 
 const LIST_PAGE_SIZE = 200
 const LIST_PARAMS = { page_size: LIST_PAGE_SIZE }
+const PRICE_HISTORY_PAGE_SIZE = 120
 const DATA_HEAVY_SECTIONS = new Set([
   'channels',
+  'channelMatrix',
+  'collectionHealth',
+  'listingRisk',
   'metaModels',
+  'modelWorkbench',
+  'priceChanges',
   'providers',
   'reconciler',
   'reseller'
 ])
 const sectionKeys = new Set([
   'monitor',
+  'collectionHealth',
+  'channelMatrix',
+  'modelWorkbench',
+  'listingRisk',
+  'priceChanges',
   'metaModels',
   'providers',
   'taskLogs',
@@ -706,7 +853,12 @@ const sectionKeys = new Set([
   'reconciler',
   'audit'
 ])
+const NAV_GROUP_STORAGE_KEY = 'llm_ops_expanded_nav_groups'
 const activeSection = ref(initialActiveSection())
+const sidebarCollapsed = ref(
+  localStorage.getItem('llm_ops_sidebar_collapsed') === 'true'
+)
+const expandedNavGroupKeys = ref(readExpandedNavGroupKeys())
 const loading = ref(false)
 const backgroundLoading = ref(false)
 const secondaryDataLoaded = ref(false)
@@ -720,10 +872,12 @@ const models = ref([])
 const channels = ref([])
 const channelPrices = ref([])
 const channelPriceItems = ref([])
+const channelPriceHistory = ref([])
 const modelPriceItems = ref([])
 const resalePlatforms = ref([])
 const resaleWorkflowConfig = ref(null)
 const listings = ref([])
+const listingPriceHistory = ref([])
 const records = ref([])
 const summary = ref({})
 const supportedDisplayCurrencies = new Set(['CNY', 'USD'])
@@ -750,6 +904,12 @@ const displayCurrencyOptions = computed(() => [
   { label: t('llmOps.currency.usd'), value: 'USD' }
 ])
 
+const sidebarToggleLabel = computed(() =>
+  sidebarCollapsed.value
+    ? t('llmOps.toolbar.expandSidebar')
+    : t('llmOps.toolbar.collapseSidebar')
+)
+
 const simulationStatusOptions = computed(() => [
   { label: t('llmOps.filters.priority'), value: 'priority' },
   { label: t('llmOps.filters.allModels'), value: 'all' },
@@ -770,10 +930,15 @@ const monitorStatusLabelKeys = {
 
 const navIcons = {
   audit: ['M4 5h16', 'M4 12h16', 'M4 19h10'],
+  channelMatrix: ['M4 6h16', 'M4 12h16', 'M4 18h16', 'M8 6v12', 'M16 6v12'],
   channels: ['M4 7h16', 'M7 7v10', 'M17 7v10', 'M4 17h16'],
+  collectionHealth: ['M4 13l4 4L20 5', 'M4 19h16'],
   globalConfig: ['M4 7h16', 'M7 7v10', 'M17 7v10', 'M4 17h16', 'M9 12h6'],
+  listingRisk: ['M12 4l8 14H4L12 4Z', 'M12 9v4', 'M12 16h.01'],
   metaModels: ['M12 3l8 4-8 4-8-4 8-4Z', 'M4 12l8 4 8-4', 'M4 17l8 4 8-4'],
+  modelWorkbench: ['M5 5h14v14H5Z', 'M8 9h8', 'M8 13h8', 'M8 17h5'],
   monitor: ['M4 19V5', 'M8 19v-6', 'M12 19v-9', 'M16 19v-4', 'M20 19V8'],
+  priceChanges: ['M4 16l5-5 4 4 7-8', 'M4 20h16'],
   providers: ['M5 5h14v14H5Z', 'M9 9h6', 'M9 13h6', 'M9 17h3'],
   reconciler: [
     'M4 7h16',
@@ -806,6 +971,27 @@ const navItems = computed(() => [
     icon: navIcons.monitor
   },
   {
+    key: 'collectionHealth',
+    label: t('llmOps.nav.collectionHealth.label'),
+    eyebrow: 'Health',
+    description: t('llmOps.nav.collectionHealth.description'),
+    icon: navIcons.collectionHealth
+  },
+  {
+    key: 'modelWorkbench',
+    label: t('llmOps.nav.modelWorkbench.label'),
+    eyebrow: 'Workbench',
+    description: t('llmOps.nav.modelWorkbench.description'),
+    icon: navIcons.modelWorkbench
+  },
+  {
+    key: 'priceChanges',
+    label: t('llmOps.nav.priceChanges.label'),
+    eyebrow: 'Changes',
+    description: t('llmOps.nav.priceChanges.description'),
+    icon: navIcons.priceChanges
+  },
+  {
     key: 'metaModels',
     label: t('llmOps.nav.metaModels.label'),
     eyebrow: 'Meta Models',
@@ -834,6 +1020,13 @@ const navItems = computed(() => [
     icon: navIcons.channels
   },
   {
+    key: 'channelMatrix',
+    label: t('llmOps.nav.channelMatrix.label'),
+    eyebrow: 'Matrix',
+    description: t('llmOps.nav.channelMatrix.description'),
+    icon: navIcons.channelMatrix
+  },
+  {
     key: 'reseller',
     label: t('llmOps.nav.reseller.label'),
     eyebrow: 'Reseller',
@@ -846,6 +1039,13 @@ const navItems = computed(() => [
     eyebrow: 'Workflow',
     description: t('llmOps.nav.workflow.description'),
     icon: navIcons.workflow
+  },
+  {
+    key: 'listingRisk',
+    label: t('llmOps.nav.listingRisk.label'),
+    eyebrow: 'Risk',
+    description: t('llmOps.nav.listingRisk.description'),
+    icon: navIcons.listingRisk
   },
   {
     key: 'globalConfig',
@@ -875,10 +1075,13 @@ function findNavItem(key) {
 }
 
 function createNavGroup(key, labelKey, itemKeys) {
+  const items = itemKeys.map(findNavItem).filter(Boolean)
+
   return {
     key,
     label: t(labelKey),
-    items: itemKeys.map(findNavItem).filter(Boolean)
+    icon: items[0]?.icon || [],
+    items
   }
 }
 
@@ -893,6 +1096,13 @@ const navGroups = computed(() =>
       'channels',
       'reseller',
       'workflow'
+    ]),
+    createNavGroup('dashboards', 'llmOps.navGroups.dashboards', [
+      'collectionHealth',
+      'channelMatrix',
+      'modelWorkbench',
+      'listingRisk',
+      'priceChanges'
     ]),
     createNavGroup('governance', 'llmOps.navGroups.governance', [
       'reconciler',
@@ -965,6 +1175,13 @@ const agionePlatform = computed(
     activeResalePlatforms.value[0] ||
     null
 )
+const currentPlatformListingLabel = computed(() => {
+  const platformName =
+    summary.value.agione?.platform_name ||
+    agionePlatform.value?.name ||
+    'Agione'
+  return t('llmOps.monitor.platformListed', { platform: platformName })
+})
 
 const showPlatformControl = computed(() =>
   ['monitor', 'reseller'].includes(activeSection.value)
@@ -986,6 +1203,10 @@ const procurementRows = computed(() => summary.value.procurement || [])
 const agioneDiagnostics = computed(
   () => summary.value.agione?.diagnostics || []
 )
+const summaryKpis = computed(() => summary.value.kpis || {})
+const diagnosticCounts = computed(
+  () => summary.value.agione?.diagnostic_counts || {}
+)
 const exchangeRate = computed(() =>
   Number(summary.value.currency?.usd_to_cny_rate || 7.15)
 )
@@ -1003,6 +1224,22 @@ const activeModels = computed(() =>
 
 const activeModelIds = computed(
   () => new Set(activeModels.value.map((model) => String(model.id)))
+)
+
+const operationalModelCount = computed(() =>
+  numberOrFallback(summaryKpis.value.active_models, activeModels.value.length)
+)
+const operationalChannelCount = computed(() =>
+  numberOrFallback(summaryKpis.value.active_channels, channels.value.length)
+)
+const enabledPriceSourceCount = computed(() =>
+  numberOrFallback(
+    summaryKpis.value.enabled_price_sources,
+    providerCollectionSources.value.length
+  )
+)
+const reconciliationAnomalyCount = computed(() =>
+  numberOrFallback(summaryKpis.value.reconciliation_anomalies, 0)
 )
 
 const agioneListingRows = computed(() => {
@@ -1082,7 +1319,13 @@ const enrichedProcurementRows = computed(() =>
   })
 )
 
-const listedCount = computed(() => agioneListingModelIds.value.size)
+const localListedCount = computed(() => agioneListingModelIds.value.size)
+const listedCount = computed(() =>
+  numberOrFallback(
+    summaryKpis.value.current_platform_listed_models,
+    localListedCount.value
+  )
+)
 const procuredCount = computed(
   () => enrichedProcurementRows.value.filter((row) => row.best_channel).length
 )
@@ -1108,19 +1351,49 @@ const nonLowestRows = computed(() =>
 const lowCoverageRows = computed(() =>
   enrichedProcurementRows.value.filter((row) => row.status_priority === 4)
 )
+const readyCount = computed(() =>
+  numberOrFallback(summaryKpis.value.ready_models, readyRows.value.length)
+)
+const missingChannelCount = computed(() =>
+  numberOrFallback(
+    diagnosticCounts.value.missing_channel,
+    missingChannelRows.value.length
+  )
+)
+const currencyMismatchCount = computed(() =>
+  numberOrFallback(
+    diagnosticCounts.value.currency_mismatch,
+    currencyMismatchRows.value.length
+  )
+)
+const unlistedCount = computed(() =>
+  numberOrFallback(diagnosticCounts.value.unlisted, unlistedRows.value.length)
+)
+const nonLowestCount = computed(() =>
+  numberOrFallback(
+    diagnosticCounts.value.not_lowest,
+    nonLowestRows.value.length
+  )
+)
+const lowCoverageCount = computed(() =>
+  numberOrFallback(
+    diagnosticCounts.value.low_coverage,
+    lowCoverageRows.value.length
+  )
+)
 
 const kpiCards = computed(() => {
-  const modelCount = activeModels.value.length
-  const channelCount = channels.value.length
+  const modelCount = operationalModelCount.value
+  const channelCount = operationalChannelCount.value
   const procurementRate = percentage(procuredCount.value, modelCount)
   const listingRate = percentage(listedCount.value, modelCount)
-  const readyRate = percentage(readyRows.value.length, modelCount)
+  const readyRate = percentage(readyCount.value, modelCount)
   return [
     {
       label: t('llmOps.kpi.ready.label'),
-      value: `${readyRows.value.length}/${modelCount}`,
+      value: `${readyCount.value}/${modelCount}`,
       badge: `${readyRate}%`,
-      hint: t('llmOps.kpi.ready.hint', { count: readyRows.value.length }),
+      hint: t('llmOps.kpi.ready.hint', { count: readyCount.value }),
       progress: readyRate,
       tone: readyRate >= 80 ? 'good' : 'warn',
       barClass: 'bg-emerald-500'
@@ -1130,8 +1403,8 @@ const kpiCards = computed(() => {
       value: `${procuredCount.value}/${modelCount}`,
       badge: `${procurementRate}%`,
       hint: t('llmOps.kpi.procurement.hint', {
-        missing: missingChannelRows.value.length,
-        currency: currencyMismatchRows.value.length
+        missing: missingChannelCount.value,
+        currency: currencyMismatchCount.value
       }),
       progress: procurementRate,
       tone: procurementRate >= 80 ? 'good' : 'warn',
@@ -1142,8 +1415,8 @@ const kpiCards = computed(() => {
       value: `${listedCount.value}/${modelCount}`,
       badge: `${listingRate}%`,
       hint: t('llmOps.kpi.listing.hint', {
-        unlisted: unlistedRows.value.length,
-        nonLowest: nonLowestRows.value.length
+        unlisted: unlistedCount.value,
+        nonLowest: nonLowestCount.value
       }),
       progress: listingRate,
       tone: listingRate >= 80 ? 'good' : 'warn',
@@ -1153,7 +1426,7 @@ const kpiCards = computed(() => {
       label: t('llmOps.kpi.channels.label'),
       value: channelCount,
       badge: t('llmOps.kpi.channels.badge', {
-        count: providerCollectionSources.value.length
+        count: enabledPriceSourceCount.value
       }),
       hint: t('llmOps.kpi.channels.hint'),
       progress: channelCount ? 100 : 0,
@@ -1162,19 +1435,16 @@ const kpiCards = computed(() => {
     },
     {
       label: t('llmOps.kpi.reconciliation.label'),
-      value: summary.value.kpis?.reconciliation_anomalies || 0,
-      badge:
-        summary.value.kpis?.reconciliation_anomalies || 0
-          ? t('llmOps.status.needsHandling')
-          : t('llmOps.status.normal'),
+      value: reconciliationAnomalyCount.value,
+      badge: reconciliationAnomalyCount.value
+        ? t('llmOps.status.needsHandling')
+        : t('llmOps.status.normal'),
       hint: t('llmOps.kpi.reconciliation.hint'),
-      progress: summary.value.kpis?.reconciliation_anomalies || 0 ? 100 : 0,
-      tone:
-        summary.value.kpis?.reconciliation_anomalies || 0 ? 'danger' : 'good',
-      barClass:
-        summary.value.kpis?.reconciliation_anomalies || 0
-          ? 'bg-rose-500'
-          : 'bg-emerald-500'
+      progress: reconciliationAnomalyCount.value ? 100 : 0,
+      tone: reconciliationAnomalyCount.value ? 'danger' : 'good',
+      barClass: reconciliationAnomalyCount.value
+        ? 'bg-rose-500'
+        : 'bg-emerald-500'
     }
   ]
 })
@@ -1183,36 +1453,36 @@ const actionItems = computed(() => [
   {
     label: t('llmOps.queue.fillChannelPrice.label'),
     hint: t('llmOps.queue.fillChannelPrice.hint'),
-    value: missingChannelRows.value.length,
-    tone: missingChannelRows.value.length ? 'danger' : 'good',
+    value: missingChannelCount.value,
+    tone: missingChannelCount.value ? 'danger' : 'good',
     section: 'channels'
   },
   {
     label: t('llmOps.queue.configureExchange.label'),
     hint: t('llmOps.queue.configureExchange.hint'),
-    value: currencyMismatchRows.value.length,
-    tone: currencyMismatchRows.value.length ? 'warn' : 'good',
+    value: currencyMismatchCount.value,
+    tone: currencyMismatchCount.value ? 'warn' : 'good',
     section: 'channels'
   },
   {
     label: t('llmOps.queue.publishToPlatform.label'),
     hint: t('llmOps.queue.publishToPlatform.hint'),
-    value: unlistedRows.value.length,
-    tone: unlistedRows.value.length ? 'warn' : 'good',
+    value: unlistedCount.value,
+    tone: unlistedCount.value ? 'warn' : 'good',
     section: 'reseller'
   },
   {
     label: t('llmOps.queue.switchLowestChannel.label'),
     hint: t('llmOps.queue.switchLowestChannel.hint'),
-    value: nonLowestRows.value.length,
-    tone: nonLowestRows.value.length ? 'warn' : 'good',
+    value: nonLowestCount.value,
+    tone: nonLowestCount.value ? 'warn' : 'good',
     section: 'reseller'
   },
   {
     label: t('llmOps.queue.addChannelCoverage.label'),
     hint: t('llmOps.queue.addChannelCoverage.hint'),
-    value: lowCoverageRows.value.length,
-    tone: lowCoverageRows.value.length ? 'warn' : 'good',
+    value: lowCoverageCount.value,
+    tone: lowCoverageCount.value ? 'warn' : 'good',
     section: 'channels'
   },
   {
@@ -1233,8 +1503,8 @@ const actionItems = computed(() => [
   {
     label: t('llmOps.queue.handleReconciliation.label'),
     hint: t('llmOps.queue.handleReconciliation.hint'),
-    value: summary.value.kpis?.reconciliation_anomalies || 0,
-    tone: summary.value.kpis?.reconciliation_anomalies || 0 ? 'danger' : 'good',
+    value: reconciliationAnomalyCount.value,
+    tone: reconciliationAnomalyCount.value ? 'danger' : 'good',
     section: 'reconciler'
   }
 ])
@@ -1276,34 +1546,38 @@ const channelCoverageRows = computed(() =>
         ...channel,
         covered,
         best_count: bestCount,
-        coverage_rate: percentage(covered, activeModels.value.length)
+        coverage_rate: percentage(covered, operationalModelCount.value)
       }
     })
     .sort((left, right) => right.covered - left.covered)
 )
 
-const providerCoverageRows = computed(() =>
-  providers.value.map((provider) => {
-    const providerModels = activeModels.value.filter(
-      (model) => String(model.provider) === String(provider.id)
-    )
-    const modelIds = new Set(providerModels.map((model) => String(model.id)))
-    const providerRows = enrichedProcurementRows.value.filter((row) =>
-      modelIds.has(String(row.model_id))
-    )
-    const procured = providerRows.filter((row) => row.best_channel).length
-    const listed = providerRows.filter((row) => row.is_agione_listed).length
-    const ready = providerRows.filter((row) => row.status_priority === 5).length
-    return {
-      name: provider.name,
-      model_count: providerModels.length,
-      procured_count: procured,
-      listed_count: listed,
-      todo_count: Math.max(providerModels.length - ready, 0),
-      ready_rate: percentage(ready, providerModels.length)
-    }
+const providerCoverageRows = computed(() => {
+  const rowsByProvider = new Map()
+  enrichedProcurementRows.value.forEach((row) => {
+    const providerName = row.provider_name || '-'
+    const rows = rowsByProvider.get(providerName) || []
+    rows.push(row)
+    rowsByProvider.set(providerName, rows)
   })
-)
+  return Array.from(rowsByProvider.entries())
+    .map(([providerName, providerRows]) => {
+      const procured = providerRows.filter((row) => row.best_channel).length
+      const listed = providerRows.filter((row) => row.is_agione_listed).length
+      const ready = providerRows.filter(
+        (row) => row.status_priority === 5
+      ).length
+      return {
+        name: providerName,
+        model_count: providerRows.length,
+        procured_count: procured,
+        listed_count: listed,
+        todo_count: Math.max(providerRows.length - ready, 0),
+        ready_rate: percentage(ready, providerRows.length)
+      }
+    })
+    .sort((left, right) => right.model_count - left.model_count)
+})
 
 const filteredProcurementRows = computed(() => {
   const rows = enrichedProcurementRows.value
@@ -1387,6 +1661,14 @@ async function fetchList(request, params = {}) {
   return results
 }
 
+async function fetchFirstPage(request, params = {}) {
+  const response = await request({
+    ...params,
+    page: 1
+  })
+  return paginationResults(paginationPayload(response))
+}
+
 function errorMessage(error, fallback) {
   return (
     error?.response?.data?.detail ||
@@ -1401,6 +1683,63 @@ function monitorModelSubtitle(row) {
   const code = String(row.model_code || '').trim()
   if (code && code !== name) return code
   return ''
+}
+
+function readExpandedNavGroupKeys() {
+  try {
+    const rawValue = localStorage.getItem(NAV_GROUP_STORAGE_KEY)
+    const parsedValue = JSON.parse(rawValue || '[]')
+
+    if (!Array.isArray(parsedValue)) return []
+
+    return parsedValue.filter((item) => typeof item === 'string')
+  } catch {
+    return []
+  }
+}
+
+function persistExpandedNavGroupKeys(keys) {
+  localStorage.setItem(NAV_GROUP_STORAGE_KEY, JSON.stringify(keys))
+}
+
+function isNavGroupExpanded(key) {
+  return expandedNavGroupKeys.value.includes(key)
+}
+
+function setExpandedNavGroupKeys(keys) {
+  expandedNavGroupKeys.value = keys
+  persistExpandedNavGroupKeys(keys)
+}
+
+function toggleNavGroup(key) {
+  const expandedKeys = new Set(expandedNavGroupKeys.value)
+  const shouldExpand = sidebarCollapsed.value || !isNavGroupExpanded(key)
+
+  if (sidebarCollapsed.value) {
+    sidebarCollapsed.value = false
+    localStorage.setItem('llm_ops_sidebar_collapsed', 'false')
+  }
+
+  if (shouldExpand) {
+    expandedKeys.add(key)
+  } else {
+    expandedKeys.delete(key)
+  }
+
+  setExpandedNavGroupKeys(Array.from(expandedKeys))
+}
+
+function selectNavItem(groupKey, itemKey) {
+  activeSection.value = itemKey
+  setExpandedNavGroupKeys([groupKey])
+}
+
+function toggleSidebar() {
+  sidebarCollapsed.value = !sidebarCollapsed.value
+  localStorage.setItem(
+    'llm_ops_sidebar_collapsed',
+    sidebarCollapsed.value ? 'true' : 'false'
+  )
 }
 
 async function refreshAll() {
@@ -1488,8 +1827,25 @@ async function refreshSectionData(section) {
     await Promise.all([refreshChannelPricingData(), refreshModelPriceItems()])
     return
   }
-  if (section === 'reseller') {
+  if (section === 'channelMatrix') {
+    await refreshChannelPricingData()
+    return
+  }
+  if (section === 'reseller' || section === 'listingRisk') {
     await Promise.all([refreshModelPriceItems(), refreshResaleListings()])
+    return
+  }
+  if (section === 'modelWorkbench') {
+    await Promise.all([
+      refreshModelPriceItems(),
+      refreshChannelPricingData(),
+      refreshResaleListings(),
+      refreshReconciliationRecords()
+    ])
+    return
+  }
+  if (section === 'priceChanges') {
+    await Promise.all([refreshModelPriceItems(), refreshPriceHistoryData()])
     return
   }
   if (section === 'reconciler') {
@@ -1524,6 +1880,19 @@ async function refreshResaleListings() {
 
 async function refreshReconciliationRecords() {
   records.value = await fetchList(llmOpsApi.listReconciliationRecords)
+}
+
+async function refreshPriceHistoryData() {
+  const [channelHistoryData, listingHistoryData] = await Promise.all([
+    fetchFirstPage(llmOpsApi.listChannelModelPriceHistory, {
+      page_size: PRICE_HISTORY_PAGE_SIZE
+    }),
+    fetchFirstPage(llmOpsApi.listResaleListingPriceHistory, {
+      page_size: PRICE_HISTORY_PAGE_SIZE
+    })
+  ])
+  channelPriceHistory.value = channelHistoryData
+  listingPriceHistory.value = listingHistoryData
 }
 
 async function refreshLight() {
@@ -1661,6 +2030,12 @@ async function loadResaleWorkflowConfig(
 function percentage(value, total) {
   if (!total) return 0
   return Math.round((Number(value || 0) / Number(total)) * 100)
+}
+
+function numberOrFallback(value, fallback = 0) {
+  const numberValue = Number(value)
+  if (Number.isFinite(numberValue)) return numberValue
+  return Number(fallback || 0)
 }
 
 function isLowestListing(listing, bestChannel, options) {
@@ -2134,9 +2509,9 @@ onBeforeUnmount(() => {
   --ui-duration-fast: 150ms;
   --ui-ease-out: cubic-bezier(0.16, 1, 0.3, 1);
   --ui-font-heading: Manrope, Inter, system-ui, sans-serif;
-  --ui-font-body: Inter, "Noto Sans SC", system-ui, sans-serif;
-  --ui-font-mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo,
-    monospace;
+  --ui-font-body: Inter, 'Noto Sans SC', system-ui, sans-serif;
+  --ui-font-mono:
+    'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
   padding: 0 !important;
 }
 
@@ -2975,11 +3350,17 @@ onBeforeUnmount(() => {
   border-right: 1px solid var(--ui-sidebar-border);
   box-shadow: var(--ui-shadow-xs);
   color: var(--ui-sidebar-text-active);
+  transition: width 180ms var(--ui-ease-out);
 }
 
 .llm-ops-sidebar-brand {
   border-bottom: 1px solid var(--ui-sidebar-border);
   padding-bottom: var(--ui-space-card);
+}
+
+.llm-ops-sidebar.is-collapsed .llm-ops-sidebar-brand {
+  padding-left: 14px;
+  padding-right: 14px;
 }
 
 .llm-ops-sidebar-brand p:first-child {
@@ -2998,6 +3379,32 @@ onBeforeUnmount(() => {
   color: var(--ui-sidebar-text);
 }
 
+.sidebar-toggle-button {
+  align-items: center;
+  background: rgba(15, 23, 42, 0.72);
+  border: 1px solid var(--ui-sidebar-border);
+  border-radius: var(--ui-radius-control);
+  color: var(--ui-sidebar-text);
+  display: inline-flex;
+  height: 30px;
+  justify-content: center;
+  transition:
+    background-color var(--ui-duration-fast) var(--ui-ease-out),
+    color var(--ui-duration-fast) var(--ui-ease-out);
+  width: 30px;
+}
+
+.sidebar-toggle-button:hover {
+  background: var(--ui-sidebar-hover-bg);
+  color: var(--ui-sidebar-text-active);
+}
+
+.sidebar-toggle-button svg {
+  height: 16px;
+  width: 16px;
+}
+
+.llm-nav-group-button,
 .llm-nav-item,
 .llm-mobile-nav-item {
   border-radius: var(--ui-radius-control);
@@ -3008,6 +3415,7 @@ onBeforeUnmount(() => {
     box-shadow var(--ui-duration-fast) var(--ui-ease-out);
 }
 
+.llm-nav-group-button:hover,
 .llm-nav-item:hover,
 .llm-mobile-nav-item:hover {
   background: var(--ui-sidebar-hover-bg);
@@ -3021,6 +3429,39 @@ onBeforeUnmount(() => {
   box-shadow: var(--ui-shadow-xs);
 }
 
+.nav-group-chevron {
+  height: 14px;
+  transition: transform var(--ui-duration-fast) var(--ui-ease-out);
+  width: 14px;
+}
+
+.llm-nav-group-button.is-expanded .nav-group-chevron {
+  transform: rotate(90deg);
+}
+
+.nav-group-items {
+  border-left: 1px solid var(--ui-sidebar-border);
+  margin-left: 18px;
+  padding-left: 10px;
+}
+
+.nav-group-items .llm-nav-item {
+  font-size: 13px;
+  padding-left: 10px;
+}
+
+.llm-ops-sidebar.is-collapsed .llm-nav-item {
+  justify-content: center;
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.llm-ops-sidebar.is-collapsed .llm-nav-group-button {
+  justify-content: center;
+  padding-left: 0;
+  padding-right: 0;
+}
+
 .llm-mobile-nav-item {
   background: var(--ui-bg-muted);
   color: var(--ui-text-secondary);
@@ -3029,6 +3470,7 @@ onBeforeUnmount(() => {
 .llm-ops-content {
   background: var(--ui-bg-page);
   border-left: 0;
+  transition: margin-left 180ms var(--ui-ease-out);
 }
 
 .llm-ops-header {


### PR DESCRIPTION
## Summary
- Add LLM Ops operations dashboard sections for collection health, channel price matrix, model workbench, listing risks, and price changes.
- Extend the summary API KPI payload with active resource, platform listing, and enabled price source counts.
- Wire frontend API methods for channel and listing price history, plus sidebar grouping/collapse navigation for the new dashboards.

## Test plan
- [x] npm run build
- [x] eslint changed frontend files with repository ignore rules
- [x] git diff --check
- [ ] python3 -m pytest backend/llm_ops/tests/test_views.py -k summary (blocked locally: missing drf_spectacular)
- [ ] python3 -m black --check backend/llm_ops/views.py backend/llm_ops/tests/test_views.py (blocked locally: missing black)
- [ ] python3 -m isort --check-only backend/llm_ops/views.py backend/llm_ops/tests/test_views.py (blocked locally: missing isort)

Made with [Orca](https://github.com/stablyai/orca) 🐋
