### PR TITLE
Move MetaModel maintenance off read paths

### DIFF
--- a/backend/llm_ops/tasks.py
+++ b/backend/llm_ops/tasks.py
@@ -192,14 +192,20 @@ def sync_meta_models_from_models_dev_task(
     self,
     *,
     source_url: str | None = None,
-) -> dict[str, int]:
+) -> dict[str, object]:
     """Refresh canonical meta models from models.dev."""
+    from .catalog_maintenance import (
+        normalize_meta_model_catalog,
+        resolve_orphan_meta_models,
+    )
     from .collection_services import sync_meta_models_from_models_dev
 
     logger.info("llm_ops.sync_meta_models_from_models_dev start")
     try:
         kwargs = {"source_url": source_url} if source_url else {}
         results = sync_meta_models_from_models_dev(**kwargs)
+        results["meta_model_normalization"] = normalize_meta_model_catalog()
+        results["meta_model_orphan_resolution"] = resolve_orphan_meta_models()
     except Exception as exc:
         logger.exception("llm_ops.sync_meta_models_from_models_dev failed")
         if self.request.retries < self.max_retries:

--- a/backend/llm_ops/tests/test_ops_bootstrap.py
+++ b/backend/llm_ops/tests/test_ops_bootstrap.py
@@ -702,6 +702,39 @@ class LLMOpsSeedCleanupCommandTests(TestCase):
 class LLMOpsPeriodicTasksTests(TestCase):
     """The Celery task and periodic entry are wired up correctly."""
 
+    @patch("llm_ops.catalog_maintenance.resolve_orphan_meta_models")
+    @patch("llm_ops.catalog_maintenance.normalize_meta_model_catalog")
+    @patch("llm_ops.collection_services.sync_meta_models_from_models_dev")
+    def test_meta_model_sync_task_runs_catalog_maintenance(
+        self,
+        mock_sync,
+        mock_normalize,
+        mock_resolve,
+    ):
+        from llm_ops.tasks import sync_meta_models_from_models_dev_task
+
+        mock_sync.return_value = {"models": 1}
+        mock_normalize.return_value = {"normalized": 1}
+        mock_resolve.return_value = {"resolved": 1}
+
+        result = sync_meta_models_from_models_dev_task.run(
+            source_url="https://example.com/api.json",
+        )
+
+        self.assertEqual(
+            result["meta_model_normalization"],
+            {"normalized": 1},
+        )
+        self.assertEqual(
+            result["meta_model_orphan_resolution"],
+            {"resolved": 1},
+        )
+        mock_sync.assert_called_once_with(
+            source_url="https://example.com/api.json",
+        )
+        mock_normalize.assert_called_once_with()
+        mock_resolve.assert_called_once_with()
+
     def test_register_periodic_tasks_registers_llm_ops_entries(self):
         from core.periodic_registry import TASK_REGISTRY
 

--- a/backend/llm_ops/tests/test_views.py
+++ b/backend/llm_ops/tests/test_views.py
@@ -186,20 +186,16 @@ class LLMOpsViewTests(TestCase):
             {"gpt-4o"},
         )
 
-    def test_meta_model_owner_summary_migrates_qwen_to_alibaba(self):
-        qwen = MetaModel.objects.create(
+    def test_meta_model_owner_summary_reads_current_catalog(self):
+        MetaModel.objects.create(
             code="qwen-max",
             name="Qwen Max",
+            owner_code="alibaba",
+            owner_name="阿里巴巴",
         )
-        qwen_plus = MetaModel.objects.create(
+        MetaModel.objects.create(
             code="qwen-plus",
             name="Qwen Plus",
-        )
-        MetaModel.objects.filter(id=qwen.id).update(
-            owner_code="aliyun",
-            owner_name="阿里云",
-        )
-        MetaModel.objects.filter(id=qwen_plus.id).update(
             owner_code="alibaba",
             owner_name="阿里巴巴",
         )
@@ -215,6 +211,96 @@ class LLMOpsViewTests(TestCase):
         self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0]["name"], "阿里巴巴")
         self.assertEqual(rows[0]["meta_model_count"], 2)
+
+    @patch("llm_ops.catalog_maintenance.resolve_orphan_meta_models")
+    @patch("llm_ops.catalog_maintenance.normalize_meta_model_catalog")
+    def test_meta_model_list_does_not_run_catalog_maintenance(
+        self,
+        mock_normalize,
+        mock_resolve,
+    ):
+        MetaModel.objects.create(
+            code="gpt-4o",
+            name="GPT-4o",
+            owner_code="openai",
+            owner_name="OpenAI",
+        )
+
+        response = self.client.get(reverse("meta-model-list"))
+
+        self.assertEqual(response.status_code, 200)
+        mock_normalize.assert_not_called()
+        mock_resolve.assert_not_called()
+
+    @patch("llm_ops.catalog_maintenance.resolve_orphan_meta_models")
+    @patch("llm_ops.catalog_maintenance.normalize_meta_model_catalog")
+    def test_meta_model_detail_does_not_run_catalog_maintenance(
+        self,
+        mock_normalize,
+        mock_resolve,
+    ):
+        meta = MetaModel.objects.create(
+            code="gpt-4o",
+            name="GPT-4o",
+            owner_code="openai",
+            owner_name="OpenAI",
+        )
+
+        response = self.client.get(
+            reverse("meta-model-detail", args=[meta.id]),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        mock_normalize.assert_not_called()
+        mock_resolve.assert_not_called()
+
+    @patch("llm_ops.catalog_maintenance.resolve_orphan_meta_models")
+    @patch("llm_ops.catalog_maintenance.normalize_meta_model_catalog")
+    def test_meta_model_owner_summary_does_not_run_catalog_maintenance(
+        self,
+        mock_normalize,
+        mock_resolve,
+    ):
+        MetaModel.objects.create(
+            code="gpt-4o",
+            name="GPT-4o",
+            owner_code="openai",
+            owner_name="OpenAI",
+        )
+
+        response = self.client.get(reverse("meta-model-owner-summary"))
+
+        self.assertEqual(response.status_code, 200)
+        mock_normalize.assert_not_called()
+        mock_resolve.assert_not_called()
+
+    @patch("llm_ops.catalog_maintenance.resolve_orphan_meta_models")
+    @patch("llm_ops.catalog_maintenance.normalize_meta_model_catalog")
+    @patch("llm_ops.views.sync_meta_models_from_models_dev")
+    def test_meta_model_sync_runs_catalog_maintenance(
+        self,
+        mock_sync,
+        mock_normalize,
+        mock_resolve,
+    ):
+        mock_sync.return_value = {"models": 1}
+        mock_normalize.return_value = {"normalized": 1}
+        mock_resolve.return_value = {"resolved": 1}
+
+        response = self.client.post(reverse("meta-model-sync"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data["meta_model_normalization"],
+            {"normalized": 1},
+        )
+        self.assertEqual(
+            response.data["meta_model_orphan_resolution"],
+            {"resolved": 1},
+        )
+        mock_sync.assert_called_once_with()
+        mock_normalize.assert_called_once_with()
+        mock_resolve.assert_called_once_with()
 
     def test_global_config_patch_syncs_periodic_tasks(self):
         from django_celery_beat.models import PeriodicTask

--- a/backend/llm_ops/views.py
+++ b/backend/llm_ops/views.py
@@ -859,16 +859,6 @@ class MetaModelViewSet(
             )
         return super().destroy(request, *args, **kwargs)
 
-    def list(self, request, *args, **kwargs):
-        from .catalog_maintenance import (
-            normalize_meta_model_catalog,
-            resolve_orphan_meta_models,
-        )
-
-        normalize_meta_model_catalog()
-        resolve_orphan_meta_models()
-        return super().list(request, *args, **kwargs)
-
     @action(
         detail=False,
         methods=["get"],
@@ -877,13 +867,6 @@ class MetaModelViewSet(
     )
     def owner_summary(self, request):
         """Return one lightweight row per canonical model owner."""
-        from .catalog_maintenance import (
-            normalize_meta_model_catalog,
-            resolve_orphan_meta_models,
-        )
-
-        normalize_meta_model_catalog()
-        resolve_orphan_meta_models()
         queryset = self.get_queryset()
         search = request.query_params.get("owner_search")
         if search:
@@ -927,23 +910,17 @@ class MetaModelViewSet(
             status=status.HTTP_200_OK,
         )
 
-    def retrieve(self, request, *args, **kwargs):
+    @action(detail=False, methods=["post"], url_path="sync")
+    def sync(self, request):
+        """Refresh meta models from the public models.dev API."""
         from .catalog_maintenance import (
             normalize_meta_model_catalog,
             resolve_orphan_meta_models,
         )
 
-        normalize_meta_model_catalog()
-        resolve_orphan_meta_models()
-        return super().retrieve(request, *args, **kwargs)
-
-    @action(detail=False, methods=["post"], url_path="sync")
-    def sync(self, request):
-        """Refresh meta models from the public models.dev API."""
-        from .catalog_maintenance import normalize_meta_model_catalog
-
         stats = sync_meta_models_from_models_dev()
         stats["meta_model_normalization"] = normalize_meta_model_catalog()
+        stats["meta_model_orphan_resolution"] = resolve_orphan_meta_models()
         record_audit_log(
             request=request,
             action=AuditLog.ACTION_SYNC,


### PR DESCRIPTION
## Summary
- Remove catalog maintenance from MetaModel list, detail, and owner summary read paths
- Run normalization and orphan resolution from the manual sync endpoint
- Run the same catalog maintenance after the scheduled models.dev sync task
- Add tests proving read APIs do not invoke maintenance and sync paths still do

Closes #117

## Test plan
- [x] `python3 -m py_compile backend/llm_ops/tasks.py backend/llm_ops/views.py backend/llm_ops/tests/test_ops_bootstrap.py backend/llm_ops/tests/test_views.py`
- [x] `git diff --check`
- [ ] `python3 -m pytest backend/llm_ops/tests/test_views.py backend/llm_ops/tests/test_ops_bootstrap.py -k "meta_model"` (blocked locally: missing dependency `dj_database_url` in the current Python environment)

Made with [Orca](https://github.com/stablyai/orca) 🐋
