### PR TITLE
Fix LLM Ops resale margin chart labels

### DIFF
--- a/frontend/src/components/llm-ops/BulletChart.vue
+++ b/frontend/src/components/llm-ops/BulletChart.vue
@@ -61,13 +61,13 @@
       <div
         class="range-ref-marker"
         :style="{ left: getMarkerPos(ref.price) + '%' }"
-        :title="`${ref.source}: ${formatDisplayValue(ref.price)}`"
+        :title="refTitle(ref)"
       >
         <div class="range-ref-label">
           {{ ref.source }}
         </div>
         <div class="range-ref-val">
-          {{ formatDisplayValue(ref.price) }}
+          {{ refDisplayValue(ref) }}
         </div>
       </div>
     </template>
@@ -76,7 +76,7 @@
       class="range-bar-marker"
       role="slider"
       tabindex="0"
-      :aria-label="label || '我方售价'"
+      :aria-label="label || t('llmOps.publishingWorkspace.margin.sliderLabel')"
       :aria-valuemin="axisMin"
       :aria-valuemax="axisMax"
       :aria-valuenow="Number(value) || 0"
@@ -100,6 +100,7 @@
 <script setup>
 import '@/components/llm-ops/bulletChart.css'
 import { computed, onBeforeUnmount, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 const props = defineProps({
   min: {
@@ -149,6 +150,7 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['change', 'update:value'])
+const { t } = useI18n()
 
 const rangeRef = ref(null)
 const isDragging = ref(false)
@@ -222,7 +224,11 @@ const axisRange = computed(() => {
 
 const axisMin = computed(() => axisRange.value.min)
 const axisMax = computed(() => axisRange.value.max)
-const boundaryLabel = computed(() => (hasBoundaryRange.value ? '市场' : '参考'))
+const boundaryLabel = computed(() =>
+  hasBoundaryRange.value
+    ? t('llmOps.publishingWorkspace.margin.boundaryMarket')
+    : t('llmOps.publishingWorkspace.margin.boundaryReference')
+)
 
 const boundaryZoneStyle = computed(() => {
   if (!hasBoundaryRange.value) return {}
@@ -243,8 +249,12 @@ const boundaryZoneStyle = computed(() => {
 const boundaryItems = computed(() => [
   {
     key: 'min',
-    title: `${boundaryLabel.value}下限`,
+    title: t('llmOps.publishingWorkspace.margin.boundaryTitle', {
+      scope: boundaryLabel.value,
+      boundary: t('llmOps.publishingWorkspace.margin.boundaryLower')
+    }),
     value: boundaryMin.value,
+    displayValue: props.lowerTooltip?.displayValue,
     percent: getMarkerPos(boundaryMin.value),
     markerClass: 'range-boundary-min',
     hitClass: 'range-boundary-hit-min',
@@ -252,8 +262,12 @@ const boundaryItems = computed(() => [
   },
   {
     key: 'max',
-    title: `${boundaryLabel.value}上限`,
+    title: t('llmOps.publishingWorkspace.margin.boundaryTitle', {
+      scope: boundaryLabel.value,
+      boundary: t('llmOps.publishingWorkspace.margin.boundaryUpper')
+    }),
     value: boundaryMax.value,
+    displayValue: props.upperTooltip?.displayValue,
     percent: getMarkerPos(boundaryMax.value),
     markerClass: 'range-boundary-max',
     hitClass: 'range-boundary-hit-max',
@@ -290,14 +304,32 @@ function getMarkerColor(price) {
 }
 
 function boundaryCaption(boundary) {
-  const title = boundary.tooltip?.title || boundary.title || ''
-  let prefix = boundary.key === 'min' ? '下限' : '上限'
-  if (title.includes('免审')) {
-    prefix = '免审'
-  } else if (title.includes('最低') || title.includes('下限')) {
-    prefix = '下限'
+  const prefix = boundaryCaptionPrefix(boundary)
+  return `${prefix} ${boundaryDisplayValue(boundary)}`
+}
+
+function boundaryCaptionPrefix(boundary) {
+  if (boundary.tooltip?.captionKind === 'auto_approve') {
+    return t('llmOps.publishingWorkspace.margin.boundaryAutoApprove')
   }
-  return `${prefix} ${formatDisplayValue(boundary.value)}`
+  if (boundary.tooltip?.captionKind === 'floor') {
+    return t('llmOps.publishingWorkspace.margin.boundaryFloor')
+  }
+  return boundary.key === 'min'
+    ? t('llmOps.publishingWorkspace.margin.boundaryLower')
+    : t('llmOps.publishingWorkspace.margin.boundaryUpper')
+}
+
+function boundaryDisplayValue(boundary) {
+  return boundary.displayValue || formatDisplayValue(boundary.value)
+}
+
+function refDisplayValue(ref) {
+  return ref.displayValue || formatDisplayValue(ref.price)
+}
+
+function refTitle(ref) {
+  return `${ref.source}: ${ref.titleValue || refDisplayValue(ref)}`
 }
 
 function getValueLabelStyle(price) {

--- a/frontend/src/components/llm-ops/ResalePublishingWorkspace.vue
+++ b/frontend/src/components/llm-ops/ResalePublishingWorkspace.vue
@@ -508,7 +508,7 @@
                 :max="marginAxisRangeFor(row).max"
                 :value="row.margin"
                 :refs="marketMarginRefsFor(row)"
-                :lower-tooltip="marginPolicyTooltip('min')"
+                :lower-tooltip="marginPolicyTooltip('min', row)"
                 :upper-tooltip="marginPolicyTooltip('max')"
                 :label="
                   t('llmOps.publishingWorkspace.margin.axisLabel', {

--- a/frontend/src/composables/useResalePricing.js
+++ b/frontend/src/composables/useResalePricing.js
@@ -238,7 +238,7 @@ export function useResalePricing({
     if (!workflowAutoApproveEnabled.value) {
       return {
         ok: true,
-        label: '免审路径已关闭'
+        label: t('llmOps.publishingWorkspace.margin.autoApproveDisabled')
       }
     }
     if (selectedPlatformAutoApproveLimit.value === null) {
@@ -306,6 +306,51 @@ export function useResalePricing({
     const value = Number(avg)
     if (!Number.isFinite(value) || value <= 0) return '-'
     return `${currencySymbol.value}${value.toFixed(2)}`
+  }
+
+  function priceAmountText(value) {
+    const amount = Number(value)
+    if (!Number.isFinite(amount)) return null
+    return `${currencySymbol.value}${amount.toFixed(2)}`
+  }
+
+  function priceAmountRows(dimensions, field, options = {}) {
+    const allowZero = options.allowZero === true
+    return dimensions
+      .map((dimension) => {
+        const amount = Number(dimension[field])
+        if (
+          !Number.isFinite(amount) ||
+          amount < 0 ||
+          (!allowZero && amount <= 0)
+        ) {
+          return null
+        }
+        return {
+          label: dimension.shortLabel || dimension.label,
+          raw: amount,
+          value: priceAmountText(amount)
+        }
+      })
+      .filter(Boolean)
+  }
+
+  function priceAmountSummary(rows) {
+    if (!rows.length) return '-'
+    const values = rows.map((row) => Number(row.raw))
+    const rounded = [...new Set(values.map((value) => value.toFixed(2)))]
+    if (rounded.length === 1) return `${currencySymbol.value}${rounded[0]}`
+    const min = Math.min(...values)
+    const max = Math.max(...values)
+    return [
+      `${currencySymbol.value}${min.toFixed(2)}`,
+      `${currencySymbol.value}${max.toFixed(2)}`
+    ].join('-')
+  }
+
+  function priceAmountDetails(rows) {
+    if (!rows.length) return '-'
+    return rows.map((row) => `${row.label} ${row.value}`).join(' / ')
   }
 
   function priceDiffText(price, avg) {
@@ -390,7 +435,9 @@ export function useResalePricing({
   }
 
   function marketMarginRefsFor(row) {
-    const margins = priceDimensions(row)
+    const dimensions = priceDimensions(row)
+    const marketRows = priceAmountRows(dimensions, 'marketAverage')
+    const margins = dimensions
       .map((dimension) => {
         const marketPrice = Number(dimension.marketAverage)
         const cost = Number(dimension.costRaw)
@@ -411,7 +458,9 @@ export function useResalePricing({
     return [
       {
         source: t('llmOps.publishingWorkspace.pricing.marketAverage'),
-        price: Number(average.toFixed(2))
+        price: Number(average.toFixed(2)),
+        displayValue: priceAmountSummary(marketRows),
+        titleValue: priceAmountDetails(marketRows)
       }
     ]
   }
@@ -430,39 +479,58 @@ export function useResalePricing({
     }
   }
 
-  function marginPolicyTooltip(type) {
+  function marginPolicyTooltip(type, row = null) {
     const isMin = type === 'min'
     const floor = referenceMarginFloor()
     const approveLimit = Number(selectedPlatformAutoApproveLimit.value)
+    const floorPriceRows = row
+      ? priceAmountRows(priceDimensions(row), 'referencePriceRaw', {
+          allowZero: true
+        })
+      : []
+    const floorSource = t('llmOps.publishingWorkspace.margin.feeBreakdown', {
+      serviceFee: formatRatioPercent(selectedPlatformServiceFeeRate.value),
+      commission: formatRatioPercent(selectedPlatformFeeRate.value)
+    })
+    let rows
+    if (isMin && floorPriceRows.length) {
+      rows = floorPriceRows.map((item) => ({
+        label: item.label,
+        value: item.value,
+        source: floorSource
+      }))
+    } else if (isMin) {
+      rows = [
+        {
+          label: t('llmOps.publishingWorkspace.margin.platformFloor'),
+          value: formatPercent(floor),
+          source: floorSource
+        }
+      ]
+    } else {
+      rows = [
+        {
+          label: t('llmOps.publishingWorkspace.margin.autoApproveLimit'),
+          value: Number.isFinite(approveLimit)
+            ? formatPercent(approveLimit)
+            : t('llmOps.publishingWorkspace.fallback.notConfigured'),
+          source: selectedPlatformLabel.value
+        }
+      ]
+    }
     return {
       title: isMin
         ? t('llmOps.publishingWorkspace.margin.minTitle')
         : t('llmOps.publishingWorkspace.margin.autoApproveTitle'),
+      captionKind: isMin ? 'floor' : 'auto_approve',
+      displayValue:
+        isMin && floorPriceRows.length
+          ? priceAmountSummary(floorPriceRows)
+          : undefined,
       source: isMin
         ? t('llmOps.publishingWorkspace.margin.minSource')
         : t('llmOps.publishingWorkspace.margin.autoApproveSource'),
-      rows: isMin
-        ? [
-            {
-              label: t('llmOps.publishingWorkspace.margin.platformFloor'),
-              value: formatPercent(floor),
-              source: t('llmOps.publishingWorkspace.margin.feeBreakdown', {
-                serviceFee: formatRatioPercent(
-                  selectedPlatformServiceFeeRate.value
-                ),
-                commission: formatRatioPercent(selectedPlatformFeeRate.value)
-              })
-            }
-          ]
-        : [
-            {
-              label: t('llmOps.publishingWorkspace.margin.autoApproveLimit'),
-              value: Number.isFinite(approveLimit)
-                ? formatPercent(approveLimit)
-                : t('llmOps.publishingWorkspace.fallback.notConfigured'),
-              source: selectedPlatformLabel.value
-            }
-          ]
+      rows
     }
   }
 

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1011,7 +1011,9 @@
         "title": "Unified Margin Target",
         "description": "Input, Output, and Cache prices are derived from the same margin rate.",
         "input": "Unified margin rate",
+        "sliderLabel": "Unified margin",
         "axisLabel": "Unified margin {value}",
+        "autoApproveDisabled": "Auto-approval path disabled",
         "noAutoApprove": "No auto-approval margin configured",
         "autoApproveInactive": "Auto-approval threshold inactive",
         "withinAutoApprove": "Within auto-approval range (<= {value})",
@@ -1022,7 +1024,14 @@
         "autoApproveSource": "Auto-approval threshold from platform settings; affects approval only",
         "platformFloor": "Platform floor",
         "feeBreakdown": "Service fee {serviceFee} + commission {commission}",
-        "autoApproveLimit": "Auto-approval limit"
+        "autoApproveLimit": "Auto-approval limit",
+        "boundaryMarket": "Market",
+        "boundaryReference": "Reference",
+        "boundaryLower": "Lower",
+        "boundaryUpper": "Upper",
+        "boundaryFloor": "Floor",
+        "boundaryAutoApprove": "Auto-approve",
+        "boundaryTitle": "{scope} {boundary}"
       },
       "fallback": {
         "platform": "Platform {id}",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1021,7 +1021,9 @@
         "title": "统一收益率",
         "description": "Input / Output / Cache 按同一收益率推导各自售价。",
         "input": "统一收益率",
+        "sliderLabel": "统一收益率",
         "axisLabel": "统一收益率 {value}",
+        "autoApproveDisabled": "免审路径已关闭",
         "noAutoApprove": "未配置免审收益率",
         "autoApproveInactive": "免审阈值未生效",
         "withinAutoApprove": "免审范围内（<= {value}）",
@@ -1032,7 +1034,14 @@
         "autoApproveSource": "平台配置的自动免审阈值，仅影响审批判断",
         "platformFloor": "平台下限",
         "feeBreakdown": "服务费 {serviceFee} + 抽佣 {commission}",
-        "autoApproveLimit": "免审上限"
+        "autoApproveLimit": "免审上限",
+        "boundaryMarket": "市场",
+        "boundaryReference": "参考",
+        "boundaryLower": "下限",
+        "boundaryUpper": "上限",
+        "boundaryFloor": "下限",
+        "boundaryAutoApprove": "免审",
+        "boundaryTitle": "{scope}{boundary}"
       },
       "fallback": {
         "platform": "平台 {id}",


### PR DESCRIPTION
## Summary
- Localize resale margin chart labels and ARIA text instead of hard-coded Chinese strings
- Show dimension-aware floor and market price summaries in margin chart markers and tooltips
- Preserve auto-approval and platform-floor captions through explicit tooltip metadata

No linked issue was found for this change.

## Test plan
- [x] npx eslint src/components/llm-ops/BulletChart.vue src/components/llm-ops/ResalePublishingWorkspace.vue src/composables/useResalePricing.js --ignore-path ../.gitignore
- [x] npm run build

## Notes
- `npm run lint` currently fails before linting because the script points `--ignore-path .gitignore` inside `frontend/`, where no `.gitignore` exists.

Made with [Orca](https://github.com/stablyai/orca) 🐋
