### PR TITLE
Fix LLM Ops price source pagination

### DIFF
--- a/backend/llm_ops/admin.py
+++ b/backend/llm_ops/admin.py
@@ -296,6 +296,7 @@ class ResalePlatformAdmin(admin.ModelAdmin):
         "currency",
         "has_api_key",
         "points_per_currency_unit",
+        "point_decimal_places",
         "fee_rate",
         "service_fee_rate",
         "auto_approve_max_margin_rate",

--- a/backend/llm_ops/audit.py
+++ b/backend/llm_ops/audit.py
@@ -150,6 +150,7 @@ AUDIT_FIELD_ALLOWLIST: dict[str, tuple[str, ...]] = {
         "point_name",
         "points_per_currency_unit",
         "point_rounding_mode",
+        "point_decimal_places",
         "fee_rate",
         "service_fee_rate",
         "auto_approve_max_margin_rate",

--- a/backend/llm_ops/collection_services.py
+++ b/backend/llm_ops/collection_services.py
@@ -93,17 +93,17 @@ OFFICIAL_SOURCE_PROVIDER_DEFAULTS = {
     "aliyun": {
         "name": "阿里云",
         "website": "https://dashscope.aliyuncs.com/",
-        "notes": "元模型厂商。",
+        "notes": "模型价格源厂商。",
     },
     "aliyun-wanx": {
         "name": "阿里云万象",
         "website": "https://dashscope.aliyuncs.com/",
-        "notes": "元模型厂商。",
+        "notes": "模型价格源厂商。",
     },
     "baidu": {
         "name": "百度千帆",
         "website": "https://cloud.baidu.com/",
-        "notes": "元模型厂商。",
+        "notes": "模型价格源厂商。",
         "source_name": "百度千帆官方价格",
         "source_url": BAIDU_PRICING_SOURCE_URL,
         "currency": "CNY",
@@ -111,7 +111,7 @@ OFFICIAL_SOURCE_PROVIDER_DEFAULTS = {
     "volcengine": {
         "name": "火山方舟",
         "website": "https://ark.cn-beijing.volces.com/",
-        "notes": "元模型厂商。",
+        "notes": "模型价格源厂商。",
         "source_name": "火山方舟官方价格",
         "source_url": VOLCENGINE_PRICING_SOURCE_URL,
         "currency": "CNY",
@@ -119,7 +119,7 @@ OFFICIAL_SOURCE_PROVIDER_DEFAULTS = {
     "anthropic": {
         "name": "Anthropic",
         "website": "https://anthropic.com/",
-        "notes": "元模型厂商。",
+        "notes": "模型价格源厂商。",
         "source_name": "Anthropic 官方价格",
         "source_url": (
             "https://docs.anthropic.com/en/docs/about-claude/pricing"
@@ -140,7 +140,7 @@ OFFICIAL_SOURCE_PROVIDER_DEFAULTS = {
     "google": {
         "name": "Google",
         "website": "https://ai.google.dev/",
-        "notes": "元模型厂商。",
+        "notes": "模型价格源厂商。",
         "source_name": "Google Gemini 官方价格",
         "source_url": (
             "https://cloud.google.com/gemini-enterprise-agent-platform/"
@@ -151,7 +151,7 @@ OFFICIAL_SOURCE_PROVIDER_DEFAULTS = {
     "minimax": {
         "name": "MiniMax",
         "website": "https://api.minimax.io/",
-        "notes": "元模型厂商。",
+        "notes": "模型价格源厂商。",
         "source_name": "MiniMax 官方价格",
         "source_url": MINIMAX_PRICING_SOURCE_URL,
         "currency": "CNY",
@@ -159,7 +159,7 @@ OFFICIAL_SOURCE_PROVIDER_DEFAULTS = {
     "zhipu": {
         "name": "智谱",
         "website": "https://open.bigmodel.cn/",
-        "notes": "元模型厂商。",
+        "notes": "模型价格源厂商。",
         "source_name": "智谱 BigModel 官方价格",
         "source_url": ZHIPU_PRICING_SOURCE_URL,
         "currency": "CNY",
@@ -207,7 +207,7 @@ MODELS_DEV_META_SOURCE_PROVIDERS = {
 }
 
 MODELS_DEV_LAB_OWNER_DEFAULTS = {
-    "alibaba": ("aliyun", "阿里巴巴", "https://www.alibaba.com/"),
+    "alibaba": ("alibaba", "阿里巴巴", "https://www.alibaba.com/"),
     "anthropic": ("anthropic", "Anthropic", "https://anthropic.com/"),
     "cohere": ("cohere", "Cohere", "https://cohere.com/"),
     "deepreinforce": (
@@ -314,6 +314,7 @@ def sync_yunce_model_prices(
         raise ValueError("Price collection source is disabled.")
     base_url = resolve_collection_base_url(source=source, base_url=base_url)
     run = PriceCollectionRun.objects.create(source=source)
+    active_offering_ids: set[int] = set()
     stats = {
         "models": 0,
         "created": 0,
@@ -363,10 +364,15 @@ def sync_yunce_model_prices(
                     offering=offering,
                     source_url=catalog.source_url,
                 )
+                active_offering_ids.add(offering.id)
                 stats["models"] += 1
                 stats["created" if created else "updated"] += 1
                 stats["changed" if changed else "unchanged"] += 1
 
+            stale_stats = close_stale_current_collected_prices(
+                source=source,
+                active_offering_ids=active_offering_ids,
+            )
             source.last_collected_at = timezone.now()
             source.save(update_fields=["last_collected_at", "updated_at"])
             run.status = PriceCollectionRun.STATUS_SUCCEEDED
@@ -386,6 +392,8 @@ def sync_yunce_model_prices(
                 "skipped_model_codes": sorted(
                     set(stats["skipped_model_codes"]),
                 ),
+                "closed_stale_price_items": stale_stats["price_items"],
+                "closed_stale_history": stale_stats["history"],
             }
             run.save()
         return stats
@@ -424,6 +432,7 @@ def sync_vendor_price_source_catalog(
         else source.name
     )
     run = PriceCollectionRun.objects.create(source=source)
+    active_offering_ids: set[int] = set()
     stats = {
         "models": 0,
         "created": 0,
@@ -487,10 +496,15 @@ def sync_vendor_price_source_catalog(
                     offering=offering,
                     source_url=catalog.source_url,
                 )
+                active_offering_ids.add(offering.id)
                 stats["models"] += 1
                 stats["created" if created else "updated"] += 1
                 stats["changed" if changed else "unchanged"] += 1
 
+            stale_stats = close_stale_current_collected_prices(
+                source=source,
+                active_offering_ids=active_offering_ids,
+            )
             source.last_collected_at = timezone.now()
             source.save(update_fields=["last_collected_at", "updated_at"])
             run.status = PriceCollectionRun.STATUS_SUCCEEDED
@@ -509,6 +523,8 @@ def sync_vendor_price_source_catalog(
                 "skipped_model_codes": sorted(
                     set(stats["skipped_model_codes"]),
                 ),
+                "closed_stale_price_items": stale_stats["price_items"],
+                "closed_stale_history": stale_stats["history"],
             }
             run.save()
         return stats
@@ -631,6 +647,7 @@ def sync_official_provider_model_prices(
         config=config,
     )
     run = PriceCollectionRun.objects.create(source=source)
+    active_offering_ids: set[int] = set()
     stats: dict[str, int | list[str]] = {
         "models": 0,
         "created": 0,
@@ -687,6 +704,7 @@ def sync_official_provider_model_prices(
                     offering=offering,
                     source_url=catalog.source_url,
                 )
+                active_offering_ids.add(offering.id)
                 stats["models"] = int(stats["models"]) + 1
                 key = "created" if created else "updated"
                 stats[key] = int(stats[key]) + 1
@@ -694,6 +712,10 @@ def sync_official_provider_model_prices(
                 stats[change_key] = int(stats[change_key]) + 1
 
             skipped_codes = sorted(set(skipped_codes))
+            stale_stats = close_stale_current_collected_prices(
+                source=source,
+                active_offering_ids=active_offering_ids,
+            )
             source.last_collected_at = timezone.now()
             source_update_fields = ["last_collected_at", "updated_at"]
             if collected_currency and source.currency != collected_currency:
@@ -714,6 +736,8 @@ def sync_official_provider_model_prices(
                 "changed_count": stats["changed"],
                 "unchanged_count": stats["unchanged"],
                 "skipped_model_codes": skipped_codes,
+                "closed_stale_price_items": stale_stats["price_items"],
+                "closed_stale_history": stale_stats["history"],
             }
             run_metadata.update(catalog_source_fetch_metadata(catalog))
             if standard_catalog is not None:
@@ -1102,7 +1126,7 @@ def official_provider_defaults(provider_code: str) -> dict[str, str]:
     return {
         "name": config.provider_label,
         "website": config.source_url,
-        "notes": "元模型厂商。",
+        "notes": "模型价格源厂商。",
     }
 
 
@@ -2887,6 +2911,38 @@ def activate_collected_price_history(
         history.effective_to = None
         history.save(update_fields=["is_current", "effective_to"])
     return history
+
+
+def close_stale_current_collected_prices(
+    *,
+    source: PriceCollectionSource,
+    active_offering_ids: set[int],
+) -> dict[str, int]:
+    """Close current collected rows for offerings absent from a fresh sync."""
+    now = timezone.now()
+    price_items = ModelPriceItem.objects.filter(
+        source=source,
+        is_current=True,
+    )
+    history = CollectedModelPriceHistory.objects.filter(
+        source=source,
+        is_current=True,
+    )
+    if active_offering_ids:
+        price_items = price_items.exclude(offering_id__in=active_offering_ids)
+        history = history.exclude(offering_id__in=active_offering_ids)
+    closed_price_items = price_items.update(
+        is_current=False,
+        effective_to=now,
+    )
+    closed_history = history.update(
+        is_current=False,
+        effective_to=now,
+    )
+    return {
+        "price_items": closed_price_items,
+        "history": closed_history,
+    }
 
 
 def sync_model_price_items(

--- a/backend/llm_ops/constants.py
+++ b/backend/llm_ops/constants.py
@@ -28,13 +28,29 @@ META_MODEL_OWNER_RULES = (
     ("gpt-image-", "openai", "OpenAI", "https://api.openai.com/"),
     ("claude-", "anthropic", "Anthropic", "https://api.anthropic.com/"),
     ("gemini-", "google", "Google", "https://ai.google.dev/"),
-    ("qwen", "aliyun", "阿里云", "https://dashscope.aliyuncs.com/"),
-    ("wan", "aliyun-wanx", "阿里云万象", "https://dashscope.aliyuncs.com/"),
-    ("wanx", "aliyun-wanx", "阿里云万象", "https://dashscope.aliyuncs.com/"),
+    ("qwen", "alibaba", "阿里巴巴", "https://dashscope.aliyuncs.com/"),
+    ("qwq", "alibaba", "阿里巴巴", "https://dashscope.aliyuncs.com/"),
+    (
+        "wan",
+        "aliyun-wanx",
+        "阿里云万象",
+        "https://dashscope.aliyuncs.com/",
+    ),
+    (
+        "wanx",
+        "aliyun-wanx",
+        "阿里云万象",
+        "https://dashscope.aliyuncs.com/",
+    ),
     ("doubao-", "volcengine", "火山", "https://ark.cn-beijing.volces.com/"),
     ("deepseek-", "deepseek", "DeepSeek", "https://api.deepseek.com/"),
     ("kimi-", "kimi", "Kimi（月之暗面）", "https://api.moonshot.cn/"),
-    ("moonshot-", "kimi", "Kimi（月之暗面）", "https://api.moonshot.cn/"),
+    (
+        "moonshot-",
+        "kimi",
+        "Kimi（月之暗面）",
+        "https://api.moonshot.cn/",
+    ),
     ("minimax-", "minimax", "MiniMax", "https://api.minimax.io/"),
     ("grok-", "xai", "xAI", "https://x.ai/api"),
     ("llama-", "meta", "Meta", "https://ai.meta.com/"),
@@ -149,6 +165,17 @@ def canonical_owner_for_model_code(model_code):
                 "website": url,
             }
     return None
+
+
+def canonical_owner_name_for_code(owner_code):
+    """Return the canonical display name for an owner code."""
+    normalized = str(owner_code or "").strip().lower()
+    if not normalized:
+        return ""
+    for _, code, name, _ in META_MODEL_OWNER_RULES:
+        if code == normalized:
+            return name
+    return ""
 
 
 def is_canonical_owner_code(owner_code):

--- a/backend/llm_ops/migrations/0005_resaleplatform_point_decimal_places.py
+++ b/backend/llm_ops/migrations/0005_resaleplatform_point_decimal_places.py
@@ -1,0 +1,19 @@
+import django.core.validators
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("llm_ops", "0004_llmopsglobalconfig_feishu_approval_enabled"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="resaleplatform",
+            name="point_decimal_places",
+            field=models.PositiveSmallIntegerField(
+                default=0,
+                validators=[django.core.validators.MaxValueValidator(6)],
+            ),
+        ),
+    ]

--- a/backend/llm_ops/migrations/0006_resaleplatform_point_ratio_precision.py
+++ b/backend/llm_ops/migrations/0006_resaleplatform_point_ratio_precision.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("llm_ops", "0005_resaleplatform_point_decimal_places"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="resaleplatform",
+            name="points_per_currency_unit",
+            field=models.DecimalField(
+                decimal_places=2,
+                default=100,
+                max_digits=14,
+            ),
+        ),
+    ]

--- a/backend/llm_ops/models.py
+++ b/backend/llm_ops/models.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.core.exceptions import ValidationError
+from django.core.validators import MaxValueValidator
 from django.db import models
 
 from hyperbdr_dashboard.encryption import encryption_service
@@ -1637,13 +1638,17 @@ class ResalePlatform(models.Model):
     point_name = models.CharField(max_length=50, default="积分")
     points_per_currency_unit = models.DecimalField(
         max_digits=14,
-        decimal_places=6,
+        decimal_places=2,
         default=100,
     )
     point_rounding_mode = models.CharField(
         max_length=20,
         choices=ROUNDING_CHOICES,
         default=ROUND_HALF_UP,
+    )
+    point_decimal_places = models.PositiveSmallIntegerField(
+        default=0,
+        validators=[MaxValueValidator(6)],
     )
     fee_rate = models.DecimalField(max_digits=8, decimal_places=4, default=0)
     service_fee_rate = models.DecimalField(

--- a/backend/llm_ops/price_collectors/parsers/azure_openai.py
+++ b/backend/llm_ops/price_collectors/parsers/azure_openai.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from decimal import Decimal, InvalidOperation
 import re
 from typing import Any
+from urllib.parse import parse_qs, urlparse
 
 import requests
 
@@ -20,10 +22,15 @@ RETAIL_PRICES_API_URL = "https://prices.azure.com/api/retail/prices"
 DEFAULT_CURRENCY = "USD"
 DEFAULT_REGION = "eastus"
 PRODUCT_FILTER = "contains(productName, 'Azure OpenAI')"
+REQUEST_HEADERS = {
+    "Accept": "application/json",
+    "User-Agent": "DevMind-LLMOpsPriceCollector/1.0",
+}
 EXCLUDED_TEXT_MARKERS = {
     " aud ",
     " audio ",
     " batch ",
+    " batch api ",
     " code-interpreter",
     " file-search",
     " fine tune",
@@ -32,17 +39,33 @@ EXCLUDED_TEXT_MARKERS = {
     " hosting",
     " image",
     " img ",
+    " pricing with batch api ",
+    " pp ",
+    " priority ",
+    " priority processing ",
+    " prty ",
     " realtime",
     " rt ",
     " transcribe",
     " training",
     " tts",
 }
+EXCLUDED_TEXT_PATTERNS = (
+    re.compile(r"\baud\d*\b"),
+    re.compile(r"\brt(?:ime)?\b"),
+    re.compile(r"\btcrb\b"),
+    re.compile(r"\btrscb\b"),
+)
 SCOPE_SCORES = {
     "global": 4,
     "regional": 3,
     "data_zone": 2,
     "unknown": 1,
+}
+CONTEXT_SCORES = {
+    "short_context": 3,
+    "unknown": 2,
+    "long_context": 1,
 }
 
 
@@ -98,31 +121,97 @@ def fetch_retail_prices(vendor: dict[str, Any]) -> list[dict[str, Any]]:
     currency = str(vendor.get("currency") or DEFAULT_CURRENCY).strip()
     query_filter = (
         f"{PRODUCT_FILTER} and armRegionName eq '{region}' "
-        f"and currencyCode eq '{currency or DEFAULT_CURRENCY}'"
+        f"and currencyCode eq '{currency or DEFAULT_CURRENCY}' "
+        "and priceType eq 'Consumption'"
     )
     params = {
         "api-version": "2023-01-01-preview",
         "$filter": query_filter,
     }
     timeout = int(vendor.get("timeout") or 30)
-    items: list[dict[str, Any]] = []
-    next_url = RETAIL_PRICES_API_URL
-    while next_url:
-        response = requests.get(
-            next_url,
-            params=params if next_url == RETAIL_PRICES_API_URL else None,
-            headers={
-                "Accept": "application/json",
-                "User-Agent": "DevMind-LLMOpsPriceCollector/1.0",
-            },
-            timeout=timeout,
-        )
-        response.raise_for_status()
-        payload = response.json()
-        items.extend(payload.get("Items") or [])
-        next_url = payload.get("NextPageLink") or ""
-        params = None
+    max_pages = max(1, int(vendor.get("max_pages") or 100))
+    concurrent_pages = max(1, int(vendor.get("concurrent_pages") or 8))
+    first_payload = fetch_retail_price_page(params, timeout)
+    items: list[dict[str, Any]] = list(first_payload.get("Items") or [])
+    next_skip = skip_from_next_page_link(
+        str(first_payload.get("NextPageLink") or "")
+    )
+    if not next_skip and len(items) >= 1000:
+        next_skip = len(items)
+    if not next_skip or max_pages == 1:
+        return items
+
+    page_size = max(next_skip, len(items), 1)
+    fetched_pages = 1
+    current_skip = next_skip
+    stop_after_batch = False
+
+    while current_skip and fetched_pages < max_pages and not stop_after_batch:
+        remaining_pages = max_pages - fetched_pages
+        batch_size = min(concurrent_pages, remaining_pages)
+        skips = [
+            current_skip + page_size * index
+            for index in range(batch_size)
+        ]
+        for page_skip, payload in fetch_price_pages_concurrently(
+            params,
+            skips,
+            timeout,
+        ):
+            page_items = list(payload.get("Items") or [])
+            items.extend(page_items)
+            fetched_pages += 1
+            if len(page_items) < page_size:
+                stop_after_batch = True
+        current_skip = skips[-1] + page_size
     return items
+
+
+def fetch_price_pages_concurrently(
+    base_params: dict[str, str],
+    skips: list[int],
+    timeout: int,
+) -> list[tuple[int, dict[str, Any]]]:
+    """Fetch multiple Azure Retail Prices API pages concurrently."""
+    pages = []
+    with ThreadPoolExecutor(max_workers=len(skips)) as executor:
+        future_map = {
+            executor.submit(
+                fetch_retail_price_page,
+                {**base_params, "$skip": str(page_skip)},
+                timeout,
+            ): page_skip
+            for page_skip in skips
+        }
+        for future in as_completed(future_map):
+            pages.append((future_map[future], future.result()))
+    return sorted(pages, key=lambda item: item[0])
+
+
+def fetch_retail_price_page(
+    params: dict[str, str],
+    timeout: int,
+) -> dict[str, Any]:
+    """Fetch one page from Azure's public retail prices API."""
+    response = requests.get(
+        RETAIL_PRICES_API_URL,
+        params=params,
+        headers=REQUEST_HEADERS,
+        timeout=timeout,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def skip_from_next_page_link(value: str) -> int:
+    """Extract the next Azure Retail Prices API skip offset."""
+    if not value:
+        return 0
+    query = parse_qs(urlparse(value).query)
+    try:
+        return int((query.get("$skip") or ["0"])[0])
+    except (TypeError, ValueError):
+        return 0
 
 
 def azure_region(vendor: dict[str, Any]) -> str:
@@ -207,6 +296,7 @@ def parse_retail_item(item: dict[str, Any]) -> dict[str, Any] | None:
         "dimension": dimension,
         "price": price,
         "scope": deployment_scope(normalized),
+        "context_window": context_window(normalized),
         "region": str(item.get("armRegionName") or "").strip(),
         "currency": str(item.get("currencyCode") or DEFAULT_CURRENCY).strip(),
         "meter_name": meter,
@@ -218,14 +308,28 @@ def is_text_token_meter(text: str, item: dict[str, Any]) -> bool:
     unit = str(item.get("unitOfMeasure") or "").strip().lower()
     if unit not in {"1k", "1m"}:
         return False
-    padded = f" {text} "
-    return not any(marker in padded for marker in EXCLUDED_TEXT_MARKERS)
+    item_text = " ".join(
+        [
+            text,
+            normalize_text(str(item.get("skuName") or "")),
+            normalize_text(str(item.get("productName") or "")),
+        ]
+    )
+    padded = f" {item_text} "
+    if any(marker in padded for marker in EXCLUDED_TEXT_MARKERS):
+        return False
+    return not any(
+        pattern.search(item_text) for pattern in EXCLUDED_TEXT_PATTERNS
+    )
 
 
 def price_dimension(text: str) -> str | None:
     """Return normalized input/output/cache dimension for one meter."""
     padded = f" {text} "
-    if any(marker in padded for marker in (" cached ", " cched ", " cchd ")):
+    if any(
+        marker in padded
+        for marker in (" cached ", " cched ", " cchd ", " ccchd ", " cd ")
+    ):
         return "cache"
     if any(
         marker in padded
@@ -244,9 +348,14 @@ def model_id_from_meter(meter: str, item: dict[str, Any]) -> str:
     """Extract an Azure OpenAI model ID from a meter name."""
     source = normalize_text(meter)
     source = re.sub(r"\b(tokens?|1k|1m|input|inp|inpt|output)\b", " ", source)
-    source = re.sub(r"\b(outp|outpt|opt|cached|cched|cchd)\b", " ", source)
+    source = re.sub(
+        r"\b(outp|outpt|opt|cached|cched|cchd|ccchd|cd)\b",
+        " ",
+        source,
+    )
     source = re.sub(r"\b(global|glbl|gl|regional|regnl|rgnl)\b", " ", source)
     source = re.sub(r"\b(data zone|dzone|dz|dzn)\b", " ", source)
+    source = re.sub(r"\b(shortco|short co|longco|long co)\b", " ", source)
     source = re.sub(r"\s+", " ", source).strip()
 
     match = re.search(
@@ -322,6 +431,16 @@ def deployment_scope(text: str) -> str:
     return "unknown"
 
 
+def context_window(text: str) -> str:
+    """Return Azure context window group from a meter name."""
+    padded = f" {text} "
+    if " shortco " in padded or " short co " in padded:
+        return "short_context"
+    if " longco " in padded or " long co " in padded:
+        return "long_context"
+    return "unknown"
+
+
 def upsert_dimension(
     models: dict[str, dict[str, Any]],
     parsed: dict[str, Any],
@@ -338,6 +457,7 @@ def upsert_dimension(
     model["aliases"].update(parsed["aliases"])
     row_key = (
         parsed["scope"],
+        parsed["context_window"],
         parsed["region"],
         parsed["currency"],
     )
@@ -345,10 +465,13 @@ def upsert_dimension(
         row_key,
         {
             "deployment_scope": parsed["scope"],
+            "context_window": parsed["context_window"],
             "region": parsed["region"],
             "currency": parsed["currency"],
         },
     )
+    if parsed["context_window"] != "unknown":
+        row["billing_scope"] = parsed["context_window"]
     if parsed["dimension"] == "input":
         row["input_price_per_million"] = parsed["price"]
     elif parsed["dimension"] == "output":
@@ -357,11 +480,16 @@ def upsert_dimension(
         row["cache_hit_price_per_million"] = parsed["price"]
 
 
-def row_score(row: dict[str, str]) -> tuple[int, int]:
-    """Rank Azure rows so global text prices become the default."""
+def row_score(row: dict[str, str]) -> tuple[int, int, int]:
+    """Rank Azure rows so global standard prices become the default."""
     scope = row.get("deployment_scope") or "unknown"
+    context = row.get("context_window") or "unknown"
     has_cache = int(bool(row.get("cache_hit_price_per_million")))
-    return SCOPE_SCORES.get(scope, 0), has_cache
+    return (
+        SCOPE_SCORES.get(scope, 0),
+        CONTEXT_SCORES.get(context, 0),
+        has_cache,
+    )
 
 
 def display_name(model_id: str) -> str:
@@ -371,7 +499,8 @@ def display_name(model_id: str) -> str:
 
 def normalize_text(value: str) -> str:
     """Normalize Azure meter text for matching."""
-    text = str(value or "").strip().lower()
-    text = text.replace("_", " ").replace("-", " ")
+    text = str(value or "").strip()
     text = re.sub(r"(?<=[a-z])(?=[A-Z])", " ", text)
+    text = text.lower()
+    text = text.replace("_", " ").replace("-", " ")
     return re.sub(r"\s+", " ", text)

--- a/backend/llm_ops/serializers.py
+++ b/backend/llm_ops/serializers.py
@@ -1520,6 +1520,13 @@ class ResalePlatformSerializer(serializers.ModelSerializer):
             )
         return value
 
+    def validate_point_decimal_places(self, value):
+        if value > 6:
+            raise serializers.ValidationError(
+                "point_decimal_places must be between 0 and 6."
+            )
+        return value
+
     def validate_metadata(self, value):
         if value in (None, ""):
             return {}

--- a/backend/llm_ops/tests/test_azure_openai_price_collector.py
+++ b/backend/llm_ops/tests/test_azure_openai_price_collector.py
@@ -1,0 +1,222 @@
+import threading
+from urllib.parse import parse_qs, urlparse
+
+from django.test import SimpleTestCase
+
+from llm_ops.price_collectors import collect_vendor_price_catalog
+from llm_ops.price_collectors.parsers import azure_openai
+
+
+def retail_item(meter_name, price, dimension="Input", unit="1K"):
+    product_name = "Azure OpenAI GPT5" if meter_name[:1].isdigit() else (
+        "Azure OpenAI"
+    )
+    return {
+        "serviceName": "Foundry Models",
+        "productName": product_name,
+        "skuName": f"gpt 4o {dimension} global",
+        "meterName": meter_name,
+        "unitOfMeasure": unit,
+        "retailPrice": price,
+        "currencyCode": "USD",
+        "armRegionName": "eastus",
+    }
+
+
+class AzureOpenAIPriceCatalogCollectorTests(SimpleTestCase):
+    def test_extract_models_keeps_only_standard_pricing(self):
+        payload = collect_vendor_price_catalog(
+            "azure-openai",
+            {
+                "provider_name": "Azure OpenAI",
+                "currency": "USD",
+                "raw_retail_items": [
+                    retail_item("gpt 4o Input global Tokens", 0.005),
+                    retail_item(
+                        "gpt 4o Output global Tokens",
+                        0.015,
+                        "Output",
+                    ),
+                    retail_item(
+                        "gpt 4o Priority Processing Input global Tokens",
+                        0.006,
+                    ),
+                    retail_item(
+                        "gpt 4o Priority Processing Output global Tokens",
+                        0.018,
+                        "Output",
+                    ),
+                    retail_item(
+                        "gpt 4o Batch API Input global Tokens",
+                        0.0025,
+                    ),
+                    retail_item(
+                        "gpt 4o Batch API Output global Tokens",
+                        0.0075,
+                        "Output",
+                    ),
+                ],
+            },
+        )
+
+        self.assertEqual(payload["total_models"], 1)
+        values = payload["models"][0]["price_rows"][0]["values"]
+        self.assertEqual(values["input_price"], "5")
+        self.assertEqual(values["output_price"], "15")
+
+    def test_extract_models_prefers_gpt_55_short_context_global_prices(self):
+        payload = collect_vendor_price_catalog(
+            "azure-openai",
+            {
+                "provider_name": "Azure OpenAI",
+                "currency": "USD",
+                "raw_retail_items": [
+                    retail_item("5.5 LongCo inp Gl 1M Tokens", 10, unit="1M"),
+                    retail_item(
+                        "5.5 LongCo cd inp Gl 1M Tokens",
+                        1,
+                        unit="1M",
+                    ),
+                    retail_item(
+                        "5.5 LongCo opt Gl 1M Tokens",
+                        45,
+                        "Output",
+                        "1M",
+                    ),
+                    retail_item("5.5 ShortCo inp Gl 1M Tokens", 5, unit="1M"),
+                    retail_item(
+                        "5.5 ShortCo cd inp Gl 1M Tokens",
+                        0.5,
+                        unit="1M",
+                    ),
+                    retail_item(
+                        "5.5 ShortCo opt Gl 1M Tokens",
+                        30,
+                        "Output",
+                        "1M",
+                    ),
+                    retail_item(
+                        "5.5 ShortCo PP inp Gl 1M Tokens",
+                        12.5,
+                        unit="1M",
+                    ),
+                    retail_item(
+                        "5.5 ShortCo PP opt Gl 1M Tokens",
+                        75,
+                        "Output",
+                        "1M",
+                    ),
+                ],
+            },
+        )
+
+        models = {item["model_id"]: item for item in payload["models"]}
+        values = models["gpt-5.5"]["price_rows"][0]["values"]
+        self.assertEqual(values["input_price"], "5")
+        self.assertEqual(values["cache_hit_input_price"], "0.5")
+        self.assertEqual(values["output_price"], "30")
+        self.assertEqual(values["deployment_scope"], "global")
+        self.assertEqual(values["billing_scope"], "short_context")
+
+    def test_extract_models_skips_audio_and_realtime_meters(self):
+        payload = collect_vendor_price_catalog(
+            "azure-openai",
+            {
+                "provider_name": "Azure OpenAI",
+                "currency": "USD",
+                "raw_retail_items": [
+                    retail_item("gpt4omini-aud1217 Inp glbl Tokens", 0.01),
+                    retail_item(
+                        "gpt4omini-aud1217 Outp glbl Tokens",
+                        0.02,
+                        "Output",
+                    ),
+                    retail_item(
+                        "gpt4omini-rt-txt1217 Inp glbl Tokens",
+                        0.0006,
+                    ),
+                    retail_item(
+                        "gpt4omini-rt-txt1217 Outp glbl Tokens",
+                        0.0024,
+                        "Output",
+                    ),
+                    retail_item("gpt 4o mini 0718 Inp glbl Tokens", 0.00015),
+                    retail_item(
+                        "gpt 4o mini 0718 Outp glbl Tokens",
+                        0.0006,
+                        "Output",
+                    ),
+                ],
+            },
+        )
+
+        models = {item["model_id"]: item for item in payload["models"]}
+        self.assertNotIn("gpt-4omini", models)
+        values = models["gpt-4o-mini-0718"]["price_rows"][0]["values"]
+        self.assertEqual(values["input_price"], "0.15")
+        self.assertEqual(values["output_price"], "0.6")
+
+    def test_fetch_retail_prices_fetches_later_pages_concurrently(self):
+        second_page_started = threading.Event()
+        third_page_started = threading.Event()
+
+        class Response:
+            def __init__(self, items, next_page_link=""):
+                self.items = items
+                self.next_page_link = next_page_link
+
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return {
+                    "Items": self.items,
+                    "NextPageLink": self.next_page_link,
+                }
+
+        def fake_get(url, params=None, headers=None, timeout=None):
+            skip = page_skip(url, params)
+            if skip == 0:
+                return Response(
+                    [{} for _ in range(1000)],
+                    (
+                        azure_openai.RETAIL_PRICES_API_URL
+                        + "?api-version=2023-01-01-preview&$skip=1000"
+                    ),
+                )
+            if skip == 1000:
+                second_page_started.set()
+                if not third_page_started.wait(timeout=1):
+                    raise AssertionError(
+                        "Subsequent Azure price pages were fetched serially."
+                    )
+                return Response([{} for _ in range(1000)])
+            if skip == 2000:
+                third_page_started.set()
+                return Response([{}])
+            return Response([])
+
+        self.patch_requests_get(fake_get)
+
+        items = azure_openai.fetch_retail_prices(
+            {
+                "concurrent_pages": 2,
+                "max_pages": 3,
+            }
+        )
+
+        self.assertEqual(len(items), 2001)
+        self.assertTrue(second_page_started.is_set())
+        self.assertTrue(third_page_started.is_set())
+
+    def patch_requests_get(self, fake_get):
+        original_get = azure_openai.requests.get
+        azure_openai.requests.get = fake_get
+        self.addCleanup(setattr, azure_openai.requests, "get", original_get)
+
+
+def page_skip(url, params):
+    query = parse_qs(urlparse(url).query)
+    if params:
+        query.update({key: [value] for key, value in params.items()})
+    return int((query.get("$skip") or ["0"])[0])

--- a/backend/llm_ops/tests/test_e2e_meta_models.py
+++ b/backend/llm_ops/tests/test_e2e_meta_models.py
@@ -16,7 +16,6 @@ class LLMOpsMetaModelsApiTests(TestCase):
     """The /v1/llm-ops/meta-models/ endpoint stays correct end-to-end."""
 
     def setUp(self):
-        aliyun = LLMProvider.objects.create(name="阿里云", code="aliyun")
         deepseek = LLMProvider.objects.create(
             name="DeepSeek",
             code="deepseek",
@@ -28,9 +27,9 @@ class LLMOpsMetaModelsApiTests(TestCase):
         MetaModel.objects.create(
             name="Qwen Plus",
             code="qwen-plus",
-            owner_code=aliyun.code,
-            owner_name=aliyun.name,
-            owner_website=aliyun.website,
+            owner_code="alibaba",
+            owner_name="阿里巴巴",
+            owner_website="https://www.alibaba.com/",
         )
         MetaModel.objects.create(
             name="DeepSeek V3",
@@ -71,12 +70,12 @@ class LLMOpsMetaModelsApiTests(TestCase):
         unbound = [r for r in rows if not r["owner_code"]]
         self.assertEqual(unbound, [])
 
-    def test_filter_by_aliyun_does_not_leak_deepseek(self):
+    def test_filter_by_alibaba_does_not_leak_deepseek(self):
         view = MetaModelViewSet()
         view.action = "list"
         view.kwargs = {}
         view.request = type("R", (), {
-            "query_params": {"owner": "aliyun"},
+            "query_params": {"owner": "alibaba"},
         })()
         rows = self._serialize(view.get_queryset())
         leaked = [r for r in rows if r["code"].startswith("deepseek")]

--- a/backend/llm_ops/tests/test_official_collector.py
+++ b/backend/llm_ops/tests/test_official_collector.py
@@ -2,6 +2,7 @@ from decimal import Decimal
 from unittest.mock import patch
 
 from django.test import TestCase
+from django.utils import timezone
 
 from llm_ops.collection_services import (
     ensure_official_model_source,
@@ -17,13 +18,16 @@ from llm_ops.collectors.official import (
 )
 from llm_ops.constants import canonical_meta_model_identity
 from llm_ops.models import (
+    CollectedModelPriceHistory,
     CollectedModelPriceSnapshot,
     LLMModel,
     LLMProvider,
     MetaModel,
+    ModelSku,
     ModelPriceItem,
     PriceCollectionRun,
     PriceCollectionSource,
+    SourceSkuOffering,
 )
 from llm_ops.skill_runner import MODEL_PRICE_CATALOG_SCHEMA_VERSION
 
@@ -285,6 +289,77 @@ class OfficialCollectionSyncTests(TestCase):
             ModelPriceItem.objects.filter(
                 model=legacy_model,
                 source=provider_source,
+                is_current=True,
+            ).exists()
+        )
+
+    def test_sync_official_prices_closes_stale_current_source_rows(self):
+        provider = LLMProvider.objects.get(code="openai")
+        source = PriceCollectionSource.objects.get(slug="openai-official")
+        meta_model = MetaModel.objects.get(code="gpt-4o-mini")
+        stale_sku = ModelSku.objects.create(
+            provider=provider,
+            meta_model=meta_model,
+            canonical_sku_code="gpt-4omini",
+            upstream_model_name="gpt-4omini",
+            display_name="GPT-4omini",
+            variant_type=ModelSku.VARIANT_OFFICIAL,
+        )
+        stale_offering = SourceSkuOffering.objects.create(
+            source=source,
+            provider=provider,
+            sku=stale_sku,
+            exposed_model_name="gpt-4omini",
+        )
+        stale_item = ModelPriceItem.objects.create(
+            provider=provider,
+            sku=stale_sku,
+            offering=stale_offering,
+            meta_model=meta_model,
+            source=source,
+            dimension=ModelPriceItem.DIMENSION_TEXT_INPUT,
+            billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
+            currency="USD",
+            unit_price=Decimal("11.000000"),
+            price_fingerprint="stale-fingerprint",
+            is_current=True,
+        )
+        stale_history = CollectedModelPriceHistory.objects.create(
+            source=source,
+            provider=provider,
+            sku=stale_sku,
+            offering=stale_offering,
+            meta_model=meta_model,
+            source_platform_id="gpt-4omini",
+            source_model_id="gpt-4omini",
+            source_model_name="GPT-4omini",
+            source_model_type="text",
+            currency="USD",
+            price_fingerprint="stale-history-fingerprint",
+            effective_from=timezone.now(),
+            is_current=True,
+        )
+
+        stats = sync_official_provider_model_prices(
+            provider=provider,
+            verify_source=False,
+        )
+
+        stale_item.refresh_from_db()
+        stale_history.refresh_from_db()
+        self.assertFalse(stale_item.is_current)
+        self.assertFalse(stale_history.is_current)
+        self.assertGreaterEqual(stats["models"], 1)
+        self.assertEqual(
+            PriceCollectionRun.objects.latest("id").metadata[
+                "closed_stale_price_items"
+            ],
+            1,
+        )
+        self.assertTrue(
+            ModelPriceItem.objects.filter(
+                source=source,
+                meta_model__code="gpt-4o-mini",
                 is_current=True,
             ).exists()
         )
@@ -595,6 +670,17 @@ class OfficialCollectionSyncTests(TestCase):
                   "output": ["text"]
                 },
                 "limit": {"context": 256000, "output": 128000}
+              },
+              "alibaba/qwen-plus": {
+                "id": "alibaba/qwen-plus",
+                "name": "Qwen Plus",
+                "family": "qwen",
+                "tool_call": true,
+                "modalities": {
+                  "input": ["text"],
+                  "output": ["text"]
+                },
+                "limit": {"context": 1000000, "output": 8192}
               }
             }
             """,
@@ -606,7 +692,8 @@ class OfficialCollectionSyncTests(TestCase):
 
         meta = MetaModel.objects.get(code="gpt-real-test")
         microsoft = MetaModel.objects.get(code="mai-code-1-flash")
-        self.assertEqual(stats["models"], 2)
+        qwen = MetaModel.objects.get(code="qwen-plus")
+        self.assertEqual(stats["models"], 3)
         self.assertEqual(second_stats["created"], 0)
         self.assertEqual(
             MetaModel.objects.filter(code="gpt-real-test").count(),
@@ -639,6 +726,8 @@ class OfficialCollectionSyncTests(TestCase):
         )
         self.assertEqual(microsoft.owner_code, "microsoft")
         self.assertEqual(microsoft.owner_name, "Microsoft")
+        self.assertEqual(qwen.owner_code, "alibaba")
+        self.assertEqual(qwen.owner_name, "阿里巴巴")
         self.assertEqual(
             microsoft.metadata["models_dev"]["lab"],
             "microsoft",

--- a/backend/llm_ops/tests/test_serializers.py
+++ b/backend/llm_ops/tests/test_serializers.py
@@ -54,6 +54,19 @@ class ResalePlatformSerializerTests(TestCase):
 
         self.assertTrue(serializer.is_valid(), serializer.errors)
 
+    def test_accepts_point_decimal_places(self):
+        serializer = ResalePlatformSerializer(
+            data={
+                "name": "Agione Test",
+                "code": "agione-test",
+                "currency": "CNY",
+                "points_per_currency_unit": "100",
+                "point_decimal_places": 2,
+            }
+        )
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
     def test_accepts_platform_metadata(self):
         serializer = ResalePlatformSerializer(
             data={
@@ -148,6 +161,33 @@ class ResalePlatformSerializerTests(TestCase):
 
         self.assertFalse(serializer.is_valid())
         self.assertIn("points_per_currency_unit", serializer.errors)
+
+    def test_rejects_point_rate_with_too_many_decimal_places(self):
+        serializer = ResalePlatformSerializer(
+            data={
+                "name": "Agione Test",
+                "code": "agione-test",
+                "currency": "CNY",
+                "points_per_currency_unit": "100.123",
+            }
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("points_per_currency_unit", serializer.errors)
+
+    def test_rejects_too_many_point_decimal_places(self):
+        serializer = ResalePlatformSerializer(
+            data={
+                "name": "Agione Test",
+                "code": "agione-test",
+                "currency": "CNY",
+                "points_per_currency_unit": "100",
+                "point_decimal_places": 7,
+            }
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("point_decimal_places", serializer.errors)
 
     def test_rejects_invalid_service_fee_rate(self):
         serializer = ResalePlatformSerializer(
@@ -904,6 +944,8 @@ class EnsureMetaModelForPriceDataTests(TestCase):
         from llm_ops.constants import canonical_owner_for_model_code
 
         cases = {
+            "qwen-plus": "alibaba",
+            "qwq-plus": "alibaba",
             "grok-4": "xai",
             "llama-3.3-70b-instruct": "meta",
             "mistral-large-latest": "mistral",

--- a/backend/llm_ops/tests/test_views.py
+++ b/backend/llm_ops/tests/test_views.py
@@ -110,6 +110,112 @@ class LLMOpsViewTests(TestCase):
             base_url="https://example.com/admin/api",
         )
 
+    def test_model_price_items_can_page_by_meta_model(self):
+        provider = LLMProvider.objects.create(
+            name="Azure OpenAI",
+            code="azure-openai",
+        )
+        source = PriceCollectionSource.objects.create(
+            name="Azure OpenAI Official",
+            slug="azure-openai-official",
+            provider=provider,
+            source_type=PriceCollectionSource.SOURCE_TYPE_CUSTOM,
+        )
+        gpt4o = MetaModel.objects.create(
+            code="gpt-4o",
+            name="GPT-4o",
+            owner_code="openai",
+            owner_name="OpenAI",
+        )
+        gpt5 = MetaModel.objects.create(
+            code="gpt-5",
+            name="GPT-5",
+            owner_code="openai",
+            owner_name="OpenAI",
+        )
+        ModelPriceItem.objects.create(
+            provider=provider,
+            meta_model=gpt4o,
+            source=source,
+            dimension=ModelPriceItem.DIMENSION_TEXT_INPUT,
+            billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
+            currency="USD",
+            unit_price=Decimal("2.500000"),
+            price_fingerprint="gpt-4o-input",
+        )
+        ModelPriceItem.objects.create(
+            provider=provider,
+            meta_model=gpt4o,
+            source=source,
+            dimension=ModelPriceItem.DIMENSION_TEXT_OUTPUT,
+            billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
+            currency="USD",
+            unit_price=Decimal("10.000000"),
+            price_fingerprint="gpt-4o-output",
+        )
+        ModelPriceItem.objects.create(
+            provider=provider,
+            meta_model=gpt5,
+            source=source,
+            dimension=ModelPriceItem.DIMENSION_TEXT_INPUT,
+            billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
+            currency="USD",
+            unit_price=Decimal("1.250000"),
+            price_fingerprint="gpt-5-input",
+        )
+
+        response = self.client.get(
+            reverse("model-price-item-list"),
+            {
+                "source": source.id,
+                "is_current": "true",
+                "group_by": "meta_model",
+                "page": 1,
+                "page_size": 1,
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["count"], 2)
+        self.assertEqual(len(response.data["results"]), 2)
+        self.assertEqual(
+            {
+                item["meta_model_code"]
+                for item in response.data["results"]
+            },
+            {"gpt-4o"},
+        )
+
+    def test_meta_model_owner_summary_migrates_qwen_to_alibaba(self):
+        qwen = MetaModel.objects.create(
+            code="qwen-max",
+            name="Qwen Max",
+        )
+        qwen_plus = MetaModel.objects.create(
+            code="qwen-plus",
+            name="Qwen Plus",
+        )
+        MetaModel.objects.filter(id=qwen.id).update(
+            owner_code="aliyun",
+            owner_name="阿里云",
+        )
+        MetaModel.objects.filter(id=qwen_plus.id).update(
+            owner_code="alibaba",
+            owner_name="阿里巴巴",
+        )
+
+        response = self.client.get(reverse("meta-model-owner-summary"))
+
+        self.assertEqual(response.status_code, 200)
+        rows = [
+            row
+            for row in response.data["results"]
+            if row["code"] == "alibaba"
+        ]
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["name"], "阿里巴巴")
+        self.assertEqual(rows[0]["meta_model_count"], 2)
+
     def test_global_config_patch_syncs_periodic_tasks(self):
         from django_celery_beat.models import PeriodicTask
 

--- a/backend/llm_ops/views.py
+++ b/backend/llm_ops/views.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 
 from django.db import transaction
-from django.db.models import Count, IntegerField, Q, Value
+from django.db.models import Count, IntegerField, Max, Q, Value
 from django.utils.text import slugify
 from drf_spectacular.utils import extend_schema
 from rest_framework import status, viewsets
@@ -23,7 +23,10 @@ from .collection_services import (
     sync_meta_models_from_models_dev,
     sync_yunce_model_prices,
 )
-from .constants import SUPPLIER_SOURCE_OWNER_ALIASES
+from .constants import (
+    SUPPLIER_SOURCE_OWNER_ALIASES,
+    canonical_owner_name_for_code,
+)
 from .global_config import (
     price_sync_source_queryset,
     sync_global_config_to_beat,
@@ -874,6 +877,13 @@ class MetaModelViewSet(
     )
     def owner_summary(self, request):
         """Return one lightweight row per canonical model owner."""
+        from .catalog_maintenance import (
+            normalize_meta_model_catalog,
+            resolve_orphan_meta_models,
+        )
+
+        normalize_meta_model_catalog()
+        resolve_orphan_meta_models()
         queryset = self.get_queryset()
         search = request.query_params.get("owner_search")
         if search:
@@ -882,8 +892,9 @@ class MetaModelViewSet(
                 | Q(owner_code__icontains=search)
             )
         rows = (
-            queryset.values("owner_code", "owner_name")
+            queryset.values("owner_code")
             .annotate(
+                owner_name=Max("owner_name"),
                 meta_model_count=Count("id", distinct=True),
                 active_model_count=Count(
                     "id",
@@ -900,7 +911,11 @@ class MetaModelViewSet(
                     {
                         "id": row["owner_code"],
                         "code": row["owner_code"],
-                        "name": row["owner_name"] or row["owner_code"],
+                        "name": (
+                            canonical_owner_name_for_code(row["owner_code"])
+                            or row["owner_name"]
+                            or row["owner_code"]
+                        ),
                         "meta_model_count": row["meta_model_count"],
                         "active_model_count": row["active_model_count"],
                         "sku_count": row["sku_count"],
@@ -1006,6 +1021,12 @@ class ModelPriceItemViewSet(
     audit_category = AuditLog.CATEGORY_PRICING
     serializer_class = ModelPriceItemSerializer
 
+    def list(self, request, *args, **kwargs):
+        """List price items, optionally paginated by meta model."""
+        if request.query_params.get("group_by") == "meta_model":
+            return self.list_by_meta_model(request)
+        return super().list(request, *args, **kwargs)
+
     def get_queryset(self):
         queryset = ModelPriceItem.objects.select_related(
             "meta_model",
@@ -1055,6 +1076,30 @@ class ModelPriceItemViewSet(
             "tier_start",
             "id",
         )
+
+    def list_by_meta_model(self, request):
+        """Return price items for a page of distinct meta models."""
+        queryset = self.filter_queryset(self.get_queryset())
+        meta_models = MetaModel.objects.filter(
+            id__in=queryset.values("meta_model_id"),
+        ).order_by("name", "code", "id")
+        page = self.paginate_queryset(meta_models)
+        selected_meta_models = page if page is not None else meta_models
+        meta_model_ids = [item.id for item in selected_meta_models]
+        grouped_queryset = queryset.filter(
+            meta_model_id__in=meta_model_ids,
+        ).order_by(
+            "meta_model__name",
+            "sku__display_name",
+            "model__name",
+            "dimension",
+            "tier_start",
+            "id",
+        )
+        serializer = self.get_serializer(grouped_queryset, many=True)
+        if page is not None:
+            return self.get_paginated_response(serializer.data)
+        return Response(serializer.data)
 
 
 class ProcurementChannelViewSet(
@@ -2473,6 +2518,7 @@ def _point_conversion_payload(platform: ResalePlatform | None):
             platform.points_per_currency_unit
         ),
         "rounding_mode": platform.point_rounding_mode,
+        "decimal_places": platform.point_decimal_places,
         "currency": platform.currency,
         "fee_rate": _as_float(platform.fee_rate),
         "service_fee_rate": _as_float(platform.service_fee_rate),

--- a/frontend/src/components/llm-ops/MetaModelManagement.vue
+++ b/frontend/src/components/llm-ops/MetaModelManagement.vue
@@ -206,11 +206,6 @@
                 :options="modalityOptions"
                 class-name="control-select sm:w-40"
               />
-              <CompactSelect
-                v-model="pageSize"
-                :options="pageSizeOptions"
-                class-name="control-select sm:w-32"
-              />
               <input
                 v-model="searchKeyword"
                 class="control-field drawer-search"
@@ -367,7 +362,19 @@
                   })
                 }}
               </p>
-              <div class="flex items-center gap-2">
+              <div class="pagination-actions">
+                <label class="page-size-control">
+                  <span>
+                    {{
+                      t('llmOps.metaModelManagement.pagination.pageSizeLabel')
+                    }}
+                  </span>
+                  <CompactSelect
+                    v-model="pageSize"
+                    :options="pageSizeOptions"
+                    class-name="control-select page-size-select"
+                  />
+                </label>
                 <button
                   class="btn-secondary pagination-btn btn-action-neutral"
                   type="button"
@@ -436,7 +443,7 @@ const searchKeyword = ref('')
 const vendorSearchKeyword = ref('')
 const statusFilter = ref('')
 const modalityFilter = ref('')
-const pageSize = ref(20)
+const pageSize = ref(10)
 const currentPage = ref(1)
 const selectedVendorId = ref('')
 const showVendorModelsDrawer = ref(false)
@@ -631,7 +638,7 @@ async function fetchVendorMetaModels() {
       modality: modalityFilter.value || undefined,
       search: searchKeyword.value.trim() || undefined,
       page: safeCurrentPage.value,
-      page_size: Number(pageSize.value) || 20
+      page_size: Number(pageSize.value) || 10
     })
     const payload = paginationPayload(response)
     drawerRows.value = paginationResults(payload).map((item) => {

--- a/frontend/src/components/llm-ops/ProviderManagement.vue
+++ b/frontend/src/components/llm-ops/ProviderManagement.vue
@@ -377,6 +377,7 @@
       @close="selectedProvider = null"
       @delete="deleteSource"
       @page-change="loadSelectedProviderPriceItems"
+      @page-size-change="handleSelectedProviderPageSizeChange"
     />
   </section>
 </template>
@@ -461,7 +462,7 @@ const sourceCategoryFilter = ref('all')
 const sourceStatusFilter = ref('all')
 const selectedProviderLoading = ref(false)
 const selectedProviderPage = ref(1)
-const selectedProviderPageSize = ref(50)
+const selectedProviderPageSize = ref(10)
 const selectedProviderTotal = ref(0)
 const selectedProviderPriceItems = ref([])
 const localPriceEntryMetaModels = ref([])
@@ -559,6 +560,7 @@ async function loadSelectedProviderPriceItems(
     const response = await llmOpsApi.listModelPriceItems({
       source: source.id,
       is_current: 'true',
+      group_by: 'meta_model',
       page,
       page_size: selectedProviderPageSize.value
     })
@@ -575,6 +577,12 @@ async function loadSelectedProviderPriceItems(
   } finally {
     selectedProviderLoading.value = false
   }
+}
+
+async function handleSelectedProviderPageSizeChange(pageSize) {
+  selectedProviderPageSize.value = pageSize
+  selectedProviderPage.value = 1
+  await loadSelectedProviderPriceItems(1)
 }
 
 function openOfficialResetModal(source = null) {

--- a/frontend/src/components/llm-ops/ResalePlatformModal.vue
+++ b/frontend/src/components/llm-ops/ResalePlatformModal.vue
@@ -203,17 +203,24 @@
               <input
                 v-model="form.points_per_currency_unit"
                 class="field"
-                min="0.000001"
-                step="0.000001"
+                min="0.01"
+                step="0.01"
                 type="number"
-                placeholder="例如：100"
+                placeholder="例如：100.00"
               />
             </label>
             <label class="field-group">
-              <span class="field-label">积分取整方式</span>
+              <span class="field-label">积分舍入方式</span>
               <CompactSelect
                 v-model="form.point_rounding_mode"
                 :options="roundingModeOptions"
+              />
+            </label>
+            <label class="field-group">
+              <span class="field-label">保留小数位</span>
+              <CompactSelect
+                v-model="form.point_decimal_places"
+                :options="decimalPlaceOptions"
               />
             </label>
           </div>
@@ -333,8 +340,17 @@ const regionOptions = [
 ]
 const roundingModeOptions = [
   { label: '四舍五入', value: 'half_up' },
-  { label: '向上取整', value: 'up' },
-  { label: '向下取整', value: 'down' }
+  { label: '向上舍入', value: 'up' },
+  { label: '向下舍入', value: 'down' }
+]
+const decimalPlaceOptions = [
+  { label: '0 位', value: 0 },
+  { label: '1 位', value: 1 },
+  { label: '2 位', value: 2 },
+  { label: '3 位', value: 3 },
+  { label: '4 位', value: 4 },
+  { label: '5 位', value: 5 },
+  { label: '6 位', value: 6 }
 ]
 const metadataError = ref('')
 
@@ -364,8 +380,9 @@ function defaults() {
     service_fee_rate: '0',
     auto_approve_max_margin_rate: '100',
     point_name: '积分',
-    points_per_currency_unit: '100',
+    points_per_currency_unit: '100.00',
     point_rounding_mode: 'half_up',
+    point_decimal_places: 0,
     metadata: {},
     metadata_text: '',
     notes: '',
@@ -382,6 +399,11 @@ function platformToForm(platform) {
     environment: platform.environment || 'production',
     fee_rate: percentFromRatio(platform.fee_rate),
     service_fee_rate: percentFromRatio(platform.service_fee_rate),
+    points_per_currency_unit: formatDecimal(
+      platform.points_per_currency_unit,
+      2
+    ),
+    point_decimal_places: platform.point_decimal_places ?? 0,
     metadata: platform.metadata || {},
     metadata_text: formatMetadata(platform.metadata)
   }
@@ -415,13 +437,37 @@ function normalizePayload(payload) {
   clean.currency = String(clean.currency || 'CNY')
     .trim()
     .toUpperCase()
+  clean.points_per_currency_unit = normalizePointRatio(
+    clean.points_per_currency_unit
+  )
   clean.fee_rate = ratioFromPercent(clean.fee_rate)
   clean.service_fee_rate = ratioFromPercent(clean.service_fee_rate)
+  clean.point_decimal_places = normalizePointDecimalPlaces(
+    clean.point_decimal_places
+  )
   clean.metadata = parseMetadata(clean.metadata_text)
   delete clean.id
   delete clean.listing_count
   delete clean.metadata_text
   return clean
+}
+
+function formatDecimal(value, digits) {
+  const numberValue = Number(value)
+  if (!Number.isFinite(numberValue)) return ''
+  return numberValue.toFixed(digits)
+}
+
+function normalizePointRatio(value) {
+  const numberValue = Number(value)
+  if (!Number.isFinite(numberValue)) return '0.00'
+  return Math.max(0, numberValue).toFixed(2)
+}
+
+function normalizePointDecimalPlaces(value) {
+  const numberValue = Number(value)
+  if (!Number.isFinite(numberValue)) return 0
+  return Math.min(6, Math.max(0, Math.trunc(numberValue)))
 }
 
 function parseMetadata(value) {

--- a/frontend/src/components/llm-ops/SourcePriceDrawer.vue
+++ b/frontend/src/components/llm-ops/SourcePriceDrawer.vue
@@ -182,9 +182,36 @@
           </div>
           <div v-if="totalItems" class="pagination-bar">
             <p class="text-xs text-slate-500">
-              第 {{ page }} / {{ totalPages }} 页，共 {{ totalItems }} 条
+              {{
+                t('llmOps.sourcePriceDrawer.pagination.summary', {
+                  page,
+                  totalPages,
+                  total: totalItems
+                })
+              }}
             </p>
-            <div class="flex items-center gap-2">
+            <div class="flex flex-wrap items-center gap-2">
+              <label class="page-size-control">
+                <span>
+                  {{ t('llmOps.sourcePriceDrawer.pagination.pageSize') }}
+                </span>
+                <select
+                  class="page-size-select"
+                  :value="pageSize"
+                  :disabled="loading"
+                  @change="
+                    $emit('page-size-change', Number($event.target.value))
+                  "
+                >
+                  <option
+                    v-for="option in pageSizeOptions"
+                    :key="option"
+                    :value="option"
+                  >
+                    {{ option }}
+                  </option>
+                </select>
+              </label>
               <button
                 class="btn-secondary pagination-btn"
                 type="button"
@@ -217,7 +244,7 @@ import {
   priceSourceOwnerType
 } from '@/utils/llmOpsPriceSources'
 
-defineEmits(['close', 'delete', 'refresh', 'page-change'])
+defineEmits(['close', 'delete', 'refresh', 'page-change', 'page-size-change'])
 
 const props = defineProps({
   source: {
@@ -254,6 +281,7 @@ const props = defineProps({
   }
 })
 
+const pageSizeOptions = [10, 20, 50]
 const { t, locale } = useI18n()
 const search = ref('')
 
@@ -723,6 +751,14 @@ function formatDateTime(value) {
 
 .pagination-btn {
   @apply px-3 py-1.5 text-xs;
+}
+
+.page-size-control {
+  @apply inline-flex items-center gap-2 text-xs font-medium text-slate-500;
+}
+
+.page-size-select {
+  @apply h-8 rounded-lg border border-slate-200 bg-white px-2 text-xs text-slate-700 outline-none transition focus:border-indigo-300 focus:ring-4 focus:ring-indigo-50 disabled:cursor-not-allowed disabled:opacity-60;
 }
 
 .btn-secondary {

--- a/frontend/src/components/llm-ops/metaModelManagement.css
+++ b/frontend/src/components/llm-ops/metaModelManagement.css
@@ -212,6 +212,18 @@
   @apply min-w-20 justify-center;
 }
 
+.meta-model-management .pagination-actions {
+  @apply flex flex-wrap items-center gap-2;
+}
+
+.meta-model-management .page-size-control {
+  @apply inline-flex items-center gap-2 text-xs font-medium text-slate-500;
+}
+
+.meta-model-management .page-size-select .compact-select-trigger {
+  @apply h-8 min-w-24 text-xs;
+}
+
 .meta-model-management .link-btn {
   @apply text-sm font-medium text-indigo-600 hover:text-indigo-700;
 }

--- a/frontend/src/composables/useAgioneListingDisplay.js
+++ b/frontend/src/composables/useAgioneListingDisplay.js
@@ -1,5 +1,6 @@
 import { computed } from 'vue'
 
+import { formatRoundedPoints } from '@/utils/pointRounding'
 import {
   averageMarginRate,
   RESALE_PRICE_DIMENSION_SPECS
@@ -226,7 +227,7 @@ export function useAgioneListingDisplay({
       props.pointConversion?.currency
     )
     if (converted === null) return '-'
-    return String(Math.round(converted * rate))
+    return formatRoundedPoints(converted * rate, props.pointConversion)
   }
 
   function listingDisplayAmount(value, currency) {

--- a/frontend/src/composables/useAgioneListingRows.js
+++ b/frontend/src/composables/useAgioneListingRows.js
@@ -2,6 +2,7 @@ import { computed, unref } from 'vue'
 
 import { resolveCanonicalMetaOwner } from '@/utils/llmOpsMeta'
 import { asArray } from '@/utils/llmOpsPagination'
+import { formatRoundedPoints } from '@/utils/pointRounding'
 
 /**
  * Centralized derived state for the Agione resale listing workbench.
@@ -697,7 +698,11 @@ export function useAgioneListingRows({
       .map((item) => {
         const platformAmount = displayAmountToPlatformCurrency(item.value)
         if (platformAmount === null) return null
-        return `${item.label} ${Math.round(platformAmount * rate)} ${
+        const points = formatRoundedPoints(
+          platformAmount * rate,
+          unref(pointConversionRef)
+        )
+        return `${item.label} ${points} ${
           unref(pointConversionRef)?.point_name || '积分'
         }`
       })

--- a/frontend/src/composables/useResalePricing.js
+++ b/frontend/src/composables/useResalePricing.js
@@ -1,3 +1,4 @@
+import { formatRoundedPoints } from '@/utils/pointRounding'
 import {
   averageMarginRate,
   isMarginAutoApprovable,
@@ -135,16 +136,7 @@ export function useResalePricing({
       props.pointConversion?.currency || platformCurrencyLabel.value
     )
     if (converted === null) return '-'
-    return formatRoundedPoints(converted * rate)
-  }
-
-  function formatRoundedPoints(value) {
-    const points = Number(value)
-    if (!Number.isFinite(points)) return '0'
-    const mode = props.pointConversion?.rounding_mode || 'half_up'
-    if (mode === 'up') return String(Math.ceil(points))
-    if (mode === 'down') return String(Math.floor(points))
-    return String(Math.round(points))
+    return formatRoundedPoints(converted * rate, props.pointConversion)
   }
 
   function formatReadonlyNumber(value, digits) {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1288,8 +1288,9 @@
       "pagination": {
         "next": "Next",
         "pageSize": "{count} / page",
+        "pageSizeLabel": "Per page",
         "previous": "Previous",
-        "summary": "{total} rows, page {current} / {pages}"
+        "summary": "{total} meta models, page {current} / {pages}"
       },
       "status": {
         "active": "Active",
@@ -1668,9 +1669,13 @@
       },
       "summary": {
         "currency": "Default currency",
-        "currentItems": "Current price items",
-        "metaModels": "Covered meta models",
+        "currentItems": "Total meta models",
+        "metaModels": "Meta models on page",
         "status": "Status"
+      },
+      "pagination": {
+        "pageSize": "Per page",
+        "summary": "Page {page} / {totalPages}, {total} meta models"
       },
       "status": {
         "disabled": "Inactive",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1298,8 +1298,9 @@
       "pagination": {
         "next": "下一页",
         "pageSize": "{count} 条/页",
+        "pageSizeLabel": "每页",
         "previous": "上一页",
-        "summary": "共 {total} 条，第 {current} / {pages} 页"
+        "summary": "共 {total} 个元模型，第 {current} / {pages} 页"
       },
       "status": {
         "active": "可用",
@@ -1678,9 +1679,13 @@
       },
       "summary": {
         "currency": "默认币种",
-        "currentItems": "当前价格项",
-        "metaModels": "覆盖元模型",
+        "currentItems": "全部元模型",
+        "metaModels": "本页元模型",
         "status": "状态"
+      },
+      "pagination": {
+        "pageSize": "每页",
+        "summary": "第 {page} / {totalPages} 页，共 {total} 个元模型"
       },
       "status": {
         "disabled": "停用",

--- a/frontend/src/utils/llmOpsMeta.js
+++ b/frontend/src/utils/llmOpsMeta.js
@@ -2,7 +2,7 @@
 //
 // Meta-model semantics:
 //   * Meta model = a real model family published by a model owner
-//     (OpenAI, Anthropic, Google, Aliyun, DeepSeek, Kimi, MiniMax, ...).
+//     (OpenAI, Anthropic, Google, Alibaba, DeepSeek, Kimi, MiniMax, ...).
 //   * Meta owner = the company that develops the model.
 //   * Supplier / price source = a third party that resells access
 //     (SiliconFlow, OpenRouter, Volcano Ark, ...). They are *never*
@@ -10,7 +10,8 @@
 
 const META_MODEL_OWNER_RULES = [
   { test: (code) => code.startsWith('deepseek-'), code: 'deepseek' },
-  { test: (code) => code.startsWith('qwen'), code: 'aliyun' },
+  { test: (code) => code.startsWith('qwen'), code: 'alibaba' },
+  { test: (code) => code.startsWith('qwq'), code: 'alibaba' },
   { test: (code) => code.startsWith('wanx'), code: 'aliyun-wanx' },
   { test: (code) => code.startsWith('wan'), code: 'aliyun-wanx' },
   { test: (code) => code.startsWith('doubao-'), code: 'volcengine' },

--- a/frontend/src/utils/pointRounding.js
+++ b/frontend/src/utils/pointRounding.js
@@ -1,0 +1,33 @@
+const MAX_POINT_DECIMAL_PLACES = 6
+
+export function normalizePointDecimalPlaces(value) {
+  const places = Number(value)
+  if (!Number.isFinite(places)) return 0
+  return Math.min(MAX_POINT_DECIMAL_PLACES, Math.max(0, Math.trunc(places)))
+}
+
+export function formatRoundedPoints(value, pointConversion = {}) {
+  const points = Number(value)
+  if (!Number.isFinite(points)) return '0'
+
+  const decimalPlaces = normalizePointDecimalPlaces(
+    pointConversion.decimal_places ?? pointConversion.point_decimal_places
+  )
+  const factor = 10 ** decimalPlaces
+  const scaled = points * factor
+  const mode =
+    pointConversion.rounding_mode ||
+    pointConversion.point_rounding_mode ||
+    'half_up'
+  let rounded
+
+  if (mode === 'up') {
+    rounded = Math.ceil(scaled)
+  } else if (mode === 'down') {
+    rounded = Math.floor(scaled)
+  } else {
+    rounded = Math.round(scaled)
+  }
+
+  return (rounded / factor).toFixed(decimalPlaces)
+}


### PR DESCRIPTION
## Summary
- Add meta-model grouped pagination for model price items in source drawers.
- Close stale current collected price rows after fresh source syncs.
- Improve Azure OpenAI retail pricing collection for concurrent paging, standard-pricing filtering, and context-window ranking.
- Add resale platform point decimal precision and shared frontend point rounding.
- Normalize Qwen/QwQ owner mapping to Alibaba.

## Test plan
- [x] python3 -m pytest backend/llm_ops/tests/test_azure_openai_price_collector.py
- [x] frontend/node_modules/.bin/eslint frontend/src/components/llm-ops/MetaModelManagement.vue frontend/src/components/llm-ops/ProviderManagement.vue frontend/src/components/llm-ops/ResalePlatformModal.vue frontend/src/components/llm-ops/SourcePriceDrawer.vue frontend/src/composables/useAgioneListingDisplay.js frontend/src/composables/useAgioneListingRows.js frontend/src/composables/useResalePricing.js frontend/src/utils/llmOpsMeta.js frontend/src/utils/pointRounding.js --ignore-path .gitignore
- [x] npm run build
- [x] git diff --check

## Notes
- No open GitHub issue was available to close.
- Full backend test selection was blocked locally because available environments were incomplete: .venv has no pytest; uv resolution is blocked by requires-python >=3.8 conflicting with deepagents>=3.11; system Python has Django 4.2 and misses drf_spectacular.

Made with [Orca](https://github.com/stablyai/orca) 🐋
