### PR TITLE
Fix LLM Ops channel price source groups

### DIFF
--- a/backend/llm_ops/services.py
+++ b/backend/llm_ops/services.py
@@ -1076,6 +1076,15 @@ def resolve_channel_model_price(
         audio_output_price = source_unit_prices.audio_output_per_second * ratio
         video_input_price = source_unit_prices.video_input_per_second * ratio
         video_output_price = source_unit_prices.video_output_per_second * ratio
+    elif override and override.price_source_id:
+        input_price = ZERO
+        output_price = ZERO
+        cache_input_price = ZERO
+        image_output_price = ZERO
+        audio_input_price = ZERO
+        audio_output_price = ZERO
+        video_input_price = ZERO
+        video_output_price = ZERO
 
     resolution_prices = model.video_resolution_prices or {}
     if video_resolution and video_resolution in resolution_prices:
@@ -1429,6 +1438,8 @@ def channel_price_item_payloads(
             )
             for base_item in base_items
         ]
+    if price.price_source_id:
+        return []
     return legacy_channel_price_item_payloads(
         price,
         currency=currency,
@@ -1440,19 +1451,23 @@ def current_model_price_items_for_channel_price(
     price: ChannelModelPrice,
 ) -> list[ModelPriceItem]:
     """Return current price items for the selected procurement source."""
-    rows = current_price_items_for_model(
-        price.model,
-        source_id=price.price_source_id,
-    )
-    if rows:
-        return rows
     if price.price_source_id:
-        rows = fallback_price_items_for_meta_model(
+        rows = current_price_items_for_model(
             price.model,
             source_id=price.price_source_id,
         )
         if rows:
-            return rows
+            return selected_price_item_group(rows, model=price.model)
+        return fallback_price_items_for_meta_model(
+            price.model,
+            source_id=price.price_source_id,
+        )
+
+    rows = current_price_items_for_model(
+        price.model,
+    )
+    if rows:
+        return selected_price_item_group(rows, model=price.model)
     return fallback_price_items_for_meta_model(price.model)
 
 
@@ -1497,6 +1512,15 @@ def fallback_price_items_for_meta_model(
     if not rows:
         return []
 
+    return selected_price_item_group(rows, model=model)
+
+
+def selected_price_item_group(
+    rows: list[ModelPriceItem],
+    *,
+    model: LLMModel | None = None,
+) -> list[ModelPriceItem]:
+    """Return the best coherent price item group from candidate rows."""
     groups: dict[str, list[ModelPriceItem]] = {}
     for item in rows:
         key = price_item_group_key(item)
@@ -1504,26 +1528,31 @@ def fallback_price_items_for_meta_model(
 
     return sorted(
         groups.values(),
-        key=price_item_group_score,
+        key=lambda group: price_item_group_score(group, model=model),
         reverse=True,
     )[0]
 
 
 def price_item_group_key(item: ModelPriceItem) -> str:
     """Return the identity used to compare coherent price item groups."""
+    spec_key = json.dumps(item.spec or {}, sort_keys=True)
     if item.offering_id:
-        return f"offering:{item.offering_id}"
+        return f"offering:{item.offering_id}:{spec_key}"
     if item.sku_id:
-        return f"sku:{item.source_id or ''}:{item.sku_id}"
+        return f"sku:{item.source_id or ''}:{item.sku_id}:{spec_key}"
     if item.model_id:
-        return f"model:{item.source_id or ''}:{item.model_id}"
-    return f"source:{item.source_id or ''}"
+        return f"model:{item.source_id or ''}:{item.model_id}:{spec_key}"
+    return f"source:{item.source_id or ''}:{spec_key}"
 
 
-def price_item_group_score(rows: list[ModelPriceItem]) -> tuple:
+def price_item_group_score(
+    rows: list[ModelPriceItem],
+    *,
+    model: LLMModel | None = None,
+) -> tuple:
     """Score fallback price groups like the frontend channel preview."""
     if not rows:
-        return (0, 0, 0)
+        return (0, 0, 0, 0)
     first = rows[0]
     role = ""
     if first.source_id:
@@ -1538,9 +1567,48 @@ def price_item_group_score(rows: list[ModelPriceItem]) -> tuple:
         LLMModel.PRICE_ROLE_CLOUD_HOSTED: 250,
         LLMModel.PRICE_ROLE_SUPPLIER: 200,
     }.get(role, 0)
+    alignment_score = price_item_group_alignment_score(rows, model)
     latest = max((item.effective_from for item in rows), default=None)
     latest_score = latest.timestamp() if latest else 0
-    return (category_score, len(rows), latest_score)
+    return (category_score, len(rows), alignment_score, latest_score)
+
+
+def price_item_group_alignment_score(
+    rows: list[ModelPriceItem],
+    model: LLMModel | None,
+) -> int:
+    """Prefer the group that matches the model's promoted base prices."""
+    if model is None:
+        return 0
+
+    field_map = {
+        ModelPriceItem.DIMENSION_TEXT_INPUT: "input_price_per_million",
+        ModelPriceItem.DIMENSION_TEXT_OUTPUT: "output_price_per_million",
+        ModelPriceItem.DIMENSION_CACHE_INPUT: "cache_input_price_per_million",
+        ModelPriceItem.DIMENSION_IMAGE_OUTPUT: "image_output_price_per_image",
+        ModelPriceItem.DIMENSION_AUDIO_INPUT: "audio_input_price_per_second",
+        ModelPriceItem.DIMENSION_AUDIO_OUTPUT: "audio_output_price_per_second",
+        ModelPriceItem.DIMENSION_VIDEO_INPUT: "video_input_price_per_second",
+        ModelPriceItem.DIMENSION_VIDEO_OUTPUT: "video_output_price_per_second",
+    }
+    score = 0
+    for item in rows:
+        field_name = field_map.get(item.dimension)
+        if not field_name:
+            continue
+        model_value = getattr(model, field_name, None)
+        if model_value is None:
+            continue
+        converted = convert_currency_between(
+            item.unit_price,
+            item.currency,
+            model.currency,
+        )
+        if converted is None:
+            continue
+        if decimal_or_zero(model_value) == decimal_or_zero(converted):
+            score += 1
+    return score
 
 
 def channel_price_payload_from_base_item(

--- a/backend/llm_ops/tests/test_services.py
+++ b/backend/llm_ops/tests/test_services.py
@@ -318,7 +318,7 @@ class LLMOpsPricingServiceTests(TestCase):
         self.assertEqual(items[0].unit_price, Decimal("1.500000"))
         self.assertEqual(cost, Decimal("1.500000"))
 
-    def test_sync_falls_back_to_meta_model_price_items(self):
+    def test_sync_does_not_fallback_when_selected_source_has_no_items(self):
         official_source = PriceCollectionSource.objects.create(
             name="OpenAI Official Meta",
             slug="openai-official-meta",
@@ -342,7 +342,7 @@ class LLMOpsPricingServiceTests(TestCase):
             name="GPT-4o Official",
             code="gpt-4o-official",
         )
-        official_item = ModelPriceItem.objects.create(
+        ModelPriceItem.objects.create(
             provider=self.provider,
             model=official_model,
             source=official_source,
@@ -367,10 +367,8 @@ class LLMOpsPricingServiceTests(TestCase):
             input_tokens=1_000_000,
         )
 
-        self.assertEqual(len(items), 1)
-        self.assertEqual(items[0].base_price_item, official_item)
-        self.assertEqual(items[0].unit_price, Decimal("1.250000"))
-        self.assertEqual(cost, Decimal("1.250000"))
+        self.assertEqual(items, [])
+        self.assertEqual(cost, Decimal("0.000000"))
 
     def test_sync_uses_selected_source_offering_price_items(self):
         first_source = PriceCollectionSource.objects.create(
@@ -450,6 +448,107 @@ class LLMOpsPricingServiceTests(TestCase):
         self.assertEqual(items[0].base_price_item, selected_item)
         self.assertEqual(items[0].unit_price, Decimal("1.500000"))
         self.assertEqual(cost, Decimal("1.500000"))
+
+    def test_sync_selects_price_group_matching_model_base_prices(self):
+        source = PriceCollectionSource.objects.create(
+            name="Aliyun Official",
+            slug="aliyun-official",
+            provider=self.provider,
+            source_category=(
+                PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
+            ),
+            currency="CNY",
+        )
+        sku = ModelSku.objects.create(
+            provider=self.provider,
+            meta_model=self.model.meta_model,
+            canonical_sku_code="deepseek-v4-flash",
+            upstream_model_name="deepseek-v4-flash",
+            display_name="Deepseek V4 Flash",
+        )
+        offering = SourceSkuOffering.objects.create(
+            source=source,
+            sku=sku,
+            provider=self.provider,
+            exposed_model_name="deepseek-v4-flash",
+        )
+        self.model.input_price_per_million = Decimal("1")
+        self.model.output_price_per_million = Decimal("2")
+        self.model.currency = "CNY"
+        self.model.save(
+            update_fields=[
+                "input_price_per_million",
+                "output_price_per_million",
+                "currency",
+            ]
+        )
+        price_specs = [
+            (
+                "mainland-input",
+                ModelPriceItem.DIMENSION_TEXT_INPUT,
+                "1",
+                "中国内地",
+            ),
+            (
+                "mainland-output",
+                ModelPriceItem.DIMENSION_TEXT_OUTPUT,
+                "2",
+                "中国内地",
+            ),
+            (
+                "intl-input",
+                ModelPriceItem.DIMENSION_TEXT_INPUT,
+                "1.499",
+                "国际",
+            ),
+            (
+                "intl-output",
+                ModelPriceItem.DIMENSION_TEXT_OUTPUT,
+                "2.998",
+                "国际",
+            ),
+        ]
+        for fingerprint, dimension, unit_price, region in price_specs:
+            ModelPriceItem.objects.create(
+                provider=self.provider,
+                sku=sku,
+                offering=offering,
+                meta_model=self.model.meta_model,
+                source=source,
+                dimension=dimension,
+                billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
+                currency="CNY",
+                unit_price=Decimal(unit_price),
+                spec={"deployment_scope": region},
+                price_fingerprint=fingerprint,
+                is_current=True,
+            )
+        cny_channel = ProcurementChannel.objects.create(
+            name="CNY Direct",
+            code="cny-direct",
+            currency="CNY",
+            settlement_ratio=Decimal("0.85"),
+        )
+        price = ChannelModelPrice.objects.create(
+            channel=cny_channel,
+            model=self.model,
+            price_source=source,
+        )
+
+        items = sync_channel_price_items(price)
+        unit_prices = resolve_channel_model_price(
+            cny_channel,
+            self.model,
+            override=price,
+        )
+
+        self.assertEqual(len(items), 2)
+        self.assertEqual(unit_prices.input_per_million, Decimal("0.850000"))
+        self.assertEqual(unit_prices.output_per_million, Decimal("1.700000"))
+        self.assertEqual(
+            {item.base_price_item.unit_price for item in items},
+            {Decimal("1.000000"), Decimal("2.000000")},
+        )
 
     def test_marks_channel_item_comparison_unknown_for_currency_mismatch(self):
         ModelPriceItem.objects.create(

--- a/frontend/src/composables/useLLMOpsData.js
+++ b/frontend/src/composables/useLLMOpsData.js
@@ -214,7 +214,7 @@ export function useLLMOpsData() {
   }
 
   function preloadResalePublishingData() {
-    const tasks = []
+    const tasks = [refreshChannelPricingData(), refreshSummary()]
     if (!asArray(metaModels.value).length) {
       tasks.push(
         fetchList(llmOpsApi.listMetaModels).then((items) => {
@@ -222,19 +222,12 @@ export function useLLMOpsData() {
         })
       )
     }
-    if (
-      !asArray(channelPrices.value).length ||
-      !asArray(channelPriceItems.value).length
-    ) {
-      tasks.push(refreshChannelPricingData())
-    }
     if (!asArray(modelPriceItems.value).length) {
       tasks.push(refreshModelPriceItems())
     }
     if (!asArray(listings.value).length) {
       tasks.push(refreshResaleListings())
     }
-    if (!tasks.length) return
 
     Promise.all(tasks).catch((error) => {
       showError(errorMessage(error, '加载发布工作台数据失败。'))


### PR DESCRIPTION
## Summary
- Keep selected procurement sources isolated when no current price items exist
- Select coherent source price item groups by spec and base-price alignment
- Refresh channel pricing and summary data when opening the resale publishing workspace

## Test plan
- [x] python3 -m pytest backend/llm_ops/tests/test_services.py -k sync
- [x] npx eslint src/composables/useLLMOpsData.js --ext .js --fix --ignore-path ../.gitignore
- [x] npm run build

## Notes
- No open GitHub issue was available to link from this repository.
- Repository lint script currently fails because frontend/.gitignore is missing; used ../.gitignore for the touched file instead.

Made with [Orca](https://github.com/stablyai/orca) 🐋
