### PR TITLE
Improve LLM Ops bullet chart reference tooltips

### DIFF
--- a/frontend/src/components/llm-ops/BulletChart.vue
+++ b/frontend/src/components/llm-ops/BulletChart.vue
@@ -21,7 +21,8 @@
       class="range-boundary-hit"
       :class="boundary.hitClass"
       :style="{ left: boundary.percent + '%' }"
-      aria-hidden="true"
+      tabindex="0"
+      :aria-label="boundaryTitle(boundary)"
       @pointerdown.stop
     >
       <span class="range-boundary-marker" :class="boundary.markerClass" />
@@ -61,14 +62,37 @@
       <div
         class="range-ref-marker"
         :style="{ left: getMarkerPos(ref.price) + '%' }"
-        :title="refTitle(ref)"
+        tabindex="0"
+        :aria-label="refTitle(ref)"
       >
         <div class="range-ref-label">
           {{ ref.source }}
         </div>
-        <div class="range-ref-val">
-          {{ refDisplayValue(ref) }}
-        </div>
+        <span class="range-ref-tooltip">
+          <span class="range-ref-tooltip-title">
+            {{ ref.source }}
+          </span>
+          <span v-if="ref.rows?.length" class="range-ref-tooltip-rows">
+            <span
+              v-for="row in ref.rows"
+              :key="`${ref.source}-${row.label}`"
+              class="range-boundary-tooltip-row range-ref-tooltip-row-compact"
+            >
+              <span>{{ row.label }}</span>
+              <strong>{{ row.value || refDisplayValue(ref) }}</strong>
+              <em aria-hidden="true">&nbsp;</em>
+            </span>
+          </span>
+          <strong v-else class="range-ref-tooltip-value">
+            {{ refDisplayValue(ref) }}
+          </strong>
+          <span
+            v-if="ref.titleValue && !ref.rows?.length"
+            class="range-ref-tooltip-source"
+          >
+            {{ ref.titleValue }}
+          </span>
+        </span>
       </div>
     </template>
 
@@ -167,9 +191,17 @@ const hasBoundaryRange = computed(
 )
 
 const axisRange = computed(() => {
+  const value = Number(props.value)
+  const refValues = props.refs.map((ref) => Number(ref.price))
   if (hasBoundaryRange.value) {
-    const rawMin = Math.min(boundaryMin.value, boundaryMax.value)
-    const rawMax = Math.max(boundaryMin.value, boundaryMax.value)
+    const candidates = [
+      boundaryMin.value,
+      boundaryMax.value,
+      value,
+      ...refValues
+    ].filter((item) => Number.isFinite(item))
+    const rawMin = Math.min(...candidates)
+    const rawMax = Math.max(...candidates)
     if (rawMax === rawMin) {
       const padding = Math.max(Math.abs(rawMax) * 0.2, 1)
       return {
@@ -186,11 +218,9 @@ const axisRange = computed(() => {
     }
   }
 
-  const value = Number(props.value)
-  const candidates = [
-    value,
-    ...props.refs.map((ref) => Number(ref.price))
-  ].filter((item) => Number.isFinite(item))
+  const candidates = [value, ...refValues].filter((item) =>
+    Number.isFinite(item)
+  )
 
   if (!candidates.length) {
     if (!fallbackCenter.value && Number.isFinite(value) && value > 0) {
@@ -305,6 +335,7 @@ function getMarkerColor(price) {
 
 function boundaryCaption(boundary) {
   const prefix = boundaryCaptionPrefix(boundary)
+  if (boundary.tooltip?.captionKind === 'floor') return prefix
   return `${prefix} ${boundaryDisplayValue(boundary)}`
 }
 
@@ -326,6 +357,10 @@ function boundaryDisplayValue(boundary) {
 
 function refDisplayValue(ref) {
   return ref.displayValue || formatDisplayValue(ref.price)
+}
+
+function boundaryTitle(boundary) {
+  return `${boundary.title}: ${boundaryDisplayValue(boundary)}`
 }
 
 function refTitle(ref) {

--- a/frontend/src/components/llm-ops/bulletChart.css
+++ b/frontend/src/components/llm-ops/bulletChart.css
@@ -731,7 +731,14 @@
   background-color: #2563eb;
   box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.16),
     0 2px 6px rgba(15, 23, 42, 0.16);
+  cursor: help;
   z-index: 6;
+}
+
+.range-bar-wrapper .range-ref-marker:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.24),
+    0 2px 8px rgba(15, 23, 42, 0.18);
 }
 
 .range-bar-wrapper .range-ref-label {
@@ -740,20 +747,68 @@
   color: #2563eb;
   font-size: 9px;
   font-weight: 800;
-  top: -60px;
+  top: -34px;
   transform: translateX(-50%);
   white-space: nowrap;
 }
 
-.range-bar-wrapper .range-ref-val {
+.range-bar-wrapper .range-ref-tooltip {
   position: absolute;
+  top: -0.75rem;
   left: 50%;
-  font-size: 9px;
-  color: #2563eb;
-  font-weight: 700;
-  top: -47px;
-  transform: translateX(-50%);
+  z-index: 32;
+  display: grid;
+  width: min(21rem, calc(100vw - 3rem));
+  gap: 0.35rem;
+  border: 1px solid #dbe4f0;
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.16);
+  opacity: 0;
+  padding: 0.55rem 0.6rem;
+  pointer-events: none;
+  transform: translate(-50%, -100%);
+  visibility: hidden;
+  transition:
+    opacity 0.16s ease,
+    transform 0.16s ease;
+}
+
+.range-bar-wrapper .range-ref-marker:hover .range-ref-tooltip,
+.range-bar-wrapper .range-ref-marker:focus-visible .range-ref-tooltip {
+  opacity: 1;
+  transform: translate(-50%, calc(-100% - 4px));
+  visibility: visible;
+}
+
+.range-bar-wrapper .range-ref-tooltip-title {
+  color: #0f172a;
+  font-size: 12px;
+  font-weight: 800;
+  line-height: 1.2;
+}
+
+.range-bar-wrapper .range-ref-tooltip-value {
+  color: #0f172a;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  line-height: 1.2;
+}
+
+.range-bar-wrapper .range-ref-tooltip-rows {
+  display: grid;
+  gap: 0.15rem;
+  padding-top: 0.15rem;
+}
+
+.range-bar-wrapper .range-ref-tooltip-row-compact em {
+  visibility: hidden;
+}
+
+.range-bar-wrapper .range-ref-tooltip-source {
+  color: #64748b;
+  font-size: 10px;
+  line-height: 1.35;
 }
 
 .range-bar-wrapper .range-bar-value {

--- a/frontend/src/composables/useResalePricing.js
+++ b/frontend/src/composables/useResalePricing.js
@@ -340,6 +340,12 @@ export function useResalePricing({
     ].join('-')
   }
 
+  function labeledPriceAmountSummary(rows) {
+    if (!rows.length) return '-'
+    if (rows.length === 1) return rows[0].value || '-'
+    return rows.map((row) => `${row.label} ${row.value}`).join(' / ')
+  }
+
   function priceAmountDetails(rows) {
     if (!rows.length) return '-'
     return rows.map((row) => `${row.label} ${row.value}`).join(' / ')
@@ -451,7 +457,11 @@ export function useResalePricing({
       {
         source: t('llmOps.publishingWorkspace.pricing.marketAverage'),
         price: Number(average.toFixed(2)),
-        displayValue: priceAmountSummary(marketRows),
+        displayValue: labeledPriceAmountSummary(marketRows),
+        rows: marketRows.map((row) => ({
+          label: row.label,
+          value: row.value
+        })),
         titleValue: priceAmountDetails(marketRows)
       }
     ]


### PR DESCRIPTION
## Summary
- Replace reference marker title text with accessible focusable tooltips
- Show labeled market average price rows in the reference tooltip
- Include current and reference prices when calculating bounded chart axis ranges

## Test plan
- [x] npm run build
- [x] git diff --check
- [ ] npm run lint (blocked: script references missing frontend/.gitignore; direct ESLint run reports existing unrelated errors)

Made with [Orca](https://github.com/stablyai/orca) 🐋
