### PR TITLE
Fix channel ratio price item sync

### DIFF
--- a/backend/llm_ops/tests/test_views.py
+++ b/backend/llm_ops/tests/test_views.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 import json
 from unittest.mock import patch
 
@@ -26,6 +27,7 @@ from llm_ops.models import (
     ResalePlatform,
     ResaleWorkflowConfig,
 )
+from llm_ops.services import sync_channel_price_items
 
 
 class LLMOpsViewTests(TestCase):
@@ -1773,6 +1775,69 @@ class LLMOpsViewTests(TestCase):
             0.8,
         )
         self.assertEqual(row["best_channel"]["input_price_per_million"], 2.0)
+
+    def test_channel_ratio_update_resyncs_listed_price_items(self):
+        provider = LLMProvider.objects.create(name="OpenAI", code="openai")
+        model = LLMModel.objects.create(
+            provider=provider,
+            name="GPT-5 Mini",
+            code="gpt-5-mini",
+            input_price_per_million="1",
+            output_price_per_million="2",
+        )
+        channel = ProcurementChannel.objects.create(
+            name="Real Resource",
+            code="real-resource-ratio",
+            settlement_ratio="0.5996",
+        )
+        price = ChannelModelPrice.objects.create(
+            channel=channel,
+            model=model,
+            is_listed=True,
+        )
+        sync_channel_price_items(price)
+
+        item = ChannelPriceItem.objects.get(
+            channel=channel,
+            model=model,
+            dimension=ModelPriceItem.DIMENSION_TEXT_INPUT,
+            is_current=True,
+        )
+        self.assertEqual(item.unit_price, Decimal("0.599600"))
+
+        response = self.client.patch(
+            reverse("channel-detail", args=[channel.id]),
+            {"settlement_ratio": "0.4"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        item.refresh_from_db()
+        self.assertFalse(item.is_current)
+        current_item = ChannelPriceItem.objects.get(
+            channel=channel,
+            model=model,
+            dimension=ModelPriceItem.DIMENSION_TEXT_INPUT,
+            is_current=True,
+        )
+        self.assertEqual(current_item.unit_price, Decimal("0.400000"))
+
+        summary = self.client.get(
+            reverse("llm-ops-summary"),
+            {"display_currency": "USD"},
+        )
+        row = next(
+            item
+            for item in summary.data["procurement"]
+            if item["model_id"] == model.id
+        )
+        best = row["best_channel"]
+        self.assertEqual(best["base_input_price_per_million"], 1.0)
+        self.assertEqual(
+            best["input_price_per_million_settlement_ratio"],
+            0.4,
+        )
+        self.assertEqual(best["input_price_per_million"], 0.4)
 
     def test_summary_exposes_channel_model_performance_metrics(self):
         provider = LLMProvider.objects.create(name="OpenAI", code="openai")

--- a/backend/llm_ops/views.py
+++ b/backend/llm_ops/views.py
@@ -1086,6 +1086,43 @@ class ProcurementChannelViewSet(
             ),
         ).order_by("name", "id")
 
+    def perform_update(self, serializer):
+        before = snapshot_instance(serializer.instance)
+        previous_ratio = _decimal_or_none(
+            serializer.instance.settlement_ratio,
+        )
+        previous_currency = serializer.instance.currency
+        with transaction.atomic():
+            channel = serializer.save()
+            record_audit_log(
+                request=self.request,
+                action=AuditLog.ACTION_UPDATE,
+                category=self.audit_category,
+                target=channel,
+                summary=f"Updated {channel}",
+                before=before,
+                after=snapshot_instance(channel),
+            )
+            if (
+                previous_ratio != _decimal_or_none(channel.settlement_ratio)
+                or previous_currency != channel.currency
+            ):
+                self._sync_listed_channel_price_items(channel)
+
+    def _sync_listed_channel_price_items(self, channel):
+        prices = ChannelModelPrice.objects.filter(
+            channel=channel,
+            is_listed=True,
+        ).select_related(
+            "channel",
+            "meta_model",
+            "model",
+            "model__provider",
+            "price_source",
+        )
+        for price in prices:
+            sync_channel_price_items(price)
+
     def perform_destroy(self, instance):
         """Delete channel-scoped records before removing the channel.
 
@@ -2130,6 +2167,12 @@ class UsageReconciliationRecordViewSet(
 
 def _as_float(value) -> float:
     return float(value or Decimal("0"))
+
+
+def _decimal_or_none(value) -> Decimal | None:
+    if value is None or value == "":
+        return None
+    return Decimal(str(value))
 
 
 def _listing_submit_status(existing: ResaleListing | None) -> dict:

--- a/frontend/src/composables/useResaleChainRows.js
+++ b/frontend/src/composables/useResaleChainRows.js
@@ -21,6 +21,18 @@ export function useResaleChainRows({
   t
 }) {
   function channelPriceValue(option, modelId, dimension, fallbackValue) {
+    const hasSummaryValue =
+      fallbackValue !== null &&
+      fallbackValue !== undefined &&
+      fallbackValue !== ''
+    if (hasSummaryValue) {
+      return {
+        value: fallbackValue,
+        currency: option.currency,
+        ratio: option.settlement_ratio
+      }
+    }
+
     const item = channelPriceItemsByKey.value.get(
       channelPriceItemKey(option.channel_id, modelId, dimension)
     )


### PR DESCRIPTION
## Summary
- Resync listed channel price items when a procurement channel settlement ratio or currency changes.
- Preserve the audit log behavior for procurement channel updates while running the price-item sync in the same transaction.
- Prefer summary-provided procurement prices in resale chain rows so the UI reflects recalculated summary values.
- Add a regression test for channel ratio updates refreshing current channel price items and summary pricing.

No linked issue: there are no open repository issues to close for this local change.

## Test plan
- [x] docker exec backend-api-dev python -m pytest llm_ops/tests/test_views.py
- [x] npx eslint src/composables/useResaleChainRows.js
- [x] npm run build

Made with [Orca](https://github.com/stablyai/orca) 🐋
