### PR TITLE
Show provider icons in meta model management

### DIFF
--- a/frontend/src/components/llm-ops/MetaModelManagement.vue
+++ b/frontend/src/components/llm-ops/MetaModelManagement.vue
@@ -83,13 +83,16 @@
             :class="{ active: vendorRowActive(row) }"
             @click="openVendorModelsDrawer(row)"
           >
-            <div class="min-w-0">
-              <p class="truncate text-sm font-semibold text-slate-900">
-                {{ row.name }}
-              </p>
-              <p class="mt-1 font-mono text-xs text-slate-400">
-                {{ row.code || '-' }}
-              </p>
+            <div class="vendor-name-cell">
+              <ProviderIcon :provider="row.code || row.name" size="lg" />
+              <div class="min-w-0">
+                <p class="truncate text-sm font-semibold text-slate-900">
+                  {{ row.name }}
+                </p>
+                <p class="mt-1 font-mono text-xs text-slate-400">
+                  {{ row.code || '-' }}
+                </p>
+              </div>
             </div>
             <div class="metric-stack">
               <p class="metric-value">
@@ -151,12 +154,19 @@
             <p class="drawer-eyebrow">
               {{ t('llmOps.metaModelManagement.drawer.eyebrow') }}
             </p>
-            <h3 class="drawer-title">
-              {{
-                selectedVendorRow?.name ||
-                t('llmOps.metaModelManagement.drawer.fallbackTitle')
-              }}
-            </h3>
+            <div class="vendor-drawer-title-row">
+              <ProviderIcon
+                v-if="selectedVendorRow"
+                :provider="selectedVendorRow.code || selectedVendorRow.name"
+                size="lg"
+              />
+              <h3 class="drawer-title">
+                {{
+                  selectedVendorRow?.name ||
+                  t('llmOps.metaModelManagement.drawer.fallbackTitle')
+                }}
+              </h3>
+            </div>
             <p class="mt-1 font-mono text-xs text-slate-500">
               {{ selectedVendorRow?.code || '-' }}
             </p>
@@ -384,6 +394,7 @@ import { useI18n } from 'vue-i18n'
 import { llmOpsApi } from '@/api/llmOps'
 import { useToast } from '@/composables/useToast'
 import CompactSelect from '@/components/llm-ops/CompactSelect.vue'
+import ProviderIcon from '@/components/llm/ProviderIcon.vue'
 import { resolveCanonicalMetaOwner } from '@/utils/llmOpsMeta'
 
 const props = defineProps({
@@ -1114,6 +1125,14 @@ function errorMessage(error, fallback) {
 
 .vendor-row-static {
   @apply cursor-default hover:bg-white;
+}
+
+.vendor-name-cell {
+  @apply flex min-w-0 items-center gap-3;
+}
+
+.vendor-drawer-title-row {
+  @apply flex min-w-0 items-center gap-2;
 }
 
 .metric-pair {

--- a/frontend/src/components/llm/providerIcons.js
+++ b/frontend/src/components/llm/providerIcons.js
@@ -13,6 +13,8 @@ const LOCAL_PROVIDER_ICON_URLS = Object.fromEntries(
 
 const PROVIDER_ICON_ALIASES = {
   amazon_nova: 'aws',
+  alibaba_cloud: 'alibabacloud',
+  aliyun: 'alibabacloud',
   azure_openai: 'azure',
   claude: 'anthropic',
   dashscope: 'qwen',


### PR DESCRIPTION
## Summary
- Add provider icons to meta model vendor rows.
- Show the same provider icon in the vendor model drawer header.
- Map Aliyun provider codes to the existing Alibaba Cloud icon asset.

## Test plan
- [x] npx eslint src/components/llm-ops/MetaModelManagement.vue src/components/llm/providerIcons.js
- [x] npm run build

Made with [Orca](https://github.com/stablyai/orca) 🐋
