### PR TITLE
Fix LLM Ops global config secret handling

### DIFF
--- a/backend/llm_ops/models.py
+++ b/backend/llm_ops/models.py
@@ -253,9 +253,9 @@ class LLMOpsGlobalConfig(models.Model):
         if not value:
             return ""
         if value.startswith(cls.ENCRYPTED_SECRET_PREFIX):
-            encrypted = value[len(cls.ENCRYPTED_SECRET_PREFIX) :]
+            encrypted = value[len(cls.ENCRYPTED_SECRET_PREFIX):]
             return encryption_service.decrypt(encrypted)
-        return encryption_service.decrypt(value)
+        return value
 
     def set_feishu_app_secret(self, value: str) -> None:
         """Store the Feishu app secret in encrypted form."""

--- a/backend/llm_ops/serializers.py
+++ b/backend/llm_ops/serializers.py
@@ -309,8 +309,8 @@ class LLMOpsGlobalConfigSerializer(serializers.ModelSerializer):
     def update(self, instance, validated_data):
         secret_marker = object()
         secret = validated_data.pop("feishu_app_secret", secret_marker)
-        if secret not in (secret_marker, ""):
-            instance.set_feishu_app_secret(secret)
+        if secret is not secret_marker:
+            instance.set_feishu_app_secret(secret or "")
         return super().update(instance, validated_data)
 
     def to_representation(self, instance):

--- a/backend/llm_ops/tests/test_serializers.py
+++ b/backend/llm_ops/tests/test_serializers.py
@@ -1,9 +1,11 @@
 from decimal import Decimal
+from unittest.mock import patch
 
 from django.test import TestCase
 
 from llm_ops.models import (
     LLMModel,
+    LLMOpsGlobalConfig,
     LLMProvider,
     MetaModel,
     ModelPriceItem,
@@ -16,6 +18,7 @@ from llm_ops.models import (
 )
 from llm_ops.serializers import (
     LLMModelSerializer,
+    LLMOpsGlobalConfigSerializer,
     ManualPriceImportRequestSerializer,
     ModelPriceItemSerializer,
     PriceCollectionSourceSerializer,
@@ -23,6 +26,41 @@ from llm_ops.serializers import (
     ResalePlatformSerializer,
     UsageReconciliationRecordSerializer,
 )
+
+
+class LLMOpsGlobalConfigSerializerTests(TestCase):
+    @patch("llm_ops.models.encryption_service.decrypt")
+    def test_plaintext_secret_falls_back_without_decrypt(self, mock_decrypt):
+        mock_decrypt.side_effect = AssertionError(
+            "Plaintext values should not be decrypted."
+        )
+        config = LLMOpsGlobalConfig.get_solo()
+        LLMOpsGlobalConfig.objects.filter(pk=config.pk).update(
+            feishu_app_secret="legacy-plaintext-secret"
+        )
+
+        config.refresh_from_db()
+
+        self.assertEqual(
+            config.get_feishu_app_secret(),
+            "legacy-plaintext-secret",
+        )
+
+    def test_blank_secret_clears_existing_secret(self):
+        config = LLMOpsGlobalConfig.get_solo()
+        config.set_feishu_app_secret("existing-secret")
+        config.save()
+
+        serializer = LLMOpsGlobalConfigSerializer(
+            config,
+            data={"feishu_app_secret": ""},
+            partial=True,
+        )
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        updated = serializer.save()
+        self.assertEqual(updated.feishu_app_secret, "")
+        self.assertEqual(updated.get_feishu_app_secret(), "")
 
 
 class ProcurementChannelSerializerTests(TestCase):

--- a/backend/llm_ops/tests/test_views.py
+++ b/backend/llm_ops/tests/test_views.py
@@ -285,6 +285,19 @@ class LLMOpsViewTests(TestCase):
             "llm_ops.tasks.run_model_price_sync_agent",
         )
 
+    def test_global_config_plaintext_secret_falls_back_without_decrypt(self):
+        config = LLMOpsGlobalConfig.get_solo()
+        LLMOpsGlobalConfig.objects.filter(pk=config.pk).update(
+            feishu_app_secret="legacy-plaintext-secret"
+        )
+
+        config.refresh_from_db()
+
+        self.assertEqual(
+            config.get_feishu_app_secret(),
+            "legacy-plaintext-secret",
+        )
+
     def test_global_config_all_sources_writes_null_task_source_ids(self):
         from django_celery_beat.models import PeriodicTask
 
@@ -337,11 +350,10 @@ class LLMOpsViewTests(TestCase):
         )
         self.assertEqual(json.loads(price_task.kwargs)["source_ids"], [])
 
-    def test_global_config_blank_secret_preserves_existing_secret(self):
+    def test_global_config_blank_secret_clears_existing_secret(self):
         config = LLMOpsGlobalConfig.get_solo()
         config.set_feishu_app_secret("existing-secret")
         config.save()
-        stored_secret = config.feishu_app_secret
 
         response = self.client.patch(
             reverse("llm-ops-global-config"),
@@ -354,8 +366,9 @@ class LLMOpsViewTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         config.refresh_from_db()
-        self.assertEqual(config.feishu_app_secret, stored_secret)
-        self.assertEqual(config.get_feishu_app_secret(), "existing-secret")
+        self.assertEqual(config.feishu_app_secret, "")
+        self.assertEqual(config.get_feishu_app_secret(), "")
+        self.assertFalse(response.data["feishu_app_secret_configured"])
 
     def test_global_config_rejects_unknown_price_source_ids(self):
         response = self.client.patch(


### PR DESCRIPTION
## Summary
- Treat legacy plaintext Feishu app secrets as readable values instead of decrypting them again
- Allow an empty Feishu app secret update to clear the stored secret
- Add serializer and API regression coverage for plaintext fallback and secret clearing

Closes #118

## Test plan
- [x] .venv/bin/python -m pytest backend/llm_ops/tests/test_serializers.py backend/llm_ops/tests/test_views.py -k \"GlobalConfig or global_config\"
- [x] .venv/bin/python -m flake8 backend/llm_ops/models.py backend/llm_ops/serializers.py backend/llm_ops/tests/test_serializers.py backend/llm_ops/tests/test_views.py
- [x] git diff --check

Made with [Orca](https://github.com/stablyai/orca) 🐋
