### PR TITLE
Add official LLM price collectors

### DIFF
--- a/backend/llm_ops/collection_services.py
+++ b/backend/llm_ops/collection_services.py
@@ -11,8 +11,12 @@ from django.utils import timezone
 from .collectors import CollectedModelPricing, CollectedPricingCatalog
 from .collectors.official import (
     ALIYUN_LEGACY_PRICING_SOURCE_URLS,
+    BAIDU_PRICING_SOURCE_URL,
+    MINIMAX_PRICING_SOURCE_URL,
     MODELS_DEV_MODELS_URL,
     OFFICIAL_PROVIDER_CONFIGS,
+    VOLCENGINE_PRICING_SOURCE_URL,
+    ZHIPU_PRICING_SOURCE_URL,
     collect_official_pricing_catalog,
     fetch_source_payload,
     normalize_model_code,
@@ -96,14 +100,30 @@ OFFICIAL_SOURCE_PROVIDER_DEFAULTS = {
         "notes": "元模型厂商。",
     },
     "baidu": {
-        "name": "百度",
+        "name": "百度千帆",
         "website": "https://cloud.baidu.com/",
         "notes": "元模型厂商。",
+        "source_name": "百度千帆官方价格",
+        "source_url": BAIDU_PRICING_SOURCE_URL,
+        "currency": "CNY",
     },
     "volcengine": {
         "name": "火山方舟",
         "website": "https://ark.cn-beijing.volces.com/",
         "notes": "元模型厂商。",
+        "source_name": "火山方舟官方价格",
+        "source_url": VOLCENGINE_PRICING_SOURCE_URL,
+        "currency": "CNY",
+    },
+    "anthropic": {
+        "name": "Anthropic",
+        "website": "https://anthropic.com/",
+        "notes": "元模型厂商。",
+        "source_name": "Anthropic 官方价格",
+        "source_url": (
+            "https://docs.anthropic.com/en/docs/about-claude/pricing"
+        ),
+        "currency": "USD",
     },
     "azure-openai": {
         "name": "Azure OpenAI",
@@ -115,6 +135,33 @@ OFFICIAL_SOURCE_PROVIDER_DEFAULTS = {
         "source_name": "Azure OpenAI 官方价格",
         "source_url": AZURE_OPENAI_PRICING_SOURCE_URL,
         "currency": "USD",
+    },
+    "google": {
+        "name": "Google",
+        "website": "https://ai.google.dev/",
+        "notes": "元模型厂商。",
+        "source_name": "Google Gemini 官方价格",
+        "source_url": (
+            "https://cloud.google.com/gemini-enterprise-agent-platform/"
+            "generative-ai/pricing?hl=en"
+        ),
+        "currency": "USD",
+    },
+    "minimax": {
+        "name": "MiniMax",
+        "website": "https://api.minimax.io/",
+        "notes": "元模型厂商。",
+        "source_name": "MiniMax 官方价格",
+        "source_url": MINIMAX_PRICING_SOURCE_URL,
+        "currency": "CNY",
+    },
+    "zhipu": {
+        "name": "智谱",
+        "website": "https://open.bigmodel.cn/",
+        "notes": "元模型厂商。",
+        "source_name": "智谱 BigModel 官方价格",
+        "source_url": ZHIPU_PRICING_SOURCE_URL,
+        "currency": "CNY",
     },
 }
 
@@ -386,16 +433,20 @@ def sync_vendor_price_source_catalog(
             "model_codes": [],
             "verify_source": verify_source,
         }
-        try:
-            standard_catalog = collect_vendor_price_catalog(
-                provider_code,
-                vendor_payload,
-            )
-        except ValueError as exc:
+        if not vendor_price_collector_exists(provider_code):
             raise ValueError(
                 "Vendor price catalog collector not found for provider "
                 f"'{provider_code}'."
-            ) from exc
+            )
+        standard_catalog = collect_vendor_price_catalog(
+            provider_code,
+            vendor_payload,
+        )
+        if not standard_catalog.get("models"):
+            raise ValueError(
+                "Vendor price catalog collector returned no models for "
+                f"provider '{provider_code}'."
+            )
         catalog = standard_catalog_to_collected_catalog(standard_catalog)
         with transaction.atomic():
             for item in catalog.models:

--- a/backend/llm_ops/collectors/official.py
+++ b/backend/llm_ops/collectors/official.py
@@ -41,6 +41,10 @@ BAIDU_PRICING_SOURCE_URL = "https://cloud.baidu.com/doc/qianfan/s/wmh4sv6ya"
 VOLCENGINE_PRICING_SOURCE_URL = (
     "https://www.volcengine.com/docs/82379/1544106?lang=zh"
 )
+MINIMAX_PRICING_SOURCE_URL = (
+    "https://platform.minimaxi.com/subscribe/token-plan?tab=api-enterprise"
+)
+ZHIPU_PRICING_SOURCE_URL = "https://bigmodel.cn/pricing"
 ALIYUN_LEGACY_PRICING_SOURCE_URLS = {
     "https://help.aliyun.com/zh/model-studio/model-price",
     "https://help.aliyun.com/zh/model-studio/models",
@@ -338,7 +342,10 @@ OFFICIAL_PROVIDER_CONFIGS = {
     "google": OfficialProviderConfig(
         provider_code="google",
         provider_label="Google",
-        source_url="https://ai.google.dev/gemini-api/docs/pricing",
+        source_url=(
+            "https://cloud.google.com/gemini-enterprise-agent-platform/"
+            "generative-ai/pricing?hl=en"
+        ),
         currency="USD",
         models=(
             OfficialPriceSpec(
@@ -717,6 +724,20 @@ OFFICIAL_PROVIDER_CONFIGS = {
                 display_name="DeepSeek R1 0528",
             ),
         ),
+    ),
+    "minimax": OfficialProviderConfig(
+        provider_code="minimax",
+        provider_label="MiniMax",
+        source_url=MINIMAX_PRICING_SOURCE_URL,
+        currency="CNY",
+        models=(),
+    ),
+    "zhipu": OfficialProviderConfig(
+        provider_code="zhipu",
+        provider_label="智谱",
+        source_url=ZHIPU_PRICING_SOURCE_URL,
+        currency="CNY",
+        models=(),
     ),
     "deepseek": OfficialProviderConfig(
         provider_code="deepseek",

--- a/backend/llm_ops/price_collectors/parsers/anthropic.py
+++ b/backend/llm_ops/price_collectors/parsers/anthropic.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+from typing import Any
+import re
+
+import requests
+
+from .common import (
+    build_text_token_standard_catalog,
+    filter_models_by_codes,
+    sync_official_vendor_catalog,
+)
+
+
+PRICING_URL = "https://docs.anthropic.com/en/docs/about-claude/pricing"
+PRICING_MARKDOWN_URL = (
+    "https://platform.claude.com/docs/en/about-claude/pricing.md"
+)
+DEFAULT_CURRENCY = "USD"
+
+
+class AnthropicPriceCatalogCollector:
+    """Collect Anthropic official prices into the standard catalog JSON."""
+
+    provider_code = "anthropic"
+
+    def collect_catalog(
+        self,
+        vendor_config: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Return Anthropic official prices as standard catalog JSON."""
+        vendor = dict(vendor_config or {})
+        source_url = str(vendor.get("source_url") or PRICING_URL).strip()
+        raw_text = str(
+            vendor.get("raw_markdown") or vendor.get("raw_html") or ""
+        )
+        markdown_url = str(
+            vendor.get("markdown_url") or PRICING_MARKDOWN_URL
+        ).strip()
+        if not raw_text and vendor.get("verify_source") is False:
+            return sync_official_vendor_catalog("anthropic", vendor)
+        if not raw_text:
+            raw_text = fetch_text(markdown_url)
+
+        models = extract_models(raw_text)
+        models = filter_models_by_codes(models, vendor.get("model_codes"))
+        if not models:
+            return sync_official_vendor_catalog("anthropic", vendor)
+
+        provider_name = str(
+            vendor.get("provider_name") or "Anthropic"
+        ).strip()
+        currency = str(vendor.get("currency") or DEFAULT_CURRENCY).strip()
+        return build_text_token_standard_catalog(
+            provider_code="anthropic",
+            provider_name=provider_name,
+            currency=currency or DEFAULT_CURRENCY,
+            source_url=source_url,
+            models=models,
+            notes=(
+                "Extracted Anthropic Claude text token prices from the "
+                "official pricing table."
+            ),
+            raw_payload={
+                "provider_code": "anthropic",
+                "collector": "llm_ops.price_collectors.anthropic",
+                "source_url": source_url,
+                "markdown_url": markdown_url,
+                "model_codes": list(vendor.get("model_codes") or []),
+                "raw_markdown_supplied": bool(vendor.get("raw_markdown")),
+                "raw_html_supplied": bool(vendor.get("raw_html")),
+            },
+        )
+
+
+def fetch_text(url: str) -> str:
+    """Fetch one Anthropic pricing document as UTF-8 text."""
+    response = requests.get(
+        url,
+        headers={
+            "Accept": "text/markdown,text/plain,text/html,*/*",
+            "User-Agent": "DevMind-LLMOpsPriceCollector/1.0",
+        },
+        timeout=30,
+    )
+    response.raise_for_status()
+    response.encoding = response.encoding or "utf-8"
+    return response.text or ""
+
+
+def extract_models(raw_text: str) -> list[dict[str, Any]]:
+    """Extract Anthropic model price rows from markdown or HTML text."""
+    rows = markdown_model_rows(raw_text)
+    if not rows:
+        rows = html_model_rows(raw_text)
+    models = [model_from_row(row) for row in rows]
+    return [
+        model
+        for model in sorted(
+            models,
+            key=lambda item: item.get("model_id", "").lower(),
+        )
+        if model
+    ]
+
+
+def markdown_model_rows(raw_text: str) -> list[list[str]]:
+    """Return markdown table rows from the model pricing table."""
+    rows = []
+    in_pricing_table = False
+    for line in str(raw_text or "").splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            if in_pricing_table and rows:
+                break
+            continue
+        cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+        normalized = [normalize_header(cell) for cell in cells]
+        if "model" in normalized and "baseinputtokens" in normalized:
+            in_pricing_table = True
+            continue
+        if not in_pricing_table:
+            continue
+        if is_markdown_separator(cells):
+            continue
+        if len(cells) >= 6:
+            rows.append(cells[:6])
+    return rows
+
+
+def html_model_rows(raw_text: str) -> list[list[str]]:
+    """Return HTML table rows from the model pricing table."""
+    table_pattern = re.compile(
+        r"<table\b.*?</table>",
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+    for table_html in table_pattern.findall(raw_text):
+        rows = []
+        has_pricing_header = False
+        for row_html in re.findall(
+            r"<tr\b.*?</tr>",
+            table_html,
+            flags=re.DOTALL | re.IGNORECASE,
+        ):
+            cells = parse_html_cells(row_html)
+            normalized = [normalize_header(cell) for cell in cells]
+            if "model" in normalized and "baseinputtokens" in normalized:
+                has_pricing_header = True
+                continue
+            if has_pricing_header and len(cells) >= 6:
+                rows.append(cells[:6])
+        if rows:
+            return rows
+    return []
+
+
+def parse_html_cells(row_html: str) -> list[str]:
+    """Parse one HTML row into cell text values."""
+    values = []
+    for inner_html in re.findall(
+        r"<(?:td|th)(?:\s[^>]*)?>(.*?)</(?:td|th)>",
+        row_html,
+        flags=re.DOTALL | re.IGNORECASE,
+    ):
+        text = re.sub(r"<br\s*/?>", "\n", inner_html, flags=re.IGNORECASE)
+        text = re.sub(r"<[^>]+>", " ", text)
+        values.append(clean_text(text))
+    return values
+
+
+def model_from_row(row: list[str]) -> dict[str, Any]:
+    """Build one parsed Anthropic model price item."""
+    model_name = clean_model_name(row[0])
+    model_id = model_id_from_name(model_name)
+    prices = [parse_price(value) for value in row[1:6]]
+    if not model_id or prices[0] is None or prices[4] is None:
+        return {}
+
+    input_price = prices[0]
+    cache_hit_price = prices[3]
+    output_price = prices[4]
+    price_row = {
+        "input_price_per_million": input_price,
+        "output_price_per_million": output_price,
+        "currency": DEFAULT_CURRENCY,
+    }
+    if cache_hit_price is not None:
+        price_row["cache_hit_price_per_million"] = cache_hit_price
+
+    item = {
+        "model_id": model_id,
+        "model_name": model_id,
+        "display_name": model_name,
+        "aliases": aliases_for_model(model_id, model_name),
+        "input_price_per_million": input_price,
+        "output_price_per_million": output_price,
+        "currency": DEFAULT_CURRENCY,
+        "price_rows": [price_row],
+        "notes": "Extracted from Anthropic official model pricing table.",
+    }
+    if cache_hit_price is not None:
+        item["cache_hit_price_per_million"] = cache_hit_price
+    return item
+
+
+def normalize_header(value: str) -> str:
+    """Normalize a table header for matching."""
+    return re.sub(r"[^a-z0-9]+", "", str(value or "").lower())
+
+
+def is_markdown_separator(cells: list[str]) -> bool:
+    """Return whether one markdown row is a separator."""
+    return all(re.fullmatch(r":?-{3,}:?", cell.strip()) for cell in cells)
+
+
+def clean_model_name(value: str) -> str:
+    """Normalize an Anthropic model name cell."""
+    text = re.sub(r"\[[^\]]+\]\([^)]+\)", " ", str(value or ""))
+    text = re.sub(r"\([^)]*\)", " ", text)
+    return clean_text(text)
+
+
+def clean_text(value: str) -> str:
+    """Collapse whitespace in one extracted text value."""
+    return re.sub(r"\s+", " ", str(value or "").replace("&amp;", "&")).strip()
+
+
+def model_id_from_name(value: str) -> str:
+    """Convert a Claude display name into a stable model code."""
+    text = clean_model_name(value).lower()
+    if not text.startswith("claude "):
+        return ""
+    text = text.replace(".", "-")
+    text = re.sub(r"[^a-z0-9]+", "-", text)
+    return text.strip("-")
+
+
+def aliases_for_model(model_id: str, model_name: str) -> list[str]:
+    """Return matching aliases for one Anthropic model."""
+    aliases = [model_id]
+    name = clean_model_name(model_name)
+    if name and name not in aliases:
+        aliases.append(name)
+    return aliases
+
+
+def parse_price(value: str) -> str | None:
+    """Parse one non-negative Anthropic USD price."""
+    text = str(value or "").replace(",", "").strip()
+    if not text or text in {"-", "n/a"}:
+        return None
+    match = re.search(r"\$?\s*([0-9]+(?:\.[0-9]+)?)", text)
+    return match.group(1) if match else None

--- a/backend/llm_ops/price_collectors/parsers/baidu.py
+++ b/backend/llm_ops/price_collectors/parsers/baidu.py
@@ -1,0 +1,401 @@
+from __future__ import annotations
+
+import re
+from decimal import Decimal, InvalidOperation
+from html import unescape
+from typing import Any
+
+import requests
+
+from .common import (
+    build_text_token_standard_catalog,
+    filter_models_by_codes,
+    sync_official_vendor_catalog,
+)
+
+
+PAGE_DATA_URL = (
+    "https://bce.bdstatic.com/p3m/bce-doc/online/qianfan/doc/qianfan/s/"
+    "page-data/wmh4sv6ya/page-data.json"
+)
+PRICING_URL = "https://cloud.baidu.com/doc/qianfan/s/wmh4sv6ya"
+DEFAULT_CURRENCY = "CNY"
+
+
+class BaiduPriceCatalogCollector:
+    """Collect Baidu Qianfan official prices into standard catalog JSON."""
+
+    provider_code = "baidu"
+
+    def collect_catalog(
+        self,
+        vendor_config: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Return Baidu Qianfan official prices as standard catalog JSON."""
+        vendor = dict(vendor_config or {})
+        pricing_url, page_data_url = resolve_urls(vendor)
+        html = str(vendor.get("raw_html") or "")
+        if not html and vendor.get("verify_source") is False:
+            return sync_official_vendor_catalog("baidu", vendor)
+        if not html:
+            payload = fetch_json(page_data_url)
+            html = extract_html_from_payload(payload)
+
+        models = extract_models(html)
+        models = filter_models_by_codes(models, vendor.get("model_codes"))
+        provider_name = str(
+            vendor.get("provider_name") or "百度千帆"
+        ).strip()
+        currency = str(vendor.get("currency") or DEFAULT_CURRENCY).strip()
+        return build_text_token_standard_catalog(
+            provider_code="baidu",
+            provider_name=provider_name,
+            currency=currency or DEFAULT_CURRENCY,
+            source_url=pricing_url,
+            models=models,
+            notes=(
+                "Extracted Baidu Qianfan text model prices from the "
+                "official pricing table."
+            ),
+            raw_payload={
+                "provider_code": "baidu",
+                "collector": "llm_ops.price_collectors.baidu",
+                "source_url": pricing_url,
+                "page_data_url": page_data_url,
+                "model_codes": list(vendor.get("model_codes") or []),
+                "raw_html_supplied": bool(vendor.get("raw_html")),
+                "parsed_models": len(models),
+            },
+        )
+
+
+def resolve_urls(vendor: dict[str, Any]) -> tuple[str, str]:
+    """Return the configured Baidu pricing page and page-data URLs."""
+    acquisition = dict(vendor.get("acquisition") or {})
+    pricing_url = str(
+        acquisition.get("page_url")
+        or vendor.get("source_url")
+        or vendor.get("pricing_url")
+        or PRICING_URL
+    ).strip()
+    page_data_url = str(
+        acquisition.get("page_data_url")
+        or vendor.get("page_data_url")
+        or PAGE_DATA_URL
+    ).strip()
+    return pricing_url, page_data_url
+
+
+def fetch_json(url: str) -> dict[str, Any]:
+    """Fetch Baidu Gatsby page-data JSON."""
+    response = requests.get(
+        url,
+        headers={
+            "Accept": "application/json,text/plain,*/*",
+            "User-Agent": "DevMind-LLMOpsPriceCollector/1.0",
+        },
+        timeout=30,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def extract_html_from_payload(payload: dict[str, Any]) -> str:
+    """Return rendered document HTML from Baidu page-data JSON."""
+    try:
+        return str(payload["result"]["data"]["markdownRemark"]["html"] or "")
+    except (KeyError, TypeError):
+        return ""
+
+
+def extract_models(html: str) -> list[dict[str, Any]]:
+    """Extract Baidu Qianfan text model price rows from HTML tables."""
+    tables = re.findall(
+        r"<table.*?>.*?</table>",
+        html,
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+    models: dict[str, dict[str, Any]] = {}
+    for table in tables:
+        for row in expand_rows(table):
+            if len(row) < 9:
+                continue
+            _, version_text, service, subitem, online_price, *_rest, unit = row
+            if "推理服务" not in service or "token" not in unit.lower():
+                continue
+            price = parse_price(online_price)
+            if price is None:
+                continue
+            for version_name in split_versions(version_text):
+                if not is_text_model(version_name):
+                    continue
+                merge_price(
+                    models=models,
+                    version_name=version_name,
+                    service=service,
+                    subitem=subitem,
+                    unit=unit,
+                    price=price,
+                )
+
+    return [
+        {key: value for key, value in item.items() if not key.startswith("_")}
+        for item in sorted(
+            models.values(),
+            key=lambda candidate: candidate["model_name"].lower(),
+        )
+        if (
+            item.get("input_price_per_million") is not None
+            or item.get("output_price_per_million") is not None
+        )
+    ]
+
+
+def expand_rows(table_html: str) -> list[list[str]]:
+    """Expand Baidu table rows while preserving row spans."""
+    rows_html = re.findall(
+        r"<tr.*?>.*?</tr>",
+        table_html,
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+    expanded_rows = []
+    active_spans: list[dict[str, Any] | None] = [None] * 9
+    for row_html in rows_html:
+        cells = parse_cells(row_html)
+        if not cells:
+            continue
+        row = []
+        cell_index = 0
+        for column in range(9):
+            span = active_spans[column]
+            if span and span["remaining"] > 0:
+                row.append(span["value"])
+                span["remaining"] -= 1
+                continue
+            if cell_index >= len(cells):
+                row.append("")
+                active_spans[column] = None
+                continue
+            value, rowspan = cells[cell_index]
+            cell_index += 1
+            row.append(value)
+            active_spans[column] = (
+                {"value": value, "remaining": rowspan - 1}
+                if rowspan > 1
+                else None
+            )
+        if row and row[0] == "模型名称":
+            continue
+        expanded_rows.append(row)
+    return expanded_rows
+
+
+def parse_cells(row_html: str) -> list[tuple[str, int]]:
+    """Parse one HTML row into cell text plus row span."""
+    results = []
+    pattern = re.compile(
+        r"<(td|th)([^>]*)>(.*?)</\1>",
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+    for _, attrs, inner_html in pattern.findall(row_html):
+        rowspan_match = re.search(
+            r'rowspan=["\']?(\d+)["\']?',
+            attrs,
+            flags=re.IGNORECASE,
+        )
+        rowspan = int(rowspan_match.group(1)) if rowspan_match else 1
+        results.append((clean_cell_text(inner_html), rowspan))
+    return results
+
+
+def clean_cell_text(inner_html: str) -> str:
+    """Convert one HTML cell body into normalized text."""
+    text = re.sub(r"<br\s*/?>", "\n", inner_html, flags=re.IGNORECASE)
+    text = re.sub(r"<[^>]+>", " ", text)
+    text = unescape(text).replace("\xa0", " ")
+    lines = [re.sub(r"\s+", " ", line).strip() for line in text.splitlines()]
+    return "\n".join(line for line in lines if line)
+
+
+def split_versions(version_text: str) -> list[str]:
+    """Split a Baidu version cell into model names."""
+    versions = []
+    for part in version_text.split("\n"):
+        cleaned = part.strip()
+        if not cleaned:
+            continue
+        if (
+            "如开启思考模式" in cleaned
+            or "计费详情请查看" in cleaned
+        ):
+            continue
+        versions.append(cleaned)
+    return versions
+
+
+def is_text_model(model_name: str) -> bool:
+    """Return whether a Baidu model row is text-token pricing."""
+    lowered = model_name.lower()
+    blocked = (
+        "-vl",
+        "vision",
+        "embedding",
+        "rerank",
+        "image",
+        "video",
+        "tts",
+        "asr",
+        "audio",
+    )
+    return not any(token in lowered for token in blocked)
+
+
+def normalize_version_name(version_name: str) -> str:
+    """Normalize Baidu version names while preserving official casing."""
+    cleaned = re.sub(r"\s+", " ", version_name).strip()
+    aliases = {
+        "moonshot-kimi-k2-instruct": "Kimi-K2-Instruct",
+        "kimi-k2-instruct": "Kimi-K2-Instruct",
+    }
+    return aliases.get(cleaned.lower(), cleaned)
+
+
+def parse_price(text: str) -> Decimal | None:
+    """Parse a non-negative Baidu price number."""
+    cleaned = text.strip()
+    if not cleaned or cleaned in {"-", "触发"}:
+        return None
+    match = re.search(r"([0-9]+(?:\.[0-9]+)?)", cleaned)
+    if not match:
+        return None
+    try:
+        value = Decimal(match.group(1))
+    except (InvalidOperation, ValueError):
+        return None
+    return value if value >= 0 else None
+
+
+def normalize_to_per_million(price: Decimal, unit: str) -> str:
+    """Normalize Baidu price units to CNY per 1M tokens."""
+    normalized_unit = unit.lower()
+    value = price
+    if "千token" in normalized_unit or "千tokens" in normalized_unit:
+        value *= Decimal("1000")
+    return format_decimal(value)
+
+
+def format_decimal(value: Decimal) -> str:
+    """Format a decimal as a compact price string."""
+    formatted = format(value.normalize(), "f")
+    if "." in formatted:
+        formatted = formatted.rstrip("0").rstrip(".")
+    return formatted or "0"
+
+
+def merge_price(
+    *,
+    models: dict[str, dict[str, Any]],
+    version_name: str,
+    service: str,
+    subitem: str,
+    unit: str,
+    price: Decimal,
+) -> None:
+    """Merge one Baidu price row into a model aggregate."""
+    normalized_name = normalize_version_name(version_name)
+    key = normalized_name.lower()
+    model = models.setdefault(
+        key,
+        {
+            "model_id": normalized_name,
+            "model_name": normalized_name,
+            "aliases": [normalized_name, version_name.strip()],
+            "input_price_per_million": None,
+            "output_price_per_million": None,
+            "cache_hit_price_per_million": None,
+            "currency": DEFAULT_CURRENCY,
+            "notes": "Extracted from Baidu Qianfan official pricing table.",
+            "_meta": {"input_score": -1, "output_score": -1},
+        },
+    )
+    normalized_price = normalize_to_per_million(price, unit)
+    subitem_clean = subitem.replace(" ", "")
+    service_clean = service.replace(" ", "")
+    pricing_context = f"{service_clean} {subitem_clean}".strip()
+    subitem_kind = subitem_kind_from_text(subitem_clean, pricing_context)
+    score = subitem_score(pricing_context)
+    if subitem_clean.startswith("命中缓存"):
+        model["cache_hit_price_per_million"] = normalized_price
+        return
+    if subitem_kind == "input" and should_replace_price(
+        current_price=model["input_price_per_million"],
+        current_score=model["_meta"]["input_score"],
+        candidate_price=normalized_price,
+        candidate_score=score,
+    ):
+        model["input_price_per_million"] = normalized_price
+        model["_meta"]["input_score"] = score
+    if subitem_kind == "output" and should_replace_price(
+        current_price=model["output_price_per_million"],
+        current_score=model["_meta"]["output_score"],
+        candidate_price=normalized_price,
+        candidate_score=score,
+    ):
+        model["output_price_per_million"] = normalized_price
+        model["_meta"]["output_score"] = score
+    notes = ["Extracted from Baidu Qianfan official pricing table."]
+    if model["cache_hit_price_per_million"] is not None:
+        notes.append(
+            "cache_hit_input="
+            f"{model['cache_hit_price_per_million']} CNY/1M tokens"
+        )
+    model["notes"] = "; ".join(notes)
+
+
+def subitem_kind_from_text(subitem: str, pricing_context: str = "") -> str:
+    """Return the normalized price role for one Baidu billing item."""
+    if "命中缓存" in subitem:
+        return ""
+    if "输入" in subitem and "输出" not in subitem:
+        return "input"
+    if "输出" in subitem and "输入" not in subitem:
+        return "output"
+    if "输入" in pricing_context and "输出" not in pricing_context:
+        return "input"
+    if "输出" in pricing_context and "输入" not in pricing_context:
+        return "output"
+    return ""
+
+
+def subitem_score(subitem: str) -> int:
+    """Return replacement priority for a Baidu billing item."""
+    if subitem in {"输入", "输出"}:
+        return 100
+    range_score = range_upper_bound_score(subitem)
+    if range_score is not None:
+        return range_score
+    return 10
+
+
+def range_upper_bound_score(subitem: str) -> int | None:
+    """Return the largest context range bound mentioned in a row."""
+    normalized = subitem.lower()
+    values = [int(value) for value in re.findall(r"(\d+)k", normalized)]
+    if not values:
+        return None
+    return max(values)
+
+
+def should_replace_price(
+    *,
+    current_price: str | None,
+    current_score: int,
+    candidate_price: str,
+    candidate_score: int,
+) -> bool:
+    """Return whether a candidate row should replace current model price."""
+    if current_price is None:
+        return True
+    if candidate_price != current_price:
+        return Decimal(candidate_price) > Decimal(current_price)
+    return candidate_score > current_score

--- a/backend/llm_ops/price_collectors/parsers/common.py
+++ b/backend/llm_ops/price_collectors/parsers/common.py
@@ -37,6 +37,24 @@ def sync_official_vendor_catalog(
         vendor.get("provider_name") or config.provider_label
     ).strip()
     currency = str(vendor.get("currency") or config.currency).strip()
+    raw_payload = {
+        "provider_code": provider_code,
+        "collector": "llm_ops.price_collectors.official_config",
+        "model_codes": sorted(model_codes),
+        "source_url": source_url,
+        "verify_source": verify_source,
+        "timeout": timeout,
+    }
+    if "fallback_used" in vendor:
+        raw_payload["fallback_used"] = as_bool(
+            vendor.get("fallback_used"),
+            default=False,
+        )
+    if vendor.get("fallback_reason"):
+        raw_payload["fallback_reason"] = str(
+            vendor.get("fallback_reason")
+        ).strip()
+
     return collected_catalog_to_standard_catalog(
         catalog=catalog,
         provider_code=provider_code,
@@ -47,14 +65,7 @@ def sync_official_vendor_catalog(
             f"Collected {catalog.total_models} {provider_code} official "
             "model price rows."
         ),
-        raw_payload={
-            "provider_code": provider_code,
-            "collector": "llm_ops.price_collectors.official_config",
-            "model_codes": sorted(model_codes),
-            "source_url": source_url,
-            "verify_source": verify_source,
-            "timeout": timeout,
-        },
+        raw_payload=raw_payload,
     )
 
 

--- a/backend/llm_ops/price_collectors/parsers/google.py
+++ b/backend/llm_ops/price_collectors/parsers/google.py
@@ -1,0 +1,423 @@
+from __future__ import annotations
+
+from html import unescape
+from typing import Any
+import re
+
+import requests
+
+from .common import (
+    build_text_token_standard_catalog,
+    filter_models_by_codes,
+    sync_official_vendor_catalog,
+)
+
+
+PRICING_URL = (
+    "https://cloud.google.com/gemini-enterprise-agent-platform/"
+    "generative-ai/pricing?hl=en"
+)
+DEFAULT_CURRENCY = "USD"
+SUPPORTED_STANDARD_SECTIONS = {
+    "standard",
+    "gemini 3",
+    "gemini omni",
+    "agents",
+    "gemini 2.5",
+    "gemini 2.0",
+    "token-based pricing",
+    "gemma",
+}
+SKIPPED_STANDARD_SECTIONS = {
+    "flex/batch",
+    "priority",
+    "modality-based pricing",
+    "tuning",
+    "imagen",
+    "veo",
+    "lyria",
+}
+
+
+class GooglePriceCatalogCollector:
+    """Collect Google Gemini official prices into standard catalog JSON."""
+
+    provider_code = "google"
+
+    def collect_catalog(
+        self,
+        vendor_config: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Return Google Gemini prices as standard catalog JSON."""
+        vendor = dict(vendor_config or {})
+        source_url = str(vendor.get("source_url") or PRICING_URL).strip()
+        page_html = str(vendor.get("raw_html") or "")
+        if not page_html and vendor.get("verify_source") is False:
+            return sync_official_vendor_catalog("google", vendor)
+        if not page_html:
+            page_html = fetch_text(source_url)
+
+        models = extract_models(page_html)
+        models = filter_models_by_codes(models, vendor.get("model_codes"))
+        if not models:
+            return sync_official_vendor_catalog("google", vendor)
+
+        provider_name = str(vendor.get("provider_name") or "Google").strip()
+        currency = str(vendor.get("currency") or DEFAULT_CURRENCY).strip()
+        return build_text_token_standard_catalog(
+            provider_code="google",
+            provider_name=provider_name,
+            currency=currency or DEFAULT_CURRENCY,
+            source_url=source_url,
+            models=models,
+            notes=(
+                "Extracted Google Gemini text token prices from the "
+                "official Google Cloud Agent Platform pricing table."
+            ),
+            raw_payload={
+                "provider_code": "google",
+                "collector": "llm_ops.price_collectors.google",
+                "source_url": source_url,
+                "model_codes": list(vendor.get("model_codes") or []),
+                "raw_html_supplied": bool(vendor.get("raw_html")),
+            },
+        )
+
+
+def fetch_text(url: str) -> str:
+    """Fetch one Google Cloud pricing document as UTF-8 text."""
+    response = requests.get(
+        url,
+        headers={
+            "Accept": "text/html,application/json,text/plain,*/*",
+            "User-Agent": "DevMind-LLMOpsPriceCollector/1.0",
+        },
+        timeout=30,
+    )
+    response.raise_for_status()
+    response.encoding = response.encoding or "utf-8"
+    return response.text or ""
+
+
+def extract_models(page_html: str) -> list[dict[str, Any]]:
+    """Extract standard Gemini text-token price rows from HTML tables."""
+    models: dict[str, dict[str, Any]] = {}
+    for section_title, table_html in extract_pricing_tables(page_html):
+        section = normalize_section_title(section_title)
+        if section in SKIPPED_STANDARD_SECTIONS:
+            continue
+        if not supports_standard_section(section):
+            continue
+        for item in models_from_table(table_html, section):
+            upsert_model(models, item)
+
+    return [
+        item
+        for item in sorted(
+            models.values(),
+            key=lambda candidate: candidate["model_id"].lower(),
+        )
+    ]
+
+
+def extract_pricing_tables(page_html: str) -> list[tuple[str, str]]:
+    """Return pricing table fragments with nearest preceding H3 title."""
+    pattern = re.compile(
+        r"(<h3\b.*?</h3>)|(<table\b.*?</table>)",
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+    section_title = ""
+    tables = []
+    for match in pattern.finditer(page_html):
+        heading_html, table_html = match.groups()
+        if heading_html:
+            section_title = clean_cell_text(heading_html)
+            continue
+        if table_html:
+            tables.append((section_title, table_html))
+    return tables
+
+
+def supports_standard_section(section: str) -> bool:
+    """Return whether a heading contains supported standard token prices."""
+    return section in SUPPORTED_STANDARD_SECTIONS
+
+
+def normalize_section_title(value: str) -> str:
+    """Normalize a pricing section heading for matching."""
+    return re.sub(r"\s+", " ", str(value or "").strip().lower())
+
+
+def models_from_table(
+    table_html: str,
+    section: str,
+) -> list[dict[str, Any]]:
+    """Build Google model price items from one table."""
+    rows = expand_rows(table_html)
+    grouped: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        if len(row) < 3 or is_header_row(row):
+            continue
+        model_id = model_id_from_name(row[0])
+        if not model_id:
+            continue
+        price_kind = price_kind_from_label(row[1])
+        if not price_kind:
+            continue
+        prices = [parse_price(value) for value in row[2:]]
+        prices = [price for price in prices if price is not None]
+        if not prices:
+            continue
+        item = grouped.setdefault(
+            model_id,
+            {
+                "model_id": model_id,
+                "model_name": model_id,
+                "display_name": display_name_from_cell(row[0]),
+                "aliases": aliases_for_model(model_id, row[0]),
+                "currency": DEFAULT_CURRENCY,
+                "_section": section,
+                "_prices": {},
+            },
+        )
+        item["_prices"][price_kind] = prices
+
+    models = []
+    for item in grouped.values():
+        model = build_model(item)
+        if model:
+            models.append(model)
+    return models
+
+
+def expand_rows(table_html: str) -> list[list[str]]:
+    """Expand table rows while preserving simple row and column spans."""
+    rows_html = re.findall(
+        r"<tr.*?>.*?</tr>",
+        table_html,
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+    expanded_rows = []
+    active_spans: dict[int, dict[str, Any]] = {}
+    for row_html in rows_html:
+        cells = parse_cells(row_html)
+        if not cells:
+            continue
+        row = []
+        column = 0
+        cell_index = 0
+        while cell_index < len(cells) or has_active_span_at_or_after(
+            active_spans,
+            column,
+        ):
+            span = active_spans.get(column)
+            if span is not None:
+                row.append(span["value"])
+                span["remaining"] -= 1
+                if span["remaining"] <= 0:
+                    del active_spans[column]
+                column += 1
+                continue
+            value, rowspan, colspan = cells[cell_index]
+            cell_index += 1
+            colspan = max(int(colspan or 1), 1)
+            for offset in range(colspan):
+                row.append(value)
+                if rowspan > 1:
+                    active_spans[column + offset] = {
+                        "value": value,
+                        "remaining": rowspan - 1,
+                    }
+            column += colspan
+        expanded_rows.append(row)
+    return expanded_rows
+
+
+def has_active_span_at_or_after(
+    active_spans: dict[int, dict[str, Any]],
+    column: int,
+) -> bool:
+    """Return whether a pending row span exists at or after column."""
+    return any(index >= column for index in active_spans)
+
+
+def parse_cells(row_html: str) -> list[tuple[str, int, int]]:
+    """Parse one HTML row into cell text plus row and column spans."""
+    results = []
+    pattern = re.compile(
+        r"<(td|th)([^>]*)>(.*?)</\1>",
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+    for _, attrs, inner_html in pattern.findall(row_html):
+        rowspan = span_value(attrs, "rowspan")
+        colspan = span_value(attrs, "colspan")
+        results.append((clean_cell_text(inner_html), rowspan, colspan))
+    return results
+
+
+def span_value(attrs: str, name: str) -> int:
+    """Return an integer span attribute value."""
+    match = re.search(
+        rf"{name}=[\"'](\d+)[\"']",
+        attrs,
+        flags=re.IGNORECASE,
+    )
+    return int(match.group(1)) if match else 1
+
+
+def clean_cell_text(inner_html: str) -> str:
+    """Convert one HTML cell body into normalized text."""
+    text = re.sub(r"<br\s*/?>", "\n", inner_html, flags=re.IGNORECASE)
+    text = re.sub(r"</(?:p|blockquote|div)>", "\n", text, flags=re.I)
+    text = re.sub(r"<[^>]+>", " ", text)
+    text = unescape(text).replace("\xa0", " ")
+    lines = [re.sub(r"\s+", " ", line).strip() for line in text.splitlines()]
+    return "\n".join(line for line in lines if line)
+
+
+def is_header_row(row: list[str]) -> bool:
+    """Return whether one row is a table header."""
+    joined = " ".join(row).lower()
+    return "model" in joined and ("price" in joined or "input" in joined)
+
+
+def model_id_from_name(value: str) -> str:
+    """Normalize a Google model display name into a model ID."""
+    text = display_name_from_cell(value).lower()
+    if not re.match(r"^(gemini|gemma)\b", text):
+        return ""
+    text = re.sub(r"\([^)]*\)", " ", text)
+    text = text.replace("flash lite", "flash-lite")
+    text = text.replace("flash-lite image", "flash-lite-image")
+    text = text.replace("image generation", "image-generation")
+    text = text.replace("live api", "live-api")
+    text = text.replace("computer use-preview", "computer-use-preview")
+    text = re.sub(r"[^a-z0-9.]+", "-", text)
+    return text.strip("-")
+
+
+def display_name_from_cell(value: str) -> str:
+    """Return a readable model name from a table cell."""
+    text = re.sub(r"\s+", " ", str(value or "").replace("\n", " "))
+    return text.strip()
+
+
+def aliases_for_model(model_id: str, display_name: str) -> list[str]:
+    """Return matching aliases for one Google model row."""
+    aliases = [model_id]
+    original = display_name_from_cell(display_name)
+    if original and original not in aliases:
+        aliases.append(original)
+    return aliases
+
+
+def price_kind_from_label(value: str) -> str:
+    """Return normalized text-token price dimension for a row label."""
+    text = normalize_label(value)
+    if "output" in text and "text" in text:
+        return "output"
+    if "input" in text and not is_audio_only_input_label(text):
+        return "input"
+    return ""
+
+
+def is_audio_only_input_label(text: str) -> bool:
+    """Return whether a Google input row only prices audio tokens."""
+    if "audio" not in text:
+        return False
+    return not any(token in text for token in ("text", "image", "video"))
+
+
+def normalize_label(value: str) -> str:
+    """Normalize a price row label for matching."""
+    return re.sub(r"\s+", " ", str(value or "").strip().lower())
+
+
+def parse_price(value: str) -> str | None:
+    """Parse the first non-negative USD price from one cell."""
+    text = str(value or "").replace(",", "").strip()
+    if not text or text in {"-", "n/a"}:
+        return None
+    match = re.search(r"\$?\s*([0-9]+(?:\.[0-9]+)?)", text)
+    return match.group(1) if match else None
+
+
+def build_model(item: dict[str, Any]) -> dict[str, Any]:
+    """Build one parsed model with complete input and output prices."""
+    prices = item.get("_prices") or {}
+    input_prices = list(prices.get("input") or [])
+    output_prices = list(prices.get("output") or [])
+    if not input_prices or not output_prices:
+        return {}
+
+    row_count = min(len(input_prices), len(output_prices), 2)
+    price_rows = []
+    for index in range(row_count):
+        row = {
+            "input_price_per_million": input_prices[index],
+            "output_price_per_million": output_prices[index],
+            "currency": DEFAULT_CURRENCY,
+        }
+        cache_price = cache_hit_price(input_prices, index)
+        if cache_price:
+            row["cache_hit_price_per_million"] = cache_price
+        token_range = token_range_for_index(index, row_count)
+        if token_range:
+            row["input_token_range"] = token_range
+            row["output_token_range"] = token_range
+        price_rows.append(row)
+
+    if not price_rows:
+        return {}
+    result = {
+        key: value
+        for key, value in item.items()
+        if not key.startswith("_")
+    }
+    result.update(
+        {
+            "input_price_per_million": price_rows[0][
+                "input_price_per_million"
+            ],
+            "output_price_per_million": price_rows[0][
+                "output_price_per_million"
+            ],
+            "price_rows": price_rows,
+            "notes": (
+                "Extracted from Google Cloud Agent Platform pricing; "
+                f"section={item.get('_section') or '-'}."
+            ),
+        }
+    )
+    return result
+
+
+def cache_hit_price(input_prices: list[str], index: int) -> str:
+    """Return parsed cache-hit price when present in the same table row."""
+    cache_index = index + 2
+    if cache_index < len(input_prices):
+        return input_prices[cache_index]
+    return ""
+
+
+def token_range_for_index(index: int, row_count: int) -> str:
+    """Return the Google context-window tier for a price row."""
+    if row_count < 2:
+        return ""
+    return "0-200000" if index == 0 else "200001-"
+
+
+def upsert_model(
+    models: dict[str, dict[str, Any]],
+    item: dict[str, Any],
+) -> None:
+    """Merge one parsed model into the extracted catalog."""
+    model_id = item["model_id"]
+    existing = models.get(model_id)
+    if existing is None:
+        models[model_id] = item
+        return
+    existing_rows = existing.setdefault("price_rows", [])
+    for row in item.get("price_rows") or []:
+        if row not in existing_rows:
+            existing_rows.append(row)

--- a/backend/llm_ops/price_collectors/parsers/minimax.py
+++ b/backend/llm_ops/price_collectors/parsers/minimax.py
@@ -1,0 +1,461 @@
+from __future__ import annotations
+
+import json
+import re
+from decimal import Decimal, InvalidOperation
+from html import unescape
+from typing import Any
+
+import requests
+
+from .common import (
+    build_text_token_standard_catalog,
+    filter_models_by_codes,
+)
+
+
+PRICING_URL = (
+    "https://platform.minimaxi.com/subscribe/token-plan?tab=api-enterprise"
+)
+DEFAULT_CURRENCY = "CNY"
+
+
+class MiniMaxPriceCatalogCollector:
+    """Collect MiniMax official prices into standard catalog JSON."""
+
+    provider_code = "minimax"
+
+    def collect_catalog(
+        self,
+        vendor_config: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Return MiniMax official prices as standard catalog JSON."""
+        vendor = dict(vendor_config or {})
+        source_url = str(vendor.get("source_url") or PRICING_URL).strip()
+        page_html = str(vendor.get("raw_html") or "")
+        if not page_html and vendor.get("verify_source") is False:
+            return build_catalog(
+                vendor=vendor,
+                source_url=source_url,
+                models=[],
+            )
+        if not page_html:
+            page_html = fetch_text(source_url)
+
+        models = extract_models(page_html)
+        models = filter_models_by_codes(models, vendor.get("model_codes"))
+        return build_catalog(
+            vendor=vendor,
+            source_url=source_url,
+            models=models,
+        )
+
+
+def build_catalog(
+    *,
+    vendor: dict[str, Any],
+    source_url: str,
+    models: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Build the standard MiniMax price catalog payload."""
+    provider_name = str(vendor.get("provider_name") or "MiniMax").strip()
+    currency = str(vendor.get("currency") or DEFAULT_CURRENCY).strip()
+    return build_text_token_standard_catalog(
+        provider_code="minimax",
+        provider_name=provider_name,
+        currency=currency or DEFAULT_CURRENCY,
+        source_url=source_url,
+        models=models,
+        notes=(
+            "Extracted MiniMax text model prices from the official pricing "
+            "page when explicit per-model token price rows are available."
+        ),
+        raw_payload={
+            "provider_code": "minimax",
+            "collector": "llm_ops.price_collectors.minimax",
+            "source_url": source_url,
+            "model_codes": list(vendor.get("model_codes") or []),
+            "raw_html_supplied": bool(vendor.get("raw_html")),
+            "parsed_models": len(models),
+        },
+    )
+
+
+def fetch_text(url: str) -> str:
+    """Fetch one MiniMax pricing document as UTF-8 text."""
+    response = requests.get(
+        url,
+        headers={
+            "Accept": "text/html,application/json,text/plain,*/*",
+            "User-Agent": "DevMind-LLMOpsPriceCollector/1.0",
+        },
+        timeout=30,
+    )
+    response.raise_for_status()
+    response.encoding = response.encoding or "utf-8"
+    if str(response.encoding).lower() in {"iso-8859-1", "latin-1"}:
+        response.encoding = "utf-8"
+    return response.text or ""
+
+
+def extract_models(content: str) -> list[dict[str, Any]]:
+    """Extract MiniMax text-token price rows from JSON and HTML tables."""
+    models: dict[str, dict[str, Any]] = {}
+    for document in extract_json_documents(content):
+        for item in extract_models_from_json(document):
+            upsert_model(models, item)
+    for item in extract_models_from_tables(content):
+        upsert_model(models, item)
+    return [
+        item
+        for item in sorted(
+            models.values(),
+            key=lambda candidate: candidate["model_id"].lower(),
+        )
+    ]
+
+
+def extract_json_documents(content: str) -> list[Any]:
+    """Return embedded JSON payloads that may contain API pricing data."""
+    documents = []
+    raw_text = unescape(str(content or ""))
+    append_json_document(documents, raw_text)
+
+    pattern = re.compile(
+        r'<script[^>]*id=["\']__NEXT_DATA__["\'][^>]*>(.*?)</script>',
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+    for match in pattern.finditer(raw_text):
+        append_json_document(documents, match.group(1))
+
+    for fragment in extract_balanced_values(raw_text, "apiPricing"):
+        append_json_document(documents, fragment)
+    return documents
+
+
+def append_json_document(documents: list[Any], raw_value: str) -> None:
+    """Append one JSON document if it can be decoded."""
+    text = str(raw_value or "").strip()
+    if not text:
+        return
+    try:
+        documents.append(json.loads(text))
+    except json.JSONDecodeError:
+        return
+
+
+def extract_balanced_values(text: str, key: str) -> list[str]:
+    """Extract balanced JSON object or array values after one key."""
+    fragments = []
+    pattern = re.compile(rf'["\']?{re.escape(key)}["\']?\s*:')
+    for match in pattern.finditer(text):
+        start = next_json_value_start(text, match.end())
+        if start < 0:
+            continue
+        fragment = balanced_fragment(text, start)
+        if fragment:
+            fragments.append(fragment)
+    return fragments
+
+
+def next_json_value_start(text: str, start: int) -> int:
+    """Return the next JSON object or array start position."""
+    positions = [
+        position
+        for position in (text.find("{", start), text.find("[", start))
+        if position >= 0
+    ]
+    return min(positions) if positions else -1
+
+
+def balanced_fragment(text: str, start: int) -> str:
+    """Return a balanced object or array fragment from text."""
+    opening = text[start]
+    closing = "}" if opening == "{" else "]"
+    depth = 0
+    in_string = False
+    escape = False
+    quote = ""
+    for index in range(start, len(text)):
+        char = text[index]
+        if in_string:
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == quote:
+                in_string = False
+            continue
+        if char in {'"', "'"}:
+            in_string = True
+            quote = char
+            continue
+        if char == opening:
+            depth += 1
+        elif char == closing:
+            depth -= 1
+            if depth == 0:
+                return text[start : index + 1]
+    return ""
+
+
+def extract_models_from_json(document: Any) -> list[dict[str, Any]]:
+    """Recursively extract explicit model price rows from JSON payloads."""
+    models = []
+    if isinstance(document, dict):
+        row = model_from_mapping(document)
+        if row:
+            models.append(row)
+        for value in document.values():
+            models.extend(extract_models_from_json(value))
+    elif isinstance(document, list):
+        for item in document:
+            models.extend(extract_models_from_json(item))
+    return models
+
+
+def model_from_mapping(item: dict[str, Any]) -> dict[str, Any]:
+    """Build one model from a structured row with explicit token prices."""
+    model_name = value_for_keys(item, MODEL_KEYS)
+    input_price = value_for_keys(item, INPUT_PRICE_KEYS)
+    output_price = value_for_keys(item, OUTPUT_PRICE_KEYS)
+    if not model_name or input_price is None or output_price is None:
+        return {}
+    input_value = parse_price(input_price)
+    output_value = parse_price(output_price)
+    if input_value is None or output_value is None:
+        return {}
+    model_id = model_id_from_name(model_name)
+    if not model_id:
+        return {}
+    return {
+        "model_id": model_id,
+        "model_name": model_id,
+        "display_name": display_name_from_cell(model_name),
+        "aliases": aliases_for_model(model_id, model_name),
+        "input_price_per_million": input_value,
+        "output_price_per_million": output_value,
+        "currency": DEFAULT_CURRENCY,
+        "notes": "Extracted from MiniMax official API pricing data.",
+    }
+
+
+MODEL_KEYS = {
+    "model",
+    "modelid",
+    "modelname",
+    "modelversion",
+    "模型",
+    "模型名称",
+}
+INPUT_PRICE_KEYS = {
+    "input",
+    "inputprice",
+    "inputtokenprice",
+    "promptprice",
+    "prompttokenprice",
+    "输入",
+    "输入价格",
+    "输入单价",
+}
+OUTPUT_PRICE_KEYS = {
+    "output",
+    "outputprice",
+    "outputtokenprice",
+    "completionprice",
+    "completiontokenprice",
+    "输出",
+    "输出价格",
+    "输出单价",
+}
+
+
+def value_for_keys(item: dict[str, Any], accepted_keys: set[str]) -> Any:
+    """Return the first value matching a normalized key name."""
+    for key, value in item.items():
+        normalized_key = normalize_key(key)
+        if normalized_key in accepted_keys:
+            return value
+    return None
+
+
+def normalize_key(value: Any) -> str:
+    """Normalize a source key for pricing field matching."""
+    text = str(value or "").strip().lower()
+    return re.sub(r"[\s_\-/.()]+", "", text)
+
+
+def extract_models_from_tables(content: str) -> list[dict[str, Any]]:
+    """Extract model rows from plain HTML pricing tables."""
+    models = []
+    for table_html in re.findall(
+        r"<table\b.*?</table>",
+        str(content or ""),
+        flags=re.DOTALL | re.IGNORECASE,
+    ):
+        models.extend(models_from_table(table_html))
+    return models
+
+
+def models_from_table(table_html: str) -> list[dict[str, Any]]:
+    """Build MiniMax model rows from one HTML table."""
+    rows = parse_table_rows(table_html)
+    if len(rows) < 2:
+        return []
+    headers = [normalize_header(value) for value in rows[0]]
+    model_index = first_header_index(
+        headers,
+        {"model", "模型", "模型名称"},
+    )
+    input_index = first_header_index(
+        headers,
+        {"input", "输入", "输入价格"},
+    )
+    output_index = first_header_index(
+        headers,
+        {"output", "输出", "输出价格"},
+    )
+    if model_index < 0 or input_index < 0 or output_index < 0:
+        return []
+
+    models = []
+    for row in rows[1:]:
+        if max(model_index, input_index, output_index) >= len(row):
+            continue
+        item = model_from_mapping(
+            {
+                "model": row[model_index],
+                "input": row[input_index],
+                "output": row[output_index],
+            }
+        )
+        if item:
+            models.append(item)
+    return models
+
+
+def parse_table_rows(table_html: str) -> list[list[str]]:
+    """Parse simple HTML table rows into normalized cell text."""
+    rows = []
+    for row_html in re.findall(
+        r"<tr\b.*?</tr>",
+        table_html,
+        flags=re.DOTALL | re.IGNORECASE,
+    ):
+        cells = []
+        for cell_html in re.findall(
+            r"<(?:td|th)\b[^>]*>(.*?)</(?:td|th)>",
+            row_html,
+            flags=re.DOTALL | re.IGNORECASE,
+        ):
+            cells.append(clean_cell_text(cell_html))
+        if cells:
+            rows.append(cells)
+    return rows
+
+
+def clean_cell_text(inner_html: str) -> str:
+    """Convert one HTML cell body into normalized text."""
+    text = re.sub(r"<br\s*/?>", "\n", inner_html, flags=re.IGNORECASE)
+    text = re.sub(r"</(?:p|blockquote|div)>", "\n", text, flags=re.I)
+    text = re.sub(r"<[^>]+>", " ", text)
+    text = unescape(text).replace("\xa0", " ")
+    lines = [re.sub(r"\s+", " ", line).strip() for line in text.splitlines()]
+    return "\n".join(line for line in lines if line)
+
+
+def normalize_header(value: str) -> str:
+    """Normalize a table header for field matching."""
+    text = re.sub(r"\s+", " ", str(value or "").strip().lower())
+    if "model" in text:
+        return "model"
+    if "模型" in text:
+        return "模型"
+    if "input" in text or "prompt" in text:
+        return "input"
+    if "输入" in text:
+        return "输入"
+    if "output" in text or "completion" in text:
+        return "output"
+    if "输出" in text:
+        return "输出"
+    return text
+
+
+def first_header_index(headers: list[str], candidates: set[str]) -> int:
+    """Return the first matching header index, or -1."""
+    for index, header in enumerate(headers):
+        if header in candidates:
+            return index
+    return -1
+
+
+def parse_price(value: Any) -> str | None:
+    """Parse a non-negative CNY token price into CNY per 1M tokens."""
+    text = str(value or "").replace(",", "").strip()
+    if not text or text in {"-", "n/a", "N/A"}:
+        return None
+    match = re.search(r"(?:¥|￥|CNY|RMB)?\s*([0-9]+(?:\.[0-9]+)?)", text)
+    if not match:
+        return None
+    try:
+        amount = Decimal(match.group(1))
+    except (InvalidOperation, ValueError):
+        return None
+    if amount < 0:
+        return None
+    if is_per_thousand_tokens(text):
+        amount *= Decimal("1000")
+    return format_decimal(amount)
+
+
+def is_per_thousand_tokens(text: str) -> bool:
+    """Return whether a price is published per thousand tokens."""
+    normalized = re.sub(r"\s+", "", text.lower())
+    if "百万" in normalized or "1m" in normalized:
+        return False
+    return "千tokens" in normalized or "千token" in normalized
+
+
+def format_decimal(value: Decimal) -> str:
+    """Format a decimal as a compact price string."""
+    formatted = format(value.normalize(), "f")
+    if "." in formatted:
+        formatted = formatted.rstrip("0").rstrip(".")
+    return formatted or "0"
+
+
+def model_id_from_name(value: Any) -> str:
+    """Normalize a MiniMax model display name into a model ID."""
+    text = display_name_from_cell(value)
+    if not text:
+        return ""
+    text = re.sub(r"\([^)]*\)", " ", text)
+    text = re.sub(r"（[^）]*）", " ", text)
+    text = re.sub(r"[^A-Za-z0-9.]+", "-", text)
+    return text.strip("-").lower()
+
+
+def display_name_from_cell(value: Any) -> str:
+    """Return a readable model name from a table or JSON value."""
+    text = re.sub(r"\s+", " ", str(value or "").replace("\n", " "))
+    return text.strip()
+
+
+def aliases_for_model(model_id: str, display_name: Any) -> list[str]:
+    """Return matching aliases for one MiniMax model row."""
+    aliases = [model_id]
+    original = display_name_from_cell(display_name)
+    if original and original not in aliases:
+        aliases.append(original)
+    return aliases
+
+
+def upsert_model(
+    models: dict[str, dict[str, Any]],
+    item: dict[str, Any],
+) -> None:
+    """Merge one parsed MiniMax model into the extracted catalog."""
+    model_id = item["model_id"]
+    if model_id not in models:
+        models[model_id] = item

--- a/backend/llm_ops/price_collectors/parsers/volcengine.py
+++ b/backend/llm_ops/price_collectors/parsers/volcengine.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+import requests
+
+from .common import (
+    build_text_token_standard_catalog,
+    filter_models_by_codes,
+    sync_official_vendor_catalog,
+)
+
+
+PRICING_URL = "https://www.volcengine.com/docs/82379/1544106?lang=zh"
+DEFAULT_CURRENCY = "CNY"
+SUFFIX_LEN = 32
+
+ONLINE_SCHEMA = {
+    "model": "nj2n42rlpl8e7b6tvpmvqhysnzfp89bh",
+    "input": "s303uu1c1g40de7oaoizn05md89iimb6",
+    "output": "5wt3pecycob8so1pho26k692zw2cgbsm",
+    "cache_hit": "cvklbb5m01p5jfrmdhooit6bknkyawsj",
+    "condition": "gagtwd6h2ui45oj1di8jtwno5ytnfdt6",
+}
+
+BATCH_SCHEMA = {
+    "model": "sd9qqqvyjh64sfk1ym6h608eym82d47r",
+    "input": "g1jev13gq4vtdf1u98drambg5e4iydrp",
+    "output": "r0s2ipdcp1is8youke6te708kops5in5",
+    "cache_hit": "59955fwlp0lm8jma3qh1nqtzurbplpg8",
+    "condition": "8tq8h7zdnkenawut121k9pl3482469oc",
+}
+
+
+class VolcEnginePriceCatalogCollector:
+    """Collect VolcEngine official prices into the standard catalog JSON."""
+
+    provider_code = "volcengine"
+
+    def collect_catalog(
+        self,
+        vendor_config: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Return VolcEngine official prices as standard catalog JSON."""
+        vendor = dict(vendor_config or {})
+        source_url = resolve_pricing_url(vendor)
+        html = str(vendor.get("raw_html") or "")
+        if not html and vendor.get("verify_source") is False:
+            return sync_official_vendor_catalog("volcengine", vendor)
+        if not html:
+            html = fetch_text(source_url)
+
+        models = extract_models(html)
+        models = filter_models_by_codes(models, vendor.get("model_codes"))
+        if not models:
+            vendor["fallback_used"] = True
+            vendor["fallback_reason"] = "official_page_parse_empty"
+            return sync_official_vendor_catalog("volcengine", vendor)
+
+        provider_name = str(
+            vendor.get("provider_name") or "火山方舟"
+        ).strip()
+        currency = str(vendor.get("currency") or DEFAULT_CURRENCY).strip()
+        return build_text_token_standard_catalog(
+            provider_code="volcengine",
+            provider_name=provider_name,
+            currency=currency or DEFAULT_CURRENCY,
+            source_url=source_url,
+            models=models,
+            notes=(
+                "Extracted VolcEngine text model prices from the official "
+                "pricing document."
+            ),
+            raw_payload={
+                "provider_code": "volcengine",
+                "collector": "llm_ops.price_collectors.volcengine",
+                "source_url": source_url,
+                "model_codes": list(vendor.get("model_codes") or []),
+                "raw_html_supplied": bool(vendor.get("raw_html")),
+            },
+        )
+
+
+def resolve_pricing_url(vendor: dict[str, Any]) -> str:
+    """Return the configured VolcEngine pricing page URL."""
+    acquisition = dict(vendor.get("acquisition") or {})
+    return str(
+        vendor.get("source_url")
+        or acquisition.get("page_url")
+        or vendor.get("pricing_url")
+        or PRICING_URL
+    ).strip()
+
+
+def fetch_text(url: str) -> str:
+    """Fetch one VolcEngine pricing document as text."""
+    response = requests.get(
+        url,
+        headers={
+            "Accept": "text/html,application/json,text/plain,*/*",
+            "User-Agent": "DevMind-LLMOpsPriceCollector/1.0",
+        },
+        timeout=30,
+    )
+    response.raise_for_status()
+    response.encoding = response.encoding or "utf-8"
+    return response.text or ""
+
+
+def extract_models(html: str) -> list[dict[str, Any]]:
+    """Extract VolcEngine text model price rows from document zones."""
+    zones = extract_zones(html)
+    models: dict[str, dict[str, Any]] = {}
+    for item in extract_rows(
+        zones=zones,
+        schema=ONLINE_SCHEMA,
+        section_name="online_inference",
+    ):
+        upsert_model(models, item)
+    for item in extract_rows(
+        zones=zones,
+        schema=BATCH_SCHEMA,
+        section_name="batch_inference",
+    ):
+        upsert_model(models, item)
+
+    return [
+        {key: value for key, value in item.items() if not key.startswith("_")}
+        for item in sorted(
+            models.values(),
+            key=lambda candidate: candidate["model_name"].lower(),
+        )
+        if (
+            item.get("input_price_per_million") is not None
+            or item.get("output_price_per_million") is not None
+        )
+    ]
+
+
+def extract_zones(html: str) -> dict[str, str]:
+    """Extract VolcEngine document zone text keyed by zone ID."""
+    pattern = re.compile(
+        r'\\"ops\\":\[(.*?)\],\\"zoneId\\":\\"([^\\"]+)\\",'
+        r'\\"zoneType\\":\\"Z\\"',
+        flags=re.DOTALL,
+    )
+    zones = {}
+    for ops, zone_id in pattern.findall(html):
+        inserts = re.findall(r'\\"insert\\":\\"(.*?)\\"', ops)
+        parts = []
+        for raw in inserts:
+            text = decode_insert(raw)
+            if not text or text == "*":
+                continue
+            normalized = normalize_whitespace(text)
+            if normalized:
+                parts.append(normalized)
+        zones[zone_id] = " ".join(parts).strip()
+    return zones
+
+
+def extract_rows(
+    *,
+    zones: dict[str, str],
+    schema: dict[str, str],
+    section_name: str,
+) -> list[dict[str, Any]]:
+    """Extract price row dictionaries for one VolcEngine table schema."""
+    prefixes = sorted(
+        {
+            zone_id[:-SUFFIX_LEN]
+            for zone_id in zones
+            if zone_id.endswith(schema["model"])
+            and zones.get(zone_id, "").strip()
+        }
+    )
+    rows = []
+    for prefix in prefixes:
+        model_text = zones.get(prefix + schema["model"], "").strip()
+        if not model_text:
+            continue
+        model_name, extra_note = split_model_name(model_text)
+        if not model_name or not is_text_model(model_name):
+            continue
+        condition = zones.get(prefix + schema["condition"], "").strip()
+        input_price = parse_price(zones.get(prefix + schema["input"], ""))
+        output_price = parse_price(zones.get(prefix + schema["output"], ""))
+        cache_hit_price = parse_price(
+            zones.get(prefix + schema["cache_hit"], "")
+        )
+        rows.append(
+            build_row(
+                model_name=model_name,
+                input_price=input_price,
+                output_price=output_price,
+                cache_hit_price=cache_hit_price,
+                condition=condition,
+                extra_note=extra_note,
+                section_name=section_name,
+            )
+        )
+    return rows
+
+
+def build_row(
+    *,
+    model_name: str,
+    input_price: str | None,
+    output_price: str | None,
+    cache_hit_price: str | None,
+    condition: str,
+    extra_note: str | None,
+    section_name: str,
+) -> dict[str, Any]:
+    """Build one parsed VolcEngine model price row."""
+    notes_parts = [f"VolcEngine official {section_name} pricing row."]
+    if condition and condition != "-":
+        notes_parts.append(f"condition={condition}")
+    if cache_hit_price is not None:
+        notes_parts.append(f"cache_hit_input={cache_hit_price} CNY/1M tokens")
+    if extra_note:
+        notes_parts.append(extra_note)
+    return {
+        "model_id": model_name,
+        "model_name": model_name,
+        "aliases": [model_name],
+        "input_price_per_million": input_price,
+        "output_price_per_million": output_price,
+        "cache_hit_price_per_million": cache_hit_price,
+        "currency": DEFAULT_CURRENCY,
+        "notes": "; ".join(notes_parts),
+        "_section_priority": 2 if section_name == "online_inference" else 1,
+    }
+
+
+def decode_insert(raw: str) -> str:
+    """Decode one escaped Quill insert value from VolcEngine page data."""
+    try:
+        value = json.loads(f'"{raw}"')
+    except json.JSONDecodeError:
+        value = raw.replace("\\u002F", "/")
+    return value.replace("\\n", "\n")
+
+
+def normalize_whitespace(text: str) -> str:
+    """Collapse whitespace in source text."""
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def split_model_name(text: str) -> tuple[str, str | None]:
+    """Split the model ID from an optional note."""
+    cleaned = normalize_whitespace(text).replace("\\n", " ").strip()
+    if not cleaned or cleaned == r"\n":
+        return "", None
+    match = re.match(r"^([A-Za-z0-9._:+-]+)(?:\s+(.*))?$", cleaned)
+    if not match:
+        return cleaned, None
+    return (
+        match.group(1).strip(),
+        match.group(2).strip() if match.group(2) else None,
+    )
+
+
+def is_text_model(model_name: str) -> bool:
+    """Return whether a VolcEngine model row is a text model."""
+    lowered = model_name.lower()
+    blocked = (
+        "vision",
+        "image",
+        "video",
+        "embedding",
+        "rerank",
+        "tts",
+        "asr",
+        "audio",
+        "speech",
+    )
+    return not any(token in lowered for token in blocked)
+
+
+def parse_price(text: str) -> str | None:
+    """Parse one non-negative VolcEngine CNY price."""
+    normalized = normalize_whitespace(text)
+    if not normalized or normalized in {"-", "不支持"}:
+        return None
+    match = re.search(r"([0-9]+(?:\.[0-9]+)?)", normalized)
+    return match.group(1) if match else None
+
+
+def upsert_model(
+    models: dict[str, dict[str, Any]],
+    item: dict[str, Any],
+) -> None:
+    """Keep the preferred row for one VolcEngine model."""
+    key = item["model_name"].strip().lower()
+    existing = models.get(key)
+    if existing is None or candidate_score(item) > candidate_score(existing):
+        models[key] = item
+
+
+def candidate_score(item: dict[str, Any]) -> tuple[int, int, float]:
+    """Rank candidate rows for the same model ID."""
+    priced_fields = int(item["input_price_per_million"] is not None)
+    priced_fields += int(item["output_price_per_million"] is not None)
+    section_priority = int(item.get("_section_priority", 0))
+    total = float(item.get("input_price_per_million") or 0)
+    total += float(item.get("output_price_per_million") or 0)
+    return priced_fields, section_priority, total

--- a/backend/llm_ops/price_collectors/parsers/zhipu.py
+++ b/backend/llm_ops/price_collectors/parsers/zhipu.py
@@ -1,0 +1,460 @@
+from __future__ import annotations
+
+import json
+import re
+from decimal import Decimal, InvalidOperation
+from html import unescape
+from typing import Any
+
+import requests
+
+from .common import (
+    build_text_token_standard_catalog,
+    filter_models_by_codes,
+)
+
+
+PRICING_URL = "https://bigmodel.cn/pricing"
+DEFAULT_CURRENCY = "CNY"
+
+
+class ZhipuPriceCatalogCollector:
+    """Collect Zhipu official prices into standard catalog JSON."""
+
+    provider_code = "zhipu"
+
+    def collect_catalog(
+        self,
+        vendor_config: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Return Zhipu official prices as standard catalog JSON."""
+        vendor = dict(vendor_config or {})
+        source_url = str(vendor.get("source_url") or PRICING_URL).strip()
+        page_html = str(vendor.get("raw_html") or "")
+        if not page_html and vendor.get("verify_source") is False:
+            return build_catalog(
+                vendor=vendor,
+                source_url=source_url,
+                models=[],
+            )
+        if not page_html:
+            page_html = fetch_text(source_url)
+
+        models = extract_models(page_html)
+        models = filter_models_by_codes(models, vendor.get("model_codes"))
+        return build_catalog(
+            vendor=vendor,
+            source_url=source_url,
+            models=models,
+        )
+
+
+def build_catalog(
+    *,
+    vendor: dict[str, Any],
+    source_url: str,
+    models: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Build the standard Zhipu price catalog payload."""
+    provider_name = str(vendor.get("provider_name") or "智谱").strip()
+    currency = str(vendor.get("currency") or DEFAULT_CURRENCY).strip()
+    return build_text_token_standard_catalog(
+        provider_code="zhipu",
+        provider_name=provider_name,
+        currency=currency or DEFAULT_CURRENCY,
+        source_url=source_url,
+        models=models,
+        notes=(
+            "Extracted Zhipu text model prices from the official BigModel "
+            "pricing page when explicit per-model token price rows exist."
+        ),
+        raw_payload={
+            "provider_code": "zhipu",
+            "collector": "llm_ops.price_collectors.zhipu",
+            "source_url": source_url,
+            "model_codes": list(vendor.get("model_codes") or []),
+            "raw_html_supplied": bool(vendor.get("raw_html")),
+            "parsed_models": len(models),
+        },
+    )
+
+
+def fetch_text(url: str) -> str:
+    """Fetch one BigModel pricing document as UTF-8 text."""
+    response = requests.get(
+        url,
+        headers={
+            "Accept": "text/html,application/json,text/plain,*/*",
+            "User-Agent": "DevMind-LLMOpsPriceCollector/1.0",
+        },
+        timeout=30,
+    )
+    response.raise_for_status()
+    response.encoding = response.encoding or "utf-8"
+    if str(response.encoding).lower() in {"iso-8859-1", "latin-1"}:
+        response.encoding = "utf-8"
+    return response.text or ""
+
+
+def extract_models(content: str) -> list[dict[str, Any]]:
+    """Extract Zhipu text-token price rows from JSON and HTML tables."""
+    models: dict[str, dict[str, Any]] = {}
+    for document in extract_json_documents(content):
+        for item in extract_models_from_json(document):
+            upsert_model(models, item)
+    for item in extract_models_from_tables(content):
+        upsert_model(models, item)
+    return [
+        item
+        for item in sorted(
+            models.values(),
+            key=lambda candidate: candidate["model_id"].lower(),
+        )
+    ]
+
+
+def extract_json_documents(content: str) -> list[Any]:
+    """Return embedded JSON payloads that may contain pricing data."""
+    documents = []
+    raw_text = unescape(str(content or ""))
+    append_json_document(documents, raw_text)
+
+    pattern = re.compile(
+        r'<script[^>]*id=["\']__NEXT_DATA__["\'][^>]*>(.*?)</script>',
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+    for match in pattern.finditer(raw_text):
+        append_json_document(documents, match.group(1))
+
+    for key in ("pricing", "priceList", "modelPrices", "modelPricing"):
+        for fragment in extract_balanced_values(raw_text, key):
+            append_json_document(documents, fragment)
+    return documents
+
+
+def append_json_document(documents: list[Any], raw_value: str) -> None:
+    """Append one JSON document if it can be decoded."""
+    text = str(raw_value or "").strip()
+    if not text:
+        return
+    try:
+        documents.append(json.loads(text))
+    except json.JSONDecodeError:
+        return
+
+
+def extract_balanced_values(text: str, key: str) -> list[str]:
+    """Extract balanced JSON object or array values after one key."""
+    fragments = []
+    pattern = re.compile(rf'["\']?{re.escape(key)}["\']?\s*:')
+    for match in pattern.finditer(text):
+        start = next_json_value_start(text, match.end())
+        if start < 0:
+            continue
+        fragment = balanced_fragment(text, start)
+        if fragment:
+            fragments.append(fragment)
+    return fragments
+
+
+def next_json_value_start(text: str, start: int) -> int:
+    """Return the next JSON object or array start position."""
+    positions = [
+        position
+        for position in (text.find("{", start), text.find("[", start))
+        if position >= 0
+    ]
+    return min(positions) if positions else -1
+
+
+def balanced_fragment(text: str, start: int) -> str:
+    """Return a balanced object or array fragment from text."""
+    opening = text[start]
+    closing = "}" if opening == "{" else "]"
+    depth = 0
+    in_string = False
+    escape = False
+    quote = ""
+    for index in range(start, len(text)):
+        char = text[index]
+        if in_string:
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == quote:
+                in_string = False
+            continue
+        if char in {'"', "'"}:
+            in_string = True
+            quote = char
+            continue
+        if char == opening:
+            depth += 1
+        elif char == closing:
+            depth -= 1
+            if depth == 0:
+                return text[start : index + 1]
+    return ""
+
+
+def extract_models_from_json(document: Any) -> list[dict[str, Any]]:
+    """Recursively extract explicit model price rows from JSON payloads."""
+    models = []
+    if isinstance(document, dict):
+        row = model_from_mapping(document)
+        if row:
+            models.append(row)
+        for value in document.values():
+            models.extend(extract_models_from_json(value))
+    elif isinstance(document, list):
+        for item in document:
+            models.extend(extract_models_from_json(item))
+    return models
+
+
+def model_from_mapping(item: dict[str, Any]) -> dict[str, Any]:
+    """Build one model from a structured row with explicit token prices."""
+    model_name = value_for_keys(item, MODEL_KEYS)
+    input_price = value_for_keys(item, INPUT_PRICE_KEYS)
+    output_price = value_for_keys(item, OUTPUT_PRICE_KEYS)
+    if not model_name or input_price is None or output_price is None:
+        return {}
+    input_value = parse_price(input_price)
+    output_value = parse_price(output_price)
+    if input_value is None or output_value is None:
+        return {}
+    model_id = model_id_from_name(model_name)
+    if not model_id:
+        return {}
+    return {
+        "model_id": model_id,
+        "model_name": model_id,
+        "display_name": display_name_from_cell(model_name),
+        "aliases": aliases_for_model(model_id, model_name),
+        "input_price_per_million": input_value,
+        "output_price_per_million": output_value,
+        "currency": DEFAULT_CURRENCY,
+        "notes": "Extracted from BigModel official pricing data.",
+    }
+
+
+MODEL_KEYS = {
+    "model",
+    "modelcode",
+    "modelid",
+    "modelname",
+    "name",
+    "productname",
+    "模型",
+    "模型名称",
+}
+INPUT_PRICE_KEYS = {
+    "input",
+    "inputprice",
+    "inputtokenprice",
+    "inputunitprice",
+    "promptprice",
+    "prompttokenprice",
+    "promptunitprice",
+    "输入",
+    "输入价格",
+    "输入单价",
+}
+OUTPUT_PRICE_KEYS = {
+    "completionprice",
+    "completiontokenprice",
+    "completionunitprice",
+    "output",
+    "outputprice",
+    "outputtokenprice",
+    "outputunitprice",
+    "输出",
+    "输出价格",
+    "输出单价",
+}
+
+
+def value_for_keys(item: dict[str, Any], accepted_keys: set[str]) -> Any:
+    """Return the first value matching a normalized key name."""
+    for key, value in item.items():
+        normalized_key = normalize_key(key)
+        if normalized_key in accepted_keys:
+            return value
+    return None
+
+
+def normalize_key(value: Any) -> str:
+    """Normalize a source key for pricing field matching."""
+    text = str(value or "").strip().lower()
+    return re.sub(r"[\s_\-/.()]+", "", text)
+
+
+def extract_models_from_tables(content: str) -> list[dict[str, Any]]:
+    """Extract model rows from plain HTML pricing tables."""
+    models = []
+    for table_html in re.findall(
+        r"<table\b.*?</table>",
+        str(content or ""),
+        flags=re.DOTALL | re.IGNORECASE,
+    ):
+        models.extend(models_from_table(table_html))
+    return models
+
+
+def models_from_table(table_html: str) -> list[dict[str, Any]]:
+    """Build Zhipu model rows from one HTML table."""
+    rows = parse_table_rows(table_html)
+    if len(rows) < 2:
+        return []
+    headers = [normalize_header(value) for value in rows[0]]
+    model_index = first_header_index(
+        headers,
+        {"model", "模型", "模型名称"},
+    )
+    input_index = first_header_index(
+        headers,
+        {"input", "输入", "输入价格"},
+    )
+    output_index = first_header_index(
+        headers,
+        {"output", "输出", "输出价格"},
+    )
+    if model_index < 0 or input_index < 0 or output_index < 0:
+        return []
+
+    models = []
+    for row in rows[1:]:
+        if max(model_index, input_index, output_index) >= len(row):
+            continue
+        item = model_from_mapping(
+            {
+                "model": row[model_index],
+                "input": row[input_index],
+                "output": row[output_index],
+            }
+        )
+        if item:
+            models.append(item)
+    return models
+
+
+def parse_table_rows(table_html: str) -> list[list[str]]:
+    """Parse simple HTML table rows into normalized cell text."""
+    rows = []
+    for row_html in re.findall(
+        r"<tr\b.*?</tr>",
+        table_html,
+        flags=re.DOTALL | re.IGNORECASE,
+    ):
+        cells = []
+        for cell_html in re.findall(
+            r"<(?:td|th)\b[^>]*>(.*?)</(?:td|th)>",
+            row_html,
+            flags=re.DOTALL | re.IGNORECASE,
+        ):
+            cells.append(clean_cell_text(cell_html))
+        if cells:
+            rows.append(cells)
+    return rows
+
+
+def clean_cell_text(inner_html: str) -> str:
+    """Convert one HTML cell body into normalized text."""
+    text = re.sub(r"<br\s*/?>", "\n", inner_html, flags=re.IGNORECASE)
+    text = re.sub(r"</(?:p|blockquote|div)>", "\n", text, flags=re.I)
+    text = re.sub(r"<[^>]+>", " ", text)
+    text = unescape(text).replace("\xa0", " ")
+    lines = [re.sub(r"\s+", " ", line).strip() for line in text.splitlines()]
+    return "\n".join(line for line in lines if line)
+
+
+def normalize_header(value: str) -> str:
+    """Normalize a table header for field matching."""
+    text = re.sub(r"\s+", " ", str(value or "").strip().lower())
+    if "model" in text or "模型" in text:
+        return "model"
+    if "input" in text or "prompt" in text or "输入" in text:
+        return "input"
+    if "output" in text or "completion" in text or "输出" in text:
+        return "output"
+    return text
+
+
+def first_header_index(headers: list[str], candidates: set[str]) -> int:
+    """Return the first matching header index, or -1."""
+    for index, header in enumerate(headers):
+        if header in candidates:
+            return index
+    return -1
+
+
+def parse_price(value: Any) -> str | None:
+    """Parse a non-negative CNY token price into CNY per 1M tokens."""
+    text = str(value or "").replace(",", "").strip()
+    if not text or text in {"-", "n/a", "N/A"}:
+        return None
+    match = re.search(r"(?:¥|￥|CNY|RMB)?\s*([0-9]+(?:\.[0-9]+)?)", text)
+    if not match:
+        return None
+    try:
+        amount = Decimal(match.group(1))
+    except (InvalidOperation, ValueError):
+        return None
+    if amount < 0:
+        return None
+    if is_per_thousand_tokens(text):
+        amount *= Decimal("1000")
+    return format_decimal(amount)
+
+
+def is_per_thousand_tokens(text: str) -> bool:
+    """Return whether a price is published per thousand tokens."""
+    normalized = re.sub(r"\s+", "", text.lower())
+    if "百万" in normalized or "1m" in normalized:
+        return False
+    return "千tokens" in normalized or "千token" in normalized
+
+
+def format_decimal(value: Decimal) -> str:
+    """Format a decimal as a compact price string."""
+    formatted = format(value.normalize(), "f")
+    if "." in formatted:
+        formatted = formatted.rstrip("0").rstrip(".")
+    return formatted or "0"
+
+
+def model_id_from_name(value: Any) -> str:
+    """Normalize a BigModel display name into a model ID."""
+    text = display_name_from_cell(value)
+    if not text:
+        return ""
+    text = re.sub(r"\([^)]*\)", " ", text)
+    text = re.sub(r"（[^）]*）", " ", text)
+    text = re.sub(r"[^A-Za-z0-9.]+", "-", text)
+    return text.strip("-").lower()
+
+
+def display_name_from_cell(value: Any) -> str:
+    """Return a readable model name from a table or JSON value."""
+    text = re.sub(r"\s+", " ", str(value or "").replace("\n", " "))
+    return text.strip()
+
+
+def aliases_for_model(model_id: str, display_name: Any) -> list[str]:
+    """Return matching aliases for one Zhipu model row."""
+    aliases = [model_id]
+    original = display_name_from_cell(display_name)
+    if original and original not in aliases:
+        aliases.append(original)
+    return aliases
+
+
+def upsert_model(
+    models: dict[str, dict[str, Any]],
+    item: dict[str, Any],
+) -> None:
+    """Merge one parsed Zhipu model into the extracted catalog."""
+    model_id = item["model_id"]
+    if model_id not in models:
+        models[model_id] = item

--- a/backend/llm_ops/price_collectors/registry.py
+++ b/backend/llm_ops/price_collectors/registry.py
@@ -4,16 +4,28 @@ from typing import Any
 
 from .base import VendorPriceCatalogCollector
 from .parsers.aliyun import AliyunPriceCatalogCollector
+from .parsers.anthropic import AnthropicPriceCatalogCollector
 from .parsers.azure_openai import AzureOpenAIPriceCatalogCollector
+from .parsers.baidu import BaiduPriceCatalogCollector
 from .parsers.deepseek import DeepSeekPriceCatalogCollector
+from .parsers.google import GooglePriceCatalogCollector
+from .parsers.minimax import MiniMaxPriceCatalogCollector
 from .parsers.siliconflow import SiliconFlowPriceCatalogCollector
+from .parsers.volcengine import VolcEnginePriceCatalogCollector
+from .parsers.zhipu import ZhipuPriceCatalogCollector
 
 
 PRICE_CATALOG_COLLECTORS: dict[str, VendorPriceCatalogCollector] = {
     "aliyun": AliyunPriceCatalogCollector(),
+    "anthropic": AnthropicPriceCatalogCollector(),
     "azure-openai": AzureOpenAIPriceCatalogCollector(),
+    "baidu": BaiduPriceCatalogCollector(),
     "deepseek": DeepSeekPriceCatalogCollector(),
+    "google": GooglePriceCatalogCollector(),
+    "minimax": MiniMaxPriceCatalogCollector(),
     "siliconflow": SiliconFlowPriceCatalogCollector(),
+    "volcengine": VolcEnginePriceCatalogCollector(),
+    "zhipu": ZhipuPriceCatalogCollector(),
 }
 
 

--- a/backend/llm_ops/skill_runner.py
+++ b/backend/llm_ops/skill_runner.py
@@ -123,6 +123,14 @@ def standard_catalog_run_metadata(payload: dict[str, Any]) -> dict[str, Any]:
     if raw_payload.get("collector"):
         metadata["vendor_catalog_collector"] = raw_payload["collector"]
         metadata["vendor_skill_collector"] = raw_payload["collector"]
+    if "fallback_used" in raw_payload:
+        metadata["vendor_catalog_fallback_used"] = bool(
+            raw_payload.get("fallback_used")
+        )
+    if raw_payload.get("fallback_reason"):
+        metadata["vendor_catalog_fallback_reason"] = str(
+            raw_payload.get("fallback_reason")
+        )
     return metadata
 
 

--- a/backend/llm_ops/tests/test_anthropic_price_collector.py
+++ b/backend/llm_ops/tests/test_anthropic_price_collector.py
@@ -1,0 +1,82 @@
+from django.test import SimpleTestCase
+
+from llm_ops.price_collectors import collect_vendor_price_catalog
+from llm_ops.price_collectors.parsers.anthropic import extract_models
+
+
+ANTHROPIC_PRICING_MARKDOWN = "\n".join(
+    [
+        "## Model pricing",
+        "",
+        (
+            "| Model | Base Input Tokens | 5m Cache Writes | "
+            "1h Cache Writes | Cache Hits & Refreshes | Output Tokens |"
+        ),
+        (
+            "| ----- | ----------------- | --------------- | "
+            "--------------- | ---------------------- | ------------- |"
+        ),
+        (
+            "| Claude Fable 5 | $10 / MTok | $12.50 / MTok | "
+            "$20 / MTok | $1 / MTok | $50 / MTok |"
+        ),
+        (
+            "| Claude Mythos 5 ([limited availability]"
+            "(https://anthropic.com/glasswing)) | $10 / MTok | "
+            "$12.50 / MTok | $20 / MTok | $1 / MTok | $50 / MTok |"
+        ),
+        (
+            "| Claude Opus 4.8 | $5 / MTok | $6.25 / MTok | "
+            "$10 / MTok | $0.50 / MTok | $25 / MTok |"
+        ),
+        (
+            "| Claude Sonnet 4.5 | $3 / MTok | $3.75 / MTok | "
+            "$6 / MTok | $0.30 / MTok | $15 / MTok |"
+        ),
+    ]
+)
+
+
+class AnthropicPriceCatalogCollectorTests(SimpleTestCase):
+    def test_extract_models_reads_model_pricing_table(self):
+        models = extract_models(ANTHROPIC_PRICING_MARKDOWN)
+
+        opus = next(
+            item for item in models if item["model_id"] == "claude-opus-4-8"
+        )
+        mythos = next(
+            item
+            for item in models
+            if item["model_id"] == "claude-mythos-5"
+        )
+
+        self.assertEqual(opus["input_price_per_million"], "5")
+        self.assertEqual(opus["output_price_per_million"], "25")
+        self.assertEqual(
+            opus["price_rows"][0]["cache_hit_price_per_million"],
+            "0.50",
+        )
+        self.assertEqual(mythos["display_name"], "Claude Mythos 5")
+
+    def test_collect_vendor_price_catalog_returns_anthropic_payload(self):
+        payload = collect_vendor_price_catalog(
+            "anthropic",
+            {
+                "raw_markdown": ANTHROPIC_PRICING_MARKDOWN,
+                "source_url": "https://example.com/anthropic-pricing",
+                "provider_name": "Anthropic",
+                "model_codes": ["claude-sonnet-4-5"],
+            },
+        )
+
+        self.assertEqual(
+            payload["schema_version"],
+            "llm_ops.model_price_catalog.v1",
+        )
+        self.assertEqual(payload["provider"]["code"], "anthropic")
+        self.assertEqual(payload["provider"]["currency"], "USD")
+        self.assertEqual(payload["total_models"], 1)
+        self.assertEqual(
+            payload["models"][0]["model_id"],
+            "claude-sonnet-4-5",
+        )

--- a/backend/llm_ops/tests/test_baidu_price_collector.py
+++ b/backend/llm_ops/tests/test_baidu_price_collector.py
@@ -1,0 +1,97 @@
+from django.test import SimpleTestCase
+
+from llm_ops.price_collectors import collect_vendor_price_catalog
+from llm_ops.price_collectors.parsers.baidu import extract_models
+
+
+BAIDU_PRICING_HTML = """
+<table>
+  <tr>
+    <th>模型名称</th><th>版本</th><th>服务</th><th>计费项</th>
+    <th>在线价格</th><th>预留</th><th>预留</th><th>预留</th>
+    <th>单位</th>
+  </tr>
+  <tr>
+    <td>文本</td><td>ERNIE-4.5-21B-A3B</td><td>推理服务</td>
+    <td>输入</td><td>0.001</td><td>-</td><td>-</td><td>-</td>
+    <td>千Token</td>
+  </tr>
+  <tr>
+    <td>文本</td><td>ERNIE-4.5-21B-A3B</td><td>推理服务</td>
+    <td>输出</td><td>0.004</td><td>-</td><td>-</td><td>-</td>
+    <td>千Token</td>
+  </tr>
+</table>
+"""
+
+BAIDU_CACHE_PRICING_HTML = """
+<table>
+  <tr>
+    <th>模型名称</th><th>版本</th><th>服务</th><th>计费项</th>
+    <th>在线价格</th><th>预留</th><th>预留</th><th>预留</th>
+    <th>单位</th>
+  </tr>
+  <tr>
+    <td>文本</td><td>ERNIE-4.5-Turbo-128K</td><td>推理服务</td>
+    <td>0-128K输入</td><td>0.0008</td><td>-</td><td>-</td><td>-</td>
+    <td>千Tokens</td>
+  </tr>
+  <tr>
+    <td>文本</td><td>ERNIE-4.5-Turbo-128K</td><td>推理服务</td>
+    <td>命中缓存输入</td><td>0.00008</td>
+    <td>-</td><td>-</td><td>-</td><td>千Tokens</td>
+  </tr>
+  <tr>
+    <td>文本</td><td>ERNIE-4.5-Turbo-128K</td><td>推理服务</td>
+    <td>输出</td><td>0.0032</td><td>-</td><td>-</td><td>-</td>
+    <td>千Tokens</td>
+  </tr>
+</table>
+"""
+
+
+class BaiduPriceCatalogCollectorTests(SimpleTestCase):
+    def test_extract_models_from_qianfan_pricing_table(self):
+        models = extract_models(BAIDU_PRICING_HTML)
+
+        self.assertEqual(len(models), 1)
+        self.assertEqual(models[0]["model_id"], "ERNIE-4.5-21B-A3B")
+        self.assertEqual(models[0]["input_price_per_million"], "1")
+        self.assertEqual(models[0]["output_price_per_million"], "4")
+
+    def test_extract_models_preserves_cache_hit_price(self):
+        models = extract_models(BAIDU_CACHE_PRICING_HTML)
+
+        self.assertEqual(len(models), 1)
+        self.assertEqual(models[0]["model_id"], "ERNIE-4.5-Turbo-128K")
+        self.assertEqual(models[0]["input_price_per_million"], "0.8")
+        self.assertEqual(models[0]["output_price_per_million"], "3.2")
+        self.assertEqual(models[0]["cache_hit_price_per_million"], "0.08")
+
+    def test_collect_vendor_price_catalog_returns_baidu_payload(self):
+        payload = collect_vendor_price_catalog(
+            "baidu",
+            {
+                "provider_name": "百度千帆",
+                "currency": "CNY",
+                "raw_html": BAIDU_PRICING_HTML,
+                "model_codes": ["ERNIE-4.5-21B-A3B"],
+            },
+        )
+
+        self.assertEqual(
+            payload["schema_version"],
+            "llm_ops.model_price_catalog.v1",
+        )
+        self.assertEqual(payload["provider"]["code"], "baidu")
+        self.assertEqual(payload["provider"]["currency"], "CNY")
+        self.assertEqual(payload["total_models"], 1)
+        self.assertEqual(payload["models"][0]["model_id"], "ERNIE-4.5-21B-A3B")
+        self.assertEqual(
+            payload["models"][0]["price_rows"][0]["values"]["input_price"],
+            "1",
+        )
+        self.assertEqual(
+            payload["models"][0]["price_rows"][0]["values"]["output_price"],
+            "4",
+        )

--- a/backend/llm_ops/tests/test_google_price_collector.py
+++ b/backend/llm_ops/tests/test_google_price_collector.py
@@ -1,0 +1,125 @@
+from django.test import SimpleTestCase
+
+from llm_ops.price_collectors import collect_vendor_price_catalog
+from llm_ops.price_collectors.parsers.google import extract_models
+
+
+GOOGLE_PRICING_HTML = """
+<h3>Gemini 2.5</h3>
+<table>
+  <tr>
+    <th>Model</th>
+    <th>Type</th>
+    <th>Price (/1M tokens) <= 200K input tokens</th>
+    <th>Price (/1M tokens) > 200K input tokens</th>
+    <th>Price (/1M cached input tokens) <= 200K</th>
+    <th>Price (/1M cached input tokens) > 200K</th>
+  </tr>
+  <tr>
+    <td rowspan="3">Gemini 2.5 Pro</td>
+    <td>Input (text, image, video, audio)</td>
+    <td>$1.25</td>
+    <td>$2.50</td>
+    <td>$0.13</td>
+    <td>$0.25</td>
+  </tr>
+  <tr>
+    <td>Output (text)</td>
+    <td>$10.00</td>
+    <td>$15.00</td>
+    <td>-</td>
+    <td>-</td>
+  </tr>
+  <tr>
+    <td>Output (audio)</td>
+    <td>$20.00</td>
+    <td>$30.00</td>
+    <td>-</td>
+    <td>-</td>
+  </tr>
+</table>
+<h3>Flex/Batch</h3>
+<table>
+  <tr><th>Model</th><th>Type</th><th>Price</th></tr>
+  <tr>
+    <td rowspan="2">Gemini 2.5 Pro</td>
+    <td>Input (text)</td>
+    <td>$0.62</td>
+  </tr>
+  <tr><td>Output (text)</td><td>$5.00</td></tr>
+</table>
+<h3>Gemini 2.0</h3>
+<table>
+  <tr><th>Model</th><th>Type</th><th>Price</th></tr>
+  <tr>
+    <td rowspan="3">Gemini 2.0 Flash</td>
+    <td>1M Input tokens</td>
+    <td>$0.15</td>
+  </tr>
+  <tr><td>1M Input audio tokens</td><td>$1.00</td></tr>
+  <tr><td>1M Output text tokens</td><td>$0.60</td></tr>
+</table>
+"""
+
+
+class GooglePriceCatalogCollectorTests(SimpleTestCase):
+    def test_extract_models_preserves_standard_context_tiers(self):
+        models = extract_models(GOOGLE_PRICING_HTML)
+
+        pro = next(
+            item for item in models if item["model_id"] == "gemini-2.5-pro"
+        )
+        self.assertEqual(pro["input_price_per_million"], "1.25")
+        self.assertEqual(pro["output_price_per_million"], "10.00")
+        self.assertEqual(len(pro["price_rows"]), 2)
+        self.assertEqual(
+            pro["price_rows"][0]["input_token_range"],
+            "0-200000",
+        )
+        self.assertEqual(
+            pro["price_rows"][1]["input_token_range"],
+            "200001-",
+        )
+        self.assertEqual(
+            pro["price_rows"][0]["cache_hit_price_per_million"],
+            "0.13",
+        )
+
+    def test_extract_models_skips_batch_and_audio_only_prices(self):
+        models = extract_models(GOOGLE_PRICING_HTML)
+
+        pro = next(
+            item for item in models if item["model_id"] == "gemini-2.5-pro"
+        )
+        flash = next(
+            item
+            for item in models
+            if item["model_id"] == "gemini-2.0-flash"
+        )
+
+        self.assertNotEqual(pro["input_price_per_million"], "0.62")
+        self.assertEqual(flash["input_price_per_million"], "0.15")
+        self.assertEqual(flash["output_price_per_million"], "0.60")
+
+    def test_collect_vendor_price_catalog_returns_google_payload(self):
+        payload = collect_vendor_price_catalog(
+            "google",
+            {
+                "raw_html": GOOGLE_PRICING_HTML,
+                "source_url": "https://example.com/google-pricing",
+                "provider_name": "Google",
+                "model_codes": ["gemini-2.0-flash"],
+            },
+        )
+
+        self.assertEqual(
+            payload["schema_version"],
+            "llm_ops.model_price_catalog.v1",
+        )
+        self.assertEqual(payload["provider"]["code"], "google")
+        self.assertEqual(payload["provider"]["currency"], "USD")
+        self.assertEqual(payload["total_models"], 1)
+        self.assertEqual(
+            payload["models"][0]["model_id"],
+            "gemini-2.0-flash",
+        )

--- a/backend/llm_ops/tests/test_minimax_price_collector.py
+++ b/backend/llm_ops/tests/test_minimax_price_collector.py
@@ -1,0 +1,142 @@
+import json
+
+from django.test import SimpleTestCase
+
+from llm_ops.price_collectors import collect_vendor_price_catalog
+from llm_ops.price_collectors.parsers.minimax import extract_models
+
+
+MINIMAX_PRICING_JSON = json.dumps(
+    {
+        "apiPricing": {
+            "currencySymbol": "¥",
+            "m3": {
+                "prices": [
+                    {
+                        "model": "MiniMax-M2.1",
+                        "input": "0.8",
+                        "output": "8",
+                    },
+                    {
+                        "model": "MiniMax-Text-01",
+                        "inputPrice": "¥1 / 1M tokens",
+                        "outputPrice": "¥8 / 1M tokens",
+                    },
+                ],
+            },
+        },
+    }
+)
+
+MINIMAX_PRICING_TABLE = """
+<table>
+  <tr>
+    <th>模型</th>
+    <th>输入</th>
+    <th>输出</th>
+  </tr>
+  <tr>
+    <td>MiniMax-M2.1</td>
+    <td>¥0.8 / 百万 tokens</td>
+    <td>¥8 / 百万 tokens</td>
+  </tr>
+</table>
+"""
+
+MINIMAX_THOUSAND_TOKEN_TABLE = """
+<table>
+  <tr>
+    <th>模型</th>
+    <th>输入</th>
+    <th>输出</th>
+  </tr>
+  <tr>
+    <td>MiniMax-M2.1</td>
+    <td>¥0.0008 / 千 tokens</td>
+    <td>¥0.008 / 千 tokens</td>
+  </tr>
+</table>
+"""
+
+MINIMAX_TOKEN_PLAN_FAQ_HTML = """
+<script id="__NEXT_DATA__" type="application/json">
+{
+  "props": {
+    "pageProps": {
+      "faqs": [
+        {
+          "question": "Token Plan 支持哪些模型？",
+          "answer": "支持所有平台模型；1,000 积分 = ¥7。"
+        }
+      ]
+    }
+  }
+}
+</script>
+"""
+
+
+class MiniMaxPriceCatalogCollectorTests(SimpleTestCase):
+    def test_extract_models_from_structured_api_pricing_json(self):
+        models = extract_models(MINIMAX_PRICING_JSON)
+
+        model_ids = {item["model_id"] for item in models}
+        self.assertEqual(
+            model_ids,
+            {"minimax-m2.1", "minimax-text-01"},
+        )
+        m2 = next(
+            item for item in models if item["model_id"] == "minimax-m2.1"
+        )
+        self.assertEqual(m2["input_price_per_million"], "0.8")
+        self.assertEqual(m2["output_price_per_million"], "8")
+
+    def test_extract_models_from_plain_html_pricing_table(self):
+        models = extract_models(MINIMAX_PRICING_TABLE)
+
+        self.assertEqual(len(models), 1)
+        self.assertEqual(models[0]["model_id"], "minimax-m2.1")
+        self.assertEqual(models[0]["input_price_per_million"], "0.8")
+        self.assertEqual(models[0]["output_price_per_million"], "8")
+
+    def test_extract_models_normalizes_thousand_token_prices(self):
+        models = extract_models(MINIMAX_THOUSAND_TOKEN_TABLE)
+
+        self.assertEqual(len(models), 1)
+        self.assertEqual(models[0]["model_id"], "minimax-m2.1")
+        self.assertEqual(models[0]["input_price_per_million"], "0.8")
+        self.assertEqual(models[0]["output_price_per_million"], "8")
+
+    def test_token_plan_faq_without_model_prices_returns_empty_catalog(self):
+        payload = collect_vendor_price_catalog(
+            "minimax",
+            {
+                "raw_html": MINIMAX_TOKEN_PLAN_FAQ_HTML,
+                "source_url": "https://example.com/minimax-token-plan",
+            },
+        )
+
+        self.assertEqual(payload["provider"]["code"], "minimax")
+        self.assertEqual(payload["provider"]["currency"], "CNY")
+        self.assertEqual(payload["total_models"], 0)
+        self.assertEqual(payload["models"], [])
+
+    def test_collect_vendor_price_catalog_returns_minimax_payload(self):
+        payload = collect_vendor_price_catalog(
+            "minimax",
+            {
+                "raw_html": MINIMAX_PRICING_TABLE,
+                "source_url": "https://example.com/minimax-pricing",
+                "provider_name": "MiniMax",
+                "model_codes": ["minimax-m2.1"],
+            },
+        )
+
+        self.assertEqual(
+            payload["schema_version"],
+            "llm_ops.model_price_catalog.v1",
+        )
+        self.assertEqual(payload["provider"]["code"], "minimax")
+        self.assertEqual(payload["provider"]["currency"], "CNY")
+        self.assertEqual(payload["total_models"], 1)
+        self.assertEqual(payload["models"][0]["model_id"], "minimax-m2.1")

--- a/backend/llm_ops/tests/test_source_collectors.py
+++ b/backend/llm_ops/tests/test_source_collectors.py
@@ -5,6 +5,7 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase
 
 from llm_ops.collection_services import (
+    sync_vendor_price_source_catalog,
     sync_model_price_items,
     upsert_collected_snapshot,
     upsert_collected_offering,
@@ -116,6 +117,175 @@ class PriceSourceCollectorRegistryTests(TestCase):
                 "https://azure.microsoft.com/en-us/pricing/details/"
                 "azure-openai/#pricing"
             ),
+            collection_method=(
+                PriceCollectionSource.COLLECTION_METHOD_AUTO_COLLECT
+            ),
+            is_enabled=True,
+            updates_model_prices=True,
+        )
+
+        collector = get_price_source_collector(source)
+
+        self.assertIsNotNone(collector)
+        self.assertEqual(collector.collector_id, "auto_price_source")
+        self.assertTrue(source_supports_code_collection(source))
+
+    def test_anthropic_source_dispatches_to_official_collector(self):
+        provider = LLMProvider.objects.create(
+            name="Anthropic",
+            code="anthropic",
+        )
+        source = PriceCollectionSource.objects.create(
+            name="Anthropic Official",
+            slug="anthropic-official",
+            provider=provider,
+            source_type=PriceCollectionSource.SOURCE_TYPE_CUSTOM,
+            source_category=(
+                PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
+            ),
+            endpoint_url=(
+                "https://docs.anthropic.com/en/docs/about-claude/pricing"
+            ),
+            collection_method=(
+                PriceCollectionSource.COLLECTION_METHOD_AUTO_COLLECT
+            ),
+            is_enabled=True,
+            updates_model_prices=True,
+        )
+
+        collector = get_price_source_collector(source)
+
+        self.assertIsNotNone(collector)
+        self.assertEqual(collector.collector_id, "auto_price_source")
+        self.assertTrue(source_supports_code_collection(source))
+
+    def test_baidu_source_dispatches_to_official_collector(self):
+        provider = LLMProvider.objects.create(
+            name="百度千帆",
+            code="baidu",
+        )
+        source = PriceCollectionSource.objects.create(
+            name="Baidu Qianfan Official",
+            slug="baidu-official",
+            provider=provider,
+            source_type=PriceCollectionSource.SOURCE_TYPE_CUSTOM,
+            source_category=(
+                PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
+            ),
+            endpoint_url="https://cloud.baidu.com/doc/qianfan/s/wmh4sv6ya",
+            collection_method=(
+                PriceCollectionSource.COLLECTION_METHOD_AUTO_COLLECT
+            ),
+            is_enabled=True,
+            updates_model_prices=True,
+        )
+
+        collector = get_price_source_collector(source)
+
+        self.assertIsNotNone(collector)
+        self.assertEqual(collector.collector_id, "auto_price_source")
+        self.assertTrue(source_supports_code_collection(source))
+
+    def test_google_source_dispatches_to_official_collector(self):
+        provider = LLMProvider.objects.create(name="Google", code="google")
+        source = PriceCollectionSource.objects.create(
+            name="Google Gemini Official",
+            slug="google-official",
+            provider=provider,
+            source_type=PriceCollectionSource.SOURCE_TYPE_CUSTOM,
+            source_category=(
+                PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
+            ),
+            endpoint_url=(
+                "https://cloud.google.com/gemini-enterprise-agent-platform/"
+                "generative-ai/pricing?hl=en"
+            ),
+            collection_method=(
+                PriceCollectionSource.COLLECTION_METHOD_AUTO_COLLECT
+            ),
+            is_enabled=True,
+            updates_model_prices=True,
+        )
+
+        collector = get_price_source_collector(source)
+
+        self.assertIsNotNone(collector)
+        self.assertEqual(collector.collector_id, "auto_price_source")
+        self.assertTrue(source_supports_code_collection(source))
+
+    def test_minimax_source_dispatches_to_official_collector(self):
+        provider = LLMProvider.objects.create(
+            name="MiniMax",
+            code="minimax",
+        )
+        source = PriceCollectionSource.objects.create(
+            name="MiniMax Official",
+            slug="minimax-official",
+            provider=provider,
+            source_type=PriceCollectionSource.SOURCE_TYPE_CUSTOM,
+            source_category=(
+                PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
+            ),
+            endpoint_url=(
+                "https://platform.minimaxi.com/subscribe/"
+                "token-plan?tab=api-enterprise"
+            ),
+            collection_method=(
+                PriceCollectionSource.COLLECTION_METHOD_AUTO_COLLECT
+            ),
+            is_enabled=True,
+            updates_model_prices=True,
+        )
+
+        collector = get_price_source_collector(source)
+
+        self.assertIsNotNone(collector)
+        self.assertEqual(collector.collector_id, "auto_price_source")
+        self.assertTrue(source_supports_code_collection(source))
+
+    def test_volcengine_source_dispatches_to_official_collector(self):
+        provider = LLMProvider.objects.create(
+            name="火山方舟",
+            code="volcengine",
+        )
+        source = PriceCollectionSource.objects.create(
+            name="VolcEngine Official",
+            slug="volcengine-official",
+            provider=provider,
+            source_type=PriceCollectionSource.SOURCE_TYPE_CUSTOM,
+            source_category=(
+                PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
+            ),
+            endpoint_url=(
+                "https://www.volcengine.com/docs/82379/1544106?lang=zh"
+            ),
+            collection_method=(
+                PriceCollectionSource.COLLECTION_METHOD_AUTO_COLLECT
+            ),
+            is_enabled=True,
+            updates_model_prices=True,
+        )
+
+        collector = get_price_source_collector(source)
+
+        self.assertIsNotNone(collector)
+        self.assertEqual(collector.collector_id, "auto_price_source")
+        self.assertTrue(source_supports_code_collection(source))
+
+    def test_zhipu_source_dispatches_to_official_collector(self):
+        provider = LLMProvider.objects.create(
+            name="智谱",
+            code="zhipu",
+        )
+        source = PriceCollectionSource.objects.create(
+            name="Zhipu Official",
+            slug="zhipu-official",
+            provider=provider,
+            source_type=PriceCollectionSource.SOURCE_TYPE_CUSTOM,
+            source_category=(
+                PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
+            ),
+            endpoint_url="https://bigmodel.cn/pricing",
             collection_method=(
                 PriceCollectionSource.COLLECTION_METHOD_AUTO_COLLECT
             ),
@@ -313,6 +483,101 @@ class PriceSourceCollectorRegistryTests(TestCase):
 
         self.assertIsNone(get_price_source_collector(source))
         self.assertFalse(source_supports_code_collection(source))
+
+    def test_source_sync_fails_when_catalog_is_empty(self):
+        provider = LLMProvider.objects.create(
+            name="MiniMax",
+            code="minimax",
+        )
+        source = PriceCollectionSource.objects.create(
+            name="MiniMax Official",
+            slug="minimax-official",
+            provider=provider,
+            source_type=PriceCollectionSource.SOURCE_TYPE_CUSTOM,
+            source_category=(
+                PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
+            ),
+            endpoint_url=(
+                "https://platform.minimaxi.com/subscribe/"
+                "token-plan?tab=api-enterprise"
+            ),
+            collection_method=(
+                PriceCollectionSource.COLLECTION_METHOD_AUTO_COLLECT
+            ),
+            is_enabled=True,
+            updates_model_prices=True,
+        )
+
+        with mock.patch(
+            "llm_ops.collection_services.collect_vendor_price_catalog"
+        ) as mock_collect:
+            mock_collect.return_value = {
+                "schema_version": "llm_ops.model_price_catalog.v1",
+                "source_type": "provider_adapter",
+                "source_url": source.endpoint_url,
+                "total_models": 0,
+                "provider": {
+                    "code": "minimax",
+                    "name": "MiniMax",
+                    "currency": "CNY",
+                },
+                "models": [],
+                "notes": "",
+                "raw_payload": {
+                    "collector": "llm_ops.price_collectors.minimax",
+                },
+            }
+            with self.assertRaisesMessage(
+                ValueError,
+                "returned no models",
+            ):
+                sync_vendor_price_source_catalog(
+                    provider_code="minimax",
+                    source=source,
+                    verify_source=True,
+                )
+
+        run = PriceCollectionRun.objects.get(source=source)
+        self.assertEqual(run.status, PriceCollectionRun.STATUS_FAILED)
+        self.assertIn("returned no models", run.error_message)
+
+    def test_source_sync_preserves_collector_value_errors(self):
+        provider = LLMProvider.objects.create(
+            name="DeepSeek",
+            code="deepseek",
+        )
+        source = PriceCollectionSource.objects.create(
+            name="DeepSeek Official",
+            slug="deepseek-official",
+            provider=provider,
+            source_type=PriceCollectionSource.SOURCE_TYPE_CUSTOM,
+            source_category=(
+                PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
+            ),
+            endpoint_url=(
+                "https://api-docs.deepseek.com/zh-cn/quick_start/pricing"
+            ),
+            collection_method=(
+                PriceCollectionSource.COLLECTION_METHOD_AUTO_COLLECT
+            ),
+            is_enabled=True,
+            updates_model_prices=True,
+        )
+
+        with mock.patch(
+            "llm_ops.collection_services.collect_vendor_price_catalog"
+        ) as mock_collect:
+            mock_collect.side_effect = ValueError("bad parser payload")
+            with self.assertRaisesMessage(ValueError, "bad parser payload"):
+                sync_vendor_price_source_catalog(
+                    provider_code="deepseek",
+                    source=source,
+                    verify_source=True,
+                )
+
+        run = PriceCollectionRun.objects.get(source=source)
+        self.assertEqual(run.status, PriceCollectionRun.STATUS_FAILED)
+        self.assertEqual(run.error_message, "bad parser payload")
 
 
 class PriceCollectionSkuPersistenceTests(TestCase):

--- a/backend/llm_ops/tests/test_views.py
+++ b/backend/llm_ops/tests/test_views.py
@@ -963,7 +963,7 @@ class LLMOpsViewTests(TestCase):
             is_enabled=True,
             updates_model_prices=True,
         )
-        PriceCollectionSource.objects.create(
+        aliyun_qwen_source = PriceCollectionSource.objects.create(
             name="Aliyun Qwen Plus Official",
             slug="aliyun-qwen-plus-official",
             provider=aliyun,
@@ -991,13 +991,21 @@ class LLMOpsViewTests(TestCase):
 
         self.assertEqual(response.status_code, 202)
         self.assertEqual(response.data["task_id"], "task-all")
-        self.assertEqual(response.data["source_count"], 2)
+        self.assertEqual(response.data["source_count"], 3)
         self.assertEqual(
             response.data["source_ids"],
-            [aliyun_source.id, siliconflow_source.id],
+            [
+                aliyun_source.id,
+                aliyun_qwen_source.id,
+                siliconflow_source.id,
+            ],
         )
         mock_delay.assert_called_once_with(
-            source_ids=[aliyun_source.id, siliconflow_source.id],
+            source_ids=[
+                aliyun_source.id,
+                aliyun_qwen_source.id,
+                siliconflow_source.id,
+            ],
             verify_source=True,
         )
         audit = AuditLog.objects.get(
@@ -1007,7 +1015,11 @@ class LLMOpsViewTests(TestCase):
         self.assertEqual(audit.metadata["task_id"], "task-all")
         self.assertEqual(
             audit.metadata["source_ids"],
-            [aliyun_source.id, siliconflow_source.id],
+            [
+                aliyun_source.id,
+                aliyun_qwen_source.id,
+                siliconflow_source.id,
+            ],
         )
 
     @patch("llm_ops.views.run_model_price_sync_agent.delay")
@@ -1030,7 +1042,17 @@ class LLMOpsViewTests(TestCase):
             item["provider_code"] for item in response.data["results"]
         }
         self.assertEqual(
-            {"aliyun", "azure-openai", "deepseek"},
+            {
+                "aliyun",
+                "anthropic",
+                "azure-openai",
+                "baidu",
+                "deepseek",
+                "google",
+                "minimax",
+                "volcengine",
+                "zhipu",
+            },
             provider_codes,
         )
 
@@ -1044,7 +1066,18 @@ class LLMOpsViewTests(TestCase):
             item["provider_code"] for item in response.data["results"]
         }
         self.assertEqual(
-            {"aliyun", "azure-openai", "deepseek", "siliconflow"},
+            {
+                "aliyun",
+                "anthropic",
+                "azure-openai",
+                "baidu",
+                "deepseek",
+                "google",
+                "minimax",
+                "siliconflow",
+                "volcengine",
+                "zhipu",
+            },
             provider_codes,
         )
         azure = next(
@@ -1066,6 +1099,34 @@ class LLMOpsViewTests(TestCase):
             "https://azure.microsoft.com/en-us/pricing/details/"
             "azure-openai/#pricing",
         )
+        anthropic = next(
+            item
+            for item in response.data["results"]
+            if item["provider_code"] == "anthropic"
+        )
+        self.assertEqual(
+            anthropic["source_owner_type"],
+            PriceCollectionSource.SOURCE_OWNER_MODEL_PROVIDER_OFFICIAL,
+        )
+        self.assertEqual(anthropic["currency"], "USD")
+        self.assertEqual(
+            anthropic["source_url"],
+            "https://docs.anthropic.com/en/docs/about-claude/pricing",
+        )
+        baidu = next(
+            item
+            for item in response.data["results"]
+            if item["provider_code"] == "baidu"
+        )
+        self.assertEqual(
+            baidu["source_owner_type"],
+            PriceCollectionSource.SOURCE_OWNER_CLOUD_PROVIDER_OFFICIAL,
+        )
+        self.assertEqual(baidu["currency"], "CNY")
+        self.assertEqual(
+            baidu["source_url"],
+            "https://cloud.baidu.com/doc/qianfan/s/wmh4sv6ya",
+        )
         siliconflow = next(
             item
             for item in response.data["results"]
@@ -1079,6 +1140,61 @@ class LLMOpsViewTests(TestCase):
             siliconflow["source_url"],
             "https://siliconflow.cn/pricing",
         )
+        google = next(
+            item
+            for item in response.data["results"]
+            if item["provider_code"] == "google"
+        )
+        self.assertEqual(
+            google["source_owner_type"],
+            PriceCollectionSource.SOURCE_OWNER_MODEL_PROVIDER_OFFICIAL,
+        )
+        self.assertEqual(google["currency"], "USD")
+        self.assertEqual(
+            google["source_url"],
+            "https://cloud.google.com/gemini-enterprise-agent-platform/"
+            "generative-ai/pricing?hl=en",
+        )
+        minimax = next(
+            item
+            for item in response.data["results"]
+            if item["provider_code"] == "minimax"
+        )
+        self.assertEqual(
+            minimax["source_owner_type"],
+            PriceCollectionSource.SOURCE_OWNER_MODEL_PROVIDER_OFFICIAL,
+        )
+        self.assertEqual(minimax["currency"], "CNY")
+        self.assertEqual(
+            minimax["source_url"],
+            "https://platform.minimaxi.com/subscribe/"
+            "token-plan?tab=api-enterprise",
+        )
+        volcengine = next(
+            item
+            for item in response.data["results"]
+            if item["provider_code"] == "volcengine"
+        )
+        self.assertEqual(
+            volcengine["source_owner_type"],
+            PriceCollectionSource.SOURCE_OWNER_CLOUD_PROVIDER_OFFICIAL,
+        )
+        self.assertEqual(volcengine["currency"], "CNY")
+        self.assertEqual(
+            volcengine["source_url"],
+            "https://www.volcengine.com/docs/82379/1544106?lang=zh",
+        )
+        zhipu = next(
+            item
+            for item in response.data["results"]
+            if item["provider_code"] == "zhipu"
+        )
+        self.assertEqual(
+            zhipu["source_owner_type"],
+            PriceCollectionSource.SOURCE_OWNER_MODEL_PROVIDER_OFFICIAL,
+        )
+        self.assertEqual(zhipu["currency"], "CNY")
+        self.assertEqual(zhipu["source_url"], "https://bigmodel.cn/pricing")
 
     def test_ensure_official_provider_source_creates_aliyun_source(self):
         response = self.client.post(
@@ -1164,6 +1280,208 @@ class LLMOpsViewTests(TestCase):
             "azure-openai/#pricing",
         )
 
+    def test_ensure_official_provider_source_creates_baidu_source(self):
+        response = self.client.post(
+            reverse("collection-source-ensure-official-provider"),
+            {"provider_code": "baidu"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 201)
+        self.assertTrue(response.data["provider_created"])
+        self.assertTrue(response.data["source_created"])
+        self.assertEqual(response.data["source"]["slug"], "baidu-official")
+        self.assertEqual(response.data["source"]["provider_code"], "baidu")
+        self.assertEqual(response.data["source"]["currency"], "CNY")
+        self.assertTrue(response.data["source"]["can_collect_prices"])
+        provider = LLMProvider.objects.get(code="baidu")
+        source = PriceCollectionSource.objects.get(slug="baidu-official")
+        self.assertEqual(source.provider, provider)
+        self.assertEqual(
+            source.source_owner_type,
+            PriceCollectionSource.SOURCE_OWNER_CLOUD_PROVIDER_OFFICIAL,
+        )
+        self.assertEqual(
+            source.collection_method,
+            PriceCollectionSource.COLLECTION_METHOD_AUTO_COLLECT,
+        )
+        self.assertTrue(source.updates_model_prices)
+        self.assertEqual(
+            source.endpoint_url,
+            "https://cloud.baidu.com/doc/qianfan/s/wmh4sv6ya",
+        )
+
+    def test_ensure_official_provider_source_creates_anthropic_source(self):
+        response = self.client.post(
+            reverse("collection-source-ensure-official-provider"),
+            {"provider_code": "anthropic"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 201)
+        self.assertTrue(response.data["provider_created"])
+        self.assertTrue(response.data["source_created"])
+        self.assertEqual(
+            response.data["source"]["slug"],
+            "anthropic-official",
+        )
+        self.assertEqual(
+            response.data["source"]["provider_code"],
+            "anthropic",
+        )
+        self.assertEqual(response.data["source"]["currency"], "USD")
+        self.assertTrue(response.data["source"]["can_collect_prices"])
+        provider = LLMProvider.objects.get(code="anthropic")
+        source = PriceCollectionSource.objects.get(slug="anthropic-official")
+        self.assertEqual(source.provider, provider)
+        self.assertEqual(
+            source.source_owner_type,
+            PriceCollectionSource.SOURCE_OWNER_MODEL_PROVIDER_OFFICIAL,
+        )
+        self.assertEqual(
+            source.collection_method,
+            PriceCollectionSource.COLLECTION_METHOD_AUTO_COLLECT,
+        )
+        self.assertTrue(source.updates_model_prices)
+        self.assertEqual(
+            source.endpoint_url,
+            "https://docs.anthropic.com/en/docs/about-claude/pricing",
+        )
+
+    def test_ensure_official_provider_source_creates_google_source(self):
+        response = self.client.post(
+            reverse("collection-source-ensure-official-provider"),
+            {"provider_code": "google"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 201)
+        self.assertTrue(response.data["provider_created"])
+        self.assertTrue(response.data["source_created"])
+        self.assertEqual(response.data["source"]["slug"], "google-official")
+        self.assertEqual(response.data["source"]["provider_code"], "google")
+        self.assertEqual(response.data["source"]["currency"], "USD")
+        self.assertTrue(response.data["source"]["can_collect_prices"])
+        provider = LLMProvider.objects.get(code="google")
+        source = PriceCollectionSource.objects.get(slug="google-official")
+        self.assertEqual(source.provider, provider)
+        self.assertEqual(
+            source.source_owner_type,
+            PriceCollectionSource.SOURCE_OWNER_MODEL_PROVIDER_OFFICIAL,
+        )
+        self.assertEqual(
+            source.collection_method,
+            PriceCollectionSource.COLLECTION_METHOD_AUTO_COLLECT,
+        )
+        self.assertTrue(source.updates_model_prices)
+        self.assertEqual(
+            source.endpoint_url,
+            "https://cloud.google.com/gemini-enterprise-agent-platform/"
+            "generative-ai/pricing?hl=en",
+        )
+
+    def test_ensure_official_provider_source_creates_minimax_source(self):
+        response = self.client.post(
+            reverse("collection-source-ensure-official-provider"),
+            {"provider_code": "minimax"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 201)
+        self.assertTrue(response.data["provider_created"])
+        self.assertTrue(response.data["source_created"])
+        self.assertEqual(response.data["source"]["slug"], "minimax-official")
+        self.assertEqual(response.data["source"]["provider_code"], "minimax")
+        self.assertEqual(response.data["source"]["currency"], "CNY")
+        self.assertTrue(response.data["source"]["can_collect_prices"])
+        provider = LLMProvider.objects.get(code="minimax")
+        source = PriceCollectionSource.objects.get(slug="minimax-official")
+        self.assertEqual(source.provider, provider)
+        self.assertEqual(
+            source.source_owner_type,
+            PriceCollectionSource.SOURCE_OWNER_MODEL_PROVIDER_OFFICIAL,
+        )
+        self.assertEqual(
+            source.collection_method,
+            PriceCollectionSource.COLLECTION_METHOD_AUTO_COLLECT,
+        )
+        self.assertTrue(source.updates_model_prices)
+        self.assertEqual(
+            source.endpoint_url,
+            "https://platform.minimaxi.com/subscribe/"
+            "token-plan?tab=api-enterprise",
+        )
+
+    def test_ensure_official_provider_source_creates_volcengine_source(self):
+        response = self.client.post(
+            reverse("collection-source-ensure-official-provider"),
+            {"provider_code": "volcengine"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 201)
+        self.assertTrue(response.data["provider_created"])
+        self.assertTrue(response.data["source_created"])
+        self.assertEqual(
+            response.data["source"]["slug"],
+            "volcengine-official",
+        )
+        self.assertEqual(
+            response.data["source"]["provider_code"],
+            "volcengine",
+        )
+        self.assertEqual(response.data["source"]["currency"], "CNY")
+        self.assertTrue(response.data["source"]["can_collect_prices"])
+        provider = LLMProvider.objects.get(code="volcengine")
+        source = PriceCollectionSource.objects.get(
+            slug="volcengine-official",
+        )
+        self.assertEqual(source.provider, provider)
+        self.assertEqual(
+            source.source_owner_type,
+            PriceCollectionSource.SOURCE_OWNER_CLOUD_PROVIDER_OFFICIAL,
+        )
+        self.assertEqual(
+            source.collection_method,
+            PriceCollectionSource.COLLECTION_METHOD_AUTO_COLLECT,
+        )
+        self.assertTrue(source.updates_model_prices)
+        self.assertEqual(
+            source.endpoint_url,
+            "https://www.volcengine.com/docs/82379/1544106?lang=zh",
+        )
+
+    def test_ensure_official_provider_source_creates_zhipu_source(self):
+        response = self.client.post(
+            reverse("collection-source-ensure-official-provider"),
+            {"provider_code": "zhipu"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 201)
+        self.assertTrue(response.data["provider_created"])
+        self.assertTrue(response.data["source_created"])
+        self.assertEqual(response.data["source"]["slug"], "zhipu-official")
+        self.assertEqual(response.data["source"]["provider_code"], "zhipu")
+        self.assertEqual(response.data["source"]["currency"], "CNY")
+        self.assertTrue(response.data["source"]["can_collect_prices"])
+        provider = LLMProvider.objects.get(code="zhipu")
+        source = PriceCollectionSource.objects.get(slug="zhipu-official")
+        self.assertEqual(source.provider, provider)
+        self.assertEqual(
+            source.source_owner_type,
+            PriceCollectionSource.SOURCE_OWNER_MODEL_PROVIDER_OFFICIAL,
+        )
+        self.assertEqual(
+            source.collection_method,
+            PriceCollectionSource.COLLECTION_METHOD_AUTO_COLLECT,
+        )
+        self.assertTrue(source.updates_model_prices)
+        self.assertEqual(
+            source.endpoint_url,
+            "https://bigmodel.cn/pricing",
+        )
+
     def test_ensure_official_provider_source_is_idempotent(self):
         first = self.client.post(
             reverse("collection-source-ensure-official-provider"),
@@ -1196,13 +1514,13 @@ class LLMOpsViewTests(TestCase):
     ):
         response = self.client.post(
             reverse("collection-source-ensure-official-provider"),
-            {"provider_code": "baidu"},
+            {"provider_code": "openai"},
             format="json",
         )
 
         self.assertEqual(response.status_code, 400)
         self.assertIn("Unsupported official provider", response.data["detail"])
-        self.assertFalse(LLMProvider.objects.filter(code="baidu").exists())
+        self.assertFalse(LLMProvider.objects.filter(code="openai").exists())
 
     @patch("llm_ops.views.collect_price_source_prices.delay")
     def test_collection_source_collect_rejects_disabled_source(
@@ -1240,7 +1558,10 @@ class LLMOpsViewTests(TestCase):
         self,
         mock_delay,
     ):
-        provider = LLMProvider.objects.create(name="DeepSeek", code="deepseek")
+        provider = LLMProvider.objects.create(
+            name="Unknown AI",
+            code="unknown-ai",
+        )
         source = PriceCollectionSource.objects.create(
             name="SiliconFlow Sheet",
             slug="siliconflow-sheet",

--- a/backend/llm_ops/tests/test_volcengine_price_collector.py
+++ b/backend/llm_ops/tests/test_volcengine_price_collector.py
@@ -1,0 +1,88 @@
+from django.test import SimpleTestCase
+
+from llm_ops.price_collectors import collect_vendor_price_catalog
+from llm_ops.price_collectors.parsers.volcengine import extract_models
+from llm_ops.skill_runner import standard_catalog_run_metadata
+
+
+VOLCENGINE_HTML = (
+    r'\"ops\":[{\"insert\":\"doubao-1.5-pro-32k\"}],'
+    r'\"zoneId\":\"row01nj2n42rlpl8e7b6tvpmvqhysnzfp89bh\",'
+    r'\"zoneType\":\"Z\"'
+    r'\"ops\":[{\"insert\":\"2\"}],'
+    r'\"zoneId\":\"row01s303uu1c1g40de7oaoizn05md89iimb6\",'
+    r'\"zoneType\":\"Z\"'
+    r'\"ops\":[{\"insert\":\"8\"}],'
+    r'\"zoneId\":\"row015wt3pecycob8so1pho26k692zw2cgbsm\",'
+    r'\"zoneType\":\"Z\"'
+    r'\"ops\":[{\"insert\":\"0.4\"}],'
+    r'\"zoneId\":\"row01cvklbb5m01p5jfrmdhooit6bknkyawsj\",'
+    r'\"zoneType\":\"Z\"'
+    r'\"ops\":[{\"insert\":\"标准推理\"}],'
+    r'\"zoneId\":\"row01gagtwd6h2ui45oj1di8jtwno5ytnfdt6\",'
+    r'\"zoneType\":\"Z\"'
+)
+
+
+class VolcEnginePriceCatalogCollectorTests(SimpleTestCase):
+    def test_extract_models_reads_document_zone_prices(self):
+        models = extract_models(VOLCENGINE_HTML)
+
+        model = models[0]
+
+        self.assertEqual(model["model_id"], "doubao-1.5-pro-32k")
+        self.assertEqual(model["input_price_per_million"], "2")
+        self.assertEqual(model["output_price_per_million"], "8")
+        self.assertEqual(model["cache_hit_price_per_million"], "0.4")
+        self.assertIn("标准推理", model["notes"])
+
+    def test_collect_vendor_price_catalog_returns_volcengine_payload(self):
+        payload = collect_vendor_price_catalog(
+            "volcengine",
+            {
+                "provider_name": "火山方舟",
+                "currency": "CNY",
+                "raw_html": VOLCENGINE_HTML,
+                "model_codes": ["doubao-1.5-pro-32k"],
+            },
+        )
+
+        self.assertEqual(
+            payload["schema_version"],
+            "llm_ops.model_price_catalog.v1",
+        )
+        self.assertEqual(payload["provider"]["code"], "volcengine")
+        self.assertEqual(payload["provider"]["currency"], "CNY")
+        self.assertEqual(payload["total_models"], 1)
+        self.assertEqual(
+            payload["models"][0]["model_id"],
+            "doubao-1.5-pro-32k",
+        )
+        values = payload["models"][0]["price_rows"][0]["values"]
+        self.assertEqual(values["input_price"], "2")
+        self.assertEqual(values["output_price"], "8")
+
+    def test_empty_live_parse_marks_static_fallback_payload(self):
+        payload = collect_vendor_price_catalog(
+            "volcengine",
+            {
+                "raw_html": "<html></html>",
+                "verify_source": False,
+            },
+        )
+
+        self.assertEqual(payload["provider"]["code"], "volcengine")
+        self.assertEqual(payload["total_models"], 1)
+        self.assertTrue(payload["raw_payload"]["fallback_used"])
+        self.assertEqual(
+            payload["raw_payload"]["fallback_reason"],
+            "official_page_parse_empty",
+        )
+
+        metadata = standard_catalog_run_metadata(payload)
+
+        self.assertTrue(metadata["vendor_catalog_fallback_used"])
+        self.assertEqual(
+            metadata["vendor_catalog_fallback_reason"],
+            "official_page_parse_empty",
+        )

--- a/backend/llm_ops/tests/test_zhipu_price_collector.py
+++ b/backend/llm_ops/tests/test_zhipu_price_collector.py
@@ -1,0 +1,112 @@
+import json
+
+from django.test import SimpleTestCase
+
+from llm_ops.price_collectors import collect_vendor_price_catalog
+from llm_ops.price_collectors.parsers.zhipu import extract_models
+
+
+ZHIPU_PRICING_JSON = json.dumps(
+    {
+        "modelPrices": [
+            {
+                "modelCode": "GLM-4.7",
+                "inputPrice": "0.5",
+                "outputPrice": "2",
+            },
+            {
+                "modelName": "GLM-4.7-Flash",
+                "promptUnitPrice": "¥0.0001 / 千tokens",
+                "completionUnitPrice": "¥0.0004 / 千tokens",
+            },
+        ]
+    }
+)
+
+ZHIPU_PRICING_TABLE = """
+<table>
+  <tr>
+    <th>模型名称</th>
+    <th>输入价格</th>
+    <th>输出价格</th>
+  </tr>
+  <tr>
+    <td>GLM-4.7</td>
+    <td>¥0.5 / 百万 tokens</td>
+    <td>¥2 / 百万 tokens</td>
+  </tr>
+</table>
+"""
+
+ZHIPU_SHELL_HTML = """
+<!DOCTYPE html>
+<html>
+  <head><title>智谱AI开放平台</title></head>
+  <body>
+    <noscript>
+      We're sorry but 智谱AI开放平台 doesn't work properly without
+      JavaScript enabled.
+    </noscript>
+    <div id="app"></div>
+    <script src="/js/app.4b35422d.js"></script>
+  </body>
+</html>
+"""
+
+
+class ZhipuPriceCatalogCollectorTests(SimpleTestCase):
+    def test_extract_models_from_structured_pricing_json(self):
+        models = extract_models(ZHIPU_PRICING_JSON)
+
+        model_ids = {item["model_id"] for item in models}
+        self.assertEqual(model_ids, {"glm-4.7", "glm-4.7-flash"})
+        glm = next(item for item in models if item["model_id"] == "glm-4.7")
+        flash = next(
+            item for item in models if item["model_id"] == "glm-4.7-flash"
+        )
+        self.assertEqual(glm["input_price_per_million"], "0.5")
+        self.assertEqual(glm["output_price_per_million"], "2")
+        self.assertEqual(flash["input_price_per_million"], "0.1")
+        self.assertEqual(flash["output_price_per_million"], "0.4")
+
+    def test_extract_models_from_plain_html_pricing_table(self):
+        models = extract_models(ZHIPU_PRICING_TABLE)
+
+        self.assertEqual(len(models), 1)
+        self.assertEqual(models[0]["model_id"], "glm-4.7")
+        self.assertEqual(models[0]["input_price_per_million"], "0.5")
+        self.assertEqual(models[0]["output_price_per_million"], "2")
+
+    def test_js_shell_without_model_prices_returns_empty_catalog(self):
+        payload = collect_vendor_price_catalog(
+            "zhipu",
+            {
+                "raw_html": ZHIPU_SHELL_HTML,
+                "source_url": "https://example.com/bigmodel-pricing",
+            },
+        )
+
+        self.assertEqual(payload["provider"]["code"], "zhipu")
+        self.assertEqual(payload["provider"]["currency"], "CNY")
+        self.assertEqual(payload["total_models"], 0)
+        self.assertEqual(payload["models"], [])
+
+    def test_collect_vendor_price_catalog_returns_zhipu_payload(self):
+        payload = collect_vendor_price_catalog(
+            "zhipu",
+            {
+                "raw_html": ZHIPU_PRICING_TABLE,
+                "source_url": "https://example.com/bigmodel-pricing",
+                "provider_name": "智谱",
+                "model_codes": ["glm-4.7"],
+            },
+        )
+
+        self.assertEqual(
+            payload["schema_version"],
+            "llm_ops.model_price_catalog.v1",
+        )
+        self.assertEqual(payload["provider"]["code"], "zhipu")
+        self.assertEqual(payload["provider"]["currency"], "CNY")
+        self.assertEqual(payload["total_models"], 1)
+        self.assertEqual(payload["models"][0]["model_id"], "glm-4.7")


### PR DESCRIPTION
## Summary
- Add official price collectors for Anthropic, Baidu Qianfan, Google Gemini, MiniMax, VolcEngine, and Zhipu BigModel.
- Register new collectors for source-backed sync and official source creation.
- Preserve collector fallback metadata and reject empty parsed catalogs.
- Extend source dispatch, source creation, and parser test coverage.

## Test plan
- [x] docker exec backend-api-dev python manage.py test llm_ops.tests.test_anthropic_price_collector llm_ops.tests.test_baidu_price_collector llm_ops.tests.test_google_price_collector llm_ops.tests.test_minimax_price_collector llm_ops.tests.test_volcengine_price_collector llm_ops.tests.test_zhipu_price_collector llm_ops.tests.test_source_collectors llm_ops.tests.test_views
- [x] git diff --cached --check
- [x] 79-character line-width scan for changed Python files

No linked issue was found in the open issue list.

Made with [Orca](https://github.com/stablyai/orca) 🐋
