### PR TITLE
Normalize LLM Ops paginated responses

### DIFF
--- a/frontend/src/components/llm-ops/ChannelModelDrawer.vue
+++ b/frontend/src/components/llm-ops/ChannelModelDrawer.vue
@@ -764,6 +764,7 @@
 import '@/components/llm-ops/channelModelDrawer.css'
 
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+
 import { llmOpsApi } from '@/api/llmOps'
 import {
   normalizeSearch,
@@ -774,6 +775,8 @@ import { useChannelModelNewDraft } from '@/composables/useChannelModelNewDraft'
 import { useChannelModelPricing } from '@/composables/useChannelModelPricing'
 import { useChannelModelRows } from '@/composables/useChannelModelRows'
 import { useChannelModelSelection } from '@/composables/useChannelModelSelection'
+import { asArray } from '@/utils/llmOpsPagination'
+
 import CompactSelect from './CompactSelect.vue'
 import OperationIconButton from './OperationIconButton.vue'
 
@@ -916,14 +919,14 @@ const saveButtonLabel = computed(() =>
 )
 
 const baseAvailableModels = computed(() =>
-  props.models.filter((model) => {
+  asArray(props.models).filter((model) => {
     return !configuredIdentityKeys.value.has(modelMetaIdentityKey(model))
   })
 )
 
 const configuredIdentityKeys = computed(() => {
   const keys = new Set()
-  props.models.forEach((model) => {
+  asArray(props.models).forEach((model) => {
     const draft = drafts.value[model.id]
     if (draft?.is_configured || shouldPersist(draft || {})) {
       keys.add(modelMetaIdentityKey(model))
@@ -934,7 +937,7 @@ const configuredIdentityKeys = computed(() => {
 
 const metaModelById = computed(() => {
   const items = new Map()
-  props.metaModels.forEach((model) => {
+  asArray(props.metaModels).forEach((model) => {
     if (model?.id !== undefined && model?.id !== null) {
       items.set(String(model.id), model)
     }
@@ -944,7 +947,7 @@ const metaModelById = computed(() => {
 
 const metaModelByCode = computed(() => {
   const items = new Map()
-  props.metaModels.forEach((model) => {
+  asArray(props.metaModels).forEach((model) => {
     const code = normalizeSearch(model?.code || '')
     if (code) {
       items.set(code, model)
@@ -986,6 +989,7 @@ const {
   selectVisibleModels,
   selectedCostModel,
   selectedModelCount,
+  selectedModelOptions,
   selectedResolvedModels,
   toggleModelSelection,
   vendorOptions
@@ -1062,12 +1066,12 @@ watch(
       return
     }
     const pricesByModel = new Map(
-      props.channelPrices
+      asArray(props.channelPrices)
         .filter((price) => String(price.channel) === String(props.channel.id))
         .map((price) => [String(price.model), price])
     )
     drafts.value = Object.fromEntries(
-      props.models.map((model) => [
+      asArray(props.models).map((model) => [
         model.id,
         draftDefaults(model, pricesByModel.get(String(model.id)))
       ])

--- a/frontend/src/components/llm-ops/ChannelPriceMatrixPanel.vue
+++ b/frontend/src/components/llm-ops/ChannelPriceMatrixPanel.vue
@@ -104,6 +104,8 @@
 <script setup>
 import { computed, ref } from 'vue'
 
+import { asArray } from '@/utils/llmOpsPagination'
+
 import CompactSelect from './CompactSelect.vue'
 
 const props = defineProps({
@@ -120,7 +122,7 @@ const statusFilterOptions = [
   { label: '多渠道覆盖', value: 'ready' }
 ]
 
-const rows = computed(() => props.summary.agione?.diagnostics || [])
+const rows = computed(() => asArray(props.summary.agione?.diagnostics))
 const visibleChannels = computed(() =>
   props.channels.filter((channel) => channel.is_active !== false)
 )

--- a/frontend/src/components/llm-ops/GlobalConfigPanel.vue
+++ b/frontend/src/components/llm-ops/GlobalConfigPanel.vue
@@ -472,7 +472,7 @@ function formatDateTime(value) {
 }
 
 function extract(response) {
-  const payload = response?.data ?? response
+  const payload = response?.data?.data ?? response?.data ?? response
   return payload?.results ?? payload
 }
 

--- a/frontend/src/components/llm-ops/ListingRiskPanel.vue
+++ b/frontend/src/components/llm-ops/ListingRiskPanel.vue
@@ -76,6 +76,8 @@
 <script setup>
 import { computed, ref } from 'vue'
 
+import { asArray } from '@/utils/llmOpsPagination'
+
 import CompactSelect from './CompactSelect.vue'
 
 const props = defineProps({
@@ -91,10 +93,12 @@ const riskFilterOptions = [
   { label: '需要汇率', value: 'currency_mismatch' }
 ]
 
-const diagnosticRows = computed(() => props.summary.agione?.diagnostics || [])
+const diagnosticRows = computed(() =>
+  asArray(props.summary.agione?.diagnostics)
+)
 const selectedPlatformId = computed(() => props.summary.agione?.platform_id)
 const listingRows = computed(() => {
-  const rows = props.summary.listings || []
+  const rows = asArray(props.summary.listings)
   if (!selectedPlatformId.value) return rows
   return rows.filter(
     (listing) =>

--- a/frontend/src/composables/useAgioneListingRows.js
+++ b/frontend/src/composables/useAgioneListingRows.js
@@ -1,5 +1,7 @@
 import { computed, unref } from 'vue'
+
 import { resolveCanonicalMetaOwner } from '@/utils/llmOpsMeta'
+import { asArray } from '@/utils/llmOpsPagination'
 
 /**
  * Centralized derived state for the Agione resale listing workbench.
@@ -29,14 +31,14 @@ export function useAgioneListingRows({
 }) {
   const listingRows = computed(() => {
     const procurementByModel = new Map(
-      (unref(summaryRef)?.procurement || []).map((row) => [
+      asArray(unref(summaryRef)?.procurement).map((row) => [
         String(row.model_id),
         row
       ])
     )
     const listingsByModel = new Map()
     const platform = unref(agionePlatformRef)
-    const listings = unref(listingsRef) || []
+    const listings = asArray(unref(listingsRef))
     listings
       .filter(
         (listing) =>
@@ -49,10 +51,10 @@ export function useAgioneListingRows({
         listingsByModel.set(key, rows)
       })
 
-    return (unref(modelsRef) || []).flatMap((model) => {
+    return asArray(unref(modelsRef)).flatMap((model) => {
       const modelId = String(model.id)
       const procurement = procurementByModel.get(modelId) || {}
-      const options = procurement.options || []
+      const options = asArray(procurement.options)
       const lowestOption = procurement.best_channel || null
       const modelListings = listingsByModel.get(modelId) || []
       if (!options.length && !modelListings.length) return []
@@ -117,9 +119,9 @@ export function useAgioneListingRows({
         source_count: 0
       }
       group.rows.push(row)
-      group.options.push(...row.options)
-      group.listings.push(...row.listings)
-      group.active_listings.push(...row.active_listings)
+      group.options.push(...asArray(row.options))
+      group.listings.push(...asArray(row.listings))
+      group.active_listings.push(...asArray(row.active_listings))
       group.is_listed = group.is_listed || row.is_listed
       group.requires_currency_conversion =
         group.requires_currency_conversion || row.requires_currency_conversion
@@ -138,7 +140,7 @@ export function useAgioneListingRows({
               Number(left.estimated_cost || 0) -
               Number(right.estimated_cost || 0)
           )[0] || null
-      const activeOptions = group.active_listings
+      const activeOptions = asArray(group.active_listings)
         .map((listing) => listingOption(listing, lowestOption, options))
         .filter(Boolean)
       const cheapestActiveOption =
@@ -336,7 +338,7 @@ export function useAgioneListingRows({
     const normalizedRate = Number.isFinite(profitRate) ? profitRate : 0
     const lowestValue = Number(lowestChannelPrice.value?.value || 0)
     return trendChannelOptions.value.map((option) => {
-      const proposedValues = option.metric_values.map((item) => ({
+      const proposedValues = asArray(option.metric_values).map((item) => ({
         ...item,
         value: Number(item.value || 0) * (1 + normalizedRate / 100)
       }))
@@ -346,9 +348,9 @@ export function useAgioneListingRows({
           ?.value ??
         proposedValues[0]?.value ??
         0
-      const activeListing = selectedTrendRow.value?.active_listings.find(
-        (listing) => String(listing.channel) === String(option.channel_id)
-      )
+      const activeListing = asArray(
+        selectedTrendRow.value?.active_listings
+      ).find((listing) => String(listing.channel) === String(option.channel_id))
       const gapValue = Math.max(0, costValue - lowestValue)
       const gapPercent = lowestValue > 0 ? (gapValue / lowestValue) * 100 : 0
       return {
@@ -391,7 +393,7 @@ export function useAgioneListingRows({
 
   const selectedOptionIsListed = computed(() => {
     if (!selectedTrendOption.value || !selectedTrendRow.value) return false
-    return selectedTrendRow.value.active_listings.some(
+    return asArray(selectedTrendRow.value.active_listings).some(
       (listing) =>
         String(listing.channel) === String(selectedTrendOption.value.channel_id)
     )
@@ -457,7 +459,7 @@ export function useAgioneListingRows({
 
   function listingOption(listing, lowestOption, options) {
     if (!listing.channel) return lowestOption
-    return options.find(
+    return asArray(options).find(
       (option) => String(option.channel_id) === String(listing.channel)
     )
   }
@@ -474,7 +476,7 @@ export function useAgioneListingRows({
 
   function uniqueTrendOptions(options) {
     const byChannel = new Map()
-    options.forEach((option) => {
+    asArray(options).forEach((option) => {
       const key = String(option.channel_id || '')
       if (!key) return
       const current = byChannel.get(key)
@@ -660,7 +662,7 @@ export function useAgioneListingRows({
   }
 
   function activeListingChannels(row) {
-    const listings = row?.active_listings || []
+    const listings = asArray(row?.active_listings)
     if (!listings.length) return '-'
     return listings
       .map((listing) => listing.channel_name || '未指定渠道')

--- a/frontend/src/composables/useLLMOpsData.js
+++ b/frontend/src/composables/useLLMOpsData.js
@@ -7,6 +7,8 @@ import {
   LIGHT_CORE_SECTIONS
 } from '@/composables/useLLMOpsNavigation'
 import {
+  asArray,
+  asObject,
   errorMessage,
   extract,
   fetchFirstPage,
@@ -47,10 +49,10 @@ export function useLLMOpsData() {
   )
 
   const providerCollectionSources = computed(() =>
-    sources.value.filter((item) => item.source_type !== 'agione')
+    asArray(sources.value).filter((item) => item.source_type !== 'agione')
   )
 
-  const procurementRows = computed(() => summary.value.procurement || [])
+  const procurementRows = computed(() => asArray(summary.value.procurement))
   const exchangeRate = computed(() =>
     Number(summary.value.currency?.usd_to_cny_rate || 7.15)
   )
@@ -100,16 +102,16 @@ export function useLLMOpsData() {
       fetchList(llmOpsApi.listResalePlatforms),
       llmOpsApi.getSummary(summaryParams())
     ])
-    sources.value = extract(sourceRes)
-    collectionRuns.value = extract(runRes)
-    providers.value = extract(providerRes)
-    metaModels.value = extract(metaModelRes)
+    sources.value = asArray(extract(sourceRes))
+    collectionRuns.value = asArray(extract(runRes))
+    providers.value = asArray(extract(providerRes))
+    metaModels.value = asArray(extract(metaModelRes))
     if (shouldLoadModels) {
-      models.value = extract(modelRes)
+      models.value = asArray(extract(modelRes))
     }
-    channels.value = extract(channelRes)
-    resalePlatforms.value = extract(platformRes)
-    summary.value = extract(summaryRes)
+    channels.value = asArray(extract(channelRes))
+    resalePlatforms.value = asArray(extract(platformRes))
+    summary.value = normalizeSummary(extract(summaryRes))
     await loadResaleWorkflowConfig()
   }
 
@@ -196,36 +198,40 @@ export function useLLMOpsData() {
         is_current: 'true'
       })
     ])
-    channelPrices.value = prices
-    channelPriceItems.value = items
+    channelPrices.value = asArray(prices)
+    channelPriceItems.value = asArray(items)
   }
 
   async function refreshModelPriceItems() {
-    modelPriceItems.value = await fetchList(llmOpsApi.listModelPriceItems, {
+    const items = await fetchList(llmOpsApi.listModelPriceItems, {
       is_current: 'true'
     })
+    modelPriceItems.value = asArray(items)
   }
 
   async function refreshResaleListings() {
-    listings.value = await fetchList(llmOpsApi.listResaleListings)
+    listings.value = asArray(await fetchList(llmOpsApi.listResaleListings))
   }
 
   function preloadResalePublishingData() {
     const tasks = []
-    if (!metaModels.value.length) {
+    if (!asArray(metaModels.value).length) {
       tasks.push(
         fetchList(llmOpsApi.listMetaModels).then((items) => {
-          metaModels.value = items
+          metaModels.value = asArray(items)
         })
       )
     }
-    if (!channelPrices.value.length || !channelPriceItems.value.length) {
+    if (
+      !asArray(channelPrices.value).length ||
+      !asArray(channelPriceItems.value).length
+    ) {
       tasks.push(refreshChannelPricingData())
     }
-    if (!modelPriceItems.value.length) {
+    if (!asArray(modelPriceItems.value).length) {
       tasks.push(refreshModelPriceItems())
     }
-    if (!listings.value.length) {
+    if (!asArray(listings.value).length) {
       tasks.push(refreshResaleListings())
     }
     if (!tasks.length) return
@@ -236,7 +242,9 @@ export function useLLMOpsData() {
   }
 
   async function refreshReconciliationRecords() {
-    records.value = await fetchList(llmOpsApi.listReconciliationRecords)
+    records.value = asArray(
+      await fetchList(llmOpsApi.listReconciliationRecords)
+    )
   }
 
   async function refreshPriceHistoryData() {
@@ -248,8 +256,8 @@ export function useLLMOpsData() {
         page_size: PRICE_HISTORY_PAGE_SIZE
       })
     ])
-    channelPriceHistory.value = channelHistoryData
-    listingPriceHistory.value = listingHistoryData
+    channelPriceHistory.value = asArray(channelHistoryData)
+    listingPriceHistory.value = asArray(listingHistoryData)
   }
 
   async function refreshLight() {
@@ -263,11 +271,11 @@ export function useLLMOpsData() {
         fetchList(llmOpsApi.listReconciliationRecords),
         llmOpsApi.getSummary(summaryParams())
       ])
-    channelPrices.value = prices
-    channelPriceItems.value = channelPriceItemsData
-    listings.value = listingData
-    records.value = recordData
-    summary.value = extract(summaryRes)
+    channelPrices.value = asArray(prices)
+    channelPriceItems.value = asArray(channelPriceItemsData)
+    listings.value = asArray(listingData)
+    records.value = asArray(recordData)
+    summary.value = normalizeSummary(extract(summaryRes))
   }
 
   async function refreshCollectionRuns() {
@@ -289,10 +297,10 @@ export function useLLMOpsData() {
           llmOpsApi.getSummary(summaryParams())
         ]
       )
-      sources.value = sourceData
-      collectionRuns.value = runData
-      providers.value = providerData
-      summary.value = extract(summaryRes)
+      sources.value = asArray(sourceData)
+      collectionRuns.value = asArray(runData)
+      providers.value = asArray(providerData)
+      summary.value = normalizeSummary(extract(summaryRes))
     } catch (error) {
       showError(errorMessage(error, '刷新价格源数据失败。'))
     }
@@ -305,9 +313,9 @@ export function useLLMOpsData() {
         fetchList(llmOpsApi.listMetaModels),
         llmOpsApi.getSummary(summaryParams())
       ])
-      providers.value = providerData
-      metaModels.value = metaModelData
-      summary.value = extract(summaryRes)
+      providers.value = asArray(providerData)
+      metaModels.value = asArray(metaModelData)
+      summary.value = normalizeSummary(extract(summaryRes))
     } catch (error) {
       showError(errorMessage(error, '刷新元模型数据失败。'))
     }
@@ -320,8 +328,8 @@ export function useLLMOpsData() {
         llmOpsApi.getSummary(summaryParams()),
         refreshChannelPricingData()
       ])
-      channels.value = channelData
-      summary.value = extract(summaryRes)
+      channels.value = asArray(channelData)
+      summary.value = normalizeSummary(extract(summaryRes))
       refreshResaleListings().catch((error) => {
         showError(errorMessage(error, '刷新转售列表失败。'))
       })
@@ -337,9 +345,9 @@ export function useLLMOpsData() {
         fetchList(llmOpsApi.listResaleListings),
         llmOpsApi.getSummary(summaryParams())
       ])
-      resalePlatforms.value = platformData
-      listings.value = listingData
-      summary.value = extract(summaryRes)
+      resalePlatforms.value = asArray(platformData)
+      listings.value = asArray(listingData)
+      summary.value = normalizeSummary(extract(summaryRes))
       await loadResaleWorkflowConfig()
     } catch (error) {
       showError(errorMessage(error, '刷新转售平台数据失败。'))
@@ -365,7 +373,7 @@ export function useLLMOpsData() {
 
   async function refreshSummary() {
     const summaryRes = await llmOpsApi.getSummary(summaryParams())
-    summary.value = extract(summaryRes)
+    summary.value = normalizeSummary(extract(summaryRes))
   }
 
   function summaryParams() {
@@ -429,4 +437,22 @@ function normalizeDisplayCurrency(value) {
 function readStorage(key) {
   if (typeof localStorage === 'undefined') return ''
   return localStorage.getItem(key) || ''
+}
+
+function normalizeSummary(value) {
+  const summary = asObject(value)
+  const agione = asObject(summary.agione)
+  return {
+    ...summary,
+    agione: {
+      ...agione,
+      diagnostic_counts: asObject(agione.diagnostic_counts),
+      diagnostics: asArray(agione.diagnostics)
+    },
+    currency: asObject(summary.currency),
+    kpis: asObject(summary.kpis),
+    listings: asArray(summary.listings),
+    procurement: asArray(summary.procurement),
+    status_counts: asObject(summary.status_counts)
+  }
 }

--- a/frontend/src/composables/useLLMOpsMonitor.js
+++ b/frontend/src/composables/useLLMOpsMonitor.js
@@ -1,6 +1,8 @@
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import { asArray, asObject } from '@/utils/llmOpsPagination'
+
 const monitorStatusLabelKeys = {
   currency_mismatch: 'llmOps.status.currencyMismatch',
   low_coverage: 'llmOps.status.lowCoverage',
@@ -36,22 +38,22 @@ export function useLLMOpsMonitor({
 
   const simulationChannelOptions = computed(() => [
     { label: t('llmOps.filters.allChannels'), value: '' },
-    ...channels.value.map((channel) => ({
+    ...asArray(channels.value).map((channel) => ({
       label: channel.name,
       value: channel.id
     }))
   ])
 
-  const agioneDiagnostics = computed(
-    () => summary.value.agione?.diagnostics || []
+  const agioneDiagnostics = computed(() =>
+    asArray(summary.value.agione?.diagnostics)
   )
-  const summaryKpis = computed(() => summary.value.kpis || {})
-  const diagnosticCounts = computed(
-    () => summary.value.agione?.diagnostic_counts || {}
+  const summaryKpis = computed(() => asObject(summary.value.kpis))
+  const diagnosticCounts = computed(() =>
+    asObject(summary.value.agione?.diagnostic_counts)
   )
 
   const activeModels = computed(() =>
-    models.value.filter((model) => model.is_active !== false)
+    asArray(models.value).filter((model) => model.is_active !== false)
   )
 
   const activeModelIds = computed(
@@ -62,12 +64,15 @@ export function useLLMOpsMonitor({
     numberOrFallback(summaryKpis.value.active_models, activeModels.value.length)
   )
   const operationalChannelCount = computed(() =>
-    numberOrFallback(summaryKpis.value.active_channels, channels.value.length)
+    numberOrFallback(
+      summaryKpis.value.active_channels,
+      asArray(channels.value).length
+    )
   )
   const enabledPriceSourceCount = computed(() =>
     numberOrFallback(
       summaryKpis.value.enabled_price_sources,
-      providerCollectionSources.value.length
+      asArray(providerCollectionSources.value).length
     )
   )
   const reconciliationAnomalyCount = computed(() =>
@@ -77,7 +82,7 @@ export function useLLMOpsMonitor({
   const agioneListingRows = computed(() => {
     const agioneId = agionePlatform.value?.id
     if (!agioneId) return []
-    return listings.value.filter(
+    return asArray(listings.value).filter(
       (listing) =>
         listing.is_active !== false &&
         String(listing.platform) === String(agioneId)
@@ -109,11 +114,12 @@ export function useLLMOpsMonitor({
       : procurementRows.value
     ).map((row) => {
       if (row.status) {
+        const options = asArray(row.options)
         return {
           ...row,
           best_channel: row.best_channel || null,
           display_channel: row.best_channel || null,
-          coverage_count: row.coverage_count ?? (row.options || []).length,
+          coverage_count: row.coverage_count ?? options.length,
           is_agione_listed: Boolean(row.is_agione_listed),
           has_lowest_listing: Boolean(row.has_lowest_listing),
           requires_currency_conversion: Boolean(
@@ -124,7 +130,7 @@ export function useLLMOpsMonitor({
           status_tone: monitorStatusTone(row.status)
         }
       }
-      const options = row.options || []
+      const options = asArray(row.options)
       const bestChannel = row.best_channel || null
       const coverageCount = options.length
       const agioneListings =
@@ -356,7 +362,7 @@ export function useLLMOpsMonitor({
 
   const latestCollectionRun = computed(
     () =>
-      collectionRuns.value
+      asArray(collectionRuns.value)
         .slice()
         .sort(
           (left, right) =>
@@ -371,20 +377,20 @@ export function useLLMOpsMonitor({
 
   const collectionAttentionCount = computed(
     () =>
-      collectionRuns.value.filter((run) =>
+      asArray(collectionRuns.value).filter((run) =>
         ['failed', 'running', 'pending', 'processing'].includes(run.status)
       ).length
   )
 
   const channelCoverageRows = computed(() =>
-    channels.value
+    asArray(channels.value)
       .map((channel) => {
-        const covered = procurementRows.value.filter((row) =>
-          (row.options || []).some(
+        const covered = asArray(procurementRows.value).filter((row) =>
+          asArray(row.options).some(
             (option) => String(option.channel_id) === String(channel.id)
           )
         ).length
-        const bestCount = procurementRows.value.filter(
+        const bestCount = asArray(procurementRows.value).filter(
           (row) => String(row.best_channel?.channel_id) === String(channel.id)
         ).length
         return {

--- a/frontend/src/composables/useLLMOpsResalePublishing.js
+++ b/frontend/src/composables/useLLMOpsResalePublishing.js
@@ -4,7 +4,7 @@ import { useI18n } from 'vue-i18n'
 import { llmOpsApi } from '@/api/llmOps'
 import { DEFAULT_WORKFLOW_POLICIES } from '@/constants/llmOpsWorkflow'
 import { useToast } from '@/composables/useToast'
-import { errorMessage, extract } from '@/utils/llmOpsPagination'
+import { asArray, errorMessage, extract } from '@/utils/llmOpsPagination'
 
 const platformTypeLabelKeys = {
   agione: 'llmOps.resalePlatform.types.agione',
@@ -51,7 +51,7 @@ export function useLLMOpsResalePublishing({
   const resalePublishingInitialModelId = ref(null)
 
   const activeResalePlatforms = computed(() =>
-    resalePlatforms.value.filter((item) => item.is_active !== false)
+    asArray(resalePlatforms.value).filter((item) => item.is_active !== false)
   )
 
   const resalePlatformOptions = computed(() =>
@@ -139,7 +139,9 @@ export function useLLMOpsResalePublishing({
 
   function mergeResaleListings(updatedItems) {
     if (!Array.isArray(updatedItems) || !updatedItems.length) return
-    const byId = new Map(listings.value.map((item) => [String(item.id), item]))
+    const byId = new Map(
+      asArray(listings.value).map((item) => [String(item.id), item])
+    )
     updatedItems.forEach((item) => {
       if (item?.id) byId.set(String(item.id), item)
     })
@@ -181,7 +183,9 @@ export function useLLMOpsResalePublishing({
     if (!Array.isArray(updatedItems) || !updatedItems.length) {
       return currentItems
     }
-    const byId = new Map(currentItems.map((item) => [String(item.id), item]))
+    const byId = new Map(
+      asArray(currentItems).map((item) => [String(item.id), item])
+    )
     updatedItems.forEach((item) => {
       if (item?.id) byId.set(String(item.id), item)
     })
@@ -191,7 +195,7 @@ export function useLLMOpsResalePublishing({
   function removeById(currentItems, ids) {
     if (!Array.isArray(ids) || !ids.length) return currentItems
     const idSet = new Set(ids.map((id) => String(id)))
-    return currentItems.filter((item) => !idSet.has(String(item.id)))
+    return asArray(currentItems).filter((item) => !idSet.has(String(item.id)))
   }
 
   function openListingActionDrawer({ modelId, kind }) {
@@ -265,7 +269,7 @@ export function useLLMOpsResalePublishing({
     }
     try {
       const response = await llmOpsApi.bulkUpsertResaleListings(items)
-      const submittedListings = extract(response)
+      const submittedListings = asArray(extract(response))
       const autoConfirmedCount = await confirmAutoApprovedListings(
         submittedListings,
         publishListings

--- a/frontend/src/utils/llmOpsPagination.js
+++ b/frontend/src/utils/llmOpsPagination.js
@@ -2,6 +2,17 @@ const LIST_PAGE_SIZE = 200
 
 export const LIST_PARAMS = { page_size: LIST_PAGE_SIZE }
 
+export function asArray(value) {
+  if (Array.isArray(value)) return value
+  if (Array.isArray(value?.results)) return value.results
+  return []
+}
+
+export function asObject(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  return value
+}
+
 export function extract(response) {
   if (Array.isArray(response)) return response
   const data = response?.data?.data || response?.data || []
@@ -13,8 +24,7 @@ export function paginationPayload(response) {
 }
 
 export function paginationResults(payload) {
-  if (Array.isArray(payload?.results)) return payload.results
-  return Array.isArray(payload) ? payload : []
+  return asArray(payload)
 }
 
 export async function fetchList(request, params = {}) {


### PR DESCRIPTION
## Summary
- Add shared normalization helpers for paginated arrays and object payloads.
- Normalize LLM Ops list and summary responses before storing composable state.
- Guard LLM Ops drawers, panels, and resale publishing flows against nested DRF payloads and paginated result objects.

No linked open Issue found for this follow-up.

## Test plan
- [x] `npx eslint src/components/llm-ops/ChannelModelDrawer.vue src/components/llm-ops/ChannelPriceMatrixPanel.vue src/components/llm-ops/GlobalConfigPanel.vue src/components/llm-ops/ListingRiskPanel.vue src/composables/useAgioneListingRows.js src/composables/useLLMOpsData.js src/composables/useLLMOpsMonitor.js src/composables/useLLMOpsResalePublishing.js src/utils/llmOpsPagination.js --ext .vue,.js --ignore-path ../.gitignore`
- [x] `git diff --check`
- [x] `npm run build`

Made with [Orca](https://github.com/stablyai/orca) 🐋
