### PR TITLE
Validate LLM Ops resale floor pricing

### DIFF
--- a/frontend/src/components/llm-ops/ChannelModelDrawer.vue
+++ b/frontend/src/components/llm-ops/ChannelModelDrawer.vue
@@ -1997,7 +1997,9 @@ function priceSummaryText(rows, model = null, limit = 3) {
 function dedupePriceSummaryRows(rows) {
   const seen = new Set()
   return (rows || []).filter((item) => {
-    const key = String(item?.label || '').trim().toLowerCase()
+    const key = String(item?.label || '')
+      .trim()
+      .toLowerCase()
     if (!key || seen.has(key)) return false
     seen.add(key)
     return true
@@ -2007,19 +2009,26 @@ function dedupePriceSummaryRows(rows) {
 function batchUpstreamPriceSummary(model) {
   const rows = providerPriceSummary(model)
   if (!rows.length) return '-'
-  return rows
-    .map((item) => `${item.label} ${priceNumberText(item, model)}`)
-    .join(' · ')
+  return batchPriceSummaryText(rows, model)
 }
 
 function batchPendingDraftPriceSummary(draft, model) {
   const rows = draftPricePreview(draft, model)
   if (!rows.length) return '-'
-  return rows
-    .map(
-      (item) =>
-        `${previewPriceLabel(item.label)} ${priceNumberText(item, model)}`
-    )
+  return batchPriceSummaryText(
+    rows.map((item) => ({
+      ...item,
+      label: previewPriceLabel(item.label)
+    })),
+    model
+  )
+}
+
+function batchPriceSummaryText(rows, model) {
+  const items = dedupePriceSummaryRows(rows).slice(0, 3)
+  if (!items.length) return '-'
+  return items
+    .map((item) => `${item.label} ${priceNumberText(item, model)}`)
     .join(' · ')
 }
 
@@ -2493,7 +2502,7 @@ function modalityLabel(modality) {
 }
 
 .add-model-layout {
-  @apply grid gap-3 xl:grid-cols-[minmax(0,1fr)_minmax(18rem,0.42fr)] xl:items-start;
+  @apply grid gap-3 xl:grid-cols-[minmax(0,1fr)_minmax(13rem,0.24fr)] xl:items-start;
 }
 
 .add-model-main {
@@ -2521,7 +2530,7 @@ function modalityLabel(modality) {
 }
 
 .channel-performance-panel {
-  @apply h-full rounded-lg border border-slate-200 bg-white px-3 py-3;
+  @apply rounded-lg border border-slate-200 bg-white px-3 py-2.5;
 }
 
 .channel-performance-title {
@@ -2569,7 +2578,7 @@ function modalityLabel(modality) {
 }
 
 .batch-selection-row {
-  @apply grid gap-2 px-3 py-2.5 xl:grid-cols-[minmax(9rem,0.8fr)_minmax(11rem,0.9fr)_minmax(0,1.35fr)] xl:items-center;
+  @apply grid gap-2 px-3 py-2.5 xl:grid-cols-[minmax(7.5rem,0.58fr)_minmax(9.5rem,0.62fr)_minmax(0,1.8fr)] xl:items-center;
 }
 
 .batch-model-main {

--- a/frontend/src/components/llm-ops/ResalePublishingDrawer.vue
+++ b/frontend/src/components/llm-ops/ResalePublishingDrawer.vue
@@ -199,6 +199,7 @@ const canPublish = computed(() => {
   if (!changedListings.length) return false
   return changedListings.every(
     (l) =>
+      !l.priceBelowReference &&
       Number.isFinite(Number(l.priceIn)) &&
       Number.isFinite(Number(l.priceOut)) &&
       Number(l.priceIn) > 0 &&

--- a/frontend/src/components/llm-ops/ResalePublishingWorkspace.vue
+++ b/frontend/src/components/llm-ops/ResalePublishingWorkspace.vue
@@ -433,16 +433,50 @@
                     <p class="pricing-card-caption text-emerald-600">
                       {{ t('llmOps.publishingWorkspace.pricing.retailPrice') }}
                     </p>
-                    <div class="terminal-price-control">
+                    <div
+                      class="terminal-price-control"
+                      :class="
+                        isBelowReferencePrice(
+                          dimension.priceRaw,
+                          dimension.referencePriceRaw
+                        )
+                          ? 'terminal-price-control-error'
+                          : ''
+                      "
+                    >
                       <span>{{ currencySymbol }}</span>
                       <input
                         :value="dimension.priceText"
                         type="number"
                         step="0.01"
                         min="0"
+                        :aria-invalid="
+                          isBelowReferencePrice(
+                            dimension.priceRaw,
+                            dimension.referencePriceRaw
+                          )
+                            ? 'true'
+                            : 'false'
+                        "
                         @input="onPriceInput(row, dimension.key, $event)"
+                        @change="onPriceCommit(row, dimension.key, $event)"
                       />
                     </div>
+                    <p
+                      v-if="
+                        isBelowReferencePrice(
+                          dimension.priceRaw,
+                          dimension.referencePriceRaw
+                        )
+                      "
+                      class="terminal-price-error"
+                    >
+                      {{
+                        t('llmOps.publishingWorkspace.pricing.belowFloor', {
+                          value: currencySymbol + dimension.referencePriceText
+                        })
+                      }}
+                    </p>
                   </div>
                   <div class="terminal-price-meta">
                     <p
@@ -1172,15 +1206,9 @@ const chainRows = computed(() => {
         priceInRaw: state.priceInRaw ?? null,
         priceOutRaw: state.priceOutRaw ?? null,
         priceCacheInRaw: state.priceCacheInRaw ?? 0,
-        priceIn:
-          state.priceInRaw !== null && state.priceInRaw !== undefined
-            ? Number(state.priceInRaw).toFixed(2)
-            : '',
-        priceOut:
-          state.priceOutRaw !== null && state.priceOutRaw !== undefined
-            ? Number(state.priceOutRaw).toFixed(2)
-            : '',
-        priceCacheIn: Number(state.priceCacheInRaw ?? 0).toFixed(2),
+        priceIn: editablePriceInputText(state.priceInRaw),
+        priceOut: editablePriceInputText(state.priceOutRaw),
+        priceCacheIn: editablePriceInputText(state.priceCacheInRaw ?? 0),
         isLowest: false
       }
     })
@@ -1425,7 +1453,25 @@ function onMarginCommit(row, event) {
 }
 
 function onPriceInput(row, key, event) {
-  const rawPrice = Number(event?.target?.value)
+  const rawValue = event?.target?.value ?? ''
+  const patch = pricePatchForDimension(key, rawValue)
+  if (rawValue === '') {
+    updateChainState(row, patch)
+    emitChange()
+    return
+  }
+  const rawPrice = Number(rawValue)
+  if (!Number.isFinite(rawPrice) || rawPrice < 0) return
+  patch.margin = normalizeMargin(marginFromRowPrices(row, patch) ?? row.margin)
+  updateChainState(row, patch)
+  emitChange()
+}
+
+function onPriceCommit(row, key, event) {
+  const rawValue = event?.target?.value ?? ''
+  if (rawValue === '') return
+  const rawPrice = Number(rawValue)
+  if (!Number.isFinite(rawPrice) || rawPrice < 0) return
   const price = applyPriceChange(row, key, rawPrice)
   if (
     event?.target &&
@@ -1437,16 +1483,23 @@ function onPriceInput(row, key, event) {
   }
 }
 
+function pricePatchForDimension(key, value) {
+  const patch = {}
+  if (key === 'input') {
+    patch.priceInRaw = value
+  } else if (key === 'cache') {
+    patch.priceCacheInRaw = value
+  } else {
+    patch.priceOutRaw = value
+  }
+  return patch
+}
+
 function applyPriceChange(row, key, rawPrice) {
   const dimension = priceDimensions(row).find((item) => item.key === key)
   const cost = dimension?.costRaw ?? 0
-  const referencePrice = Number(dimension?.referencePriceRaw)
   const inputPrice = Number.isFinite(rawPrice) ? rawPrice : 0
-  const price =
-    Number.isFinite(referencePrice) && referencePrice > 0
-      ? Math.max(inputPrice, referencePrice)
-      : inputPrice
-  const formattedPrice = formatEditablePrice(price)
+  const formattedPrice = formatEditablePrice(inputPrice)
   const margin =
     Number(cost) > 0
       ? ((Number(formattedPrice) - Number(cost)) / Number(cost)) * 100
@@ -1500,6 +1553,14 @@ function formatEditablePrice(value) {
   return Number(amount.toFixed(2))
 }
 
+function editablePriceInputText(value) {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'string') return value
+  const amount = Number(value)
+  if (!Number.isFinite(amount)) return ''
+  return amount.toFixed(2)
+}
+
 function formatMinimumPrice(value) {
   const amount = Number(value)
   if (!Number.isFinite(amount)) return 0
@@ -1546,12 +1607,19 @@ function referencePriceTitle(dimension) {
 }
 
 function isBelowReferencePrice(price, referencePrice) {
+  if (price === null || price === undefined || price === '') return false
   const priceValue = Number(price)
   const referenceValue = Number(referencePrice)
   if (!Number.isFinite(priceValue) || !Number.isFinite(referenceValue)) {
     return false
   }
   return priceValue + 0.000001 < referenceValue
+}
+
+function rowHasBelowReferencePrice(row) {
+  return priceDimensions(row).some((dimension) =>
+    isBelowReferencePrice(dimension.priceRaw, dimension.referencePriceRaw)
+  )
 }
 
 function autoApproveStatus(margin) {
@@ -1978,6 +2046,7 @@ function workspacePayload() {
       priceOut: row.priceOutRaw,
       priceCacheIn: row.priceCacheInRaw,
       margin: row.margin,
+      priceBelowReference: rowHasBelowReferencePrice(row),
       hasChanges: listingRowHasChanges(row)
     }))
   }
@@ -2770,6 +2839,29 @@ defineExpose({
 .terminal-price-control:focus-within {
   border-color: #86efac;
   box-shadow: 0 0 0 2px #dcfce7;
+}
+
+.terminal-price-control-error,
+.terminal-price-control-error:focus-within {
+  border-color: #f87171;
+  box-shadow: 0 0 0 2px #fee2e2;
+}
+
+.terminal-price-control-error span {
+  border-right-color: #fecaca;
+  color: #dc2626;
+}
+
+.terminal-price-control-error input {
+  color: #991b1b;
+}
+
+.terminal-price-error {
+  margin-top: 0.25rem;
+  color: #dc2626;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1.3;
 }
 
 .terminal-price-control span {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -989,6 +989,7 @@
         "costPrice": "Cost price",
         "retailPrice": "Retail price",
         "floor": "Floor {value}",
+        "belowFloor": "Below floor {value}. Please revise.",
         "average": "Average",
         "referenceTitle": "Minimum reference price = cost price × (1 + service fee rate + platform commission rate); current service fee {serviceFee}; current platform commission {commission}; reference price {reference}",
         "costFormulaTitle": "Cost price = supplier cost price × discount; {formula}",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -999,6 +999,7 @@
         "costPrice": "成本价",
         "retailPrice": "终端售卖价",
         "floor": "下限 {value}",
+        "belowFloor": "低于下限 {value}，请重新修改",
         "average": "均价",
         "referenceTitle": "最低参考定价 = 成本价 × (1 + 服务费率 + 平台抽佣比例)；当前服务费率 {serviceFee}；当前平台抽佣比例 {commission}；参考价 {reference}",
         "costFormulaTitle": "成本价 = 供应商成本价 × 折扣；{formula}",

--- a/frontend/src/pages/LLMOps.vue
+++ b/frontend/src/pages/LLMOps.vue
@@ -2356,7 +2356,10 @@ async function handleResaleWorkspacePublished(payload) {
     return
   }
   const publishListings = changedListings.filter(
-    (item) => Number(item.priceIn) > 0 && Number(item.priceOut) > 0
+    (item) =>
+      !item.priceBelowReference &&
+      Number(item.priceIn) > 0 &&
+      Number(item.priceOut) > 0
   )
   const items = publishListings.map(mapWorkspaceListingToPayload)
   if (!items.length) {


### PR DESCRIPTION
## Summary
- Add inline validation when resale retail prices fall below the computed floor price.
- Prevent publishing changed listings that are below the reference floor.
- Preserve editable price input text while recalculating margins on input and commit.
- Tighten batch price summary layout and deduplicate displayed price rows.

No linked issue: no matching GitHub issue exists in this repository.

## Test plan
- [x] npm run build
- [x] git diff --check

Made with [Orca](https://github.com/stablyai/orca) 🐋
