### PR TITLE
Add LLM Ops auto sync price sources

### DIFF
--- a/backend/llm_ops/collection_services.py
+++ b/backend/llm_ops/collection_services.py
@@ -34,6 +34,7 @@ from .models import (
 )
 from .price_collectors import (
     collect_vendor_price_catalog,
+    registered_vendor_price_collector_codes,
     vendor_price_collector_exists,
 )
 from .services import (
@@ -51,7 +52,9 @@ from .skill_runner import (
 )
 
 SUPPORTED_OFFICIAL_PRICE_SYNC_PROVIDER_CODES = tuple(
-    sorted(OFFICIAL_PROVIDER_CONFIGS.keys())
+    code
+    for code in registered_vendor_price_collector_codes()
+    if code in OFFICIAL_PROVIDER_CONFIGS
 )
 DEFAULT_OFFICIAL_PRICE_SYNC_PROVIDER_CODES: tuple[str, ...] = ()
 FULL_CATALOG_PROVIDER_CODES = (
@@ -89,6 +92,21 @@ OFFICIAL_SOURCE_PROVIDER_DEFAULTS = {
     },
 }
 
+AUTO_SYNC_SOURCE_DEFAULTS = {
+    "siliconflow": {
+        "name": "硅基流动",
+        "source_name": "硅基流动价格页",
+        "source_slug": "siliconflow-pricing",
+        "source_url": "https://siliconflow.cn/pricing",
+        "currency": "CNY",
+        "source_category": PriceCollectionSource.SOURCE_CATEGORY_SUPPLIER,
+        "source_owner_type": PriceCollectionSource.SOURCE_OWNER_SUPPLIER,
+        "collection_method": (
+            PriceCollectionSource.COLLECTION_METHOD_AUTO_COLLECT
+        ),
+    },
+}
+
 MODELS_DEV_META_SOURCE_PROVIDERS = {
     "alibaba",
     "alibaba-cn",
@@ -118,6 +136,13 @@ MODELS_DEV_META_SOURCE_PROVIDERS = {
 def source_owner_type_for_provider(provider: LLMProvider) -> str:
     """Return the publisher type for provider official price sources."""
     if str(provider.code or "").lower() in CLOUD_PROVIDER_OFFICIAL_CODES:
+        return PriceCollectionSource.SOURCE_OWNER_CLOUD_PROVIDER_OFFICIAL
+    return PriceCollectionSource.SOURCE_OWNER_MODEL_PROVIDER_OFFICIAL
+
+
+def source_owner_type_for_provider_code(provider_code: str) -> str:
+    """Return the publisher type for one official provider code."""
+    if str(provider_code or "").lower() in CLOUD_PROVIDER_OFFICIAL_CODES:
         return PriceCollectionSource.SOURCE_OWNER_CLOUD_PROVIDER_OFFICIAL
     return PriceCollectionSource.SOURCE_OWNER_MODEL_PROVIDER_OFFICIAL
 
@@ -800,9 +825,74 @@ def supported_official_provider_options() -> list[dict]:
                     else config.source_url
                 ),
                 "currency": source.currency if source else config.currency,
+                "option_code": provider_code,
+                "source_category": (
+                    PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
+                ),
+                "source_owner_type": source_owner_type_for_provider_code(
+                    provider_code
+                ),
+                "collection_method": (
+                    PriceCollectionSource.COLLECTION_METHOD_AUTO_COLLECT
+                ),
+                "updates_model_prices": True,
             }
         )
     return options
+
+
+def supported_auto_sync_source_options() -> list[dict]:
+    """Return source presets backed by concrete collection code."""
+    options = supported_official_provider_options()
+    supplier_codes = [
+        code
+        for code in registered_vendor_price_collector_codes()
+        if code not in OFFICIAL_PROVIDER_CONFIGS
+    ]
+    supplier_slugs = [
+        AUTO_SYNC_SOURCE_DEFAULTS[code]["source_slug"]
+        for code in supplier_codes
+        if code in AUTO_SYNC_SOURCE_DEFAULTS
+    ]
+    sources = {
+        source.slug: source
+        for source in PriceCollectionSource.objects.filter(
+            slug__in=supplier_slugs
+        )
+    }
+    for source_code in supplier_codes:
+        defaults = AUTO_SYNC_SOURCE_DEFAULTS.get(source_code)
+        if not defaults:
+            continue
+        source_slug = defaults["source_slug"]
+        source = sources.get(source_slug)
+        options.append(
+            {
+                "option_code": source_code,
+                "provider_code": source_code,
+                "provider_name": defaults["name"],
+                "provider_exists": False,
+                "source_id": source.id if source else None,
+                "source_slug": source_slug,
+                "source_name": (
+                    source.name if source else defaults["source_name"]
+                ),
+                "source_exists": source is not None,
+                "source_url": (
+                    source.endpoint_url
+                    if source and source.endpoint_url
+                    else defaults["source_url"]
+                ),
+                "currency": (
+                    source.currency if source else defaults["currency"]
+                ),
+                "source_category": defaults["source_category"],
+                "source_owner_type": defaults["source_owner_type"],
+                "collection_method": defaults["collection_method"],
+                "updates_model_prices": True,
+            }
+        )
+    return sorted(options, key=lambda item: item["source_name"])
 
 
 def ensure_supported_official_provider_source(

--- a/backend/llm_ops/constants.py
+++ b/backend/llm_ops/constants.py
@@ -116,6 +116,10 @@ def normalize_meta_model_name(value, canonical_code):
     name = str(value or "").strip()
     if not name:
         return canonical_code
+    if "/" in name:
+        name = name.rsplit("/", 1)[-1]
+    if ":" in name:
+        name = name.split(":", 1)[0]
     name = re.sub(r"\s+\d{4}-\d{2}-\d{2}$", "", name)
     name = re.sub(r"\s+\d{8}$", "", name)
     name = re.sub(r"\s+\d{6}$", "", name)

--- a/backend/llm_ops/global_config.py
+++ b/backend/llm_ops/global_config.py
@@ -7,7 +7,7 @@ import re
 from typing import Optional
 
 from .models import LLMOpsGlobalConfig, PriceCollectionSource
-from .collectors.official import OFFICIAL_PROVIDER_CONFIGS
+from .source_collectors.official import SUPPORTED_OFFICIAL_PROVIDER_CODES
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +19,7 @@ MODEL_PRICE_SYNC_AGENT_TASK_NAME = "llm_ops_model_price_sync_agent"
 MODEL_PRICE_SYNC_AGENT_TASK = "llm_ops.tasks.run_model_price_sync_agent"
 PRICE_SOURCE_TASK_PREFIX = "llm_ops_price_source_collect_"
 PRICE_SOURCE_TASK = "llm_ops.tasks.collect_price_source_prices"
-SUPPORTED_PRICE_SYNC_PROVIDER_CODES = tuple(sorted(OFFICIAL_PROVIDER_CONFIGS))
+SUPPORTED_PRICE_SYNC_PROVIDER_CODES = SUPPORTED_OFFICIAL_PROVIDER_CODES
 
 
 def price_source_task_name(source_id: int) -> str:
@@ -171,14 +171,18 @@ def price_sync_task_source_ids(config: LLMOpsGlobalConfig) -> list[int] | None:
 
 def price_sync_source_queryset():
     """Return sources currently supported by runtime price sync."""
-    return PriceCollectionSource.objects.filter(
-        provider__code__in=SUPPORTED_PRICE_SYNC_PROVIDER_CODES,
-        slug__in=official_provider_source_slugs(),
-        source_category=(
-            PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
-        ),
-        updates_model_prices=True,
+    from .source_collectors import source_supports_code_collection
+
+    candidate_sources = (
+        PriceCollectionSource.objects.filter(updates_model_prices=True)
+        .select_related("provider")
     )
+    supported_source_ids = [
+        source.id
+        for source in candidate_sources
+        if source_supports_code_collection(source)
+    ]
+    return PriceCollectionSource.objects.filter(id__in=supported_source_ids)
 
 
 def official_provider_source_slugs() -> tuple[str, ...]:

--- a/backend/llm_ops/price_collectors/__init__.py
+++ b/backend/llm_ops/price_collectors/__init__.py
@@ -1,9 +1,11 @@
 from .registry import (
     collect_vendor_price_catalog,
+    registered_vendor_price_collector_codes,
     vendor_price_collector_exists,
 )
 
 __all__ = [
     "collect_vendor_price_catalog",
+    "registered_vendor_price_collector_codes",
     "vendor_price_collector_exists",
 ]

--- a/backend/llm_ops/price_collectors/parsers/siliconflow.py
+++ b/backend/llm_ops/price_collectors/parsers/siliconflow.py
@@ -28,6 +28,7 @@ COMPONENT_PRICE_KEYS = {
     "output-tokens": "output_price",
     "cached-input-tokens": "cache_hit_input_price",
 }
+PRICE_VALUE_KEYS = tuple(COMPONENT_PRICE_KEYS.values())
 UPSTREAM_PROVIDER_ALIASES = {
     "deepseek-ai": "DeepSeek",
     "zai-org": "智谱",
@@ -155,7 +156,12 @@ def extract_models(page_html: str) -> list[dict[str, Any]]:
         )
         row[price_key] = price
 
-    return [normalize_grouped_model(item) for item in grouped.values()]
+    models = []
+    for item in grouped.values():
+        normalized = normalize_grouped_model(item)
+        if normalized["price_rows"]:
+            models.append(normalized)
+    return models
 
 
 def extract_pricing_api_items(page_html: str) -> list[dict[str, Any]]:
@@ -301,6 +307,8 @@ def normalize_grouped_model(item: dict[str, Any]) -> dict[str, Any]:
     """Convert grouped component prices into standard model rows."""
     rows = []
     for row_key, row in item["price_rows"].items():
+        if not row_has_positive_price(row):
+            continue
         normalized = dict(row)
         token_range = token_range_from_coordinate(row_key)
         if token_range:
@@ -317,6 +325,18 @@ def normalize_grouped_model(item: dict[str, Any]) -> dict[str, Any]:
         "price_rows": rows,
         "notes": "SiliconFlow supplier token prices.",
     }
+
+
+def row_has_positive_price(row: dict[str, Any]) -> bool:
+    """Return whether a SiliconFlow row has at least one real price."""
+    for key in PRICE_VALUE_KEYS:
+        value = row.get(key)
+        try:
+            if Decimal(str(value)) > 0:
+                return True
+        except (InvalidOperation, TypeError, ValueError):
+            continue
+    return False
 
 
 def token_range_from_coordinate(value: str) -> str:

--- a/backend/llm_ops/price_collectors/registry.py
+++ b/backend/llm_ops/price_collectors/registry.py
@@ -15,6 +15,11 @@ PRICE_CATALOG_COLLECTORS: dict[str, VendorPriceCatalogCollector] = {
 }
 
 
+def registered_vendor_price_collector_codes() -> tuple[str, ...]:
+    """Return provider codes with a concrete price catalog collector."""
+    return tuple(sorted(PRICE_CATALOG_COLLECTORS))
+
+
 def vendor_price_collector_exists(provider_code: str) -> bool:
     """Return whether a formal catalog collector exists for a provider."""
     return normalize_provider_code(provider_code) in PRICE_CATALOG_COLLECTORS

--- a/backend/llm_ops/serializers.py
+++ b/backend/llm_ops/serializers.py
@@ -1035,6 +1035,11 @@ def collection_method_for_source(source):
         return method
     if source.source_type == PriceCollectionSource.SOURCE_TYPE_YUNCE:
         return PriceCollectionSource.COLLECTION_METHOD_API_SYNC
+    if source.updates_model_prices:
+        from .source_collectors import source_supports_code_collection
+
+        if source_supports_code_collection(source):
+            return PriceCollectionSource.COLLECTION_METHOD_AUTO_COLLECT
     if (
         source.source_category
         == PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER

--- a/backend/llm_ops/source_collectors/official.py
+++ b/backend/llm_ops/source_collectors/official.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 from llm_ops.collection_services import sync_official_provider_model_prices
 from llm_ops.collectors.official import OFFICIAL_PROVIDER_CONFIGS
 from llm_ops.models import PriceCollectionSource
+from llm_ops.price_collectors import registered_vendor_price_collector_codes
 
 from .base import CollectorResult
 
 SUPPORTED_OFFICIAL_PROVIDER_CODES = tuple(
-    sorted(OFFICIAL_PROVIDER_CONFIGS.keys())
+    code
+    for code in registered_vendor_price_collector_codes()
+    if code in OFFICIAL_PROVIDER_CONFIGS
 )
 
 

--- a/backend/llm_ops/tests/test_meta_model_identity.py
+++ b/backend/llm_ops/tests/test_meta_model_identity.py
@@ -1,0 +1,18 @@
+from django.test import SimpleTestCase
+
+from llm_ops.constants import canonical_meta_model_identity
+
+
+class MetaModelIdentityTests(SimpleTestCase):
+    def test_supplier_namespace_is_removed_from_meta_model_name(self):
+        identity = canonical_meta_model_identity(
+            "siliconflow/deepseek-v3.1-terminus",
+            "siliconflow/deepseek-v3.1-terminus",
+        )
+
+        self.assertEqual(identity["code"], "deepseek-v3.1-terminus")
+        self.assertEqual(identity["name"], "deepseek-v3.1-terminus")
+        self.assertIn(
+            "siliconflow/deepseek-v3.1-terminus",
+            identity["aliases"],
+        )

--- a/backend/llm_ops/tests/test_ops_bootstrap.py
+++ b/backend/llm_ops/tests/test_ops_bootstrap.py
@@ -17,10 +17,11 @@ from llm_ops.catalog_maintenance import (
     resolve_orphan_meta_models,
 )
 from llm_ops.collection_services import (
+    SUPPORTED_OFFICIAL_PRICE_SYNC_PROVIDER_CODES,
     reset_official_price_catalog,
+    supported_auto_sync_source_options,
     supported_official_provider_options,
 )
-from llm_ops.collectors.official import OFFICIAL_PROVIDER_CONFIGS
 from llm_ops.management.commands.cleanup_llm_ops_seed_prices import (
     build_cleanup_plan,
     execute_cleanup,
@@ -79,7 +80,12 @@ class LLMOpsCatalogMaintenanceTests(TestCase):
     """Catalog maintenance is separate from seed bootstrap."""
 
     def test_resolve_orphan_meta_models_uses_canonical_owner_rules(self):
-        MetaModel.objects.create(name="DeepSeek R1", code="deepseek-r1")
+        meta = MetaModel.objects.create(name="DeepSeek R1", code="deepseek-r1")
+        MetaModel.objects.filter(id=meta.id).update(
+            owner_code="",
+            owner_name="",
+            owner_website="",
+        )
 
         stats = resolve_orphan_meta_models()
 
@@ -88,11 +94,14 @@ class LLMOpsCatalogMaintenanceTests(TestCase):
         self.assertEqual(meta.owner_code, "deepseek")
 
     def test_normalize_meta_model_catalog_repairs_stale_owner(self):
-        MetaModel.objects.create(
+        meta = MetaModel.objects.create(
             name="DeepSeek R1",
             code="deepseek-r1",
+        )
+        MetaModel.objects.filter(id=meta.id).update(
             owner_code="aliyun",
             owner_name="阿里云",
+            owner_website="",
         )
 
         stats = normalize_meta_model_catalog()
@@ -267,8 +276,18 @@ class LLMOpsOfficialProviderOptionTests(TestCase):
         options = supported_official_provider_options()
 
         provider_codes = {option["provider_code"] for option in options}
-        self.assertIn("aliyun", provider_codes)
-        self.assertIn("baidu", provider_codes)
+        self.assertEqual({"aliyun", "deepseek"}, provider_codes)
+        self.assertFalse(LLMProvider.objects.exists())
+        self.assertFalse(PriceCollectionSource.objects.exists())
+
+    def test_auto_sync_source_options_do_not_create_rows(self):
+        options = supported_auto_sync_source_options()
+
+        provider_codes = {option["provider_code"] for option in options}
+        self.assertEqual(
+            {"aliyun", "deepseek", "siliconflow"},
+            provider_codes,
+        )
         self.assertFalse(LLMProvider.objects.exists())
         self.assertFalse(PriceCollectionSource.objects.exists())
 
@@ -526,7 +545,7 @@ class LLMOpsOfficialPriceResetCommandTests(TestCase):
             "legacy_source_slugs": [],
         }
         mock_sync.return_value = {}
-        provider_codes = sorted(OFFICIAL_PROVIDER_CONFIGS)
+        provider_codes = sorted(SUPPORTED_OFFICIAL_PRICE_SYNC_PROVIDER_CODES)
 
         call_command(
             "reset_llm_ops_official_prices",

--- a/backend/llm_ops/tests/test_serializers.py
+++ b/backend/llm_ops/tests/test_serializers.py
@@ -7,10 +7,12 @@ from llm_ops.models import (
     LLMProvider,
     MetaModel,
     ModelPriceItem,
+    ModelSku,
     PriceCollectionRun,
     PriceCollectionSource,
     ProcurementChannel,
     ResalePlatform,
+    SourceSkuOffering,
 )
 from llm_ops.serializers import (
     LLMModelSerializer,
@@ -402,22 +404,22 @@ class PriceCollectionSourceSerializerTests(TestCase):
         self.assertEqual(data["business_source_category"], "cloud_hosted")
 
     def test_source_representation_includes_stable_summary_fields(self):
-        provider = LLMProvider.objects.create(name="OpenAI", code="openai")
+        provider = LLMProvider.objects.create(name="DeepSeek", code="deepseek")
         source = PriceCollectionSource.objects.create(
-            name="OpenAI Official",
-            slug="openai-official",
+            name="DeepSeek Official",
+            slug="deepseek-official",
             provider=provider,
             source_category=(
                 PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
             ),
-            endpoint_url="https://openai.com/api/pricing/",
+            endpoint_url="https://api-docs.deepseek.com/quick_start/pricing",
             updates_model_prices=True,
         )
         model = LLMModel.objects.create(
             provider=provider,
             source=source,
-            name="GPT-4o mini",
-            code="gpt-4o-mini",
+            name="DeepSeek Chat",
+            code="deepseek-chat",
         )
         ModelPriceItem.objects.create(
             provider=provider,
@@ -426,9 +428,9 @@ class PriceCollectionSourceSerializerTests(TestCase):
             source=source,
             dimension=ModelPriceItem.DIMENSION_TEXT_INPUT,
             billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
-            currency="USD",
+            currency="CNY",
             unit_price=Decimal("0.150000"),
-            price_fingerprint="openai-input",
+            price_fingerprint="deepseek-input",
         )
         PriceCollectionRun.objects.create(
             source=source,
@@ -442,6 +444,24 @@ class PriceCollectionSourceSerializerTests(TestCase):
         self.assertEqual(data["latest_run_status"], "succeeded")
         self.assertTrue(data["capabilities"]["can_collect_prices"])
         self.assertTrue(data["capabilities"]["updates_model_prices"])
+
+    def test_supplier_collector_representation_infers_auto_collect(self):
+        source = PriceCollectionSource.objects.create(
+            name="SiliconFlow Pricing",
+            slug="siliconflow-pricing",
+            source_category=PriceCollectionSource.SOURCE_CATEGORY_SUPPLIER,
+            source_owner_type=PriceCollectionSource.SOURCE_OWNER_SUPPLIER,
+            collection_method=PriceCollectionSource.COLLECTION_METHOD_UNKNOWN,
+            endpoint_url="https://siliconflow.cn/pricing",
+            currency="CNY",
+            updates_model_prices=True,
+        )
+
+        data = PriceCollectionSourceSerializer(source).data
+
+        self.assertEqual(data["source_category"], "supplier")
+        self.assertEqual(data["collection_method"], "auto_collect")
+        self.assertTrue(data["capabilities"]["can_collect_prices"])
 
 
 class LLMModelSerializerTests(TestCase):
@@ -577,7 +597,7 @@ class ManualPriceImportRequestSerializerTests(TestCase):
         self.assertTrue(serializer.is_valid(), serializer.errors)
         self.assertFalse(serializer.validated_data["updates_model_prices"])
 
-    def test_existing_official_source_manual_import_never_promotes_prices(self):
+    def test_manual_import_never_promotes_prices(self):
         provider = LLMProvider.objects.create(name="OpenAI", code="openai")
         source = PriceCollectionSource.objects.create(
             name="OpenAI Official",
@@ -673,6 +693,28 @@ class ModelPriceItemSerializerTests(TestCase):
             input_price_per_million=Decimal("4"),
             output_price_per_million=Decimal("16"),
         )
+        source = PriceCollectionSource.objects.create(
+            name="DeepSeek Official",
+            slug="deepseek-official",
+            provider=deepseek,
+            source_category=(
+                PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
+            ),
+        )
+        sku = ModelSku.objects.create(
+            meta_model=model.meta_model,
+            provider=deepseek,
+            canonical_sku_code=model.code,
+            upstream_model_name=model.code,
+            display_name=model.name,
+            variant_type=ModelSku.VARIANT_OFFICIAL,
+        )
+        offering = SourceSkuOffering.objects.create(
+            source=source,
+            sku=sku,
+            provider=deepseek,
+            exposed_model_name=model.code,
+        )
         wrong_meta = MetaModel.objects.create(
             name="阿里云 DeepSeek R1 250528",
             code="aliyun-deepseek-r1-250528",
@@ -685,6 +727,9 @@ class ModelPriceItemSerializerTests(TestCase):
             data={
                 "provider": deepseek.id,
                 "model": model.id,
+                "sku": sku.id,
+                "offering": offering.id,
+                "source": source.id,
                 "meta_model": wrong_meta.id,
                 "dimension": ModelPriceItem.DIMENSION_TEXT_INPUT,
                 "billing_unit": ModelPriceItem.UNIT_PER_1M_TOKENS,

--- a/backend/llm_ops/tests/test_skill_runner.py
+++ b/backend/llm_ops/tests/test_skill_runner.py
@@ -418,6 +418,69 @@ class ModelPriceSkillRunnerTests(SimpleTestCase):
             "1",
         )
 
+    def test_siliconflow_provider_adapter_skips_free_models(self):
+        payload = collect_vendor_price_catalog(
+            "siliconflow",
+            {
+                "provider_name": "SiliconFlow",
+                "currency": "CNY",
+                "raw_html": siliconflow_html(
+                    [
+                        {
+                            "playgroundName": (
+                                "deepseek-ai/DeepSeek-R1-0528-Qwen3-8B"
+                            ),
+                            "playgroundSort": 80100,
+                            "skuName": "free-text-model.online",
+                            "componentCode": "input-tokens",
+                            "coordinateDesc": "",
+                            "price_scenario": "活动价",
+                            "realTimePriceCnyUnit": "0",
+                            "unitZhCnName": "K tokens",
+                        },
+                        {
+                            "playgroundName": (
+                                "deepseek-ai/DeepSeek-R1-0528-Qwen3-8B"
+                            ),
+                            "playgroundSort": 80100,
+                            "skuName": "free-text-model.online",
+                            "componentCode": "output-tokens",
+                            "coordinateDesc": "",
+                            "price_scenario": "活动价",
+                            "realTimePriceCnyUnit": "0",
+                            "unitZhCnName": "K tokens",
+                        },
+                        {
+                            "playgroundName": "deepseek-ai/DeepSeek-V4-Pro",
+                            "playgroundSort": 81000,
+                            "skuName": "deepseek-ai/deepseek-v4-pro.online",
+                            "componentCode": "input-tokens",
+                            "coordinateDesc": "",
+                            "price_scenario": "兜底价",
+                            "realTimePriceCnyUnit": "0.012000",
+                            "unitZhCnName": "K tokens",
+                        },
+                        {
+                            "playgroundName": "deepseek-ai/DeepSeek-V4-Pro",
+                            "playgroundSort": 81000,
+                            "skuName": "deepseek-ai/deepseek-v4-pro.online",
+                            "componentCode": "output-tokens",
+                            "coordinateDesc": "",
+                            "price_scenario": "兜底价",
+                            "realTimePriceCnyUnit": "0.024000",
+                            "unitZhCnName": "K tokens",
+                        },
+                    ]
+                ),
+            },
+        )
+
+        self.assertEqual(payload["total_models"], 1)
+        self.assertEqual(
+            payload["models"][0]["model_id"],
+            "deepseek-ai/DeepSeek-V4-Pro",
+        )
+
     def test_aliyun_vendor_skill_extracts_unconfigured_page_rows(self):
         payload = run_vendor_pricing_skill(
             "aliyun",

--- a/backend/llm_ops/tests/test_source_collectors.py
+++ b/backend/llm_ops/tests/test_source_collectors.py
@@ -10,7 +10,7 @@ from llm_ops.collection_services import (
     upsert_collected_offering,
 )
 from llm_ops.collectors import CollectedModelPricing, NormalizedPriceRow
-from llm_ops.collectors.official import OFFICIAL_PROVIDER_CONFIGS
+from llm_ops.global_config import price_sync_source_queryset
 from llm_ops.models import (
     LLMProvider,
     MetaModel,
@@ -31,9 +31,9 @@ from llm_ops.source_collectors.official import (
 
 
 class PriceSourceCollectorRegistryTests(TestCase):
-    def test_all_official_configs_have_registered_collectors(self):
+    def test_official_collectors_follow_price_source_implementations(self):
         self.assertEqual(
-            set(OFFICIAL_PROVIDER_CONFIGS),
+            {"aliyun", "deepseek"},
             set(SUPPORTED_OFFICIAL_PROVIDER_CODES),
         )
 
@@ -103,7 +103,7 @@ class PriceSourceCollectorRegistryTests(TestCase):
         self.assertEqual(collector.collector_id, "official_provider:deepseek")
         self.assertTrue(source_supports_code_collection(source))
 
-    def test_baidu_official_provider_source_dispatches_to_collector(self):
+    def test_unimplemented_official_source_is_not_supported(self):
         provider = LLMProvider.objects.create(name="百度", code="baidu")
         source = PriceCollectionSource.objects.create(
             name="Baidu Official",
@@ -120,9 +120,8 @@ class PriceSourceCollectorRegistryTests(TestCase):
 
         collector = get_price_source_collector(source)
 
-        self.assertIsNotNone(collector)
-        self.assertEqual(collector.collector_id, "official_provider:baidu")
-        self.assertTrue(source_supports_code_collection(source))
+        self.assertIsNone(collector)
+        self.assertFalse(source_supports_code_collection(source))
 
     def test_model_level_official_source_is_not_supported(self):
         provider = LLMProvider.objects.create(name="阿里云", code="aliyun")
@@ -198,6 +197,49 @@ class PriceSourceCollectorRegistryTests(TestCase):
             verify_source=False,
         )
         self.assertEqual(result, {"models": 2})
+
+    def test_price_sync_queryset_includes_code_backed_supplier_source(self):
+        aliyun = LLMProvider.objects.create(name="阿里云", code="aliyun")
+        aliyun_source = PriceCollectionSource.objects.create(
+            name="Aliyun Official",
+            slug="aliyun-official",
+            provider=aliyun,
+            source_type=PriceCollectionSource.SOURCE_TYPE_CUSTOM,
+            source_category=(
+                PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
+            ),
+            endpoint_url=(
+                "https://help.aliyun.com/zh/model-studio/model-pricing"
+            ),
+            is_enabled=True,
+            updates_model_prices=True,
+        )
+        siliconflow_source = PriceCollectionSource.objects.create(
+            name="SiliconFlow Pricing",
+            slug="siliconflow-pricing",
+            source_type=PriceCollectionSource.SOURCE_TYPE_CUSTOM,
+            source_category=PriceCollectionSource.SOURCE_CATEGORY_SUPPLIER,
+            endpoint_url="https://siliconflow.cn/pricing",
+            is_enabled=True,
+            updates_model_prices=True,
+        )
+        unsupported_source = PriceCollectionSource.objects.create(
+            name="Supplier Sheet",
+            slug="supplier-sheet",
+            source_type=PriceCollectionSource.SOURCE_TYPE_CUSTOM,
+            source_category=PriceCollectionSource.SOURCE_CATEGORY_SUPPLIER,
+            endpoint_url="https://example.com/pricing",
+            is_enabled=True,
+            updates_model_prices=True,
+        )
+
+        source_ids = set(
+            price_sync_source_queryset().values_list("id", flat=True)
+        )
+
+        self.assertIn(aliyun_source.id, source_ids)
+        self.assertIn(siliconflow_source.id, source_ids)
+        self.assertNotIn(unsupported_source.id, source_ids)
 
     def test_unknown_official_provider_does_not_match_collector(self):
         provider = LLMProvider.objects.create(

--- a/backend/llm_ops/tests/test_views.py
+++ b/backend/llm_ops/tests/test_views.py
@@ -879,7 +879,7 @@ class LLMOpsViewTests(TestCase):
         self.assertEqual(response.status_code, 409)
         self.assertTrue(MetaModel.objects.filter(id=meta.id).exists())
 
-    @patch("llm_ops.views.run_model_price_sync_agent.delay")
+    @patch("llm_ops.views.collect_price_source_prices.delay")
     def test_collection_source_collects_official_provider(self, mock_delay):
         provider = LLMProvider.objects.create(name="阿里云", code="aliyun")
         source = PriceCollectionSource.objects.create(
@@ -909,13 +909,40 @@ class LLMOpsViewTests(TestCase):
         self.assertEqual(response.data["provider_code"], "aliyun")
         self.assertEqual(response.data["source_id"], source.id)
         mock_delay.assert_called_once_with(
-            source_ids=[source.id],
+            source_id=source.id,
             verify_source=True,
         )
         audit = AuditLog.objects.get(target_id=str(source.id))
         self.assertEqual(audit.action, AuditLog.ACTION_COLLECT)
         self.assertEqual(audit.category, AuditLog.CATEGORY_COLLECTION)
         self.assertEqual(audit.metadata["task_id"], "task-123")
+
+    @patch("llm_ops.views.collect_price_source_prices.delay")
+    def test_collection_source_collects_code_backed_supplier(self, mock_delay):
+        source = PriceCollectionSource.objects.create(
+            name="SiliconFlow Pricing",
+            slug="siliconflow-pricing",
+            source_type=PriceCollectionSource.SOURCE_TYPE_CUSTOM,
+            source_category=PriceCollectionSource.SOURCE_CATEGORY_SUPPLIER,
+            endpoint_url="https://siliconflow.cn/pricing",
+            is_enabled=True,
+            updates_model_prices=True,
+        )
+        mock_delay.return_value.id = "task-siliconflow"
+
+        response = self.client.post(
+            reverse("collection-source-collect", args=[source.id]),
+            {},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(response.data["task_id"], "task-siliconflow")
+        self.assertEqual(response.data["source_id"], source.id)
+        mock_delay.assert_called_once_with(
+            source_id=source.id,
+            verify_source=True,
+        )
 
     @patch("llm_ops.views.run_model_price_sync_agent.delay")
     def test_collection_sources_sync_all_submits_supported_sources(
@@ -949,15 +976,12 @@ class LLMOpsViewTests(TestCase):
             is_enabled=True,
             updates_model_prices=True,
         )
-        openai = LLMProvider.objects.create(name="OpenAI", code="openai")
-        openai_source = PriceCollectionSource.objects.create(
-            name="OpenAI Official",
-            slug="openai-official",
-            provider=openai,
-            source_category=(
-                PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
-            ),
-            endpoint_url="https://openai.com/api/pricing/",
+        siliconflow_source = PriceCollectionSource.objects.create(
+            name="SiliconFlow Pricing",
+            slug="siliconflow-pricing",
+            source_type=PriceCollectionSource.SOURCE_TYPE_CUSTOM,
+            source_category=PriceCollectionSource.SOURCE_CATEGORY_SUPPLIER,
+            endpoint_url="https://siliconflow.cn/pricing",
             is_enabled=True,
             updates_model_prices=True,
         )
@@ -970,10 +994,10 @@ class LLMOpsViewTests(TestCase):
         self.assertEqual(response.data["source_count"], 2)
         self.assertEqual(
             response.data["source_ids"],
-            [aliyun_source.id, openai_source.id],
+            [aliyun_source.id, siliconflow_source.id],
         )
         mock_delay.assert_called_once_with(
-            source_ids=[aliyun_source.id, openai_source.id],
+            source_ids=[aliyun_source.id, siliconflow_source.id],
             verify_source=True,
         )
         audit = AuditLog.objects.get(
@@ -983,7 +1007,7 @@ class LLMOpsViewTests(TestCase):
         self.assertEqual(audit.metadata["task_id"], "task-all")
         self.assertEqual(
             audit.metadata["source_ids"],
-            [aliyun_source.id, openai_source.id],
+            [aliyun_source.id, siliconflow_source.id],
         )
 
     @patch("llm_ops.views.run_model_price_sync_agent.delay")
@@ -996,7 +1020,7 @@ class LLMOpsViewTests(TestCase):
         self.assertEqual(response.status_code, 400)
         mock_delay.assert_not_called()
 
-    def test_official_provider_options_include_aliyun_presets(self):
+    def test_official_provider_options_follow_collector_implementations(self):
         response = self.client.get(
             reverse("collection-source-official-provider-options")
         )
@@ -1005,10 +1029,31 @@ class LLMOpsViewTests(TestCase):
         provider_codes = {
             item["provider_code"] for item in response.data["results"]
         }
-        self.assertIn("aliyun", provider_codes)
-        self.assertIn("aliyun-wanx", provider_codes)
-        self.assertIn("baidu", provider_codes)
-        self.assertIn("volcengine", provider_codes)
+        self.assertEqual({"aliyun", "deepseek"}, provider_codes)
+
+    def test_auto_sync_options_include_supplier_collectors(self):
+        response = self.client.get(
+            reverse("collection-source-auto-sync-options")
+        )
+
+        self.assertEqual(response.status_code, 200)
+        provider_codes = {
+            item["provider_code"] for item in response.data["results"]
+        }
+        self.assertEqual({"aliyun", "deepseek", "siliconflow"}, provider_codes)
+        siliconflow = next(
+            item
+            for item in response.data["results"]
+            if item["provider_code"] == "siliconflow"
+        )
+        self.assertEqual(
+            siliconflow["source_category"],
+            PriceCollectionSource.SOURCE_CATEGORY_SUPPLIER,
+        )
+        self.assertEqual(
+            siliconflow["source_url"],
+            "https://siliconflow.cn/pricing",
+        )
 
     def test_ensure_official_provider_source_creates_aliyun_source(self):
         response = self.client.post(
@@ -1075,7 +1120,20 @@ class LLMOpsViewTests(TestCase):
             1,
         )
 
-    @patch("llm_ops.views.run_model_price_sync_agent.delay")
+    def test_ensure_official_provider_source_rejects_unimplemented_source(
+        self,
+    ):
+        response = self.client.post(
+            reverse("collection-source-ensure-official-provider"),
+            {"provider_code": "baidu"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Unsupported official provider", response.data["detail"])
+        self.assertFalse(LLMProvider.objects.filter(code="baidu").exists())
+
+    @patch("llm_ops.views.collect_price_source_prices.delay")
     def test_collection_source_collect_rejects_disabled_source(
         self,
         mock_delay,
@@ -1106,7 +1164,7 @@ class LLMOpsViewTests(TestCase):
         )
         mock_delay.assert_not_called()
 
-    @patch("llm_ops.views.run_model_price_sync_agent.delay")
+    @patch("llm_ops.views.collect_price_source_prices.delay")
     def test_collection_source_collect_rejects_unsupported_source(
         self,
         mock_delay,
@@ -1140,7 +1198,7 @@ class LLMOpsViewTests(TestCase):
         mock_delay.assert_not_called()
 
     @patch("llm_ops.views.source_supports_code_collection")
-    @patch("llm_ops.views.run_model_price_sync_agent.delay")
+    @patch("llm_ops.views.collect_price_source_prices.delay")
     def test_collection_source_collect_does_not_require_provider(
         self,
         mock_delay,
@@ -1169,7 +1227,7 @@ class LLMOpsViewTests(TestCase):
         self.assertEqual(response.data["provider_code"], "")
         self.assertEqual(response.data["source_id"], source.id)
         mock_delay.assert_called_once_with(
-            source_ids=[source.id],
+            source_id=source.id,
             verify_source=True,
         )
 

--- a/backend/llm_ops/views.py
+++ b/backend/llm_ops/views.py
@@ -17,6 +17,7 @@ from .collection_services import (
     ensure_supported_official_provider_source,
     official_provider_source_slug,
     reset_official_price_catalog,
+    supported_auto_sync_source_options,
     supported_official_provider_options,
     sync_configured_official_model_prices,
     sync_meta_models_from_models_dev,
@@ -86,7 +87,7 @@ from .services import (
     sync_channel_price_items,
 )
 from .source_collectors import source_supports_code_collection
-from .tasks import run_model_price_sync_agent
+from .tasks import collect_price_source_prices, run_model_price_sync_agent
 from .workflow_config import (
     merge_resale_workflow_config,
     validate_resale_workflow_config,
@@ -241,6 +242,19 @@ class PriceCollectionSourceViewSet(
 
     @action(
         detail=False,
+        methods=["get"],
+        url_path="auto-sync-options",
+        url_name="auto-sync-options",
+    )
+    def auto_sync_options(self, request):
+        """List price source presets backed by collection code."""
+        return Response(
+            {"results": supported_auto_sync_source_options()},
+            status=status.HTTP_200_OK,
+        )
+
+    @action(
+        detail=False,
         methods=["post"],
         url_path="official-provider",
         url_name="ensure-official-provider",
@@ -312,8 +326,8 @@ class PriceCollectionSourceViewSet(
                 status=status.HTTP_400_BAD_REQUEST,
             )
         if source_supports_code_collection(source):
-            task = run_model_price_sync_agent.delay(
-                source_ids=[source.id],
+            task = collect_price_source_prices.delay(
+                source_id=source.id,
                 verify_source=True,
             )
             record_audit_log(

--- a/frontend/src/api/llmOps.js
+++ b/frontend/src/api/llmOps.js
@@ -25,6 +25,10 @@ export const llmOpsApi = {
     )
   },
 
+  listAutoSyncSourceOptions() {
+    return apiClient.get(`${base}/collection-sources/auto-sync-options/`)
+  },
+
   ensureOfficialProviderSource(providerCode) {
     return apiClient.post(`${base}/collection-sources/official-provider/`, {
       provider_code: providerCode

--- a/frontend/src/components/llm-ops/ChannelManagement.vue
+++ b/frontend/src/components/llm-ops/ChannelManagement.vue
@@ -179,6 +179,7 @@
     <ChannelModelDrawer
       :channel="selectedChannelForModels"
       :providers="providers"
+      :meta-models="metaModels"
       :models="models"
       :channel-prices="channelPrices"
       :channel-price-items="channelPriceItems"
@@ -264,6 +265,10 @@ const props = defineProps({
   providers: {
     type: Array,
     required: true
+  },
+  metaModels: {
+    type: Array,
+    default: () => []
   },
   models: {
     type: Array,

--- a/frontend/src/components/llm-ops/ChannelModelDrawer.vue
+++ b/frontend/src/components/llm-ops/ChannelModelDrawer.vue
@@ -314,10 +314,14 @@
                       <span class="truncate">无可用上游</span>
                     </div>
                     <div v-if="item.model" class="batch-price-preview">
-                      <span>上游 {{ upstreamPriceSummary(item.model) }}</span>
+                      <span>
+                        上游 {{ batchUpstreamPriceSummary(item.model) }}
+                      </span>
                       <strong>
                         成本
-                        {{ pendingDraftPriceSummary(newDraft, item.model) }}
+                        {{
+                          batchPendingDraftPriceSummary(newDraft, item.model)
+                        }}
                       </strong>
                     </div>
                     <div v-else class="batch-price-preview muted">
@@ -771,6 +775,10 @@ const props = defineProps({
     type: Array,
     required: true
   },
+  metaModels: {
+    type: Array,
+    default: () => []
+  },
   models: {
     type: Array,
     required: true
@@ -912,12 +920,69 @@ const configuredIdentityKeys = computed(() => {
   return keys
 })
 
+const metaModelById = computed(() => {
+  const items = new Map()
+  props.metaModels.forEach((model) => {
+    if (model?.id !== undefined && model?.id !== null) {
+      items.set(String(model.id), model)
+    }
+  })
+  return items
+})
+
+const metaModelByCode = computed(() => {
+  const items = new Map()
+  props.metaModels.forEach((model) => {
+    const code = normalizeSearch(model?.code || '')
+    if (code) {
+      items.set(code, model)
+    }
+  })
+  return items
+})
+
+const candidateMetaModelGroups = computed(() => {
+  const groups = new Map()
+  baseAvailableModels.value.forEach((model) => {
+    const metaModel = metaModelForSourceModel(model)
+    if (!metaModel) return
+
+    const key = metaModelIdentityKey(metaModel)
+    const group = groups.get(key) || {
+      key,
+      metaModel,
+      name: metaModelDisplayName(metaModel),
+      code: metaModel.code || model.meta_model_code || '',
+      ownerCode: metaModel.owner_code || model.meta_model_owner_code || '',
+      ownerName: metaModel.owner_name || model.meta_model_owner_name || '',
+      modality: metaModel.modality || model.modality,
+      modalities: new Set(),
+      models: []
+    }
+    group.models.push(model)
+    const modality = metaModel.modality || model.modality
+    if (modality) {
+      group.modalities.add(modality)
+    }
+    group.providerCount = uniqueProviderModelsForGroup(group).length
+    groups.set(key, group)
+  })
+  return Array.from(groups.values())
+    .map((group) => ({
+      ...group,
+      modalitySummary: Array.from(group.modalities)
+        .map((modality) => modalityLabel(modality))
+        .join(' / ')
+    }))
+    .sort((left, right) => left.name.localeCompare(right.name))
+})
+
 const vendorOptions = computed(() => {
   const vendors = new Map()
-  baseAvailableModels.value.forEach((model) => {
-    const key = modelVendorKey(model)
+  candidateMetaModelGroups.value.forEach((group) => {
+    const key = metaModelVendorKey(group)
     const vendor = vendors.get(key) || {
-      label: modelVendorName(model),
+      label: metaModelVendorName(group),
       value: key,
       count: 0
     }
@@ -934,38 +999,11 @@ const vendorOptions = computed(() => {
 })
 
 const availableModelGroups = computed(() => {
-  const groups = new Map()
-  baseAvailableModels.value
-    .filter(
-      (model) =>
-        !selectedVendorKey.value ||
-        modelVendorKey(model) === selectedVendorKey.value
-    )
-    .forEach((model) => {
-      const key = modelMetaIdentityKey(model)
-      const group = groups.get(key) || {
-        key,
-        name: modelDisplayName(model),
-        code: model.meta_model_code || model.code,
-        modality: model.modality,
-        modalities: new Set(),
-        models: []
-      }
-      group.models.push(model)
-      if (model.modality) {
-        group.modalities.add(model.modality)
-      }
-      group.providerCount = uniqueProviderModelsForGroup(group).length
-      groups.set(key, group)
-    })
-  return Array.from(groups.values())
-    .map((group) => ({
-      ...group,
-      modalitySummary: Array.from(group.modalities)
-        .map((modality) => modalityLabel(modality))
-        .join(' / ')
-    }))
-    .sort((left, right) => left.name.localeCompare(right.name))
+  return candidateMetaModelGroups.value.filter(
+    (group) =>
+      !selectedVendorKey.value ||
+      metaModelVendorKey(group) === selectedVendorKey.value
+  )
 })
 
 const availableModelCount = computed(() => availableModelGroups.value.length)
@@ -1525,23 +1563,43 @@ function normalizeSearch(value) {
     .replace(/\s+/g, '')
 }
 
-function modelVendorKey(model) {
-  return normalizeSearch(
-    model.meta_model_owner_code ||
-      model.meta_model_owner_name ||
-      model.provider_code ||
-      model.provider_name ||
-      'unknown'
-  )
+function metaModelForSourceModel(model) {
+  const metaId = String(model?.meta_model || '').trim()
+  if (metaId && metaModelById.value.has(metaId)) {
+    return metaModelById.value.get(metaId)
+  }
+  const metaCode = normalizeSearch(model?.meta_model_code || '')
+  if (metaCode && metaModelByCode.value.has(metaCode)) {
+    return metaModelByCode.value.get(metaCode)
+  }
+  return null
 }
 
-function modelVendorName(model) {
+function metaModelIdentityKey(metaModel) {
+  const id = String(metaModel?.id || '').trim()
+  if (id) return id
+  return normalizeSearch(metaModel?.code || metaModel?.name || '')
+}
+
+function metaModelVendorKey(group) {
+  return normalizeSearch(group.ownerCode || group.ownerName || 'unknown')
+}
+
+function metaModelVendorName(group) {
+  return group.ownerName || group.ownerCode || '未归属厂商'
+}
+
+function stripModelNamespace(value) {
+  const text = String(value || '').trim()
+  if (!text.includes('/')) return text
+  return text.split('/').pop() || text
+}
+
+function metaModelDisplayName(metaModel) {
   return (
-    model.meta_model_owner_name ||
-    model.meta_model_owner_code ||
-    model.provider_name ||
-    model.provider_code ||
-    '未归属厂商'
+    stripModelNamespace(metaModel?.name) ||
+    stripModelNamespace(metaModel?.code) ||
+    ''
   )
 }
 
@@ -1552,7 +1610,12 @@ function modelMetaIdentityKey(model) {
 }
 
 function modelDisplayName(model) {
-  return model?.meta_model_name || model?.name || model?.code || ''
+  return (
+    stripModelNamespace(model?.meta_model_name) ||
+    stripModelNamespace(model?.name) ||
+    stripModelNamespace(model?.code) ||
+    ''
+  )
 }
 
 function modelOptionSearchText(option) {
@@ -1590,7 +1653,7 @@ function modelOptionMeta(option) {
   if (normalizeSearch(option.code) !== normalizeSearch(option.name)) {
     parts.push(option.code)
   }
-  parts.push(`${option.providerCount} 个可选上游`)
+  parts.push(`${option.providerCount} 个上游价格源`)
   return parts.filter(Boolean).join(' · ')
 }
 
@@ -1924,11 +1987,22 @@ function upstreamPriceSummary(model) {
     .join(' · ')
 }
 
-function pendingDraftPriceSummary(draft, model) {
+function batchUpstreamPriceSummary(model) {
+  const rows = providerPriceSummary(model)
+  if (!rows.length) return '-'
+  return rows
+    .map((item) => `${item.label} ${priceNumberText(item, model)}`)
+    .join(' · ')
+}
+
+function batchPendingDraftPriceSummary(draft, model) {
   const rows = draftPricePreview(draft, model)
   if (!rows.length) return '-'
   return rows
-    .map((item) => `${previewPriceLabel(item.label)} ${priceText(item, model)}`)
+    .map(
+      (item) =>
+        `${previewPriceLabel(item.label)} ${priceNumberText(item, model)}`
+    )
     .join(' · ')
 }
 
@@ -1963,6 +2037,25 @@ function priceText(item, model) {
     return '不适用'
   }
   return '缺价格'
+}
+
+function priceNumberText(item, model) {
+  if (!item) return '-'
+  if (item.missingReason) return item.missingReason
+  if (item.value === null || item.value === undefined || item.value === '') {
+    return '-'
+  }
+  if (Number(item.value) !== 0) {
+    const displayValue = convertCurrencyAmount(item.value, item.currency)
+    if (displayValue === null) {
+      return Number(item.value).toFixed(4)
+    }
+    return displayValue.toFixed(4)
+  }
+  if (isNotApplicablePrice(item, model)) {
+    return '不适用'
+  }
+  return '0.0000'
 }
 
 function isNotApplicablePrice(item, model) {

--- a/frontend/src/components/llm-ops/PriceSourceModal.vue
+++ b/frontend/src/components/llm-ops/PriceSourceModal.vue
@@ -80,44 +80,30 @@
             </label>
             <label class="field-group">
               <span class="field-label">
-                {{ t('llmOps.priceSourceModal.fields.sourceOwnerType') }}
+                {{ t('llmOps.priceSourceModal.fields.syncMode') }}
               </span>
-              <CompactSelect
-                v-model="sourceOwnerTypeSelection"
-                :options="sourceOwnerTypeOptions"
-              />
+              <CompactSelect v-model="syncMode" :options="syncModeOptions" />
             </label>
             <label class="field-group">
               <span class="field-label">
-                {{ t('llmOps.priceSourceModal.fields.collectionMethod') }}
+                {{ t('llmOps.priceSourceModal.fields.autoSyncSource') }}
               </span>
               <CompactSelect
-                v-model="form.collection_method"
-                :options="collectionMethodOptions"
-              />
-            </label>
-            <label
-              class="field-group"
-            >
-              <span class="field-label">
-                {{ t('llmOps.priceSourceModal.fields.officialProvider') }}
-              </span>
-              <CompactSelect
-                v-model="selectedOfficialProviderCode"
+                v-model="selectedAutoSyncSourceCode"
                 :disabled="
-                  !shouldUseOfficialPreset ||
-                  loadingOfficialProviderOptions ||
+                  !shouldCreateAutoSyncPreset ||
+                  loadingAutoSyncSourceOptions ||
                   saving
                 "
-                :options="officialProviderSelectOptions"
+                :options="autoSyncSourceSelectOptions"
                 class-name="w-full"
                 :menu-min-width="360"
                 :placeholder="
-                  t('llmOps.priceSourceModal.officialPreset.selectProvider')
+                  t('llmOps.priceSourceModal.autoSyncPreset.selectSource')
                 "
               />
               <span class="field-help">
-                {{ officialProviderHelpText }}
+                {{ autoSyncSourceHelpText }}
               </span>
             </label>
             <label class="field-group">
@@ -229,23 +215,18 @@ const { t } = useI18n()
 
 const saving = ref(false)
 const form = ref(defaults())
-const officialProviderOptions = ref([])
-const selectedOfficialProviderCode = ref('')
-const loadingOfficialProviderOptions = ref(false)
-const officialSourceOwnerTypes = [
-  'model_provider_official',
-  'cloud_provider_official'
-]
-const visibleSourceOwnerTypes = ['supplier', 'internal']
-const sourceOwnerOfficialOption = 'official'
+const autoSyncSourceOptions = ref([])
+const selectedAutoSyncSourceCode = ref('')
+const loadingAutoSyncSourceOptions = ref(false)
 const isEditing = computed(() => Boolean(props.source?.id))
-const shouldUseOfficialPreset = computed(
-  () =>
-    !isEditing.value &&
-    officialSourceOwnerTypes.includes(form.value.source_owner_type)
+const isAutoSyncMode = computed(
+  () => form.value.source_owner_type !== 'internal'
+)
+const shouldCreateAutoSyncPreset = computed(
+  () => !isEditing.value && isAutoSyncMode.value
 )
 const canEditSlug = computed(
-  () => !shouldUseOfficialPreset.value && !isStableOfficialSource.value
+  () => !shouldCreateAutoSyncPreset.value && !isStableOfficialSource.value
 )
 const isStableOfficialSource = computed(() => {
   if (!isEditing.value) return false
@@ -258,14 +239,14 @@ const isStableOfficialSource = computed(() => {
   )
 })
 const slugHelpText = computed(() => {
-  if (shouldUseOfficialPreset.value && !selectedOfficialProviderOption.value) {
-    return t('llmOps.priceSourceModal.help.officialSlugPreset')
+  if (shouldCreateAutoSyncPreset.value && !selectedAutoSyncSourceOption.value) {
+    return t('llmOps.priceSourceModal.help.autoSyncSlugPreset')
   }
   if (isStableOfficialSource.value) {
-    return t('llmOps.priceSourceModal.help.officialSlugLocked')
+    return t('llmOps.priceSourceModal.help.autoSyncSlugLocked')
   }
-  if (shouldUseOfficialPreset.value) {
-    return t('llmOps.priceSourceModal.help.officialSlugLocked')
+  if (shouldCreateAutoSyncPreset.value) {
+    return t('llmOps.priceSourceModal.help.autoSyncSlugLocked')
   }
   if (isEditing.value) {
     return t('llmOps.priceSourceModal.help.slug')
@@ -275,127 +256,103 @@ const slugHelpText = computed(() => {
   })
 })
 const sourceSlugLabel = computed(() => {
-  if (shouldUseOfficialPreset.value && selectedOfficialProviderOption.value) {
-    return selectedOfficialProviderOption.value.source_slug || '-'
+  if (shouldCreateAutoSyncPreset.value && selectedAutoSyncSourceOption.value) {
+    return selectedAutoSyncSourceOption.value.source_slug || '-'
   }
   return autoSlug(form.value.name || '')
 })
-const sourceOwnerTypeOptions = computed(() => [
+const syncModeOptions = computed(() => [
   {
-    label: t('llmOps.priceSourceModal.sourceOwnerTypes.official'),
-    value: sourceOwnerOfficialOption
+    label: t('llmOps.priceSourceModal.syncModes.auto'),
+    value: 'auto'
   },
   {
-    label: t('llmOps.priceSourceModal.sourceOwnerTypes.supplier'),
-    value: 'supplier'
-  },
-  {
-    label: t('llmOps.priceSourceModal.sourceOwnerTypes.internal'),
-    value: 'internal'
+    label: t('llmOps.priceSourceModal.syncModes.manual'),
+    value: 'manual'
   }
 ])
 
-const sourceOwnerTypeSelection = computed({
+const syncMode = computed({
   get() {
-    if (officialSourceOwnerTypes.includes(form.value.source_owner_type)) {
-      return sourceOwnerOfficialOption
-    }
-    if (visibleSourceOwnerTypes.includes(form.value.source_owner_type)) {
-      return form.value.source_owner_type
-    }
-    return 'internal'
+    return form.value.source_owner_type === 'internal' ? 'manual' : 'auto'
   },
   set(value) {
-    if (value === sourceOwnerOfficialOption) {
-      selectedOfficialProviderCode.value = ''
-      form.value.source_owner_type = sourceOwnerTypeForOfficialProvider(
-        { provider_code: selectedOfficialProviderCode.value }
-      )
-      form.value.collection_method = 'auto_collect'
+    if (value === 'manual') {
+      selectedAutoSyncSourceCode.value = ''
+      form.value = {
+        ...form.value,
+        source_owner_type: 'internal',
+        source_category: 'manual',
+        collection_method: 'manual_entry',
+        updates_model_prices: false
+      }
       return
     }
-    selectedOfficialProviderCode.value = ''
-    form.value.source_owner_type = value
-    if (['supplier', 'internal'].includes(value)) {
-      form.value.collection_method = 'manual_entry'
+    selectedAutoSyncSourceCode.value = ''
+    form.value = {
+      ...form.value,
+      source_owner_type: 'supplier',
+      source_category: 'supplier',
+      collection_method: 'unknown',
+      updates_model_prices: true
+    }
+    if (!autoSyncSourceOptions.value.length) {
+      loadAutoSyncSourceOptions()
     }
   }
 })
-
-const collectionMethodOptions = computed(() => [
-  {
-    label: t('llmOps.priceSourceModal.collectionMethods.autoCollect'),
-    value: 'auto_collect'
-  },
-  {
-    label: t('llmOps.priceSourceModal.collectionMethods.manualEntry'),
-    value: 'manual_entry'
-  },
-  {
-    label: t('llmOps.priceSourceModal.collectionMethods.manualImport'),
-    value: 'manual_import'
-  },
-  {
-    label: t('llmOps.priceSourceModal.collectionMethods.apiSync'),
-    value: 'api_sync'
-  },
-  {
-    label: t('llmOps.priceSourceModal.collectionMethods.unknown'),
-    value: 'unknown'
-  }
-])
 
 const currencyOptions = computed(() => [
   { label: t('llmOps.priceSourceModal.currencies.cny'), value: 'CNY' },
   { label: t('llmOps.priceSourceModal.currencies.usd'), value: 'USD' }
 ])
 
-const officialProviderSelectOptions = computed(() =>
-  officialProviderOptions.value.map((option) => ({
-    value: option.provider_code,
+const autoSyncSourceSelectOptions = computed(() =>
+  autoSyncSourceOptions.value.map((option) => ({
+    value: option.option_code || option.provider_code,
     label: option.provider_name,
     description: option.source_name,
     badge: option.source_exists
-      ? t('llmOps.priceSourceModal.officialPreset.existsBadge')
+      ? t('llmOps.priceSourceModal.autoSyncPreset.existsBadge')
       : option.currency
   }))
 )
 
-const selectedOfficialProviderOption = computed(() =>
-  officialProviderOptions.value.find(
+const selectedAutoSyncSourceOption = computed(() =>
+  autoSyncSourceOptions.value.find(
     (option) =>
-      String(option.provider_code) ===
-      String(selectedOfficialProviderCode.value)
+      String(option.option_code || option.provider_code) ===
+      String(selectedAutoSyncSourceCode.value)
   )
 )
 
-const officialProviderStatus = computed(() => {
-  if (loadingOfficialProviderOptions.value) {
-    return t('llmOps.priceSourceModal.officialPreset.loading')
+const autoSyncSourceStatus = computed(() => {
+  if (loadingAutoSyncSourceOptions.value) {
+    return t('llmOps.priceSourceModal.autoSyncPreset.loading')
   }
-  const option = selectedOfficialProviderOption.value
-  if (!option && officialProviderOptions.value.length) {
-    return t('llmOps.priceSourceModal.officialPreset.selectProvider')
+  const option = selectedAutoSyncSourceOption.value
+  if (!option && autoSyncSourceOptions.value.length) {
+    return t('llmOps.priceSourceModal.autoSyncPreset.selectSource')
   }
-  if (!option) return t('llmOps.priceSourceModal.officialPreset.empty')
+  if (!option) return t('llmOps.priceSourceModal.autoSyncPreset.empty')
   if (option.source_exists) {
-    return t('llmOps.priceSourceModal.officialPreset.exists')
+    return t('llmOps.priceSourceModal.autoSyncPreset.exists')
   }
-  return t('llmOps.priceSourceModal.officialPreset.ready')
+  return t('llmOps.priceSourceModal.autoSyncPreset.ready')
 })
 
-const officialProviderHelpText = computed(() => {
-  if (!shouldUseOfficialPreset.value) {
-    return t('llmOps.priceSourceModal.officialPreset.onlyOfficial')
+const autoSyncSourceHelpText = computed(() => {
+  if (!shouldCreateAutoSyncPreset.value) {
+    return t('llmOps.priceSourceModal.autoSyncPreset.manualMode')
   }
-  return officialProviderStatus.value
+  return autoSyncSourceStatus.value
 })
 
 const saveDisabled = computed(
   () =>
-    shouldUseOfficialPreset.value &&
-    (!selectedOfficialProviderOption.value ||
-      selectedOfficialProviderOption.value.source_exists)
+    shouldCreateAutoSyncPreset.value &&
+    (!selectedAutoSyncSourceOption.value ||
+      selectedAutoSyncSourceOption.value.source_exists)
 )
 
 watch(
@@ -407,17 +364,30 @@ watch(
 )
 
 watch(
-  () => [props.open, form.value.source_owner_type, isEditing.value],
-  ([open]) => {
-    if (open && shouldUseOfficialPreset.value) {
-      loadOfficialProviderOptions()
+  () => props.open,
+  (open) => {
+    if (open && shouldCreateAutoSyncPreset.value) {
+      loadAutoSyncSourceOptions()
     }
   }
 )
 
-watch(selectedOfficialProviderOption, (option) => {
-  if (!shouldUseOfficialPreset.value || !option) return
-  applyOfficialProviderOption(option)
+watch(
+  () => form.value.source_owner_type,
+  () => {
+    if (
+      props.open &&
+      shouldCreateAutoSyncPreset.value &&
+      !autoSyncSourceOptions.value.length
+    ) {
+      loadAutoSyncSourceOptions()
+    }
+  }
+)
+
+watch(selectedAutoSyncSourceOption, (option) => {
+  if (!shouldCreateAutoSyncPreset.value || !option) return
+  applyAutoSyncSourceOption(option)
 })
 
 function defaults() {
@@ -458,8 +428,8 @@ function close() {
 async function save() {
   saving.value = true
   try {
-    if (shouldUseOfficialPreset.value) {
-      await saveOfficialProviderSource()
+    if (shouldCreateAutoSyncPreset.value) {
+      await saveAutoSyncSource()
       return
     }
     const submittedSlug = canEditSlug.value
@@ -470,9 +440,12 @@ async function save() {
       slug: submittedSlug,
       source_type: props.source?.source_type || 'custom'
     }
-    payload.source_category = legacyCategoryForSourceOwnerType(
-      payload.source_owner_type
-    )
+    if (!isAutoSyncMode.value) {
+      payload.source_category = 'manual'
+      payload.source_owner_type = 'internal'
+      payload.collection_method = 'manual_entry'
+      payload.updates_model_prices = false
+    }
     if (isEditing.value) {
       await llmOpsApi.updateCollectionSource(props.source.id, payload)
       showSuccess(t('llmOps.priceSourceModal.messages.updated'))
@@ -488,55 +461,62 @@ async function save() {
   }
 }
 
-async function saveOfficialProviderSource() {
-  const option = selectedOfficialProviderOption.value
+async function saveAutoSyncSource() {
+  const option = selectedAutoSyncSourceOption.value
   if (!option || option.source_exists) return
 
-  const response = await llmOpsApi.ensureOfficialProviderSource(
-    option.provider_code
-  )
-  const payload = response?.data?.data || response?.data || {}
-  const sourceName = payload.source?.name || option.source_name
+  let sourceName = option.source_name
+  if (option.source_category === 'official_provider') {
+    const response = await llmOpsApi.ensureOfficialProviderSource(
+      option.provider_code
+    )
+    const payload = response?.data?.data || response?.data || {}
+    sourceName = payload.source?.name || sourceName
+  } else {
+    await llmOpsApi.createCollectionSource(autoSyncSourcePayload(option))
+  }
   showSuccess(
-    t('llmOps.priceSourceModal.messages.officialCreated', {
+    t('llmOps.priceSourceModal.messages.autoSyncCreated', {
       name: sourceName
     })
   )
   emit('saved')
 }
 
-async function loadOfficialProviderOptions() {
-  if (loadingOfficialProviderOptions.value) return
-  loadingOfficialProviderOptions.value = true
+async function loadAutoSyncSourceOptions() {
+  if (loadingAutoSyncSourceOptions.value) return
+  loadingAutoSyncSourceOptions.value = true
   try {
-    const response = await llmOpsApi.listOfficialProviderSourceOptions()
+    const response = await llmOpsApi.listAutoSyncSourceOptions()
     const payload = response?.data?.data || response?.data || {}
     const options = Array.isArray(payload.results) ? payload.results : []
-    officialProviderOptions.value = options
+    autoSyncSourceOptions.value = options
     const current = options.find(
       (option) =>
-        String(option.provider_code) ===
-        String(selectedOfficialProviderCode.value)
+        String(option.option_code || option.provider_code) ===
+        String(selectedAutoSyncSourceCode.value)
     )
-    selectedOfficialProviderCode.value = current?.provider_code || ''
-    if (current) applyOfficialProviderOption(current)
+    selectedAutoSyncSourceCode.value =
+      current?.option_code || current?.provider_code || ''
+    if (current) applyAutoSyncSourceOption(current)
   } catch (error) {
     showError(
       errorMessage(
         error,
-        t('llmOps.priceSourceModal.errors.loadOfficialSources')
+        t('llmOps.priceSourceModal.errors.loadAutoSyncSources')
       )
     )
   } finally {
-    loadingOfficialProviderOptions.value = false
+    loadingAutoSyncSourceOptions.value = false
   }
 }
 
-function applyOfficialProviderOption(option) {
+function applyAutoSyncSourceOption(option) {
   form.value = {
     ...form.value,
-    source_owner_type: sourceOwnerTypeForOfficialProvider(option),
-    collection_method: 'auto_collect',
+    source_category: option.source_category || 'supplier',
+    source_owner_type: option.source_owner_type || 'supplier',
+    collection_method: option.collection_method || 'unknown',
     name: option.source_name || option.provider_name || form.value.name,
     slug: option.source_slug || form.value.slug,
     currency: option.currency || form.value.currency,
@@ -545,13 +525,20 @@ function applyOfficialProviderOption(option) {
   }
 }
 
-function legacyCategoryForSourceOwnerType(value) {
-  if (officialSourceOwnerTypes.includes(value)) {
-    return 'official_provider'
+function autoSyncSourcePayload(option) {
+  return {
+    name: option.source_name,
+    slug: option.source_slug,
+    source_type: 'custom',
+    source_category: option.source_category,
+    source_owner_type: option.source_owner_type,
+    collection_method: option.collection_method || 'unknown',
+    endpoint_url: option.source_url || '',
+    currency: option.currency || 'CNY',
+    is_enabled: true,
+    updates_model_prices: true,
+    notes: form.value.notes || ''
   }
-  if (value === 'supplier') return 'supplier'
-  if (value === 'internal') return 'manual'
-  return 'unknown'
 }
 
 function sourceOwnerTypeFromLegacyCategory(value) {
@@ -559,14 +546,6 @@ function sourceOwnerTypeFromLegacyCategory(value) {
   if (value === 'supplier') return 'supplier'
   if (value === 'manual') return 'internal'
   return 'unknown'
-}
-
-function sourceOwnerTypeForOfficialProvider(option) {
-  const code = String(option?.provider_code || '').toLowerCase()
-  if (['aliyun', 'aliyun-wanx', 'baidu', 'volcengine'].includes(code)) {
-    return 'cloud_provider_official'
-  }
-  return 'model_provider_official'
 }
 
 function errorMessage(error, fallback) {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1500,8 +1500,8 @@
         "edit": "Edit Model Price Source"
       },
       "description": {
-        "create": "Create an official, supplier, or manually maintained price source for later price entry and collection.",
-        "edit": "Maintain the source name, pricing scope, price URL, and enabled status."
+        "create": "Create an official collector, supplier, or manually maintained price source for later price entry and collection.",
+        "edit": "Maintain the source name, type, price URL, and enabled status."
       },
       "sections": {
         "basic": "Basic information",
@@ -1511,14 +1511,16 @@
       },
       "fields": {
         "category": "Pricing scope",
+        "autoSyncSource": "Sync source",
         "collectionMethod": "Maintenance method",
         "currency": "Default currency",
         "endpointUrl": "Price URL",
         "name": "Price source name",
-        "officialProvider": "Official provider",
+        "officialProvider": "Official collector",
         "slug": "System slug",
-        "sourceOwnerType": "Source owner",
-        "sourceType": "Source mode"
+        "sourceOwnerType": "Price source type",
+        "sourceType": "Source mode",
+        "syncMode": "Sync mode"
       },
       "placeholders": {
         "name": "Example: Yunce / Alibaba Bailian East China line",
@@ -1527,8 +1529,10 @@
       "help": {
         "autoSlug": "The system slug will be generated after creation: {slug}",
         "endpointUrl": "Official pricing page, supplier price API, or manual price source URL.",
+        "autoSyncSlugLocked": "Auto-sync source slugs are used by collectors and cannot be changed.",
+        "autoSyncSlugPreset": "The system slug is filled after selecting a sync source.",
         "officialSlugLocked": "Official collection source slugs are used by collectors and cannot be changed.",
-        "officialSlugPreset": "The system slug is filled after selecting an official provider.",
+        "officialSlugPreset": "The system slug is filled after selecting an official collector.",
         "slug": "Use lowercase letters, numbers, and hyphens only. It is normalized on save."
       },
       "actions": {
@@ -1549,8 +1553,8 @@
         "cloudProvider": "Cloud provider official",
         "internal": "Internal",
         "modelProvider": "Model provider official",
-        "official": "Official pricing",
-        "supplier": "Supplier",
+        "official": "Official collector",
+        "supplier": "Supplier pricing",
         "unknown": "Unknown"
       },
       "collectionMethods": {
@@ -1559,6 +1563,10 @@
         "manualEntry": "Manual entry",
         "manualImport": "Manual import",
         "unknown": "Unknown"
+      },
+      "syncModes": {
+        "auto": "Auto sync",
+        "manual": "Manual maintenance"
       },
       "categories": {
         "manual": "Manual maintenance",
@@ -1572,24 +1580,35 @@
       },
       "officialPreset": {
         "currency": "Currency",
-        "empty": "No official price source presets are available.",
-        "exists": "This official source has already been added.",
+        "empty": "No official collectors are available to add.",
+        "exists": "This official collector has already been added.",
         "existsBadge": "Added",
-        "loading": "Loading official sources.",
-        "onlyOfficial": "Only official pricing requires an official provider.",
-        "ready": "Confirm to create the official price source.",
-        "selectProvider": "Select an official provider.",
+        "loading": "Loading official collectors.",
+        "onlyOfficial": "Only official collector sources require a collector.",
+        "ready": "Confirm to create the official collector source.",
+        "selectProvider": "Select an official collector.",
         "slug": "System slug",
         "source": "Price source",
         "url": "Price URL"
       },
+      "autoSyncPreset": {
+        "empty": "No auto-sync sources are available to add.",
+        "exists": "This sync source has already been added.",
+        "existsBadge": "Added",
+        "loading": "Loading sync sources.",
+        "manualMode": "Manual maintenance does not need a sync source.",
+        "ready": "Confirm to create the auto-sync price source.",
+        "selectSource": "Select a sync source."
+      },
       "messages": {
+        "autoSyncCreated": "Auto-sync price source \"{name}\" added",
         "created": "Model price source created",
-        "officialCreated": "Official price source \"{name}\" added",
+        "officialCreated": "Official collector source \"{name}\" added",
         "updated": "Model price source updated"
       },
       "errors": {
-        "loadOfficialSources": "Failed to load official price sources",
+        "loadAutoSyncSources": "Failed to load auto-sync sources",
+        "loadOfficialSources": "Failed to load official collectors",
         "save": "Failed to save model price source"
       }
     },

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1510,8 +1510,8 @@
         "edit": "编辑模型价格源"
       },
       "description": {
-        "create": "新建原厂、供货商或人工维护价格源，用于后续录价和采集模型价格。",
-        "edit": "维护价格源名称、口径、价格地址和启停状态。"
+        "create": "新建官方采集、供货商或人工维护价格源，用于后续录价和采集模型价格。",
+        "edit": "维护价格源名称、类型、价格地址和启停状态。"
       },
       "sections": {
         "basic": "基础信息",
@@ -1521,14 +1521,16 @@
       },
       "fields": {
         "category": "价格口径",
+        "autoSyncSource": "同步来源",
         "collectionMethod": "维护方式",
         "currency": "默认币种",
         "endpointUrl": "价格地址",
         "name": "价格源名称",
-        "officialProvider": "原厂厂商",
+        "officialProvider": "官方采集源",
         "slug": "系统标识",
-        "sourceOwnerType": "来源归属",
-        "sourceType": "来源方式"
+        "sourceOwnerType": "价格源类型",
+        "sourceType": "来源方式",
+        "syncMode": "同步方式"
       },
       "placeholders": {
         "name": "例如：云测 / 阿里云百炼华东专线",
@@ -1537,8 +1539,10 @@
       "help": {
         "autoSlug": "创建后系统标识将自动生成：{slug}",
         "endpointUrl": "官方价格页、供货商价格接口或人工价格来源地址。",
+        "autoSyncSlugLocked": "自动同步源的系统标识用于匹配采集器，不能修改。",
+        "autoSyncSlugPreset": "选择同步来源后会自动填充系统标识。",
         "officialSlugLocked": "官方采集源的系统标识用于匹配采集器，不能修改。",
-        "officialSlugPreset": "选择原厂厂商后会自动填充系统标识。",
+        "officialSlugPreset": "选择官方采集源后会自动填充系统标识。",
         "slug": "仅支持小写字母、数字和短横线；保存时会自动规范化。"
       },
       "actions": {
@@ -1559,8 +1563,8 @@
         "cloudProvider": "云厂商官方",
         "internal": "内部维护",
         "modelProvider": "模型厂商官方",
-        "official": "官方价格",
-        "supplier": "供货商",
+        "official": "官方采集",
+        "supplier": "供货商价格",
         "unknown": "未知"
       },
       "collectionMethods": {
@@ -1569,6 +1573,10 @@
         "manualEntry": "手工录入",
         "manualImport": "批量导入",
         "unknown": "未知"
+      },
+      "syncModes": {
+        "auto": "自动同步",
+        "manual": "手动维护"
       },
       "categories": {
         "manual": "人工维护",
@@ -1582,24 +1590,35 @@
       },
       "officialPreset": {
         "currency": "币种",
-        "empty": "暂无可添加的原厂价格源。",
-        "exists": "当前原厂源已经添加。",
+        "empty": "暂无可添加的官方采集源。",
+        "exists": "当前官方采集源已经添加。",
         "existsBadge": "已添加",
-        "loading": "正在加载原厂源。",
-        "onlyOfficial": "仅官方价格需要选择原厂厂商。",
-        "ready": "确认后会创建原厂价格源。",
-        "selectProvider": "请选择原厂厂商。",
+        "loading": "正在加载官方采集源。",
+        "onlyOfficial": "仅官方采集类型需要选择采集源。",
+        "ready": "确认后会创建官方采集源。",
+        "selectProvider": "请选择官方采集源。",
         "slug": "系统标识",
         "source": "价格源",
         "url": "价格地址"
       },
+      "autoSyncPreset": {
+        "empty": "暂无可添加的自动同步来源。",
+        "exists": "当前同步来源已经添加。",
+        "existsBadge": "已添加",
+        "loading": "正在加载同步来源。",
+        "manualMode": "手动维护无需选择同步来源。",
+        "ready": "确认后会创建自动同步价格源。",
+        "selectSource": "请选择同步来源。"
+      },
       "messages": {
+        "autoSyncCreated": "自动同步价格源「{name}」已添加",
         "created": "模型价格源已创建",
-        "officialCreated": "原厂价格源「{name}」已添加",
+        "officialCreated": "官方采集源「{name}」已添加",
         "updated": "模型价格源已更新"
       },
       "errors": {
-        "loadOfficialSources": "加载原厂价格源失败",
+        "loadAutoSyncSources": "加载自动同步来源失败",
+        "loadOfficialSources": "加载官方采集源失败",
         "save": "保存模型价格源失败"
       }
     },

--- a/frontend/src/pages/LLMOps.vue
+++ b/frontend/src/pages/LLMOps.vue
@@ -736,6 +736,7 @@
               v-else-if="activeSection === 'channels'"
               :channels="channels"
               :providers="providers"
+              :meta-models="metaModels"
               :models="models"
               :channel-prices="channelPrices"
               :channel-price-items="channelPriceItems"

--- a/frontend/src/utils/llmOpsPriceSources.js
+++ b/frontend/src/utils/llmOpsPriceSources.js
@@ -73,6 +73,9 @@ export function priceSourceCollectionMethod(source) {
   if (method && method !== 'unknown') return method
 
   if (source?.source_type === 'yunce') return 'api_sync'
+  if (source?.can_collect_prices && source?.updates_model_prices) {
+    return 'auto_collect'
+  }
   if (
     normalizePriceSourceCategory(source) === 'official_provider' &&
     source?.updates_model_prices
@@ -88,11 +91,7 @@ export function priceSourceCollectionMethod(source) {
 export function canCollectPriceSource(source) {
   if (!source) return false
   if (source.can_collect === true) return true
-  return Boolean(
-    source.can_collect_prices &&
-      priceSourceCollectionMethod(source) === 'auto_collect' &&
-      source.updates_model_prices
-  )
+  return Boolean(source.can_collect_prices && source.updates_model_prices)
 }
 
 export function canApiSyncPriceSource(source) {
@@ -101,6 +100,7 @@ export function canApiSyncPriceSource(source) {
 
 export function canManualEntryPriceSource(source) {
   if (!source) return false
+  if (canCollectPriceSource(source)) return false
   if (source.can_manual_entry === true) return true
   return ['manual_entry', 'manual_import', 'unknown'].includes(
     priceSourceCollectionMethod(source)


### PR DESCRIPTION
## Summary
- Expose code-backed auto-sync source options for official and supplier collectors.
- Add SiliconFlow supplier pricing source support and skip free-only SiliconFlow rows.
- Update LLM Ops source modal and channel model drawer to use auto-sync presets and canonical meta-model grouping.
- Tighten tests around supported collectors, supplier collection, and meta-model identity normalization.

## Test plan
- [x] PYTHONPATH=\"backend:backend/agentcore/agentcore-metering:backend/agentcore/agentcore-task:backend/agentcore/agentcore-notifier\" uv run --no-project --python /Users/zhengwei/.local/bin/python3.11 ... pytest backend/llm_ops/tests/test_ops_bootstrap.py backend/llm_ops/tests/test_serializers.py backend/llm_ops/tests/test_skill_runner.py backend/llm_ops/tests/test_source_collectors.py backend/llm_ops/tests/test_views.py backend/llm_ops/tests/test_meta_model_identity.py
- [x] ./node_modules/.bin/eslint src/api/llmOps.js src/components/llm-ops/ChannelManagement.vue src/components/llm-ops/ChannelModelDrawer.vue src/components/llm-ops/PriceSourceModal.vue src/pages/LLMOps.vue src/utils/llmOpsPriceSources.js --ext .vue,.js --ignore-path ../.gitignore
- [x] npm run build

Note: npm run lint currently fails before linting because frontend/.gitignore is missing; the equivalent targeted ESLint command above used ../.gitignore.

Made with [Orca](https://github.com/stablyai/orca) 🐋
