### PR TITLE
Fix atomic model price item sync

### DIFF
--- a/backend/llm_ops/collection_services.py
+++ b/backend/llm_ops/collection_services.py
@@ -2968,27 +2968,42 @@ def sync_model_price_items(
         "source": source,
         "is_current": True,
     }
-    ModelPriceItem.objects.filter(**current_filter).update(
-        is_current=False,
-        effective_to=now,
-    )
     items = []
-    for payload in payloads:
-        fingerprint = model_price_item_fingerprint(payload)
-        payload["price_fingerprint"] = fingerprint
-        price_item, _ = ModelPriceItem.objects.update_or_create(
-            offering=offering,
-            dimension=payload["dimension"],
-            billing_unit=payload["billing_unit"],
-            currency=payload["currency"],
-            price_fingerprint=fingerprint,
-            defaults=payload,
+    with transaction.atomic():
+        old_current_ids = set(
+            ModelPriceItem.objects.filter(**current_filter).values_list(
+                "id",
+                flat=True,
+            )
         )
-        if not price_item.is_current or price_item.effective_to is not None:
-            price_item.is_current = True
-            price_item.effective_to = None
-            price_item.save(update_fields=["is_current", "effective_to"])
-        items.append(price_item)
+        for payload in payloads:
+            fingerprint = model_price_item_fingerprint(payload)
+            payload["price_fingerprint"] = fingerprint
+            price_item, _ = ModelPriceItem.objects.update_or_create(
+                offering=offering,
+                dimension=payload["dimension"],
+                billing_unit=payload["billing_unit"],
+                currency=payload["currency"],
+                price_fingerprint=fingerprint,
+                defaults=payload,
+            )
+            needs_reactivate = (
+                not price_item.is_current
+                or price_item.effective_to is not None
+            )
+            if needs_reactivate:
+                price_item.is_current = True
+                price_item.effective_to = None
+                price_item.save(update_fields=["is_current", "effective_to"])
+            items.append(price_item)
+
+        current_item_ids = {price_item.id for price_item in items}
+        stale_item_ids = old_current_ids - current_item_ids
+        if stale_item_ids:
+            ModelPriceItem.objects.filter(id__in=stale_item_ids).update(
+                is_current=False,
+                effective_to=now,
+            )
     return items
 
 

--- a/backend/llm_ops/services.py
+++ b/backend/llm_ops/services.py
@@ -951,40 +951,51 @@ def sync_manual_model_price_items(
         source=source,
         is_current=True,
     )
-    old_current_ids = set(current_queryset.values_list("id", flat=True))
-    current_queryset.update(is_current=False, effective_to=now)
 
     current_items = []
-    for payload in payloads:
-        fingerprint = stable_fingerprint(
-            {
-                "source": source.id,
-                "dimension": payload["dimension"],
-                "billing_unit": payload["billing_unit"],
-                "currency": payload["currency"],
-                "unit_price": str(payload["unit_price"]),
-                "tier_type": payload["tier_type"],
-                "tier_start": "",
-                "tier_end": "",
-                "spec": payload["spec"],
-            }
-        )
-        payload["price_fingerprint"] = fingerprint
-        price_item, _ = ModelPriceItem.objects.update_or_create(
-            model=model,
-            dimension=payload["dimension"],
-            billing_unit=payload["billing_unit"],
-            currency=payload["currency"],
-            price_fingerprint=fingerprint,
-            defaults=payload,
-        )
-        if not price_item.is_current or price_item.effective_to is not None:
-            price_item.is_current = True
-            price_item.effective_to = None
-            price_item.save(update_fields=["is_current", "effective_to"])
-        current_items.append(price_item)
+    with transaction.atomic():
+        old_current_ids = set(current_queryset.values_list("id", flat=True))
+        for payload in payloads:
+            fingerprint = stable_fingerprint(
+                {
+                    "source": source.id,
+                    "dimension": payload["dimension"],
+                    "billing_unit": payload["billing_unit"],
+                    "currency": payload["currency"],
+                    "unit_price": str(payload["unit_price"]),
+                    "tier_type": payload["tier_type"],
+                    "tier_start": "",
+                    "tier_end": "",
+                    "spec": payload["spec"],
+                }
+            )
+            payload["price_fingerprint"] = fingerprint
+            price_item, _ = ModelPriceItem.objects.update_or_create(
+                model=model,
+                dimension=payload["dimension"],
+                billing_unit=payload["billing_unit"],
+                currency=payload["currency"],
+                price_fingerprint=fingerprint,
+                defaults=payload,
+            )
+            needs_reactivate = (
+                not price_item.is_current
+                or price_item.effective_to is not None
+            )
+            if needs_reactivate:
+                price_item.is_current = True
+                price_item.effective_to = None
+                price_item.save(update_fields=["is_current", "effective_to"])
+            current_items.append(price_item)
 
-    current_item_ids = {item.id for item in current_items}
+        current_item_ids = {item.id for item in current_items}
+        stale_item_ids = old_current_ids - current_item_ids
+        if stale_item_ids:
+            ModelPriceItem.objects.filter(id__in=stale_item_ids).update(
+                is_current=False,
+                effective_to=now,
+            )
+
     return {
         "current_items": current_items,
         "deactivated_item_ids": sorted(old_current_ids - current_item_ids),

--- a/backend/llm_ops/tests/test_services.py
+++ b/backend/llm_ops/tests/test_services.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from unittest import mock
 
 from django.test import TestCase
 
@@ -777,6 +778,60 @@ class LLMOpsPricingServiceTests(TestCase):
             .get(),
             ModelPriceItem.DIMENSION_TEXT_OUTPUT,
         )
+
+    def test_manual_import_keeps_current_rows_when_write_fails(self):
+        source = PriceCollectionSource.objects.create(
+            provider=self.provider,
+            name="Supplier Sheet",
+            slug="supplier-sheet",
+            source_category=PriceCollectionSource.SOURCE_CATEGORY_SUPPLIER,
+            currency="USD",
+            updates_model_prices=False,
+        )
+        import_manual_model_prices(
+            source=source,
+            provider=self.provider,
+            rows=[
+                {
+                    "model_code": "gpt-4o",
+                    "model_name": "GPT-4o",
+                    "currency": "USD",
+                    "input_price_per_million": Decimal("1.5"),
+                }
+            ],
+            default_currency="USD",
+            updates_model_prices=False,
+        )
+        current_item = ModelPriceItem.objects.get(
+            source=source,
+            model=self.model,
+            dimension=ModelPriceItem.DIMENSION_TEXT_INPUT,
+        )
+
+        with mock.patch.object(
+            ModelPriceItem.objects,
+            "update_or_create",
+            side_effect=RuntimeError("write failed"),
+        ):
+            with self.assertRaisesMessage(RuntimeError, "write failed"):
+                import_manual_model_prices(
+                    source=source,
+                    provider=self.provider,
+                    rows=[
+                        {
+                            "model_code": "gpt-4o",
+                            "model_name": "GPT-4o",
+                            "currency": "USD",
+                            "output_price_per_million": Decimal("3.5"),
+                        }
+                    ],
+                    default_currency="USD",
+                    updates_model_prices=False,
+                )
+
+        current_item.refresh_from_db()
+        self.assertTrue(current_item.is_current)
+        self.assertIsNone(current_item.effective_to)
 
     def test_manual_import_omits_deactivated_items_from_affected_ids(self):
         source = PriceCollectionSource.objects.create(

--- a/backend/llm_ops/tests/test_source_collectors.py
+++ b/backend/llm_ops/tests/test_source_collectors.py
@@ -720,6 +720,45 @@ class PriceCollectionSkuPersistenceTests(TestCase):
         self.assertEqual(offerings.count(), 2)
         self.assertEqual(current_inputs.count(), 2)
 
+    def test_sync_price_items_keeps_current_rows_when_write_fails(self):
+        item = self.collected_item()
+        offering, _ = upsert_collected_offering(
+            item,
+            source=self.source,
+            source_url=self.source.endpoint_url,
+            meta_model=self.meta_model,
+        )
+        sync_model_price_items(
+            item,
+            source=self.source,
+            offering=offering,
+            source_url=self.source.endpoint_url,
+        )
+        current_item = ModelPriceItem.objects.get(
+            source=self.source,
+            offering=offering,
+            dimension=ModelPriceItem.DIMENSION_TEXT_INPUT,
+        )
+
+        refreshed_item = self.collected_item()
+        refreshed_item.price_rows[0].values["input_price"] = "1.5"
+        with mock.patch.object(
+            ModelPriceItem.objects,
+            "update_or_create",
+            side_effect=RuntimeError("write failed"),
+        ):
+            with self.assertRaisesMessage(RuntimeError, "write failed"):
+                sync_model_price_items(
+                    refreshed_item,
+                    source=self.source,
+                    offering=offering,
+                    source_url=self.source.endpoint_url,
+                )
+
+        current_item.refresh_from_db()
+        self.assertTrue(current_item.is_current)
+        self.assertIsNone(current_item.effective_to)
+
     def test_snapshots_are_scoped_by_offering(self):
         first = self.collected_item(exposed_model_name="deepseek-chat")
         second = self.collected_item(exposed_model_name="deepseek-chat-fast")


### PR DESCRIPTION
## Summary
- Make automatic collected price item sync atomic by delaying stale row deactivation until new current rows are written.
- Apply the same atomic stale-row handling to manual model price imports.
- Add regression tests proving existing current rows remain current when a write fails.

Closes #116

## Test plan
- [x] python3 -m pytest backend/llm_ops/tests/test_services.py backend/llm_ops/tests/test_source_collectors.py
- [x] git diff --check
- [x] 79-character line length check for changed Python files

Made with [Orca](https://github.com/stablyai/orca) 🐋
