### PR TITLE
Optimize LLM Ops catalog management

### DIFF
--- a/backend/llm_ops/serializers.py
+++ b/backend/llm_ops/serializers.py
@@ -72,6 +72,8 @@ class PriceCollectionSourceSerializer(serializers.ModelSerializer):
     business_source_category_label = serializers.SerializerMethodField()
     capabilities = serializers.SerializerMethodField()
     can_collect_prices = serializers.SerializerMethodField()
+    current_meta_model_count = serializers.SerializerMethodField()
+    current_price_item_count = serializers.SerializerMethodField()
     latest_run_status = serializers.SerializerMethodField()
     model_count = serializers.SerializerMethodField()
     price_item_count = serializers.SerializerMethodField()
@@ -109,6 +111,23 @@ class PriceCollectionSourceSerializer(serializers.ModelSerializer):
             instance.updates_model_prices
             and source_supports_code_collection(instance)
         )
+
+    def get_current_meta_model_count(self, instance):
+        value = getattr(instance, "current_meta_model_count", None)
+        if value is not None:
+            return value
+        return (
+            instance.model_price_items.filter(is_current=True)
+            .values("meta_model_id")
+            .distinct()
+            .count()
+        )
+
+    def get_current_price_item_count(self, instance):
+        value = getattr(instance, "current_price_item_count", None)
+        if value is not None:
+            return value
+        return instance.model_price_items.filter(is_current=True).count()
 
     def get_latest_run_status(self, instance):
         return (

--- a/backend/llm_ops/views.py
+++ b/backend/llm_ops/views.py
@@ -214,17 +214,43 @@ class PriceCollectionSourceViewSet(
     serializer_class = PriceCollectionSourceSerializer
 
     def get_queryset(self):
-        return (
+        queryset = (
             PriceCollectionSource.objects.select_related(
                 "provider",
                 "channel",
             )
+            .annotate(
+                current_price_item_count=Count(
+                    "model_price_items",
+                    filter=Q(model_price_items__is_current=True),
+                ),
+                current_meta_model_count=Count(
+                    "model_price_items__meta_model",
+                    filter=Q(model_price_items__is_current=True),
+                    distinct=True,
+                ),
+            )
             .prefetch_related(
                 "models__meta_model",
             )
-            .order_by(
-                "source_category", "provider__name", "channel__name", "id"
+        )
+        search = self.request.query_params.get("search")
+        source_category = self.request.query_params.get("source_category")
+        is_enabled = self.request.query_params.get("is_enabled")
+        if source_category:
+            queryset = queryset.filter(source_category=source_category)
+        if is_enabled in {"true", "false"}:
+            queryset = queryset.filter(is_enabled=is_enabled == "true")
+        if search:
+            queryset = queryset.filter(
+                Q(name__icontains=search)
+                | Q(slug__icontains=search)
+                | Q(provider__name__icontains=search)
+                | Q(provider__code__icontains=search)
+                | Q(channel__name__icontains=search)
             )
+        return queryset.order_by(
+            "source_category", "provider__name", "channel__name", "id"
         )
 
     @action(
@@ -765,8 +791,23 @@ class MetaModelViewSet(
             .exclude(owner_code="")
         )
         owner = self.request.query_params.get("owner")
+        status_filter = self.request.query_params.get("status")
+        modality = self.request.query_params.get("modality")
+        search = self.request.query_params.get("search")
         if owner:
             queryset = queryset.filter(owner_code=owner)
+        if status_filter:
+            queryset = queryset.filter(status=status_filter)
+        if modality:
+            queryset = queryset.filter(modality=modality)
+        if search:
+            queryset = queryset.filter(
+                Q(name__icontains=search)
+                | Q(code__icontains=search)
+                | Q(family__icontains=search)
+                | Q(owner_name__icontains=search)
+                | Q(owner_code__icontains=search)
+            )
         return queryset.order_by("name", "id")
 
     def destroy(self, request, *args, **kwargs):
@@ -796,6 +837,52 @@ class MetaModelViewSet(
         normalize_meta_model_catalog()
         resolve_orphan_meta_models()
         return super().list(request, *args, **kwargs)
+
+    @action(
+        detail=False,
+        methods=["get"],
+        url_path="owner-summary",
+        url_name="owner-summary",
+    )
+    def owner_summary(self, request):
+        """Return one lightweight row per canonical model owner."""
+        queryset = self.get_queryset()
+        search = request.query_params.get("owner_search")
+        if search:
+            queryset = queryset.filter(
+                Q(owner_name__icontains=search)
+                | Q(owner_code__icontains=search)
+            )
+        rows = (
+            queryset.values("owner_code", "owner_name")
+            .annotate(
+                meta_model_count=Count("id", distinct=True),
+                active_model_count=Count(
+                    "id",
+                    filter=Q(status=MetaModel.STATUS_ACTIVE),
+                    distinct=True,
+                ),
+                sku_count=Count("provider_prices", distinct=True),
+            )
+            .order_by("-meta_model_count", "owner_name", "owner_code")
+        )
+        return Response(
+            {
+                "results": [
+                    {
+                        "id": row["owner_code"],
+                        "code": row["owner_code"],
+                        "name": row["owner_name"] or row["owner_code"],
+                        "meta_model_count": row["meta_model_count"],
+                        "active_model_count": row["active_model_count"],
+                        "sku_count": row["sku_count"],
+                    }
+                    for row in rows
+                    if row["owner_code"]
+                ]
+            },
+            status=status.HTTP_200_OK,
+        )
 
     def retrieve(self, request, *args, **kwargs):
         from .catalog_maintenance import (
@@ -843,10 +930,25 @@ class LLMModelViewSet(
         )
         provider = self.request.query_params.get("provider")
         meta_model = self.request.query_params.get("meta_model")
+        source = self.request.query_params.get("source")
+        search = self.request.query_params.get("search")
         if provider:
             queryset = queryset.filter(provider_id=provider)
         if meta_model:
             queryset = queryset.filter(meta_model_id=meta_model)
+        if source:
+            queryset = queryset.filter(source_id=source)
+        if search:
+            queryset = queryset.filter(
+                Q(name__icontains=search)
+                | Q(code__icontains=search)
+                | Q(meta_model__name__icontains=search)
+                | Q(meta_model__code__icontains=search)
+                | Q(provider__name__icontains=search)
+                | Q(provider__code__icontains=search)
+                | Q(source__name__icontains=search)
+                | Q(source__slug__icontains=search)
+            )
         return queryset.order_by("meta_model__name", "provider__name", "id")
 
     def destroy(self, request, *args, **kwargs):
@@ -892,6 +994,7 @@ class ModelPriceItemViewSet(
         source = self.request.query_params.get("source")
         dimension = self.request.query_params.get("dimension")
         is_current = self.request.query_params.get("is_current")
+        search = self.request.query_params.get("search")
         if provider:
             queryset = queryset.filter(provider_id=provider)
         if meta_model:
@@ -904,6 +1007,18 @@ class ModelPriceItemViewSet(
             queryset = queryset.filter(dimension=dimension)
         if is_current in {"true", "false"}:
             queryset = queryset.filter(is_current=is_current == "true")
+        if search:
+            queryset = queryset.filter(
+                Q(meta_model__name__icontains=search)
+                | Q(meta_model__code__icontains=search)
+                | Q(model__name__icontains=search)
+                | Q(model__code__icontains=search)
+                | Q(provider__name__icontains=search)
+                | Q(provider__code__icontains=search)
+                | Q(source__name__icontains=search)
+                | Q(source__slug__icontains=search)
+                | Q(dimension__icontains=search)
+            )
         return queryset.order_by(
             "provider__name",
             "sku__display_name",

--- a/frontend/src/api/llmOps.js
+++ b/frontend/src/api/llmOps.js
@@ -113,6 +113,13 @@ export const llmOpsApi = {
     return apiClient.get(`${base}/meta-models/`, paramsOrEmpty(params))
   },
 
+  listMetaModelOwnerSummary(params) {
+    return apiClient.get(
+      `${base}/meta-models/owner-summary/`,
+      paramsOrEmpty(params)
+    )
+  },
+
   syncMetaModels() {
     return apiClient.post(`${base}/meta-models/sync/`)
   },

--- a/frontend/src/components/llm-ops/MetaModelManagement.vue
+++ b/frontend/src/components/llm-ops/MetaModelManagement.vue
@@ -222,7 +222,7 @@
               <p class="drawer-result-note">
                 {{
                   t('llmOps.metaModelManagement.summary.modelResult', {
-                    total: vendorMetaRows.length,
+                    total: drawerTotal,
                     active: selectedVendorActiveCount
                   })
                 }}
@@ -260,6 +260,11 @@
                   </tr>
                 </thead>
                 <tbody>
+                  <tr v-if="drawerLoading">
+                    <td class="table-cell text-slate-500" colspan="5">
+                      加载中...
+                    </td>
+                  </tr>
                   <tr v-for="item in paginatedVendorMetaRows" :key="item.id">
                     <td class="table-cell">
                       <div
@@ -344,7 +349,7 @@
                       </div>
                     </td>
                   </tr>
-                  <tr v-if="!vendorMetaRows.length">
+                  <tr v-if="!drawerLoading && !vendorMetaRows.length">
                     <td class="table-cell text-slate-500" colspan="5">
                       {{ t('llmOps.metaModelManagement.empty.models') }}
                     </td>
@@ -352,11 +357,11 @@
                 </tbody>
               </table>
             </div>
-            <div v-if="vendorMetaRows.length" class="pagination-bar">
+            <div v-if="drawerTotal" class="pagination-bar">
               <p class="text-xs text-slate-500">
                 {{
                   t('llmOps.metaModelManagement.pagination.summary', {
-                    total: vendorMetaRows.length,
+                    total: drawerTotal,
                     current: safeCurrentPage,
                     pages: totalPages
                   })
@@ -389,7 +394,7 @@
 </template>
 
 <script setup>
-import { computed, ref, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { llmOpsApi } from '@/api/llmOps'
 import { useToast } from '@/composables/useToast'
@@ -429,6 +434,11 @@ const currentPage = ref(1)
 const selectedVendorId = ref('')
 const showVendorModelsDrawer = ref(false)
 const syncingMetaModels = ref(false)
+const ownerRows = ref([])
+const drawerRows = ref([])
+const drawerTotal = ref(0)
+const drawerLoading = ref(false)
+const ownerSummaryLoading = ref(false)
 
 const statusOptions = computed(() => [
   {
@@ -472,63 +482,7 @@ const pageSizeOptions = computed(() => [
   }
 ])
 
-const rows = computed(() =>
-  props.metaModels.map((item) => {
-    const skuCount = props.models.filter(
-      (model) => String(model.meta_model) === String(item.id)
-    ).length
-    const canonicalVendor = resolveCanonicalMetaOwner(item, props.providers)
-    return {
-      ...item,
-      owner_key: item.owner_code || canonicalVendor.code,
-      owner_code: item.owner_code || canonicalVendor.code,
-      owner_name: item.owner_name || canonicalVendor.name,
-      sku_count: skuCount
-    }
-  })
-)
-
-const vendorRows = computed(() => {
-  const map = new Map()
-  props.providers.forEach((provider) => {
-    map.set(String(provider.code), {
-      id: provider.code,
-      name: provider.name,
-      code: provider.code,
-      meta_model_count: 0,
-      sku_count: 0
-    })
-  })
-  rows.value.forEach((item) => {
-    if (!item.owner_key) {
-      // The backend canonical resolver guarantees every meta
-      // model has an owner. Rows without one are skipped so
-      // the UI never shows an "unbound" owner bucket.
-      return
-    }
-    const key = String(item.owner_key)
-    if (!map.has(key)) {
-      map.set(key, {
-        id: key,
-        name: item.owner_name || key,
-        code: item.owner_code || key,
-        meta_model_count: 0,
-        sku_count: 0
-      })
-    }
-    const row = map.get(key)
-    row.meta_model_count += 1
-    row.sku_count += item.sku_count
-  })
-  return Array.from(map.values())
-    .filter((row) => row.meta_model_count > 0)
-    .sort((left, right) => {
-      if (right.meta_model_count !== left.meta_model_count) {
-        return right.meta_model_count - left.meta_model_count
-      }
-      return String(left.name).localeCompare(String(right.name))
-    })
-})
+const vendorRows = computed(() => ownerRows.value)
 
 const filteredVendorRows = computed(() => {
   const keyword = vendorSearchKeyword.value.trim().toLowerCase()
@@ -548,86 +502,57 @@ const selectedVendorRow = computed(() =>
   )
 )
 
-const vendorMetaRows = computed(() => {
-  const keyword = searchKeyword.value.trim().toLowerCase()
-  return rows.value
-    .filter((item) => {
-      if (!selectedVendorId.value) {
-        return false
-      }
-      if (String(item.owner_key || '') !== String(selectedVendorId.value)) {
-        return false
-      }
-      if (statusFilter.value && item.status !== statusFilter.value) {
-        return false
-      }
-      if (modalityFilter.value && item.modality !== modalityFilter.value) {
-        return false
-      }
-      if (!keyword) return true
-      return searchableText(item).includes(keyword)
-    })
-    .sort((left, right) => {
-      const leftTime = releaseDateTime(left.release_date)
-      const rightTime = releaseDateTime(right.release_date)
-      if (rightTime !== leftTime) {
-        return rightTime - leftTime
-      }
-      return String(left.name).localeCompare(String(right.name))
-    })
-})
+const vendorMetaRows = computed(() => drawerRows.value)
 
 const totalPages = computed(() =>
-  Math.max(1, Math.ceil(vendorMetaRows.value.length / Number(pageSize.value)))
+  Math.max(1, Math.ceil(drawerTotal.value / Number(pageSize.value)))
 )
 
 const safeCurrentPage = computed(() =>
   Math.min(Math.max(Number(currentPage.value) || 1, 1), totalPages.value)
 )
 
-const paginatedVendorMetaRows = computed(() => {
-  const size = Number(pageSize.value)
-  const start = (safeCurrentPage.value - 1) * size
-  return vendorMetaRows.value.slice(start, start + size)
-})
+const paginatedVendorMetaRows = computed(() => vendorMetaRows.value)
 
 // resolveCanonicalVendor / canonicalMetaOwnerCode moved to
 // frontend/src/utils/llmOpsMeta.js for reuse across the
 // immersive publishing workspace and the meta model library.
 
 const metricCards = computed(() => {
-  const active = props.metaModels.filter((item) => item.status === 'active')
-  const deprecated = props.metaModels.filter(
-    (item) => item.status === 'deprecated'
+  const totalModels = ownerRows.value.reduce(
+    (total, row) => total + Number(row.meta_model_count || 0),
+    0
   )
-  const boundVendorIds = new Set(
-    props.metaModels
-      .map((item) => item.owner_code)
-      .filter((vendor) => vendor !== null && vendor !== undefined)
-      .map(String)
+  const activeModels = ownerRows.value.reduce(
+    (total, row) => total + Number(row.active_model_count || 0),
+    0
   )
   return [
     {
       label: t('llmOps.metaModelManagement.metrics.metaModels.label'),
-      value: props.metaModels.length,
+      value: ownerSummaryLoading.value ? '-' : totalModels,
       hint: t('llmOps.metaModelManagement.metrics.metaModels.hint')
     },
     {
       label: t('llmOps.metaModelManagement.metrics.boundVendors.label'),
-      value: boundVendorIds.size,
+      value: ownerSummaryLoading.value ? '-' : ownerRows.value.length,
       hint: t('llmOps.metaModelManagement.metrics.boundVendors.hint')
     },
     {
       label: t('llmOps.metaModelManagement.metrics.status.label'),
-      value: `${active.length}/${deprecated.length}`,
+      value: ownerSummaryLoading.value
+        ? '-'
+        : `${activeModels}/${Math.max(totalModels - activeModels, 0)}`,
       hint: t('llmOps.metaModelManagement.metrics.status.hint')
     }
   ]
 })
 
-const selectedVendorActiveCount = computed(
-  () => vendorMetaRows.value.filter((item) => item.status === 'active').length
-)
+const selectedVendorActiveCount = computed(() => {
+  if (statusFilter.value === 'active') return drawerTotal.value
+  if (statusFilter.value) return 0
+  return Number(selectedVendorRow.value?.active_model_count || 0)
+})
 
 const syncActionLabel = computed(() =>
   syncingMetaModels.value
@@ -651,6 +576,7 @@ function openVendorModelsDrawer(row) {
   selectedVendorId.value = row?.id ? String(row.id) : ''
   currentPage.value = 1
   showVendorModelsDrawer.value = Boolean(selectedVendorId.value)
+  fetchVendorMetaModels()
 }
 
 function closeVendorModelsDrawer() {
@@ -659,18 +585,66 @@ function closeVendorModelsDrawer() {
 
 function goToPreviousPage() {
   currentPage.value = Math.max(safeCurrentPage.value - 1, 1)
+  fetchVendorMetaModels()
 }
 
 function goToNextPage() {
   currentPage.value = Math.min(safeCurrentPage.value + 1, totalPages.value)
+  fetchVendorMetaModels()
 }
 
-watch(
-  [searchKeyword, statusFilter, modalityFilter, selectedVendorId, pageSize],
-  () => {
-    currentPage.value = 1
+watch([searchKeyword, statusFilter, modalityFilter, pageSize], () => {
+  currentPage.value = 1
+  if (showVendorModelsDrawer.value) fetchVendorMetaModels()
+})
+
+onMounted(() => {
+  fetchOwnerSummary()
+})
+
+async function fetchOwnerSummary() {
+  ownerSummaryLoading.value = true
+  try {
+    const response = await llmOpsApi.listMetaModelOwnerSummary()
+    ownerRows.value = paginationResults(paginationPayload(response))
+  } catch (error) {
+    showError(errorMessage(error, '加载元模型厂商汇总失败。'))
+  } finally {
+    ownerSummaryLoading.value = false
   }
-)
+}
+
+async function fetchVendorMetaModels() {
+  if (!selectedVendorId.value) return
+  drawerLoading.value = true
+  try {
+    const response = await llmOpsApi.listMetaModels({
+      owner: selectedVendorId.value,
+      status: statusFilter.value || undefined,
+      modality: modalityFilter.value || undefined,
+      search: searchKeyword.value.trim() || undefined,
+      page: safeCurrentPage.value,
+      page_size: Number(pageSize.value) || 20
+    })
+    const payload = paginationPayload(response)
+    drawerRows.value = paginationResults(payload).map((item) => {
+      const canonicalVendor = resolveCanonicalMetaOwner(item, props.providers)
+      return {
+        ...item,
+        owner_key: item.owner_code || canonicalVendor.code,
+        owner_code: item.owner_code || canonicalVendor.code,
+        owner_name: item.owner_name || canonicalVendor.name
+      }
+    })
+    drawerTotal.value = Number(payload?.count || drawerRows.value.length)
+  } catch (error) {
+    drawerRows.value = []
+    drawerTotal.value = 0
+    showError(errorMessage(error, '加载元模型明细失败。'))
+  } finally {
+    drawerLoading.value = false
+  }
+}
 
 async function syncMetaModels() {
   syncingMetaModels.value = true
@@ -682,24 +656,14 @@ async function syncMetaModels() {
         count: stats.models || 0
       })
     )
+    await fetchOwnerSummary()
+    if (showVendorModelsDrawer.value) await fetchVendorMetaModels()
     emit('refresh')
   } catch (error) {
     showError(errorMessage(error, t('llmOps.metaModelManagement.errors.sync')))
   } finally {
     syncingMetaModels.value = false
   }
-}
-
-function searchableText(item) {
-  return [
-    item.name,
-    item.code,
-    item.family,
-    item.owner_name,
-    ...(Array.isArray(item.aliases) ? item.aliases : [])
-  ]
-    .join(' ')
-    .toLowerCase()
 }
 
 function vendorRowActive(row) {
@@ -813,12 +777,6 @@ function releaseDateLabel(value) {
   return String(value).slice(0, 10)
 }
 
-function releaseDateTime(value) {
-  if (!value) return 0
-  const parsed = Date.parse(value)
-  return Number.isNaN(parsed) ? 0 : parsed
-}
-
 function compactTokenLabel(value) {
   const numeric = Number(value || 0)
   if (!numeric) return '-'
@@ -864,6 +822,15 @@ function statusTone(value) {
     unknown: 'muted'
   }
   return tones[value] || 'muted'
+}
+
+function paginationPayload(response) {
+  return response?.data?.data || response?.data || []
+}
+
+function paginationResults(payload) {
+  if (Array.isArray(payload?.results)) return payload.results
+  return Array.isArray(payload) ? payload : []
 }
 
 function errorMessage(error, fallback) {
@@ -1121,6 +1088,10 @@ function errorMessage(error, fallback) {
 
 .vendor-row.active {
   @apply bg-indigo-50;
+}
+
+.vendor-name-cell {
+  @apply flex min-w-0 items-center gap-3;
 }
 
 .vendor-row-static {

--- a/frontend/src/components/llm-ops/PriceSourceModal.vue
+++ b/frontend/src/components/llm-ops/PriceSourceModal.vue
@@ -309,7 +309,7 @@ const currencyOptions = computed(() => [
 
 const autoSyncSourceSelectOptions = computed(() =>
   autoSyncSourceOptions.value.map((option) => ({
-    value: option.option_code || option.provider_code,
+    value: sourceOptionKey(option),
     label: option.provider_name,
     description: option.source_name,
     badge: option.source_exists
@@ -320,9 +320,7 @@ const autoSyncSourceSelectOptions = computed(() =>
 
 const selectedAutoSyncSourceOption = computed(() =>
   autoSyncSourceOptions.value.find(
-    (option) =>
-      String(option.option_code || option.provider_code) ===
-      String(selectedAutoSyncSourceCode.value)
+    (option) => sourceOptionKey(option) === selectedAutoSyncSourceCode.value
   )
 )
 
@@ -349,9 +347,7 @@ const autoSyncSourceHelpText = computed(() => {
 })
 
 const saveDisabled = computed(
-  () =>
-    shouldCreateAutoSyncPreset.value &&
-    !selectedAutoSyncSourceOption.value
+  () => shouldCreateAutoSyncPreset.value && !selectedAutoSyncSourceOption.value
 )
 
 watch(
@@ -465,7 +461,7 @@ async function saveAutoSyncSource() {
   if (!option) return
 
   let sourceName = option.source_name
-  if (option.source_category === 'official_provider') {
+  if (isStableOfficialOption(option)) {
     const response = await llmOpsApi.ensureOfficialProviderSource(
       option.provider_code
     )
@@ -496,12 +492,9 @@ async function loadAutoSyncSourceOptions() {
     const options = Array.isArray(payload.results) ? payload.results : []
     autoSyncSourceOptions.value = options
     const current = options.find(
-      (option) =>
-        String(option.option_code || option.provider_code) ===
-        String(selectedAutoSyncSourceCode.value)
+      (option) => sourceOptionKey(option) === selectedAutoSyncSourceCode.value
     )
-    selectedAutoSyncSourceCode.value =
-      current?.option_code || current?.provider_code || ''
+    selectedAutoSyncSourceCode.value = current ? sourceOptionKey(current) : ''
     if (current) applyAutoSyncSourceOption(current)
   } catch (error) {
     showError(
@@ -543,6 +536,25 @@ function autoSyncSourcePayload(option) {
     updates_model_prices: true,
     notes: form.value.notes || ''
   }
+}
+
+function sourceOptionKey(option) {
+  return String(
+    option?.source_slug ||
+      option?.option_code ||
+      option?.provider_code ||
+      option?.source_name ||
+      ''
+  )
+}
+
+function isStableOfficialOption(option) {
+  if (option?.source_category !== 'official_provider') return false
+  const providerCode = String(option.provider_code || '').trim()
+  return Boolean(
+    providerCode &&
+      String(option.source_slug || '') === `${providerCode}-official`
+  )
 }
 
 function sourceOwnerTypeFromLegacyCategory(value) {

--- a/frontend/src/components/llm-ops/ProviderManagement.vue
+++ b/frontend/src/components/llm-ops/ProviderManagement.vue
@@ -138,7 +138,7 @@
               v-for="provider in filteredSourceProviderRows"
               :key="provider.id"
               class="cursor-pointer"
-              @click="selectedProvider = provider"
+              @click="openSourceDetail(provider)"
             >
               <td class="table-cell">
                 <p class="truncate font-medium text-slate-900">
@@ -357,26 +357,26 @@
       :open="Boolean(priceEntrySource)"
       :source="priceEntrySource"
       :providers="providers"
-      :meta-models="metaModels"
-      :models="models"
+      :meta-models="priceEntryMetaModels"
+      :models="priceEntryModels"
       @close="priceEntrySource = null"
       @saved="handlePriceEntrySaved"
     />
-    <ProviderPricingDrawer
-      :provider="selectedProvider"
-      :models="selectedProviderModels"
-      :sources="selectedProviderSources"
+    <SourcePriceDrawer
+      :source="selectedProvider?.primary_source || null"
+      :models="[]"
       :price-items="selectedProviderPriceItems"
-      :display-currency="displayCurrency"
-      :exchange-rate="exchangeRate"
-      :collecting-source-id="collectingSourceId"
-      :deleting-source-id="deletingSourceId"
+      :deleting="
+        String(deletingSourceId || '') ===
+        String(selectedProvider?.primary_source?.id || '')
+      "
+      :loading="selectedProviderLoading"
+      :page="selectedProviderPage"
+      :page-size="selectedProviderPageSize"
+      :total-items="selectedProviderTotal"
       @close="selectedProvider = null"
-      @manual-entry-source="openManualEntryFromProvider"
-      @edit-source="editSourceFromProvider"
-      @toggle-source="toggleSource"
-      @collect-source="collectSource"
-      @delete-source="deleteSource"
+      @delete="deleteSource"
+      @page-change="loadSelectedProviderPriceItems"
     />
   </section>
 </template>
@@ -389,7 +389,7 @@ import { useToast } from '@/composables/useToast'
 import ManualPriceImportModal from '@/components/llm-ops/ManualPriceImportModal.vue'
 import ManualPriceEntryModal from '@/components/llm-ops/ManualPriceEntryModal.vue'
 import PriceSourceModal from '@/components/llm-ops/PriceSourceModal.vue'
-import ProviderPricingDrawer from '@/components/llm-ops/ProviderPricingDrawer.vue'
+import SourcePriceDrawer from '@/components/llm-ops/SourcePriceDrawer.vue'
 import OperationIconButton from '@/components/llm-ops/OperationIconButton.vue'
 import {
   canApiSyncPriceSource as canApiSyncSource,
@@ -461,6 +461,13 @@ const deletingSourceId = ref(null)
 const sourceSearch = ref('')
 const sourceCategoryFilter = ref('all')
 const sourceStatusFilter = ref('all')
+const selectedProviderLoading = ref(false)
+const selectedProviderPage = ref(1)
+const selectedProviderPageSize = ref(50)
+const selectedProviderTotal = ref(0)
+const selectedProviderPriceItems = ref([])
+const localPriceEntryMetaModels = ref([])
+const localPriceEntryModels = ref([])
 
 const sourceCategoryFilterOptions = computed(() => [
   {
@@ -504,6 +511,14 @@ const sourceStatusFilterOptions = computed(() => [
   }
 ])
 
+const priceEntryMetaModels = computed(() =>
+  props.metaModels.length ? props.metaModels : localPriceEntryMetaModels.value
+)
+
+const priceEntryModels = computed(() =>
+  props.models.length ? props.models : localPriceEntryModels.value
+)
+
 // Source rows
 const sourceRows = computed(() =>
   props.sources
@@ -528,11 +543,6 @@ const sourceProviderRows = computed(() =>
 
 // Metrics
 const sourceMetrics = computed(() => {
-  const coveredMetaModelIds = new Set()
-  entrySourceRows.value.forEach((source) => {
-    source.meta_model_ids.forEach((id) => coveredMetaModelIds.add(id))
-  })
-
   const official = entrySourceRows.value.filter(
     (source) => source.business_source_category === 'official_provider'
   ).length
@@ -554,7 +564,10 @@ const sourceMetrics = computed(() => {
     },
     {
       label: t('llmOps.providerManagement.metrics.metaModels.label'),
-      value: coveredMetaModelIds.size,
+      value: entrySourceRows.value.reduce(
+        (total, source) => total + Number(source.covered_model_count || 0),
+        0
+      ),
       hint: t('llmOps.providerManagement.metrics.metaModels.hint')
     },
     {
@@ -637,27 +650,6 @@ const officialResetLegacySources = computed(
   () => officialResetPreview.value?.stats?.legacy_source_slugs || []
 )
 
-// Drawer selection
-const selectedProviderModels = computed(() => {
-  if (!selectedProvider.value) return []
-  return modelsForSourceIds(selectedProviderSourceIds.value)
-})
-
-const selectedProviderPriceItems = computed(() => {
-  if (!selectedProvider.value) return []
-  return priceItemsForSourceIds(selectedProviderSourceIds.value)
-})
-
-const selectedProviderSources = computed(() => {
-  if (!selectedProvider.value) return []
-  const sourceIds = selectedProviderSourceIds.value
-  return sourceRows.value.filter((source) => sourceIds.has(String(source.id)))
-})
-
-const selectedProviderSourceIds = computed(
-  () => new Set(selectedProvider.value?.source_ids || [])
-)
-
 function buildSourceProviderRow(source) {
   return {
     id: `source-${source.id}`,
@@ -665,6 +657,8 @@ function buildSourceProviderRow(source) {
     code: source.slug,
     category_keys: [source.business_source_category],
     covered_model_count: source.covered_model_count,
+    collect_mode_label: source.collect_mode_label,
+    collect_mode_tone: source.collect_mode_tone,
     meta_model_ids: source.meta_model_ids,
     price_item_count: source.price_item_count,
     primary_source: source,
@@ -679,35 +673,19 @@ function buildSourceProviderRow(source) {
   }
 }
 
-function modelsForSourceIds(sourceIds) {
-  const pricedModelIds = new Set(
-    priceItemsForSourceIds(sourceIds)
-      .map((item) => String(item.model || ''))
-      .filter(Boolean)
-  )
-  return props.models.filter(
-    (model) =>
-      sourceIds.has(String(model.source || '')) ||
-      pricedModelIds.has(String(model.id))
-  )
-}
-
-function priceItemsForSourceIds(sourceIds) {
-  return props.priceItems.filter(
-    (item) =>
-      item.is_current !== false && sourceIds.has(String(item.source || ''))
-  )
-}
-
 function buildSourceRow(source) {
   const relation = sourceRelation(source)
   const categoryKey = businessSourceCategory(source)
   const category = sourceCategory(categoryKey)
-  const currentItems = currentPriceItemsForSource(source.id)
   const latestRun = latestRunForSource(source.id)
   const status = sourceStatus(source, latestRun)
   const syncMode = sourceSyncMode(source)
-  const metaModelIds = metaModelIdsForSource(source, currentItems)
+  const modelCount = Number(
+    source.current_meta_model_count || source.model_count || 0
+  )
+  const priceItemCount = Number(
+    source.current_price_item_count || source.price_item_count || 0
+  )
 
   return {
     ...source,
@@ -722,19 +700,20 @@ function buildSourceRow(source) {
     status_hint: status.hint,
     sync_mode_label: syncMode.label,
     sync_mode_tone: syncMode.tone,
-    meta_model_ids: metaModelIds,
-    covered_model_count: metaModelIds.length,
-    price_item_count: currentItems.length,
-    dimension_count: dimensionCount(currentItems),
+    meta_model_ids: [],
+    covered_model_count: modelCount,
+    price_item_count: priceItemCount,
+    dimension_count: 0,
     can_collect: canCollectSource(source),
     can_manual_entry: canManualEntrySource(source),
     collect_action_label: collectActionLabel(source),
     collect_mode_label: collectModeLabel(source),
-    search_text: buildSourceSearchText(source, relation, category, currentItems)
+    collect_mode_tone: collectModeTone(source),
+    search_text: buildSourceSearchText(source, relation, category)
   }
 }
 
-function buildSourceSearchText(source, relation, category, currentItems) {
+function buildSourceSearchText(source, relation, category) {
   return [
     source.name,
     source.slug,
@@ -743,50 +722,11 @@ function buildSourceSearchText(source, relation, category, currentItems) {
     category.label,
     source.provider_name,
     source.channel_name,
-    source.endpoint_url,
-    ...currentItems.map((item) =>
-      [
-        item.meta_model_name,
-        item.meta_model_code,
-        item.meta_model_owner_name,
-        item.meta_model_owner_code,
-        item.provider_name,
-        item.dimension
-      ]
-        .filter(Boolean)
-        .join(' ')
-    )
+    source.endpoint_url
   ]
     .filter(Boolean)
     .join(' ')
     .toLowerCase()
-}
-
-function currentPriceItemsForSource(sourceId) {
-  return props.priceItems.filter(
-    (item) =>
-      String(item.source) === String(sourceId) && item.is_current !== false
-  )
-}
-
-function metaModelIdsForSource(source, items) {
-  const ids = items
-    .map((item) =>
-      String(item.meta_model || item.meta_model_code || item.model || '')
-    )
-    .filter(Boolean)
-  if (ids.length) return Array.from(new Set(ids))
-
-  return props.models
-    .filter((model) => String(model.source) === String(source.id))
-    .map((model) => String(model.meta_model || model.id))
-}
-
-function dimensionCount(items) {
-  const dimensions = items
-    .map((item) => `${item.dimension}:${item.billing_unit || ''}`)
-    .filter(Boolean)
-  return new Set(dimensions).size
 }
 
 // Actions
@@ -813,6 +753,42 @@ function handleSourceSaved() {
 function handlePriceEntrySaved(payload) {
   priceEntrySource.value = null
   emit('manual-price-saved', payload)
+}
+
+async function openSourceDetail(provider) {
+  selectedProvider.value = provider
+  selectedProviderPage.value = 1
+  selectedProviderPriceItems.value = []
+  selectedProviderTotal.value = 0
+  await loadSelectedProviderPriceItems(1)
+}
+
+async function loadSelectedProviderPriceItems(
+  page = selectedProviderPage.value
+) {
+  const source = selectedProvider.value?.primary_source
+  if (!source?.id) return
+  selectedProviderLoading.value = true
+  try {
+    const response = await llmOpsApi.listModelPriceItems({
+      source: source.id,
+      is_current: 'true',
+      page,
+      page_size: selectedProviderPageSize.value
+    })
+    const payload = paginationPayload(response)
+    selectedProviderPriceItems.value = paginationResults(payload)
+    selectedProviderTotal.value = Number(
+      payload?.count || selectedProviderPriceItems.value.length
+    )
+    selectedProviderPage.value = page
+  } catch (error) {
+    selectedProviderPriceItems.value = []
+    selectedProviderTotal.value = 0
+    showError(errorMessage(error, '加载价格源明细失败。'))
+  } finally {
+    selectedProviderLoading.value = false
+  }
 }
 
 function openOfficialResetModal(source = null) {
@@ -884,8 +860,9 @@ async function executeOfficialReset() {
   }
 }
 
-function openManualEntryFromProvider(source) {
+async function openManualEntryFromProvider(source) {
   selectedProvider.value = null
+  await ensurePriceEntryCatalogLoaded()
   priceEntrySource.value = source
 }
 
@@ -896,23 +873,33 @@ function openManualImportFromProvider(source) {
   showManualImportModal.value = true
 }
 
+async function ensurePriceEntryCatalogLoaded() {
+  const requests = []
+  if (!priceEntryMetaModels.value.length) {
+    requests.push(
+      fetchAllPages(llmOpsApi.listMetaModels).then((rows) => {
+        localPriceEntryMetaModels.value = rows
+      })
+    )
+  }
+  if (!priceEntryModels.value.length) {
+    requests.push(
+      fetchAllPages(llmOpsApi.listModels).then((rows) => {
+        localPriceEntryModels.value = rows
+      })
+    )
+  }
+  if (!requests.length) return
+  try {
+    await Promise.all(requests)
+  } catch (error) {
+    showError(errorMessage(error, '加载手工录价模型目录失败。'))
+  }
+}
+
 function editSourceFromProvider(source) {
   selectedProvider.value = null
   editingSource.value = source
-}
-
-async function toggleSource(source) {
-  if (!source?.id) return
-  try {
-    await llmOpsApi.updateCollectionSource(source.id, {
-      is_enabled: !source.is_enabled
-    })
-    emit('refresh')
-  } catch (error) {
-    showError(
-      errorMessage(error, t('llmOps.providerManagement.errors.saveFailed'))
-    )
-  }
 }
 
 async function collectSource(source) {
@@ -1053,7 +1040,7 @@ function sourceConfigSummary(source, relation = sourceRelation(source)) {
     .join(' · ')
 }
 
-function sourceStatus(source, latestRun) {
+function sourceStatus(source, latestRun = null) {
   if (!source.is_enabled) {
     return {
       label: t('llmOps.providerManagement.sourceStatus.inactive.label'),
@@ -1092,7 +1079,7 @@ function sourceStatus(source, latestRun) {
   return {
     label: t('llmOps.providerManagement.sourceStatus.active.label'),
     tone: 'ok',
-    hint: t('llmOps.providerManagement.sourceStatus.active.hint')
+    hint: collectModeLabel(source)
   }
 }
 
@@ -1179,6 +1166,13 @@ function latestRunForSource(sourceId) {
   return rows[0] || null
 }
 
+function collectModeTone(source) {
+  if (canCollectSource(source)) return 'auto'
+  if (canApiSyncSource(source) || source.source_type === 'yunce') return 'api'
+  if (canManualEntrySource(source)) return 'manual'
+  return 'unknown'
+}
+
 function errorMessage(error, fallback) {
   return (
     error?.response?.data?.detail ||
@@ -1190,6 +1184,38 @@ function errorMessage(error, fallback) {
 
 function apiPayload(response) {
   return response?.data?.data || response?.data || {}
+}
+
+function paginationPayload(response) {
+  return response?.data?.data || response?.data || []
+}
+
+function paginationResults(payload) {
+  if (Array.isArray(payload?.results)) return payload.results
+  return Array.isArray(payload) ? payload : []
+}
+
+async function fetchAllPages(request, params = {}) {
+  const firstResponse = await request({
+    ...params,
+    page: 1,
+    page_size: 200
+  })
+  const firstPayload = paginationPayload(firstResponse)
+  const results = paginationResults(firstPayload)
+  const total = Number(firstPayload?.count || results.length)
+  const totalPages = Math.max(1, Math.ceil(total / 200))
+  if (!firstPayload?.results || totalPages <= 1) return results
+
+  const pageRequests = []
+  for (let page = 2; page <= totalPages; page += 1) {
+    pageRequests.push(request({ ...params, page, page_size: 200 }))
+  }
+  const pageResponses = await Promise.all(pageRequests)
+  pageResponses.forEach((response) => {
+    results.push(...paginationResults(paginationPayload(response)))
+  })
+  return results
 }
 </script>
 
@@ -1386,6 +1412,10 @@ function apiPayload(response) {
 
 .source-badge.auto {
   @apply border-emerald-100 bg-emerald-50 text-emerald-700;
+}
+
+.source-badge.api {
+  @apply border-sky-100 bg-sky-50 text-sky-700;
 }
 
 .source-badge.supplier {

--- a/frontend/src/components/llm-ops/SourcePriceDrawer.vue
+++ b/frontend/src/components/llm-ops/SourcePriceDrawer.vue
@@ -56,7 +56,7 @@
           </div>
           <div class="summary-card">
             <p>{{ t('llmOps.sourcePriceDrawer.summary.currentItems') }}</p>
-            <strong>{{ sourceItemRows.length }}</strong>
+            <strong>{{ totalItems || sourceItemRows.length }}</strong>
           </div>
           <div class="summary-card">
             <p>{{ t('llmOps.sourcePriceDrawer.summary.currency') }}</p>
@@ -131,6 +131,11 @@
                 </tr>
               </thead>
               <tbody>
+                <tr v-if="loading">
+                  <td class="table-cell text-slate-500" colspan="3">
+                    加载中...
+                  </td>
+                </tr>
                 <template v-for="row in filteredModelRows" :key="row.key">
                   <tr>
                     <td class="table-cell">
@@ -167,13 +172,36 @@
                     </td>
                   </tr>
                 </template>
-                <tr v-if="!filteredModelRows.length">
+                <tr v-if="!loading && !filteredModelRows.length">
                   <td class="table-cell text-slate-500" colspan="3">
                     {{ t('llmOps.sourcePriceDrawer.empty.noRows') }}
                   </td>
                 </tr>
               </tbody>
             </table>
+          </div>
+          <div v-if="totalItems" class="pagination-bar">
+            <p class="text-xs text-slate-500">
+              第 {{ page }} / {{ totalPages }} 页，共 {{ totalItems }} 条
+            </p>
+            <div class="flex items-center gap-2">
+              <button
+                class="btn-secondary pagination-btn"
+                type="button"
+                :disabled="page <= 1 || loading"
+                @click="$emit('page-change', page - 1)"
+              >
+                上一页
+              </button>
+              <button
+                class="btn-secondary pagination-btn"
+                type="button"
+                :disabled="page >= totalPages || loading"
+                @click="$emit('page-change', page + 1)"
+              >
+                下一页
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -185,7 +213,7 @@
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-defineEmits(['close', 'delete', 'refresh'])
+defineEmits(['close', 'delete', 'refresh', 'page-change'])
 
 const props = defineProps({
   source: {
@@ -203,6 +231,22 @@ const props = defineProps({
   deleting: {
     type: Boolean,
     default: false
+  },
+  loading: {
+    type: Boolean,
+    default: false
+  },
+  page: {
+    type: Number,
+    default: 1
+  },
+  pageSize: {
+    type: Number,
+    default: 50
+  },
+  totalItems: {
+    type: Number,
+    default: 0
   }
 })
 
@@ -304,6 +348,10 @@ const sourceAddressLabel = computed(() => {
 
 const priceHeaderLabel = computed(() =>
   t('llmOps.sourcePriceDrawer.table.price')
+)
+
+const totalPages = computed(() =>
+  Math.max(1, Math.ceil(Number(props.totalItems || 0) / props.pageSize))
 )
 
 function buildRawItemRow(item) {
@@ -680,6 +728,14 @@ function formatDateTime(value) {
 
 .token-price-row strong {
   @apply truncate text-right font-mono font-semibold text-slate-800;
+}
+
+.pagination-bar {
+  @apply flex flex-col gap-3 border-t border-slate-100 px-4 py-3 sm:flex-row sm:items-center sm:justify-between;
+}
+
+.pagination-btn {
+  @apply px-3 py-1.5 text-xs;
 }
 
 .btn-secondary {

--- a/frontend/src/components/llm/providerIcons.js
+++ b/frontend/src/components/llm/providerIcons.js
@@ -9,8 +9,8 @@ const LOCAL_MODELS_DEV_LAB_ICON_MODULES = import.meta.glob(
 
 const LOCAL_PROVIDER_ICON_URLS = Object.fromEntries(
   Object.entries({
-    ...LOCAL_LOBEHUB_PROVIDER_ICON_MODULES,
-    ...LOCAL_MODELS_DEV_LAB_ICON_MODULES
+    ...LOCAL_MODELS_DEV_LAB_ICON_MODULES,
+    ...LOCAL_LOBEHUB_PROVIDER_ICON_MODULES
   }).map(([filePath, iconUrl]) => {
     const fileName = filePath.split('/').pop() || ''
     const providerSlug = fileName.replace(/\.svg$/, '')
@@ -19,9 +19,9 @@ const LOCAL_PROVIDER_ICON_URLS = Object.fromEntries(
 )
 
 const PROVIDER_ICON_ALIASES = {
-  amazon_nova: 'aws',
   alibaba_cloud: 'alibabacloud',
   aliyun: 'alibabacloud',
+  amazon_nova: 'aws',
   azure_openai: 'azure',
   claude: 'anthropic',
   dashscope: 'qwen',

--- a/frontend/src/pages/LLMOps.vue
+++ b/frontend/src/pages/LLMOps.vue
@@ -827,6 +827,7 @@ import { DEFAULT_WORKFLOW_POLICIES } from '@/constants/llmOpsWorkflow'
 const LIST_PAGE_SIZE = 200
 const LIST_PARAMS = { page_size: LIST_PAGE_SIZE }
 const PRICE_HISTORY_PAGE_SIZE = 120
+const LIGHT_CORE_SECTIONS = new Set(['metaModels', 'providers'])
 const DATA_HEAVY_SECTIONS = new Set([
   'channels',
   'channelMatrix',
@@ -1749,7 +1750,7 @@ async function refreshAll() {
   loading.value = true
   const section = activeSection.value
   try {
-    await refreshCoreData()
+    await refreshCoreData(section)
     await refreshSectionData(section)
   } finally {
     loading.value = false
@@ -1758,7 +1759,8 @@ async function refreshAll() {
   refreshSecondaryData({ force: true, silent: true })
 }
 
-async function refreshCoreData() {
+async function refreshCoreData(section = activeSection.value) {
+  const shouldLoadModels = !LIGHT_CORE_SECTIONS.has(section)
   const [
     sourceRes,
     runRes,
@@ -1771,7 +1773,7 @@ async function refreshCoreData() {
     fetchList(llmOpsApi.listCollectionSources),
     fetchList(llmOpsApi.listCollectionRuns),
     fetchList(llmOpsApi.listProviders),
-    fetchList(llmOpsApi.listModels),
+    shouldLoadModels ? fetchList(llmOpsApi.listModels) : Promise.resolve([]),
     fetchList(llmOpsApi.listChannels),
     fetchList(llmOpsApi.listResalePlatforms),
     llmOpsApi.getSummary(summaryParams())
@@ -1779,7 +1781,9 @@ async function refreshCoreData() {
   sources.value = extract(sourceRes)
   collectionRuns.value = extract(runRes)
   providers.value = extract(providerRes)
-  models.value = extract(modelRes)
+  if (shouldLoadModels) {
+    models.value = extract(modelRes)
+  }
   channels.value = extract(channelRes)
   resalePlatforms.value = extract(platformRes)
   summary.value = extract(summaryRes)
@@ -1800,9 +1804,7 @@ async function refreshSecondaryData({ force = false, silent = false } = {}) {
   backgroundLoading.value = true
   try {
     await Promise.all([
-      refreshMetaModels(),
       refreshChannelPricingData(),
-      refreshModelPriceItems(),
       refreshResaleListings(),
       refreshReconciliationRecords()
     ])
@@ -1822,8 +1824,12 @@ async function refreshSecondaryData({ force = false, silent = false } = {}) {
 
 async function refreshSectionData(section) {
   if (!DATA_HEAVY_SECTIONS.has(section)) return
-  if (section === 'providers' || section === 'metaModels') {
-    await Promise.all([refreshMetaModels(), refreshModelPriceItems()])
+  if (section === 'providers') {
+    await refreshProviderManagementData()
+    return
+  }
+  if (section === 'metaModels') {
+    await refreshMetaModelManagementData()
     return
   }
   if (section === 'channels') {
@@ -1854,10 +1860,6 @@ async function refreshSectionData(section) {
   if (section === 'reconciler') {
     await refreshReconciliationRecords()
   }
-}
-
-async function refreshMetaModels() {
-  metaModels.value = await fetchList(llmOpsApi.listMetaModels)
 }
 
 async function refreshChannelPricingData() {
@@ -1927,31 +1929,15 @@ async function refreshCollectionRuns() {
 
 async function refreshProviderManagementData() {
   try {
-    const [
-      sourceData,
-      runData,
-      providerData,
-      modelData,
-      metaModelData,
-      priceItemData,
-      summaryRes
-    ] = await Promise.all([
+    const [sourceData, runData, providerData, summaryRes] = await Promise.all([
       fetchList(llmOpsApi.listCollectionSources),
       fetchList(llmOpsApi.listCollectionRuns),
       fetchList(llmOpsApi.listProviders),
-      fetchList(llmOpsApi.listModels),
-      fetchList(llmOpsApi.listMetaModels),
-      fetchList(llmOpsApi.listModelPriceItems, {
-        is_current: 'true'
-      }),
       llmOpsApi.getSummary(summaryParams())
     ])
     sources.value = sourceData
     collectionRuns.value = runData
     providers.value = providerData
-    models.value = modelData
-    metaModels.value = metaModelData
-    modelPriceItems.value = priceItemData
     summary.value = extract(summaryRes)
   } catch (error) {
     showError(errorMessage(error, '刷新价格源数据失败。'))
@@ -1960,20 +1946,11 @@ async function refreshProviderManagementData() {
 
 async function refreshMetaModelManagementData() {
   try {
-    const [providerData, modelData, metaModelData, priceItemData, summaryRes] =
-      await Promise.all([
-        fetchList(llmOpsApi.listProviders),
-        fetchList(llmOpsApi.listModels),
-        fetchList(llmOpsApi.listMetaModels),
-        fetchList(llmOpsApi.listModelPriceItems, {
-          is_current: 'true'
-        }),
-        llmOpsApi.getSummary(summaryParams())
-      ])
+    const [providerData, summaryRes] = await Promise.all([
+      fetchList(llmOpsApi.listProviders),
+      llmOpsApi.getSummary(summaryParams())
+    ])
     providers.value = providerData
-    models.value = modelData
-    metaModels.value = metaModelData
-    modelPriceItems.value = priceItemData
     summary.value = extract(summaryRes)
   } catch (error) {
     showError(errorMessage(error, '刷新元模型数据失败。'))
@@ -2152,6 +2129,15 @@ watch(activeSection, (section) => {
   ) {
     refreshSectionData(section).catch((error) => {
       showError(errorMessage(error, '加载当前页面数据失败。'))
+    })
+  }
+  if (
+    !LIGHT_CORE_SECTIONS.has(section) &&
+    !models.value.length &&
+    !loading.value
+  ) {
+    refreshCoreData(section).catch((error) => {
+      showError(errorMessage(error, '加载基础模型数据失败。'))
     })
   }
 })


### PR DESCRIPTION
## Summary
- Add backend filters and current-count annotations for LLM Ops price sources, meta models, models, and price items.
- Add meta model owner summary API for lightweight owner-grouped catalog browsing.
- Optimize LLM Ops provider and meta model management views to load large catalogs on demand with paginated drawer details.
- Preserve source sync-mode, official reset, and provider icon behavior while reducing frontend full-list aggregation.

No linked open Issue found for this follow-up.

## Test plan
- [x] `git diff --check origin/main...HEAD`
- [x] `.venv/bin/python -m py_compile backend/llm_ops/serializers.py backend/llm_ops/views.py`
- [x] `npx eslint src/api/llmOps.js src/components/llm-ops/MetaModelManagement.vue src/components/llm-ops/PriceSourceModal.vue src/components/llm-ops/ProviderManagement.vue src/components/llm-ops/SourcePriceDrawer.vue src/components/llm/providerIcons.js src/pages/LLMOps.vue --ext .js,.vue --ignore-path ../.gitignore`
- [x] `npm run build`

Made with [Orca](https://github.com/stablyai/orca) 🐋
