### PR TITLE
Add LLM Ops Feishu approval controls

### DIFF
--- a/backend/llm_ops/admin.py
+++ b/backend/llm_ops/admin.py
@@ -31,6 +31,7 @@ class LLMOpsGlobalConfigAdmin(admin.ModelAdmin):
         "meta_model_sync_enabled",
         "price_collection_enabled",
         "price_sync_llm_config_uuid",
+        "feishu_approval_enabled",
         "updated_by",
         "updated_at",
     )

--- a/backend/llm_ops/audit.py
+++ b/backend/llm_ops/audit.py
@@ -33,6 +33,7 @@ AUDIT_FIELD_ALLOWLIST: dict[str, tuple[str, ...]] = {
         "price_collection_enabled",
         "price_collection_source_ids",
         "price_collection_cron",
+        "feishu_approval_enabled",
         "feishu_app_id",
         "feishu_approval_code",
         "feishu_tenant_key",

--- a/backend/llm_ops/migrations/0004_llmopsglobalconfig_feishu_approval_enabled.py
+++ b/backend/llm_ops/migrations/0004_llmopsglobalconfig_feishu_approval_enabled.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("llm_ops", "0003_update_meta_model_sync_default"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="llmopsglobalconfig",
+            name="feishu_approval_enabled",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/backend/llm_ops/models.py
+++ b/backend/llm_ops/models.py
@@ -205,6 +205,7 @@ class LLMOpsGlobalConfig(models.Model):
         null=True,
         db_index=True,
     )
+    feishu_approval_enabled = models.BooleanField(default=False)
     feishu_app_id = models.CharField(max_length=255, blank=True, default="")
     feishu_app_secret = models.TextField(blank=True, default="")
     feishu_approval_code = models.CharField(

--- a/backend/llm_ops/tests/test_views.py
+++ b/backend/llm_ops/tests/test_views.py
@@ -134,6 +134,7 @@ class LLMOpsViewTests(TestCase):
                 "price_collection_enabled": True,
                 "price_collection_source_ids": [source.id],
                 "price_collection_cron": "10 */6 * * *",
+                "feishu_approval_enabled": True,
                 "feishu_app_id": "cli_xxx",
                 "feishu_app_secret": "secret",
                 "feishu_approval_code": "approval_code",
@@ -147,6 +148,7 @@ class LLMOpsViewTests(TestCase):
         config = LLMOpsGlobalConfig.objects.get()
         self.assertEqual(config.updated_by, self.user)
         self.assertEqual(config.price_collection_source_ids, [source.id])
+        self.assertTrue(config.feishu_approval_enabled)
         self.assertNotEqual(config.feishu_app_secret, "secret")
         self.assertTrue(
             config.feishu_app_secret.startswith(
@@ -155,6 +157,7 @@ class LLMOpsViewTests(TestCase):
         )
         self.assertEqual(config.get_feishu_app_secret(), "secret")
         self.assertNotIn("feishu_app_secret", response.data)
+        self.assertTrue(response.data["feishu_approval_enabled"])
         self.assertTrue(response.data["feishu_app_secret_configured"])
 
         meta_task = PeriodicTask.objects.get(
@@ -2640,6 +2643,81 @@ class LLMOpsViewTests(TestCase):
         )
         self.assertEqual(patch_response.data["notes"], "disable auto approval")
         self.assertIn("runtime", patch_response.data["config"])
+
+    def test_resale_workflow_config_clears_feishu_when_global_disabled(self):
+        platform, _ = ResalePlatform.objects.get_or_create(
+            code="agione",
+            defaults={"name": "Agione"},
+        )
+        response = self.client.get(
+            reverse("resale-workflow-config-effective"),
+            {"platform": platform.id},
+        )
+        config = response.data["config"]
+        config["policies"]["feishu_approval_enabled"] = True
+        for node in config["nodes"]:
+            if node["id"] == "feishu_approval":
+                node["enabled"] = True
+        for edge in config["edges"]:
+            if edge["id"] in ("gate_to_feishu", "feishu_to_online"):
+                edge["enabled"] = True
+
+        patch_response = self.client.patch(
+            f"{reverse('resale-workflow-config-effective')}"
+            f"?platform={platform.id}",
+            {"config": config},
+            format="json",
+        )
+
+        self.assertEqual(patch_response.status_code, 200)
+        saved = ResaleWorkflowConfig.objects.get(platform=platform)
+        self.assertFalse(
+            saved.config["policies"]["feishu_approval_enabled"]
+        )
+        response_config = patch_response.data["config"]
+        self.assertFalse(
+            response_config["policies"]["feishu_approval_enabled"]
+        )
+        feishu_node = next(
+            node
+            for node in response_config["nodes"]
+            if node["id"] == "feishu_approval"
+        )
+        self.assertFalse(feishu_node["enabled"])
+        feishu_edges = [
+            edge
+            for edge in response_config["edges"]
+            if edge["id"] in ("gate_to_feishu", "feishu_to_online")
+        ]
+        self.assertTrue(feishu_edges)
+        self.assertTrue(all(not edge["enabled"] for edge in feishu_edges))
+
+    def test_resale_workflow_config_rejects_feishu_only_when_disabled(self):
+        platform, _ = ResalePlatform.objects.get_or_create(
+            code="agione",
+            defaults={"name": "Agione"},
+        )
+        response = self.client.get(
+            reverse("resale-workflow-config-effective"),
+            {"platform": platform.id},
+        )
+        config = response.data["config"]
+        config["policies"]["auto_approve_enabled"] = False
+        config["policies"]["manual_confirm_required"] = False
+        config["policies"]["feishu_approval_enabled"] = True
+
+        patch_response = self.client.patch(
+            f"{reverse('resale-workflow-config-effective')}"
+            f"?platform={platform.id}",
+            {"config": config},
+            format="json",
+        )
+
+        self.assertEqual(patch_response.status_code, 400)
+        self.assertIn("publishing path", str(patch_response.data))
+        self.assertFalse(
+            ResaleWorkflowConfig.objects.filter(platform=platform).exists()
+        )
 
     def test_resale_workflow_config_patch_requires_config(self):
         platform, _ = ResalePlatform.objects.get_or_create(

--- a/backend/llm_ops/views.py
+++ b/backend/llm_ops/views.py
@@ -1411,6 +1411,12 @@ class ResaleWorkflowConfigViewSet(
             config = self._editable_config(
                 validate_resale_workflow_config(raw_config)
             )
+            config = self._apply_global_feishu_policy(config)
+            if not self._has_publish_path(config):
+                return Response(
+                    {"detail": "At least one publishing path must be enabled."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
             instance, _created = ResaleWorkflowConfig.objects.update_or_create(
                 platform=platform,
                 defaults={
@@ -1429,13 +1435,15 @@ class ResaleWorkflowConfigViewSet(
         saved_config = (
             instance.config if instance and instance.is_active else None
         )
+        config = merge_resale_workflow_config(platform, saved_config)
+        config = self._apply_global_feishu_policy(config)
         return {
             "id": instance.id if instance else None,
             "platform": platform.id,
             "platform_name": platform.name,
             "is_active": instance.is_active if instance else True,
             "notes": instance.notes if instance else "",
-            "config": merge_resale_workflow_config(platform, saved_config),
+            "config": config,
             "updated_at": instance.updated_at if instance else None,
         }
 
@@ -1446,6 +1454,29 @@ class ResaleWorkflowConfigViewSet(
             "nodes": config.get("nodes", []),
             "edges": config.get("edges", []),
         }
+
+    def _apply_global_feishu_policy(self, config):
+        if LLMOpsGlobalConfig.get_solo().feishu_approval_enabled:
+            return config
+        config["policies"]["feishu_approval_enabled"] = False
+        for node in config.get("nodes", []):
+            if node.get("id") == "feishu_approval":
+                node["enabled"] = False
+        for edge in config.get("edges", []):
+            if edge.get("id") in ("gate_to_feishu", "feishu_to_online"):
+                edge["enabled"] = False
+        return config
+
+    def _has_publish_path(self, config):
+        policies = config.get("policies", {})
+        return any(
+            bool(policies.get(key))
+            for key in (
+                "auto_approve_enabled",
+                "manual_confirm_required",
+                "feishu_approval_enabled",
+            )
+        )
 
 
 class ResaleListingViewSet(

--- a/frontend/src/components/llm-ops/GlobalConfigPanel.vue
+++ b/frontend/src/components/llm-ops/GlobalConfigPanel.vue
@@ -40,140 +40,265 @@
 
     <BaseLoading v-if="loading" />
 
-    <form v-else class="global-config-grid" @submit.prevent="saveConfig">
-      <div class="global-config-main">
-        <section class="config-section">
-          <div class="config-section-header">
-            <div>
-              <h4>{{ t('llmOps.globalConfigPanel.metaSync.title') }}</h4>
-              <p>{{ t('llmOps.globalConfigPanel.metaSync.description') }}</p>
-            </div>
-            <label class="config-switch">
-              <span>{{
-                form.meta_model_sync_enabled
-                  ? t('llmOps.globalConfigPanel.status.enabled')
-                  : t('llmOps.globalConfigPanel.status.disabled')
-              }}</span>
-              <input v-model="form.meta_model_sync_enabled" type="checkbox" />
-            </label>
+    <form v-else class="global-config-stack" @submit.prevent="saveConfig">
+      <section class="config-section">
+        <div class="config-section-header">
+          <div>
+            <h4>{{ t('llmOps.globalConfigPanel.metaSync.title') }}</h4>
+            <p>{{ t('llmOps.globalConfigPanel.metaSync.description') }}</p>
           </div>
-
-          <label class="config-field">
-            <span>{{ t('llmOps.globalConfigPanel.fields.sourceUrl') }}</span>
-            <input
-              v-model.trim="form.meta_model_sync_source_url"
-              type="url"
-              required
-              placeholder="https://models.dev/api.json"
-            />
+          <label class="config-switch">
+            <span>{{
+              form.meta_model_sync_enabled
+                ? t('llmOps.globalConfigPanel.status.enabled')
+                : t('llmOps.globalConfigPanel.status.disabled')
+            }}</span>
+            <input v-model="form.meta_model_sync_enabled" type="checkbox" />
           </label>
-          <label class="config-field">
-            <span>{{ t('llmOps.globalConfigPanel.fields.cron') }}</span>
-            <input
-              v-model.trim="form.meta_model_sync_cron"
-              type="text"
-              required
-              placeholder="35 2 * * *"
-            />
-          </label>
-        </section>
+        </div>
 
-        <section class="config-section">
-          <div class="config-section-header">
+        <label class="config-field">
+          <span>{{ t('llmOps.globalConfigPanel.fields.sourceUrl') }}</span>
+          <input
+            v-model.trim="form.meta_model_sync_source_url"
+            type="url"
+            required
+            placeholder="https://models.dev/api.json"
+          />
+        </label>
+        <div class="schedule-editor">
+          <div class="schedule-editor-head">
             <div>
-              <h4>{{ t('llmOps.globalConfigPanel.priceCollection.title') }}</h4>
-              <p>
-                {{ t('llmOps.globalConfigPanel.priceCollection.description') }}
-              </p>
+              <span>{{ t('llmOps.globalConfigPanel.fields.schedule') }}</span>
+              <strong>{{ scheduleSummary(metaSchedule) }}</strong>
             </div>
-            <label class="config-switch">
-              <span>{{
-                form.price_collection_enabled
-                  ? t('llmOps.globalConfigPanel.status.enabled')
-                  : t('llmOps.globalConfigPanel.status.disabled')
-              }}</span>
-              <input v-model="form.price_collection_enabled" type="checkbox" />
-            </label>
-          </div>
-
-          <label class="config-field">
-            <span>{{ t('llmOps.globalConfigPanel.fields.cron') }}</span>
-            <input
-              v-model.trim="form.price_collection_cron"
-              type="text"
-              required
-              placeholder="15 1,7,13,19 * * *"
-            />
-          </label>
-          <label class="config-field">
-            <span>{{ t('llmOps.globalConfigPanel.fields.llmConfig') }}</span>
-            <select
-              v-model="form.price_sync_llm_config_uuid"
-              :disabled="llmConfigLoading"
+            <button
+              v-if="metaSchedule.mode === 'custom'"
+              type="button"
+              class="schedule-reset-button"
+              @click="resetScheduleEditor(metaSchedule, [2])"
             >
-              <option value="">
-                {{ t('llmOps.globalConfigPanel.llmConfig.default') }}
-              </option>
-              <option
-                v-for="option in llmConfigOptions"
-                :key="option.uuid"
-                :value="option.uuid"
+              {{ t('llmOps.globalConfigPanel.schedule.reselect') }}
+            </button>
+          </div>
+          <p v-if="metaSchedule.mode === 'custom'" class="schedule-custom-note">
+            {{ t('llmOps.globalConfigPanel.schedule.customDescription') }}
+          </p>
+          <template v-else>
+            <div class="schedule-hour-selector">
+              <span>{{ t('llmOps.globalConfigPanel.schedule.hours') }}</span>
+              <small>
+                {{ t('llmOps.globalConfigPanel.schedule.fixedMinute') }}
+              </small>
+            </div>
+            <div class="schedule-hour-list">
+              <div
+                v-for="(_, index) in metaSchedule.hours"
+                :key="`meta-${index}`"
+                class="schedule-hour-row"
               >
-                {{ option.label }}
-              </option>
-            </select>
-            <small>
-              {{ t('llmOps.globalConfigPanel.llmConfig.description') }}
-            </small>
+                <CompactSelect
+                  :model-value="metaSchedule.hours[index]"
+                  :options="availableHourOptions(metaSchedule, index)"
+                  :placeholder="
+                    t('llmOps.globalConfigPanel.schedule.selectHour')
+                  "
+                  class-name="schedule-hour-select"
+                  :menu-min-width="220"
+                  @update:model-value="
+                    updateScheduleHour(metaSchedule, index, $event)
+                  "
+                />
+                <button
+                  type="button"
+                  class="schedule-hour-action"
+                  :aria-label="t('llmOps.globalConfigPanel.schedule.addHour')"
+                  :disabled="!canAddScheduleHour(metaSchedule)"
+                  @click="addScheduleHour(metaSchedule)"
+                >
+                  +
+                </button>
+                <button
+                  type="button"
+                  class="schedule-hour-action"
+                  :aria-label="
+                    t('llmOps.globalConfigPanel.schedule.removeHour')
+                  "
+                  :disabled="metaSchedule.hours.length <= 1"
+                  @click="removeScheduleHour(metaSchedule, index)"
+                >
+                  -
+                </button>
+              </div>
+            </div>
+          </template>
+        </div>
+      </section>
+
+      <section class="config-section">
+        <div class="config-section-header">
+          <div>
+            <h4>{{ t('llmOps.globalConfigPanel.priceCollection.title') }}</h4>
+            <p>
+              {{ t('llmOps.globalConfigPanel.priceCollection.description') }}
+            </p>
+          </div>
+          <label class="config-switch">
+            <span>{{
+              form.price_collection_enabled
+                ? t('llmOps.globalConfigPanel.status.enabled')
+                : t('llmOps.globalConfigPanel.status.disabled')
+            }}</span>
+            <input v-model="form.price_collection_enabled" type="checkbox" />
           </label>
+        </div>
 
-          <div class="source-mode-group" role="radiogroup">
-            <label
-              v-for="mode in sourceModes"
-              :key="mode.value"
-              class="source-mode"
-              :class="{ active: sourceMode === mode.value }"
-            >
-              <input
-                v-model="sourceMode"
-                type="radio"
-                name="price_source_mode"
-                :value="mode.value"
-              />
-              <span>{{ mode.label }}</span>
-            </label>
-          </div>
-
-          <div v-if="sourceMode === 'selected'" class="source-list">
-            <label
-              v-for="source in priceSourceOptions"
-              :key="source.id"
-              class="source-row"
-            >
-              <input
-                v-model="form.price_collection_source_ids"
-                type="checkbox"
-                :value="source.id"
-              />
-              <span>
-                <strong>{{ source.name }}</strong>
-                <small>{{ sourceMeta(source) }}</small>
-              </span>
-            </label>
-            <div v-if="!priceSourceOptions.length" class="empty-source">
-              {{ t('llmOps.globalConfigPanel.empty.noPriceSources') }}
-            </div>
-          </div>
-        </section>
-      </div>
-
-      <aside class="global-config-side">
-        <section class="config-section">
-          <div class="config-section-header">
+        <div class="schedule-editor">
+          <div class="schedule-editor-head">
             <div>
-              <h4>{{ t('llmOps.globalConfigPanel.feishu.title') }}</h4>
-              <p>{{ t('llmOps.globalConfigPanel.feishu.description') }}</p>
+              <span>{{ t('llmOps.globalConfigPanel.fields.schedule') }}</span>
+              <strong>{{ scheduleSummary(priceSchedule) }}</strong>
             </div>
+            <button
+              v-if="priceSchedule.mode === 'custom'"
+              type="button"
+              class="schedule-reset-button"
+              @click="resetScheduleEditor(priceSchedule, [1, 7, 13, 19])"
+            >
+              {{ t('llmOps.globalConfigPanel.schedule.reselect') }}
+            </button>
+          </div>
+          <p
+            v-if="priceSchedule.mode === 'custom'"
+            class="schedule-custom-note"
+          >
+            {{ t('llmOps.globalConfigPanel.schedule.customDescription') }}
+          </p>
+          <template v-else>
+            <div class="schedule-hour-selector">
+              <span>{{ t('llmOps.globalConfigPanel.schedule.hours') }}</span>
+              <small>
+                {{ t('llmOps.globalConfigPanel.schedule.fixedMinute') }}
+              </small>
+            </div>
+            <div class="schedule-hour-list">
+              <div
+                v-for="(_, index) in priceSchedule.hours"
+                :key="`price-${index}`"
+                class="schedule-hour-row"
+              >
+                <CompactSelect
+                  :model-value="priceSchedule.hours[index]"
+                  :options="availableHourOptions(priceSchedule, index)"
+                  :placeholder="
+                    t('llmOps.globalConfigPanel.schedule.selectHour')
+                  "
+                  class-name="schedule-hour-select"
+                  :menu-min-width="220"
+                  @update:model-value="
+                    updateScheduleHour(priceSchedule, index, $event)
+                  "
+                />
+                <button
+                  type="button"
+                  class="schedule-hour-action"
+                  :aria-label="t('llmOps.globalConfigPanel.schedule.addHour')"
+                  :disabled="!canAddScheduleHour(priceSchedule)"
+                  @click="addScheduleHour(priceSchedule)"
+                >
+                  +
+                </button>
+                <button
+                  type="button"
+                  class="schedule-hour-action"
+                  :aria-label="
+                    t('llmOps.globalConfigPanel.schedule.removeHour')
+                  "
+                  :disabled="priceSchedule.hours.length <= 1"
+                  @click="removeScheduleHour(priceSchedule, index)"
+                >
+                  -
+                </button>
+              </div>
+            </div>
+          </template>
+        </div>
+        <label class="config-field">
+          <span>{{ t('llmOps.globalConfigPanel.fields.llmConfig') }}</span>
+          <select
+            v-model="form.price_sync_llm_config_uuid"
+            :disabled="llmConfigLoading"
+          >
+            <option value="">
+              {{ t('llmOps.globalConfigPanel.llmConfig.default') }}
+            </option>
+            <option
+              v-for="option in llmConfigOptions"
+              :key="option.uuid"
+              :value="option.uuid"
+            >
+              {{ option.label }}
+            </option>
+          </select>
+          <small>
+            {{ t('llmOps.globalConfigPanel.llmConfig.description') }}
+          </small>
+        </label>
+
+        <div class="source-mode-group" role="radiogroup">
+          <label
+            v-for="mode in sourceModes"
+            :key="mode.value"
+            class="source-mode"
+            :class="{ active: sourceMode === mode.value }"
+          >
+            <input
+              v-model="sourceMode"
+              type="radio"
+              name="price_source_mode"
+              :value="mode.value"
+            />
+            <span>{{ mode.label }}</span>
+          </label>
+        </div>
+
+        <div v-if="sourceMode === 'selected'" class="source-list">
+          <label
+            v-for="source in priceSourceOptions"
+            :key="source.id"
+            class="source-row"
+          >
+            <input
+              v-model="form.price_collection_source_ids"
+              type="checkbox"
+              :value="source.id"
+            />
+            <span>
+              <strong>{{ source.name }}</strong>
+              <small>{{ sourceMeta(source) }}</small>
+            </span>
+          </label>
+          <div v-if="!priceSourceOptions.length" class="empty-source">
+            {{ t('llmOps.globalConfigPanel.empty.noPriceSources') }}
+          </div>
+        </div>
+      </section>
+
+      <section class="config-section">
+        <div class="config-section-header">
+          <div>
+            <h4>{{ t('llmOps.globalConfigPanel.feishu.title') }}</h4>
+            <p>{{ t('llmOps.globalConfigPanel.feishu.description') }}</p>
+          </div>
+          <div class="feishu-header-actions">
+            <label class="config-switch">
+              <span>{{
+                form.feishu_approval_enabled
+                  ? t('llmOps.globalConfigPanel.status.enabled')
+                  : t('llmOps.globalConfigPanel.status.disabled')
+              }}</span>
+              <input v-model="form.feishu_approval_enabled" type="checkbox" />
+            </label>
             <span
               class="secret-status"
               :class="{ active: config?.feishu_app_secret_configured }"
@@ -185,60 +310,64 @@
               }}
             </span>
           </div>
+        </div>
 
-          <label class="config-field">
-            <span>App ID</span>
-            <input
-              v-model.trim="form.feishu_app_id"
-              type="text"
-              autocomplete="off"
-            />
-          </label>
-          <label class="config-field">
-            <span>App Secret</span>
-            <input
-              v-model.trim="form.feishu_app_secret"
-              type="password"
-              autocomplete="new-password"
-              :placeholder="
-                config?.feishu_app_secret_configured
-                  ? t('llmOps.globalConfigPanel.feishu.secretPlaceholder')
-                  : ''
-              "
-            />
-          </label>
-          <label class="config-field">
-            <span>{{ t('llmOps.globalConfigPanel.fields.approvalCode') }}</span>
-            <input
-              v-model.trim="form.feishu_approval_code"
-              type="text"
-              autocomplete="off"
-            />
-          </label>
-          <label class="config-field">
-            <span>Tenant Key</span>
-            <input
-              v-model.trim="form.feishu_tenant_key"
-              type="text"
-              autocomplete="off"
-            />
-          </label>
-        </section>
+        <p class="feishu-option-hint">
+          {{ t('llmOps.globalConfigPanel.feishu.enabledHint') }}
+        </p>
 
-        <section class="config-section">
-          <div class="config-section-header">
-            <div>
-              <h4>{{ t('llmOps.globalConfigPanel.notes.title') }}</h4>
-              <p>{{ t('llmOps.globalConfigPanel.notes.description') }}</p>
-            </div>
+        <label class="config-field">
+          <span>App ID</span>
+          <input
+            v-model.trim="form.feishu_app_id"
+            type="text"
+            autocomplete="off"
+          />
+        </label>
+        <label class="config-field">
+          <span>App Secret</span>
+          <input
+            v-model.trim="form.feishu_app_secret"
+            type="password"
+            autocomplete="new-password"
+            :placeholder="
+              config?.feishu_app_secret_configured
+                ? t('llmOps.globalConfigPanel.feishu.secretPlaceholder')
+                : ''
+            "
+          />
+        </label>
+        <label class="config-field">
+          <span>{{ t('llmOps.globalConfigPanel.fields.approvalCode') }}</span>
+          <input
+            v-model.trim="form.feishu_approval_code"
+            type="text"
+            autocomplete="off"
+          />
+        </label>
+        <label class="config-field">
+          <span>Tenant Key</span>
+          <input
+            v-model.trim="form.feishu_tenant_key"
+            type="text"
+            autocomplete="off"
+          />
+        </label>
+      </section>
+
+      <section class="config-section">
+        <div class="config-section-header">
+          <div>
+            <h4>{{ t('llmOps.globalConfigPanel.notes.title') }}</h4>
+            <p>{{ t('llmOps.globalConfigPanel.notes.description') }}</p>
           </div>
-          <textarea v-model.trim="form.notes" rows="5" />
-          <div class="config-runtime">
-            <span>{{ t('llmOps.globalConfigPanel.fields.updatedAt') }}</span>
-            <strong>{{ formatDateTime(config?.updated_at) }}</strong>
-          </div>
-        </section>
-      </aside>
+        </div>
+        <textarea v-model.trim="form.notes" rows="5" />
+        <div class="config-runtime">
+          <span>{{ t('llmOps.globalConfigPanel.fields.updatedAt') }}</span>
+          <strong>{{ formatDateTime(config?.updated_at) }}</strong>
+        </div>
+      </section>
     </form>
   </section>
 </template>
@@ -250,6 +379,7 @@ import { useI18n } from 'vue-i18n'
 import BaseLoading from '@/components/ui/BaseLoading.vue'
 import { llmAdminApi } from '@/admin/api'
 import { llmOpsApi } from '@/api/llmOps'
+import CompactSelect from '@/components/llm-ops/CompactSelect.vue'
 import { useToast } from '@/composables/useToast'
 import { priceSourceCollectionMethod } from '@/utils/llmOpsPriceSources'
 
@@ -271,6 +401,10 @@ const llmConfigLoading = ref(false)
 const llmConfigs = ref([])
 const sourceMode = ref('all')
 
+const metaSchedule = reactive(createScheduleEditor())
+const priceSchedule = reactive(createScheduleEditor())
+const FIXED_SCHEDULE_MINUTE = 5
+
 const form = reactive({
   meta_model_sync_enabled: true,
   meta_model_sync_source_url: 'https://models.dev/api.json',
@@ -281,10 +415,16 @@ const form = reactive({
   price_sync_llm_config_uuid: '',
   feishu_app_id: '',
   feishu_app_secret: '',
+  feishu_approval_enabled: false,
   feishu_approval_code: '',
   feishu_tenant_key: '',
   notes: ''
 })
+
+const hourOptions = Array.from({ length: 24 }, (_, hour) => ({
+  label: hourLabel(hour),
+  value: hour
+}))
 
 const sourceModes = computed(() => [
   {
@@ -355,18 +495,23 @@ async function saveConfig() {
     showError(t('llmOps.globalConfigPanel.errors.sourceRequired'))
     return
   }
+  if (!isScheduleValid(metaSchedule) || !isScheduleValid(priceSchedule)) {
+    showError(t('llmOps.globalConfigPanel.errors.scheduleRequired'))
+    return
+  }
   saving.value = true
   try {
     const payload = {
       meta_model_sync_enabled: form.meta_model_sync_enabled,
       meta_model_sync_source_url: form.meta_model_sync_source_url,
-      meta_model_sync_cron: form.meta_model_sync_cron,
+      meta_model_sync_cron: scheduleToCron(metaSchedule),
       price_collection_enabled: form.price_collection_enabled,
       price_collection_source_ids:
         sourceMode.value === 'all' ? [] : form.price_collection_source_ids,
-      price_collection_cron: form.price_collection_cron,
+      price_collection_cron: scheduleToCron(priceSchedule),
       price_sync_llm_config_uuid: form.price_sync_llm_config_uuid || null,
       feishu_app_id: form.feishu_app_id,
+      feishu_approval_enabled: form.feishu_approval_enabled,
       feishu_approval_code: form.feishu_approval_code,
       feishu_tenant_key: form.feishu_tenant_key,
       notes: form.notes
@@ -409,23 +554,218 @@ function applyConfig(nextConfig) {
   form.meta_model_sync_enabled = nextConfig.meta_model_sync_enabled
   form.meta_model_sync_source_url = nextConfig.meta_model_sync_source_url
   form.meta_model_sync_cron = nextConfig.meta_model_sync_cron
+  applySchedule(
+    metaSchedule,
+    parseScheduleCron(nextConfig.meta_model_sync_cron)
+  )
   form.price_collection_enabled = nextConfig.price_collection_enabled
   form.price_collection_source_ids = [
     ...(nextConfig.price_collection_source_ids || [])
   ]
   form.price_collection_cron = nextConfig.price_collection_cron
+  applySchedule(
+    priceSchedule,
+    parseScheduleCron(nextConfig.price_collection_cron)
+  )
   form.price_sync_llm_config_uuid =
     nextConfig.price_sync_llm_config?.uuid ||
     nextConfig.price_sync_llm_config_uuid ||
     ''
   form.feishu_app_id = nextConfig.feishu_app_id || ''
   form.feishu_app_secret = ''
+  form.feishu_approval_enabled = Boolean(nextConfig.feishu_approval_enabled)
   form.feishu_approval_code = nextConfig.feishu_approval_code || ''
   form.feishu_tenant_key = nextConfig.feishu_tenant_key || ''
   form.notes = nextConfig.notes || ''
   sourceMode.value = form.price_collection_source_ids.length
     ? 'selected'
     : 'all'
+}
+
+function createScheduleEditor() {
+  return {
+    mode: 'hours',
+    minute: 0,
+    hours: [],
+    originalCron: '',
+    touched: false
+  }
+}
+
+function parseScheduleCron(cron) {
+  const normalized = String(cron || '')
+    .trim()
+    .replace(/\s+/g, ' ')
+  const parts = normalized.split(' ')
+  if (parts.length !== 5 || parts.slice(2).some((part) => part !== '*')) {
+    return customSchedule(normalized)
+  }
+
+  const minute = parseIntegerPart(parts[0], 0, 59)
+  if (minute === null) return customSchedule(normalized)
+
+  const hours = parseHourPart(parts[1])
+  if (!hours.length) return customSchedule(normalized)
+
+  if (hours.length === 1) {
+    return {
+      hours,
+      minute,
+      mode: 'hours',
+      originalCron: normalized,
+      touched: false
+    }
+  }
+  return {
+    hours,
+    minute,
+    mode: 'hours',
+    originalCron: normalized,
+    touched: false
+  }
+}
+
+function parseHourPart(value) {
+  if (value === '*') return hourOptions.map((option) => option.value)
+
+  if (value.startsWith('*/')) {
+    const step = parseIntegerPart(value.slice(2), 1, 23)
+    if (!step) return []
+    return hourOptions
+      .map((option) => option.value)
+      .filter((hour) => hour % step === 0)
+  }
+
+  const hours = value.split(',').map((part) => parseIntegerPart(part, 0, 23))
+  if (hours.some((hour) => hour === null)) return []
+  return Array.from(new Set(hours)).sort((left, right) => left - right)
+}
+
+function parseIntegerPart(value, min, max) {
+  if (!/^\d+$/.test(String(value))) return null
+  const number = Number(value)
+  return number >= min && number <= max ? number : null
+}
+
+function customSchedule(cron) {
+  return {
+    hours: [],
+    minute: 0,
+    mode: 'custom',
+    originalCron: cron,
+    touched: false
+  }
+}
+
+function applySchedule(target, nextSchedule) {
+  target.mode = nextSchedule.mode
+  target.minute = nextSchedule.minute
+  target.hours = [...nextSchedule.hours]
+  target.originalCron = nextSchedule.originalCron
+  target.touched = nextSchedule.touched
+}
+
+function resetScheduleEditor(target, hours) {
+  applySchedule(target, {
+    hours,
+    minute: FIXED_SCHEDULE_MINUTE,
+    mode: 'hours',
+    originalCron: '',
+    touched: true
+  })
+}
+
+function markScheduleTouched(schedule) {
+  schedule.touched = true
+  schedule.minute = FIXED_SCHEDULE_MINUTE
+}
+
+function availableHourOptions(schedule, index) {
+  const currentHour = schedule.hours[index]
+  const usedHours = new Set(schedule.hours)
+  const minute = schedule.touched ? FIXED_SCHEDULE_MINUTE : schedule.minute
+  return hourOptions
+    .filter((hour) => hour.value === currentHour || !usedHours.has(hour.value))
+    .map((hour) => ({
+      ...hour,
+      description: t('llmOps.globalConfigPanel.schedule.optionDescription', {
+        time: timeLabel(hour.value, minute)
+      }),
+      label: timeLabel(hour.value, minute)
+    }))
+}
+
+function canAddScheduleHour(schedule) {
+  return schedule.hours.length < hourOptions.length
+}
+
+function updateScheduleHour(schedule, index, value) {
+  schedule.hours[index] = Number(value)
+  markScheduleTouched(schedule)
+}
+
+function addScheduleHour(schedule) {
+  const usedHours = new Set(schedule.hours)
+  const nextHour = hourOptions.find((hour) => !usedHours.has(hour.value))
+  if (!nextHour) return
+  schedule.hours.push(nextHour.value)
+  markScheduleTouched(schedule)
+}
+
+function removeScheduleHour(schedule, index) {
+  if (schedule.hours.length <= 1) return
+  schedule.hours.splice(index, 1)
+  markScheduleTouched(schedule)
+}
+
+function isScheduleValid(schedule) {
+  if (schedule.mode === 'custom') return Boolean(schedule.originalCron)
+  return schedule.hours.length > 0
+}
+
+function scheduleToCron(schedule) {
+  if (schedule.mode === 'custom') {
+    return schedule.originalCron
+  }
+  if (!schedule.touched && schedule.originalCron) {
+    return schedule.originalCron
+  }
+  const hours = Array.from(new Set(schedule.hours))
+    .sort((left, right) => left - right)
+    .join(',')
+  return `${FIXED_SCHEDULE_MINUTE} ${hours} * * *`
+}
+
+function scheduleSummary(schedule) {
+  if (schedule.mode === 'custom') {
+    return t('llmOps.globalConfigPanel.schedule.custom')
+  }
+
+  const minute = schedule.touched ? FIXED_SCHEDULE_MINUTE : schedule.minute
+  const times = Array.from(new Set(schedule.hours))
+    .sort((left, right) => left - right)
+    .map((hour) => timeLabel(hour, minute))
+    .join(t('llmOps.globalConfigPanel.schedule.timeSeparator'))
+
+  if (!times) {
+    return t('llmOps.globalConfigPanel.schedule.emptyHours')
+  }
+
+  return t('llmOps.globalConfigPanel.schedule.summarySelectedHours', {
+    times
+  })
+}
+
+function timeLabel(hour, minute) {
+  return `${hourLabel(hour)}:${minuteLabel(minute)}`
+}
+
+function hourLabel(hour) {
+  return String(hour).padStart(2, '0')
+}
+
+function minuteLabel(minute) {
+  return String(minute).padStart(2, '0')
 }
 
 function sourceSupportsRuntimePriceSync(source) {
@@ -537,19 +877,11 @@ function errorMessage(error, fallback) {
   justify-content: flex-end;
 }
 
-.global-config-grid {
-  align-items: start;
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: minmax(0, 1.45fr) minmax(20rem, 0.8fr);
-}
-
-.global-config-main,
-.global-config-side {
+.global-config-stack {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  min-width: 0;
+  width: 100%;
 }
 
 .config-section {
@@ -615,6 +947,155 @@ function errorMessage(error, fallback) {
   color: #64748b;
   font-size: 0.75rem;
   line-height: 1.5;
+}
+
+.schedule-editor {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0.875rem;
+}
+
+.schedule-editor-head {
+  align-items: flex-start;
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+}
+
+.schedule-editor-head span,
+.schedule-hour-selector span {
+  color: #334155;
+  display: block;
+  font-size: 0.8125rem;
+  font-weight: 700;
+}
+
+.schedule-editor-head strong {
+  color: #0f172a;
+  display: block;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  margin-top: 0.25rem;
+}
+
+.schedule-reset-button {
+  background: #ffffff;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.5rem;
+  color: #047857;
+  cursor: pointer;
+  flex: 0 0 auto;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  padding: 0.45rem 0.65rem;
+}
+
+.schedule-custom-note {
+  color: #64748b;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.schedule-hour-selector {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.schedule-hour-selector small {
+  color: #64748b;
+  font-size: 0.75rem;
+  line-height: 1.5;
+}
+
+.schedule-hour-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.schedule-hour-row {
+  align-items: center;
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: minmax(0, 1fr) 2.375rem 2.375rem;
+}
+
+.schedule-hour-row :deep(.schedule-hour-select) {
+  min-width: 0;
+  width: 100%;
+}
+
+.schedule-hour-row :deep(.schedule-hour-select .compact-select-trigger) {
+  border-color: #cbd5e1;
+  border-radius: 0.5rem;
+  color: #0f172a;
+  min-height: 2.625rem;
+  padding: 0.625rem 0.75rem;
+}
+
+.schedule-hour-row :deep(.schedule-hour-select .compact-select-trigger:hover) {
+  border-color: #94a3b8;
+  background: #ffffff;
+}
+
+.schedule-hour-row :deep(.schedule-hour-select .compact-select-trigger:focus) {
+  border-color: #059669;
+  box-shadow: 0 0 0 3px rgba(5, 150, 105, 0.12);
+}
+
+.schedule-hour-row :deep(.schedule-hour-select .compact-select-menu) {
+  border-color: #dbe4ee;
+  box-shadow: 0 1rem 2rem rgba(15, 23, 42, 0.14);
+  padding: 0.375rem;
+}
+
+.schedule-hour-row :deep(.schedule-hour-select .compact-select-option) {
+  border-radius: 0.5rem;
+  min-height: 2.5rem;
+  padding: 0.5rem 0.625rem;
+}
+
+.schedule-hour-row :deep(.schedule-hour-select .compact-select-option-active) {
+  background: #ecfdf5;
+  color: #047857;
+}
+
+.schedule-hour-row :deep(.schedule-hour-select .compact-select-check) {
+  color: #059669;
+}
+
+.schedule-hour-action {
+  align-items: center;
+  background: #ffffff;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.5rem;
+  color: #047857;
+  cursor: pointer;
+  display: inline-flex;
+  font-size: 1rem;
+  font-weight: 700;
+  height: 2.625rem;
+  justify-content: center;
+  line-height: 1;
+  width: 2.375rem;
+}
+
+.schedule-hour-action:disabled {
+  background: #f8fafc;
+  color: #94a3b8;
+  cursor: not-allowed;
+}
+
+.schedule-hour-action:focus {
+  border-color: #059669;
+  box-shadow: 0 0 0 3px rgba(5, 150, 105, 0.12);
+  outline: none;
 }
 
 .source-mode-group {
@@ -683,6 +1164,22 @@ function errorMessage(error, fallback) {
   padding: 0.9rem;
 }
 
+.feishu-header-actions {
+  align-items: center;
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.feishu-option-hint {
+  color: #64748b;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  margin: -0.25rem 0 0;
+}
+
 .secret-status {
   background: #f1f5f9;
   border-radius: 999px;
@@ -713,12 +1210,6 @@ function errorMessage(error, fallback) {
   font-weight: 700;
 }
 
-@media (max-width: 1024px) {
-  .global-config-grid {
-    grid-template-columns: 1fr;
-  }
-}
-
 @media (max-width: 768px) {
   .global-config-toolbar,
   .config-section-header {
@@ -728,6 +1219,18 @@ function errorMessage(error, fallback) {
   .global-config-actions {
     justify-content: flex-start;
     width: 100%;
+  }
+
+  .feishu-header-actions {
+    justify-content: flex-start;
+  }
+
+  .schedule-editor-head {
+    flex-direction: column;
+  }
+
+  .schedule-hour-row {
+    grid-template-columns: minmax(0, 1fr) 2.375rem 2.375rem;
   }
 }
 </style>

--- a/frontend/src/components/llm-ops/ResaleWorkflowConfigPanel.vue
+++ b/frontend/src/components/llm-ops/ResaleWorkflowConfigPanel.vue
@@ -157,10 +157,10 @@
                     <option value="internal">
                       {{ t('llmOps.workflowConfig.approvalModes.internal') }}
                     </option>
-                    <option value="external">
+                    <option v-if="feishuApprovalAvailable" value="external">
                       {{ t('llmOps.workflowConfig.approvalModes.external') }}
                     </option>
-                    <option value="both">
+                    <option v-if="feishuApprovalAvailable" value="both">
                       {{ t('llmOps.workflowConfig.approvalModes.both') }}
                     </option>
                     <option
@@ -175,6 +175,12 @@
                 <span>{{
                   t('llmOps.workflowConfig.policy.reviewFallback')
                 }}</span>
+                <span
+                  v-if="!feishuApprovalAvailable"
+                  class="workflow-node-hint"
+                >
+                  {{ t('llmOps.workflowConfig.policy.feishuDisabledHint') }}
+                </span>
               </article>
             </div>
 
@@ -263,6 +269,7 @@ const loading = ref(false)
 const saving = ref(false)
 const workflow = ref(null)
 const localPlatformId = ref(props.platformId || '')
+const feishuApprovalAvailable = ref(false)
 
 const platformOptions = computed(() =>
   props.platforms.map((platform) => ({
@@ -352,10 +359,15 @@ async function loadConfig() {
   if (!localPlatformId.value) return
   loading.value = true
   try {
-    const response = await llmOpsApi.getResaleWorkflowConfig(
-      localPlatformId.value
+    const [response, globalResponse] = await Promise.all([
+      llmOpsApi.getResaleWorkflowConfig(localPlatformId.value),
+      llmOpsApi.getGlobalConfig()
+    ])
+    feishuApprovalAvailable.value = Boolean(
+      normalizeGlobalConfigPayload(globalResponse.data).feishu_approval_enabled
     )
     workflow.value = normalizeWorkflowPayload(response.data)
+    enforceFeishuApprovalAvailability()
     syncPolicyEdges()
   } catch (error) {
     showError(
@@ -374,6 +386,7 @@ async function saveConfig() {
   }
   saving.value = true
   try {
+    enforceFeishuApprovalAvailability()
     syncPolicyEdges()
     const response = await llmOpsApi.updateResaleWorkflowConfig(
       localPlatformId.value,
@@ -384,6 +397,7 @@ async function saveConfig() {
       }
     )
     workflow.value = normalizeWorkflowPayload(response.data)
+    enforceFeishuApprovalAvailability()
     syncPolicyEdges()
     showSuccess(t('llmOps.workflowConfig.messages.saved'))
     emit('saved', workflow.value)
@@ -405,6 +419,7 @@ async function resetConfig() {
       localPlatformId.value
     )
     workflow.value = normalizeWorkflowPayload(response.data)
+    enforceFeishuApprovalAvailability()
     syncPolicyEdges()
     showSuccess(t('llmOps.workflowConfig.messages.reset'))
     emit('saved', workflow.value)
@@ -420,6 +435,7 @@ async function resetConfig() {
 function syncPolicyEdges() {
   const config = editableConfig.value
   if (!config?.edges || !config?.nodes || !config?.policies) return
+  enforceFeishuApprovalAvailability()
   setNodeEnabled('auto_confirm', config.policies.auto_approve_enabled)
   setNodeEnabled('manual_review', config.policies.manual_confirm_required)
   setNodeEnabled('feishu_approval', config.policies.feishu_approval_enabled)
@@ -443,6 +459,9 @@ function onAutoApproveToggle() {
 function setApprovalMode(mode) {
   const config = editableConfig.value
   if (!config?.policies) return
+  if (!feishuApprovalAvailable.value && ['external', 'both'].includes(mode)) {
+    mode = 'internal'
+  }
   if (mode === 'disabled' && !config.policies.auto_approve_enabled) {
     config.policies.manual_confirm_required = true
     config.policies.feishu_approval_enabled = false
@@ -475,8 +494,14 @@ function hasPublishPath(policyState = {}) {
   return Boolean(
     policyState.auto_approve_enabled ||
       policyState.manual_confirm_required ||
-      policyState.feishu_approval_enabled
+      (feishuApprovalAvailable.value && policyState.feishu_approval_enabled)
   )
+}
+
+function enforceFeishuApprovalAvailability() {
+  const config = editableConfig.value
+  if (!config?.policies || feishuApprovalAvailable.value) return
+  config.policies.feishu_approval_enabled = false
 }
 
 function normalizeWorkflowPayload(payload) {
@@ -494,6 +519,11 @@ function normalizeWorkflowPayload(payload) {
     runtime: isPlainObject(config.runtime) ? config.runtime : {}
   }
   return next
+}
+
+function normalizeGlobalConfigPayload(payload) {
+  const source = isPlainObject(payload?.data) ? payload.data : payload
+  return isPlainObject(source) ? source : {}
 }
 
 function isPlainObject(value) {

--- a/frontend/src/components/llm-ops/resaleWorkflowConfigPanel.css
+++ b/frontend/src/components/llm-ops/resaleWorkflowConfigPanel.css
@@ -329,6 +329,11 @@
   margin-top: 0.2rem;
 }
 
+.workflow-panel .workflow-flow-node span.workflow-node-hint {
+  color: #047857;
+  font-weight: 700;
+}
+
 .workflow-panel .workflow-node-top {
   align-items: flex-start;
   display: flex;

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1075,6 +1075,7 @@
         "llmConfigLoad": "Failed to load LLM configurations",
         "loadFailed": "Failed to load global settings",
         "resetFailed": "Failed to restore default settings",
+        "scheduleRequired": "Select a valid execution schedule",
         "saveFailed": "Failed to save global settings",
         "sourceRequired": "Select at least one model price source"
       },
@@ -1082,11 +1083,13 @@
         "approvalCode": "Approval definition code",
         "cron": "Schedule",
         "llmConfig": "Agent LLM configuration",
+        "schedule": "Schedule",
         "sourceUrl": "Source URL",
         "updatedAt": "Last updated"
       },
       "feishu": {
-        "description": "Used to submit approval instances for model listing workflows.",
+        "description": "When enabled, listing workflows can use the external Feishu approval path.",
+        "enabledHint": "When disabled, Feishu approval options are hidden from workflow configuration.",
         "secretConfigured": "Secret configured",
         "secretMissing": "Not configured",
         "secretPlaceholder": "Leave blank to keep the current secret",
@@ -1111,6 +1114,20 @@
       "priceCollection": {
         "description": "Sync official or supplier model price data.",
         "title": "Model Price Collection"
+      },
+      "schedule": {
+        "addHour": "Add run hour",
+        "custom": "Custom schedule",
+        "customDescription": "The current schedule is outside the visual editor range. Saving other settings keeps it unchanged. Reselect run hours to switch it to minute 05.",
+        "emptyHours": "Select at least one run time",
+        "fixedMinute": "After changes, runs at minute 05 in each selected hour.",
+        "hours": "Run hours",
+        "optionDescription": "Runs daily at {time}",
+        "removeHour": "Remove run hour",
+        "reselect": "Reselect",
+        "selectHour": "Select run hour",
+        "summarySelectedHours": "Runs daily at {times}",
+        "timeSeparator": ", "
       },
       "sourceModes": {
         "all": "All enabled sources",
@@ -1183,6 +1200,7 @@
         "autoApproveThreshold": "Margin <= {rate}",
         "autoApproveHint": "Skip review when matched",
         "autoPath": "Enable auto-approval",
+        "feishuDisabledHint": "Feishu approval is not enabled in global settings",
         "postApprovalAction": "Post-approval action",
         "publishPolicy": "Post-approval action",
         "reviewFallback": "Used when auto-approval is not matched",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1085,6 +1085,7 @@
         "llmConfigLoad": "加载 LLM 配置失败",
         "loadFailed": "加载全局配置失败",
         "resetFailed": "恢复默认配置失败",
+        "scheduleRequired": "请选择有效的执行周期",
         "saveFailed": "保存全局配置失败",
         "sourceRequired": "请至少选择一个模型价格源"
       },
@@ -1092,11 +1093,13 @@
         "approvalCode": "审批定义 Code",
         "cron": "执行周期",
         "llmConfig": "Agent 使用的 LLM 配置",
+        "schedule": "执行周期",
         "sourceUrl": "数据源 URL",
         "updatedAt": "最近更新"
       },
       "feishu": {
-        "description": "用于模型上架审核流程提交审批实例。",
+        "description": "启用后，模型上架流程可选择外部飞书审批路径。",
+        "enabledHint": "关闭后，上架流程配置中不会出现飞书审批选项。",
         "secretConfigured": "密钥已配置",
         "secretMissing": "未配置",
         "secretPlaceholder": "留空则保留当前密钥",
@@ -1121,6 +1124,20 @@
       "priceCollection": {
         "description": "同步官方或供货商模型价格数据。",
         "title": "模型价格采集"
+      },
+      "schedule": {
+        "addHour": "添加执行小时",
+        "custom": "自定义周期",
+        "customDescription": "当前周期超出可视化编辑范围，保存其它配置时会保留原周期；如需调整，请重新选择执行小时，之后统一在 05 分执行。",
+        "emptyHours": "请选择至少一个执行时间",
+        "fixedMinute": "修改后统一在所选小时的 05 分执行。",
+        "hours": "执行小时",
+        "optionDescription": "每天 {time} 执行",
+        "removeHour": "删除执行小时",
+        "reselect": "重新选择",
+        "selectHour": "选择执行小时",
+        "summarySelectedHours": "每天 {times} 执行",
+        "timeSeparator": "、"
       },
       "sourceModes": {
         "all": "全部启用的数据源",
@@ -1193,6 +1210,7 @@
         "autoApproveThreshold": "收益率 <= {rate}",
         "autoApproveHint": "命中后跳过审核",
         "autoPath": "是否启用免审",
+        "feishuDisabledHint": "飞书审批未在全局配置中启用",
         "postApprovalAction": "通过后上线方式",
         "publishPolicy": "通过后上线方式",
         "reviewFallback": "未命中免审时执行",


### PR DESCRIPTION
## Summary
- Add a global `feishu_approval_enabled` switch to LLM Ops config with migration, admin visibility, API serialization, and audit coverage.
- Enforce the global switch in resale workflow config so Feishu-only publishing is rejected when the switch is disabled.
- Update LLM Ops UI to manage the global Feishu approval switch, visual schedule selection, and hide external approval choices when unavailable.

## Test plan
- [x] `npm run build`
- [x] `./node_modules/.bin/eslint src/components/llm-ops/GlobalConfigPanel.vue src/components/llm-ops/ResaleWorkflowConfigPanel.vue --fix --ignore-path ../.gitignore`
- [x] `git diff --cached --check`
- [ ] `python3 -m pytest backend/llm_ops/tests/test_views.py -k "global_config or resale_workflow_config"` blocked locally: `ModuleNotFoundError: No module named 'drf_spectacular'`
- [ ] `npm run lint` blocked locally: package script points `--ignore-path .gitignore`, but `frontend/.gitignore` does not exist; full fallback lint also reports existing errors outside this change.

Made with [Orca](https://github.com/stablyai/orca) 🐋
