### PR TITLE
Fix LLM Ops official price collectors

### DIFF
--- a/backend/llm_ops/collection_services.py
+++ b/backend/llm_ops/collection_services.py
@@ -5,13 +5,14 @@ import json
 import re
 from decimal import Decimal, InvalidOperation
 
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.utils import timezone
 
 from .collectors import CollectedModelPricing, CollectedPricingCatalog
 from .collectors.official import (
     ALIYUN_LEGACY_PRICING_SOURCE_URLS,
     BAIDU_PRICING_SOURCE_URL,
+    MINIMAX_LEGACY_PRICING_SOURCE_URLS,
     MINIMAX_PRICING_SOURCE_URL,
     MODELS_DEV_MODELS_URL,
     OFFICIAL_PROVIDER_CONFIGS,
@@ -410,6 +411,13 @@ def sync_vendor_price_source_catalog(
     if not source.is_enabled:
         raise ValueError("Price collection source is disabled.")
     source_url = source.endpoint_url or ""
+    if (
+        provider_code in OFFICIAL_PROVIDER_CONFIGS
+        and is_legacy_official_pricing_url(provider_code, source_url)
+    ):
+        source_url = OFFICIAL_PROVIDER_CONFIGS[provider_code].source_url
+        source.endpoint_url = source_url
+        source.save(update_fields=["endpoint_url", "updated_at"])
     provider_name = (
         source.provider.name
         if source.provider_id and source.provider
@@ -1876,9 +1884,17 @@ def official_source_url(
 ) -> str:
     """Return the effective official source URL for collection."""
     endpoint_url = source.endpoint_url or config.source_url
-    if is_legacy_aliyun_pricing_url(provider.code, endpoint_url):
+    if is_legacy_official_pricing_url(provider.code, endpoint_url):
         return config.source_url
     return endpoint_url
+
+
+def is_legacy_official_pricing_url(provider_code: str, url: str) -> bool:
+    """Return whether a persisted URL should follow current config."""
+    return (
+        is_legacy_aliyun_pricing_url(provider_code, url)
+        or is_legacy_minimax_pricing_url(provider_code, url)
+    )
 
 
 def is_legacy_aliyun_pricing_url(provider_code: str, url: str) -> bool:
@@ -1886,6 +1902,13 @@ def is_legacy_aliyun_pricing_url(provider_code: str, url: str) -> bool:
     if provider_code not in {"aliyun", "aliyun-wanx"}:
         return False
     return url in ALIYUN_LEGACY_PRICING_SOURCE_URLS
+
+
+def is_legacy_minimax_pricing_url(provider_code: str, url: str) -> bool:
+    """Return whether a persisted MiniMax URL should follow current config."""
+    if provider_code != "minimax":
+        return False
+    return url in MINIMAX_LEGACY_PRICING_SOURCE_URLS
 
 
 def upsert_collected_offering(
@@ -2666,7 +2689,15 @@ def upsert_collected_snapshot(
         source_platform_id=str(item.platform_id),
     ).first()
     changed = existing is None or existing.price_fingerprint != fingerprint
-    if changed:
+    has_matching_history = collected_price_history_exists(
+        source=source,
+        offering=offering,
+        source_platform_id=str(item.platform_id),
+        price_hash=fingerprint,
+    )
+    if existing is None and has_matching_history:
+        changed = False
+    if existing is None or changed:
         create_collected_price_history(
             payload,
             source=source,
@@ -2683,6 +2714,22 @@ def upsert_collected_snapshot(
         defaults=payload,
     )
     return snapshot, changed
+
+
+def collected_price_history_exists(
+    *,
+    source: PriceCollectionSource,
+    offering: SourceSkuOffering,
+    source_platform_id: str,
+    price_hash: str,
+) -> bool:
+    """Return whether one collected history fingerprint already exists."""
+    return CollectedModelPriceHistory.objects.filter(
+        source=source,
+        offering=offering,
+        source_platform_id=source_platform_id,
+        price_fingerprint=price_hash,
+    ).exists()
 
 
 def normalized_rows_payload(item: CollectedModelPricing) -> list[dict]:
@@ -2753,6 +2800,24 @@ def create_collected_price_history(
 ) -> CollectedModelPriceHistory:
     """Insert a history row and close the previous current version."""
     now = timezone.now()
+    lookup = {
+        "source": source,
+        "offering": payload["offering"],
+        "source_platform_id": source_platform_id,
+        "price_fingerprint": price_hash,
+    }
+    existing_history = CollectedModelPriceHistory.objects.filter(
+        **lookup,
+    ).first()
+    if existing_history is not None:
+        return activate_collected_price_history(
+            existing_history,
+            source=source,
+            offering=payload["offering"],
+            source_platform_id=source_platform_id,
+            now=now,
+        )
+
     CollectedModelPriceHistory.objects.filter(
         source=source,
         offering=payload["offering"],
@@ -2762,30 +2827,66 @@ def create_collected_price_history(
         is_current=False,
         effective_to=now,
     )
-    return CollectedModelPriceHistory.objects.create(
+    try:
+        with transaction.atomic():
+            return CollectedModelPriceHistory.objects.create(
+                source=source,
+                run=payload["run"],
+                provider=payload["provider"],
+                model=payload["model"],
+                sku=payload["sku"],
+                offering=payload["offering"],
+                meta_model=payload["meta_model"],
+                source_platform_id=source_platform_id,
+                source_model_id=payload["source_model_id"],
+                source_model_name=payload["source_model_name"],
+                source_model_type=payload["source_model_type"],
+                source_provider_name=payload["source_provider_name"],
+                currency=payload["currency"],
+                billing_unit=payload["billing_unit"],
+                billing_mode=payload["billing_mode"],
+                normalized_price_rows=payload["normalized_price_rows"],
+                raw_price_info=payload["raw_price_info"],
+                raw_detail=payload["raw_detail"],
+                price_fingerprint=price_hash,
+                changed_fields=changed_fields(previous, payload),
+                effective_from=now,
+                is_current=True,
+            )
+    except IntegrityError:
+        existing_history = CollectedModelPriceHistory.objects.get(**lookup)
+        return activate_collected_price_history(
+            existing_history,
+            source=source,
+            offering=payload["offering"],
+            source_platform_id=source_platform_id,
+            now=now,
+        )
+
+
+def activate_collected_price_history(
+    history: CollectedModelPriceHistory,
+    *,
+    source: PriceCollectionSource,
+    offering: SourceSkuOffering,
+    source_platform_id: str,
+    now,
+) -> CollectedModelPriceHistory:
+    """Make one existing collected history row current."""
+    CollectedModelPriceHistory.objects.filter(
         source=source,
-        run=payload["run"],
-        provider=payload["provider"],
-        model=payload["model"],
-        sku=payload["sku"],
-        offering=payload["offering"],
-        meta_model=payload["meta_model"],
+        offering=offering,
         source_platform_id=source_platform_id,
-        source_model_id=payload["source_model_id"],
-        source_model_name=payload["source_model_name"],
-        source_model_type=payload["source_model_type"],
-        source_provider_name=payload["source_provider_name"],
-        currency=payload["currency"],
-        billing_unit=payload["billing_unit"],
-        billing_mode=payload["billing_mode"],
-        normalized_price_rows=payload["normalized_price_rows"],
-        raw_price_info=payload["raw_price_info"],
-        raw_detail=payload["raw_detail"],
-        price_fingerprint=price_hash,
-        changed_fields=changed_fields(previous, payload),
-        effective_from=now,
         is_current=True,
+    ).exclude(id=history.id).update(
+        is_current=False,
+        effective_to=now,
     )
+    if not history.is_current or history.effective_to is not None:
+        history.is_current = True
+        history.effective_to = None
+        history.save(update_fields=["is_current", "effective_to"])
+    return history
 
 
 def sync_model_price_items(
@@ -3438,7 +3539,7 @@ def ensure_official_source(*, provider: LLMProvider):
             "不做跨币种换算。"
         ),
     }
-    if not source.endpoint_url or is_legacy_aliyun_pricing_url(
+    if not source.endpoint_url or is_legacy_official_pricing_url(
         provider.code,
         source.endpoint_url,
     ):

--- a/backend/llm_ops/collectors/official.py
+++ b/backend/llm_ops/collectors/official.py
@@ -42,8 +42,11 @@ VOLCENGINE_PRICING_SOURCE_URL = (
     "https://www.volcengine.com/docs/82379/1544106?lang=zh"
 )
 MINIMAX_PRICING_SOURCE_URL = (
-    "https://platform.minimaxi.com/subscribe/token-plan?tab=api-enterprise"
+    "https://platform.minimaxi.com/docs/guides/pricing-paygo"
 )
+MINIMAX_LEGACY_PRICING_SOURCE_URLS = {
+    "https://platform.minimaxi.com/subscribe/token-plan?tab=api-enterprise",
+}
 ZHIPU_PRICING_SOURCE_URL = "https://bigmodel.cn/pricing"
 ALIYUN_LEGACY_PRICING_SOURCE_URLS = {
     "https://help.aliyun.com/zh/model-studio/model-price",

--- a/backend/llm_ops/price_collectors/parsers/minimax.py
+++ b/backend/llm_ops/price_collectors/parsers/minimax.py
@@ -15,7 +15,7 @@ from .common import (
 
 
 PRICING_URL = (
-    "https://platform.minimaxi.com/subscribe/token-plan?tab=api-enterprise"
+    "https://platform.minimaxi.com/docs/guides/pricing-paygo"
 )
 DEFAULT_CURRENCY = "CNY"
 

--- a/backend/llm_ops/price_collectors/parsers/zhipu.py
+++ b/backend/llm_ops/price_collectors/parsers/zhipu.py
@@ -5,6 +5,7 @@ import re
 from decimal import Decimal, InvalidOperation
 from html import unescape
 from typing import Any
+from urllib.parse import urljoin
 
 import requests
 
@@ -93,16 +94,48 @@ def fetch_text(url: str) -> str:
     response.encoding = response.encoding or "utf-8"
     if str(response.encoding).lower() in {"iso-8859-1", "latin-1"}:
         response.encoding = "utf-8"
-    return response.text or ""
+    content = response.text or ""
+    scripts = fetch_linked_pricing_scripts(url, content)
+    return "\n".join([content, *scripts])
+
+
+def fetch_linked_pricing_scripts(url: str, content: str) -> list[str]:
+    """Fetch same-origin JS bundles that contain BigModel pricing rows."""
+    scripts = []
+    for path in re.findall(
+        r'<script[^>]+src=["\']([^"\']+\.js)["\']',
+        content,
+        flags=re.IGNORECASE,
+    ):
+        script_url = urljoin(url, path)
+        if not script_url.startswith("https://bigmodel.cn/"):
+            continue
+        try:
+            response = requests.get(
+                script_url,
+                headers={
+                    "Accept": "application/javascript,text/javascript,*/*",
+                    "User-Agent": "DevMind-LLMOpsPriceCollector/1.0",
+                },
+                timeout=20,
+            )
+            response.raise_for_status()
+        except requests.RequestException:
+            continue
+        response.encoding = response.encoding or "utf-8"
+        scripts.append(response.text or "")
+    return scripts
 
 
 def extract_models(content: str) -> list[dict[str, Any]]:
-    """Extract Zhipu text-token price rows from JSON and HTML tables."""
+    """Extract Zhipu text-token price rows from supported source formats."""
     models: dict[str, dict[str, Any]] = {}
     for document in extract_json_documents(content):
         for item in extract_models_from_json(document):
             upsert_model(models, item)
     for item in extract_models_from_tables(content):
+        upsert_model(models, item)
+    for item in extract_models_from_js_model_lists(content):
         upsert_model(models, item)
     return [
         item
@@ -337,6 +370,87 @@ def models_from_table(table_html: str) -> list[dict[str, Any]]:
         if item:
             models.append(item)
     return models
+
+
+def extract_models_from_js_model_lists(content: str) -> list[dict[str, Any]]:
+    """Extract model prices from BigModel Vue bundle modelList arrays."""
+    models = []
+    for fragment in extract_balanced_values(str(content or ""), "modelList"):
+        for item in js_objects_from_array(fragment):
+            model = model_from_js_object(item)
+            if model:
+                models.append(model)
+    return models
+
+
+def js_objects_from_array(fragment: str) -> list[str]:
+    """Return top-level object fragments from a JavaScript array literal."""
+    objects = []
+    index = 0
+    while index < len(fragment):
+        start = fragment.find("{", index)
+        if start < 0:
+            break
+        item = balanced_fragment(fragment, start)
+        if not item:
+            break
+        objects.append(item)
+        index = start + len(item)
+    return objects
+
+
+def model_from_js_object(fragment: str) -> dict[str, Any]:
+    """Build one model from a BigModel JavaScript pricing row."""
+    model_name = js_string_field(fragment, "name")
+    input_prices = js_string_array_field(fragment, "inPrice")
+    output_prices = js_string_array_field(fragment, "outPrice")
+    if not model_name or not input_prices or not output_prices:
+        return {}
+    return model_from_mapping(
+        {
+            "model": model_name,
+            "input": input_prices[0],
+            "output": output_prices[0],
+        }
+    )
+
+
+def js_string_field(fragment: str, key: str) -> str:
+    """Return one quoted JavaScript object string field."""
+    match = re.search(
+        rf"\b{re.escape(key)}\s*:\s*([\"'])(.*?)\1",
+        fragment,
+        flags=re.DOTALL,
+    )
+    if not match:
+        return ""
+    return unescape_js_string(match.group(2))
+
+
+def js_string_array_field(fragment: str, key: str) -> list[str]:
+    """Return quoted strings from one JavaScript object array field."""
+    match = re.search(
+        rf"\b{re.escape(key)}\s*:\s*\[(.*?)\]",
+        fragment,
+        flags=re.DOTALL,
+    )
+    if not match:
+        return []
+    return [
+        unescape_js_string(item.group(2))
+        for item in re.finditer(r"([\"'])(.*?)\1", match.group(1))
+    ]
+
+
+def unescape_js_string(value: str) -> str:
+    """Decode common JavaScript string escapes used in pricing bundles."""
+    text = str(value or "")
+    if "\\" not in text:
+        return text
+    try:
+        return bytes(text, "utf-8").decode("unicode_escape")
+    except UnicodeDecodeError:
+        return text
 
 
 def parse_table_rows(table_html: str) -> list[list[str]]:

--- a/backend/llm_ops/tests/test_source_collectors.py
+++ b/backend/llm_ops/tests/test_source_collectors.py
@@ -13,6 +13,7 @@ from llm_ops.collection_services import (
 from llm_ops.collectors import CollectedModelPricing, NormalizedPriceRow
 from llm_ops.global_config import price_sync_source_queryset
 from llm_ops.models import (
+    CollectedModelPriceHistory,
     LLMProvider,
     MetaModel,
     ModelPriceItem,
@@ -227,8 +228,7 @@ class PriceSourceCollectorRegistryTests(TestCase):
                 PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
             ),
             endpoint_url=(
-                "https://platform.minimaxi.com/subscribe/"
-                "token-plan?tab=api-enterprise"
+                "https://platform.minimaxi.com/docs/guides/pricing-paygo"
             ),
             collection_method=(
                 PriceCollectionSource.COLLECTION_METHOD_AUTO_COLLECT
@@ -498,8 +498,7 @@ class PriceSourceCollectorRegistryTests(TestCase):
                 PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
             ),
             endpoint_url=(
-                "https://platform.minimaxi.com/subscribe/"
-                "token-plan?tab=api-enterprise"
+                "https://platform.minimaxi.com/docs/guides/pricing-paygo"
             ),
             collection_method=(
                 PriceCollectionSource.COLLECTION_METHOD_AUTO_COLLECT
@@ -755,6 +754,54 @@ class PriceCollectionSkuPersistenceTests(TestCase):
         self.assertNotEqual(first_snapshot.id, second_snapshot.id)
         self.assertEqual(first_snapshot.offering, first_offering)
         self.assertEqual(second_snapshot.offering, second_offering)
+
+    def test_snapshot_rebuild_reuses_existing_price_history(self):
+        item = self.collected_item()
+        first_run = PriceCollectionRun.objects.create(source=self.source)
+        second_run = PriceCollectionRun.objects.create(source=self.source)
+        offering, _ = upsert_collected_offering(
+            item,
+            source=self.source,
+            source_url=self.source.endpoint_url,
+            meta_model=self.meta_model,
+        )
+        first_snapshot, first_changed = upsert_collected_snapshot(
+            item,
+            source=self.source,
+            run=first_run,
+            offering=offering,
+        )
+        first_history = CollectedModelPriceHistory.objects.get(
+            source=self.source,
+            offering=offering,
+            source_platform_id="deepseek-v4-flash",
+        )
+        first_snapshot.delete()
+
+        rebuilt_snapshot, second_changed = upsert_collected_snapshot(
+            item,
+            source=self.source,
+            run=second_run,
+            offering=offering,
+        )
+
+        self.assertTrue(first_changed)
+        self.assertFalse(second_changed)
+        self.assertEqual(
+            CollectedModelPriceHistory.objects.filter(
+                source=self.source,
+                offering=offering,
+                source_platform_id="deepseek-v4-flash",
+            ).count(),
+            1,
+        )
+        first_history.refresh_from_db()
+        self.assertTrue(first_history.is_current)
+        self.assertIsNone(first_history.effective_to)
+        self.assertEqual(
+            rebuilt_snapshot.price_fingerprint,
+            first_history.price_fingerprint,
+        )
 
     def test_source_sku_offering_rejects_upstream_cycle(self):
         item = self.collected_item()

--- a/backend/llm_ops/tests/test_views.py
+++ b/backend/llm_ops/tests/test_views.py
@@ -1167,8 +1167,7 @@ class LLMOpsViewTests(TestCase):
         self.assertEqual(minimax["currency"], "CNY")
         self.assertEqual(
             minimax["source_url"],
-            "https://platform.minimaxi.com/subscribe/"
-            "token-plan?tab=api-enterprise",
+            "https://platform.minimaxi.com/docs/guides/pricing-paygo",
         )
         volcengine = next(
             item
@@ -1408,8 +1407,7 @@ class LLMOpsViewTests(TestCase):
         self.assertTrue(source.updates_model_prices)
         self.assertEqual(
             source.endpoint_url,
-            "https://platform.minimaxi.com/subscribe/"
-            "token-plan?tab=api-enterprise",
+            "https://platform.minimaxi.com/docs/guides/pricing-paygo",
         )
 
     def test_ensure_official_provider_source_creates_volcengine_source(self):

--- a/backend/llm_ops/tests/test_zhipu_price_collector.py
+++ b/backend/llm_ops/tests/test_zhipu_price_collector.py
@@ -53,6 +53,28 @@ ZHIPU_SHELL_HTML = """
 </html>
 """
 
+ZHIPU_BUNDLE_MODEL_LIST = """
+newModel:{model:[{
+  modelName:"文本模型",
+  unit2:"百万tokens",
+  modelList:[
+    {
+      name:"GLM-5.2",
+      upDownText:["1M"],
+      inPrice:["8元"],
+      outPrice:["28元"],
+      hit:["2元"]
+    },
+    {
+      name:"",
+      upDownText:["输入长度 [32+)"],
+      inPrice:["8元"],
+      outPrice:["28元"]
+    }
+  ]
+}]}
+"""
+
 
 class ZhipuPriceCatalogCollectorTests(SimpleTestCase):
     def test_extract_models_from_structured_pricing_json(self):
@@ -76,6 +98,14 @@ class ZhipuPriceCatalogCollectorTests(SimpleTestCase):
         self.assertEqual(models[0]["model_id"], "glm-4.7")
         self.assertEqual(models[0]["input_price_per_million"], "0.5")
         self.assertEqual(models[0]["output_price_per_million"], "2")
+
+    def test_extract_models_from_bigmodel_bundle_model_list(self):
+        models = extract_models(ZHIPU_BUNDLE_MODEL_LIST)
+
+        self.assertEqual(len(models), 1)
+        self.assertEqual(models[0]["model_id"], "glm-5.2")
+        self.assertEqual(models[0]["input_price_per_million"], "8")
+        self.assertEqual(models[0]["output_price_per_million"], "28")
 
     def test_js_shell_without_model_prices_returns_empty_catalog(self):
         payload = collect_vendor_price_catalog(


### PR DESCRIPTION
## Summary
- Update MiniMax official collection to use the current CNY pay-as-you-go pricing page and normalize persisted legacy MiniMax token-plan URLs during source sync.
- Parse Zhipu BigModel pricing rows from same-origin app bundles when the pricing page shell does not contain explicit model rows.
- Reuse existing collected price history rows for identical fingerprints when the current snapshot is missing, avoiding duplicate-history constraint failures.

No linked open Issue found for this follow-up.

## Test plan
- [x] `python3 -m pytest backend/llm_ops/tests/test_source_collectors.py backend/llm_ops/tests/test_zhipu_price_collector.py`
- [x] `python3 -m py_compile backend/llm_ops/collection_services.py backend/llm_ops/collectors/official.py backend/llm_ops/price_collectors/parsers/minimax.py backend/llm_ops/price_collectors/parsers/zhipu.py backend/llm_ops/tests/test_source_collectors.py backend/llm_ops/tests/test_views.py backend/llm_ops/tests/test_zhipu_price_collector.py`
- [x] `git diff --check`
- [ ] `python3 -m pytest backend/llm_ops/tests/test_zhipu_price_collector.py backend/llm_ops/tests/test_source_collectors.py backend/llm_ops/tests/test_views.py` did not fully pass locally: `test_views.py` fails at import time because the active system interpreter is missing `drf_spectacular`; the collector/service tests passed.
- [ ] `python3 -m black --check ...` not run: the active system interpreter has no `black` module.