### PR TITLE
Improve resale market benchmark pricing

### DIFF
--- a/frontend/src/components/llm-ops/AgioneListingStatusBoard.vue
+++ b/frontend/src/components/llm-ops/AgioneListingStatusBoard.vue
@@ -237,9 +237,6 @@
               </td>
               <td class="table-cell">
                 <p class="font-medium text-slate-900">
-                  {{ row.provider_name || '—' }}
-                </p>
-                <p class="mt-0.5 text-[11px] text-slate-500">
                   {{ activeListingChannelLabel(row) }}
                 </p>
               </td>

--- a/frontend/src/components/llm-ops/BulletChart.vue
+++ b/frontend/src/components/llm-ops/BulletChart.vue
@@ -86,10 +86,7 @@
           <strong v-else class="range-ref-tooltip-value">
             {{ refDisplayValue(ref) }}
           </strong>
-          <span
-            v-if="ref.titleValue && !ref.rows?.length"
-            class="range-ref-tooltip-source"
-          >
+          <span v-if="ref.titleValue" class="range-ref-tooltip-source">
             {{ ref.titleValue }}
           </span>
         </span>
@@ -105,7 +102,7 @@
       :aria-valuemax="axisMax"
       :aria-valuenow="Number(value) || 0"
       :style="{
-        left: getMarkerPos(Number(value) || 0) + '%',
+        left: getVisualMarkerPos(Number(value) || 0) + '%',
         backgroundColor: getMarkerColor(Number(value) || 0)
       }"
       @keydown="onMarkerKeydown"
@@ -178,11 +175,17 @@ const { t } = useI18n()
 
 const rangeRef = ref(null)
 const isDragging = ref(false)
+const dragAxisRange = ref(null)
+const dragMarkerPercent = ref(null)
 const fallbackCenter = ref(0)
 
 const AXIS_START_PERCENT = 10
 const AXIS_END_PERCENT = 90
 const AXIS_WIDTH_PERCENT = AXIS_END_PERCENT - AXIS_START_PERCENT
+const AXIS_DRAG_OVERFLOW_RATIO = 0.05
+const AXIS_VALUE_EXTENSION_TRIGGER_PERCENT = 90
+const LABEL_EDGE_START_PERCENT = 4
+const LABEL_EDGE_END_PERCENT = 96
 
 const boundaryMin = computed(() => Number(props.min))
 const boundaryMax = computed(() => Number(props.max))
@@ -194,33 +197,22 @@ const axisRange = computed(() => {
   const value = Number(props.value)
   const refValues = props.refs.map((ref) => Number(ref.price))
   if (hasBoundaryRange.value) {
-    const candidates = [
+    const baseCandidates = [
       boundaryMin.value,
       boundaryMax.value,
-      value,
       ...refValues
     ].filter((item) => Number.isFinite(item))
-    const rawMin = Math.min(...candidates)
-    const rawMax = Math.max(...candidates)
-    if (rawMax === rawMin) {
-      const padding = Math.max(Math.abs(rawMax) * 0.2, 1)
-      return {
-        min: Math.max(0, rawMin - padding),
-        max: rawMax + padding
-      }
-    }
-    const span = rawMax - rawMin
-    const leftPadding = Math.max(span * 0.04, 1)
-    const rightPadding = Math.max(span * 0.14, 10)
-    return {
-      min: Math.max(0, Math.floor((rawMin - leftPadding) / 5) * 5),
-      max: Math.ceil((rawMax + rightPadding) / 5) * 5
-    }
+    return axisRangeWithValueExtension(baseCandidates, value, {
+      leftRatio: 0.04,
+      rightMin: 10,
+      rightRatio: 0.14
+    })
   }
 
-  const candidates = [value, ...refValues].filter((item) =>
-    Number.isFinite(item)
-  )
+  const baseCandidates = refValues.filter((item) => Number.isFinite(item))
+  const candidates = baseCandidates.length
+    ? baseCandidates
+    : [value].filter((item) => Number.isFinite(item))
 
   if (!candidates.length) {
     if (!fallbackCenter.value && Number.isFinite(value) && value > 0) {
@@ -234,6 +226,29 @@ const axisRange = computed(() => {
     }
   }
 
+  return axisRangeWithValueExtension(candidates, value, {
+    leftRatio: 0.08,
+    rightRatio: 0.08
+  })
+})
+
+function axisRangeWithValueExtension(baseCandidates, value, options = {}) {
+  const baseRange = paddedAxisRange(baseCandidates, options)
+  if (!Number.isFinite(value)) return baseRange
+  const markerPercent = markerPercentForRange(value, baseRange)
+  if (markerPercent > AXIS_VALUE_EXTENSION_TRIGGER_PERCENT) {
+    return paddedAxisRange([...baseCandidates, value], options)
+  }
+  return baseRange
+}
+
+function markerPercentForRange(value, range) {
+  const span = range.max - range.min
+  if (span <= 0) return 50
+  return ((value - range.min) / span) * AXIS_WIDTH_PERCENT + AXIS_START_PERCENT
+}
+
+function paddedAxisRange(candidates, options = {}) {
   const rawMin = Math.min(...candidates)
   const rawMax = Math.max(...candidates)
   if (rawMax === rawMin) {
@@ -245,12 +260,16 @@ const axisRange = computed(() => {
   }
 
   const span = rawMax - rawMin
-  const padding = Math.max(span * 0.08, 1)
+  const leftPadding = Math.max(span * (options.leftRatio ?? 0.08), 1)
+  const rightPadding = Math.max(
+    span * (options.rightRatio ?? 0.08),
+    options.rightMin ?? 1
+  )
   return {
-    min: Math.max(0, Math.floor((rawMin - padding) / 5) * 5),
-    max: Math.ceil((rawMax + padding) / 5) * 5
+    min: Math.max(0, Math.floor((rawMin - leftPadding) / 5) * 5),
+    max: Math.ceil((rawMax + rightPadding) / 5) * 5
   }
-})
+}
 
 const axisMin = computed(() => axisRange.value.min)
 const axisMax = computed(() => axisRange.value.max)
@@ -322,6 +341,10 @@ function getMarkerPos(price) {
   return Math.max(0, Math.min(pos, 100))
 }
 
+function getVisualMarkerPos(price) {
+  return dragMarkerPercent.value ?? getMarkerPos(price)
+}
+
 function getMarkerColor(price) {
   const p = Number(price)
   const min = axisMin.value
@@ -368,16 +391,16 @@ function refTitle(ref) {
 }
 
 function getValueLabelStyle(price) {
-  const pos = getMarkerPos(price)
+  const pos = getVisualMarkerPos(price)
   const color = getMarkerColor(price)
-  if (pos < 12) {
+  if (pos < LABEL_EDGE_START_PERCENT) {
     return {
       left: '0%',
       color,
       transform: 'translateX(0)'
     }
   }
-  if (pos > 88) {
+  if (pos > LABEL_EDGE_END_PERCENT) {
     return {
       left: '100%',
       color,
@@ -396,12 +419,23 @@ function getPriceFromPointer(event) {
   if (!el) return null
   const rect = el.getBoundingClientRect()
   const percent = ((event.clientX - rect.left) / rect.width) * 100
-  const clamped = Math.max(
+  const visualPercent = Math.max(0, Math.min(percent, 100))
+  const valuePercent = Math.max(
     AXIS_START_PERCENT,
-    Math.min(percent, AXIS_END_PERCENT)
+    Math.min(visualPercent, 100)
   )
-  const ratio = (clamped - AXIS_START_PERCENT) / AXIS_WIDTH_PERCENT
-  const price = axisMin.value + ratio * (axisMax.value - axisMin.value)
+  dragMarkerPercent.value = visualPercent
+  const ratio =
+    valuePercent <= AXIS_END_PERCENT
+      ? (valuePercent - AXIS_START_PERCENT) / AXIS_WIDTH_PERCENT
+      : 1 +
+        ((valuePercent - AXIS_END_PERCENT) / (100 - AXIS_END_PERCENT)) *
+          AXIS_DRAG_OVERFLOW_RATIO
+  const range = dragAxisRange.value || {
+    max: axisMax.value,
+    min: axisMin.value
+  }
+  const price = range.min + ratio * (range.max - range.min)
   return Number(price.toFixed(4))
 }
 
@@ -419,6 +453,8 @@ function handleValueDrag(event) {
 function stopValueDrag() {
   if (!isDragging.value) return
   isDragging.value = false
+  dragAxisRange.value = null
+  dragMarkerPercent.value = null
   document.removeEventListener('pointermove', handleValueDrag)
   document.removeEventListener('pointerup', stopValueDrag)
 }
@@ -427,6 +463,10 @@ function startValueDrag(event) {
   if (event?.button > 0) return
   event.preventDefault()
   isDragging.value = true
+  dragAxisRange.value = {
+    max: axisMax.value,
+    min: axisMin.value
+  }
   handleValueDrag(event)
   document.addEventListener('pointermove', handleValueDrag)
   document.addEventListener('pointerup', stopValueDrag)

--- a/frontend/src/components/llm-ops/ResalePlatformModal.vue
+++ b/frontend/src/components/llm-ops/ResalePlatformModal.vue
@@ -21,7 +21,7 @@
               {{ form.id ? '编辑挂售平台' : '新建挂售平台' }}
             </h3>
             <p class="mt-1 text-sm text-slate-500">
-              配置平台类型、区域、接口、抽佣、免审收益率和积分规则。
+              配置 Agione 平台实例、区域、接口、抽佣、免审收益率和积分规则。
             </p>
           </div>
           <button
@@ -41,7 +41,7 @@
         <section class="form-section">
           <div class="section-heading">
             <h4>平台信息</h4>
-            <p>用于区分 Agione 或其他上架平台实例和后续接口适配。</p>
+            <p>用于区分 Agione 上架平台实例和后续接口适配。</p>
           </div>
           <div class="grid gap-4 md:grid-cols-2">
             <label class="field-group">
@@ -312,14 +312,7 @@ const currencyOptions = [
   { label: 'CNY', value: 'CNY' },
   { label: 'USD', value: 'USD' }
 ]
-const platformTypeOptions = [
-  { label: 'Agione', value: 'agione' },
-  { label: '云市场', value: 'cloud_marketplace' },
-  { label: 'API 网关', value: 'api_gateway' },
-  { label: '代理商平台', value: 'reseller' },
-  { label: '内部平台', value: 'internal' },
-  { label: '其他平台', value: 'other' }
-]
+const platformTypeOptions = [{ label: 'Agione', value: 'agione' }]
 const environmentOptions = [
   { label: '生产', value: 'production' },
   { label: '预发', value: 'staging' },
@@ -393,7 +386,7 @@ function defaults() {
 function platformToForm(platform) {
   return {
     ...platform,
-    platform_type: platform.platform_type || 'agione',
+    platform_type: 'agione',
     region_code: platform.region_code || '',
     region_name: platform.region_name || '',
     environment: platform.environment || 'production',
@@ -429,6 +422,7 @@ function ratioFromPercent(value) {
 
 function normalizePayload(payload) {
   const clean = { ...payload }
+  clean.platform_type = 'agione'
   clean.code = String(clean.code || '')
     .trim()
     .toLowerCase()

--- a/frontend/src/components/llm-ops/ResalePublishingWorkspace.vue
+++ b/frontend/src/components/llm-ops/ResalePublishingWorkspace.vue
@@ -520,6 +520,9 @@
                 :digits="1"
                 @change="onMarginAxisChange(row, $event)"
               />
+              <p class="pricing-axis-reference">
+                {{ marketMarginReferenceText(row) }}
+              </p>
             </div>
           </div>
         </article>
@@ -693,6 +696,7 @@ const {
   marginPolicyTooltip,
   marketAverageText,
   marketMarginRefsFor,
+  marketMarginReferenceText,
   normalizeDiscountRatio,
   normalizeMargin,
   priceDiffAmountText,

--- a/frontend/src/components/llm-ops/resalePublishingWorkspace.css
+++ b/frontend/src/components/llm-ops/resalePublishingWorkspace.css
@@ -663,11 +663,19 @@
 
 .resale-publishing-workspace .compact-pricing-axis {
   position: relative;
-  padding: 1.5rem 0 2.75rem;
+  padding: 1.5rem 0 2.25rem;
 }
 
 .resale-publishing-workspace .pricing-axis-block .range-bar-wrapper {
   margin: 0;
+}
+
+.resale-publishing-workspace .pricing-axis-reference {
+  margin-top: 1.75rem;
+  color: #64748b;
+  font-size: 11px;
+  line-height: 1.35;
+  text-align: center;
 }
 
 .resale-publishing-workspace .pricing-matrix-card {

--- a/frontend/src/composables/useAgioneListingDisplay.js
+++ b/frontend/src/composables/useAgioneListingDisplay.js
@@ -173,12 +173,13 @@ export function useAgioneListingDisplay({
   }
 
   function activeListingChannelLabel(row) {
-    const activeListings = row.active_listings || []
-    if (activeListings.length > 1) {
-      return t('llmOps.listingBoard.supply.activeLinks', {
-        count: activeListings.length
-      })
-    }
+    const listings = row.active_listings?.length
+      ? row.active_listings
+      : row.listings || []
+    const channelNames = Array.from(
+      new Set(listings.map((listing) => listing.channel_name).filter(Boolean))
+    )
+    if (channelNames.length) return channelNames.join(' / ')
     return (
       row.lowest_option?.channel_name || t('llmOps.listingBoard.supply.none')
     )
@@ -295,13 +296,97 @@ export function useAgioneListingDisplay({
     return Number.isFinite(limit) ? limit : null
   }
 
+  function priceSpecForItemDimension(dimension) {
+    return RESALE_PRICE_DIMENSION_SPECS.find(
+      (spec) => spec.itemDimension === dimension
+    )
+  }
+
+  function itemBelongsToRowModel(item, row) {
+    const rowModel = row?.model || {}
+    const rowMetaModelId = rowModel.meta_model || rowModel.meta_model_id
+    if (rowMetaModelId && String(item.meta_model) === String(rowMetaModelId)) {
+      return true
+    }
+    if (String(item.model || '') === String(rowModel.id || '')) return true
+    const itemModel = (props.models || []).find(
+      (model) => String(model.id) === String(item.model || '')
+    )
+    return (
+      rowMetaModelId &&
+      String(itemModel?.meta_model || itemModel?.meta_model_id || '') ===
+        String(rowMetaModelId)
+    )
+  }
+
+  function marketAverageRows(row) {
+    const samples = Object.fromEntries(
+      RESALE_PRICE_DIMENSION_SPECS.map((spec) => [spec.key, []])
+    )
+    ;(props.priceItems || []).forEach((item) => {
+      if (item.source_is_enabled === false || item.is_current === false) return
+      if (!itemBelongsToRowModel(item, row)) return
+      const spec = priceSpecForItemDimension(item.dimension)
+      if (!spec) return
+      const amount = listingDisplayAmount(item.unit_price, item.currency)
+      if (amount !== null && amount > 0) samples[spec.key].push(amount)
+    })
+    RESALE_PRICE_DIMENSION_SPECS.forEach((spec) => {
+      if (samples[spec.key].length) return
+      ;(row.options || []).forEach((option) => {
+        const amount = Number(option[spec.costField])
+        if (Number.isFinite(amount) && amount > 0) {
+          samples[spec.key].push(amount)
+        }
+      })
+    })
+    return RESALE_PRICE_DIMENSION_SPECS.map((spec) => {
+      const values = samples[spec.key]
+      const average = values.length
+        ? values.reduce((sum, value) => sum + value, 0) / values.length
+        : null
+      const price = listingDisplayAmount(
+        row.status_listing?.[spec.retailField],
+        row.status_listing?.currency
+      )
+      return {
+        average,
+        label: spec.label,
+        price
+      }
+    }).filter(
+      (item) =>
+        item.price !== null && Number.isFinite(item.average) && item.average > 0
+    )
+  }
+
+  function priceAboveMarket(row) {
+    return marketAverageRows(row).some(
+      (item) => Number(item.price) > Number(item.average) + 0.000001
+    )
+  }
+
+  function marketAverageTitle(row) {
+    const rows = marketAverageRows(row).filter(
+      (item) => Number(item.price) > Number(item.average) + 0.000001
+    )
+    if (!rows.length) return ''
+    return rows
+      .map(
+        (item) =>
+          `${item.label} ${listingAmountText(item.price)} > ${listingAmountText(
+            item.average
+          )}`
+      )
+      .join(' / ')
+  }
+
   function marginToneKey(row) {
     const margin = listingUnifiedMarginRate(row)
     if (margin === null) return 'muted'
+    if (priceAboveMarket(row)) return 'high'
     const floor = platformMarginFloor()
     if (margin < floor) return 'low'
-    const limit = platformMarginLimit()
-    if (limit !== null && margin > limit) return 'high'
     return 'ok'
   }
 
@@ -312,6 +397,12 @@ export function useAgioneListingDisplay({
   function marginPillTitle(row) {
     const margin = listingUnifiedMarginRate(row)
     const tone = marginToneKey(row)
+    if (tone === 'high') {
+      return t('llmOps.listingBoard.marginTone.high', {
+        market: marketAverageTitle(row),
+        value: formatMarginText(margin)
+      })
+    }
     return t(`llmOps.listingBoard.marginTone.${tone}`, {
       value: formatMarginText(margin),
       floor: formatMarginText(platformMarginFloor()),

--- a/frontend/src/composables/useResalePricing.js
+++ b/frontend/src/composables/useResalePricing.js
@@ -346,11 +346,6 @@ export function useResalePricing({
     return rows.map((row) => `${row.label} ${row.value}`).join(' / ')
   }
 
-  function priceAmountDetails(rows) {
-    if (!rows.length) return '-'
-    return rows.map((row) => `${row.label} ${row.value}`).join(' / ')
-  }
-
   function priceDiffText(price, avg) {
     const p = Number(price)
     const a = Number(avg)
@@ -432,39 +427,56 @@ export function useResalePricing({
     })
   }
 
+  function inputMarketMarginReference(row) {
+    const inputDimension = priceDimensions(row).find(
+      (dimension) => dimension.key === 'input'
+    )
+    const marketPrice = Number(inputDimension?.marketAverage)
+    const cost = Number(inputDimension?.costRaw)
+    if (
+      !Number.isFinite(marketPrice) ||
+      !Number.isFinite(cost) ||
+      marketPrice <= 0 ||
+      cost <= 0
+    ) {
+      return null
+    }
+    const marketMargin = averageMarginRate([{ cost, price: marketPrice }])
+    if (marketMargin === null) return null
+    return {
+      label: inputDimension.shortLabel || inputDimension.label,
+      marketMargin,
+      marketPrice
+    }
+  }
+
   function marketMarginRefsFor(row) {
-    const dimensions = priceDimensions(row)
-    const marketRows = priceAmountRows(dimensions, 'marketAverage')
-    const margins = dimensions
-      .map((dimension) => {
-        const marketPrice = Number(dimension.marketAverage)
-        const cost = Number(dimension.costRaw)
-        if (
-          !Number.isFinite(marketPrice) ||
-          !Number.isFinite(cost) ||
-          marketPrice <= 0 ||
-          cost <= 0
-        ) {
-          return null
-        }
-        return ((marketPrice - cost) / cost) * 100
-      })
-      .filter((value) => value !== null)
-    if (!margins.length) return []
-    const average =
-      margins.reduce((total, value) => total + value, 0) / margins.length
+    const reference = inputMarketMarginReference(row)
+    if (!reference) return []
+    const marketRows = priceAmountRows(priceDimensions(row), 'marketAverage')
     return [
       {
         source: t('llmOps.publishingWorkspace.pricing.marketAverage'),
-        price: Number(average.toFixed(2)),
+        price: normalizeMargin(reference.marketMargin),
         displayValue: labeledPriceAmountSummary(marketRows),
         rows: marketRows.map((row) => ({
           label: row.label,
           value: row.value
         })),
-        titleValue: priceAmountDetails(marketRows)
+        titleValue: marketMarginReferenceText(row)
       }
     ]
+  }
+
+  function marketMarginReferenceText(row) {
+    const reference = inputMarketMarginReference(row)
+    if (!reference) {
+      return t('llmOps.publishingWorkspace.pricing.noBenchmark')
+    }
+    return t('llmOps.publishingWorkspace.pricing.marketMarginReference', {
+      margin: formatPercent(reference.marketMargin),
+      price: priceAmountText(reference.marketPrice)
+    })
   }
 
   function marginAxisRangeFor(row) {
@@ -557,6 +569,7 @@ export function useResalePricing({
     marginPolicyTooltip,
     marketAverageText,
     marketMarginRefsFor,
+    marketMarginReferenceText,
     normalizeDiscountRatio,
     normalizeMargin,
     priceDiffAmountText,

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -997,7 +997,8 @@
         "lowerThanAverage": "↓ {pct}% lower",
         "higherThanAverage": "↑ {pct}% higher",
         "sameAsAverage": "- Flat",
-        "marketAverage": "Market average"
+        "marketAverage": "Market average",
+        "marketMarginReference": "Axis reference: Input market average {price}, margin {margin}"
       },
       "performance": {
         "title": "Link Performance Benchmark",
@@ -2077,7 +2078,7 @@
         "default": "No models match the current filters."
       },
       "marginTone": {
-        "high": "Too high: current {value}, above auto-approval limit {limit}",
+        "high": "Price is above market average: {market}; current margin {value}",
         "low": "Too low: current {value}, below platform cost floor {floor}",
         "muted": "No margin available",
         "ok": "Suitable: current {value}, platform floor {floor}, auto-approval limit {limit}"

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1007,7 +1007,8 @@
         "lowerThanAverage": "↓ 低 {pct}%",
         "higherThanAverage": "↑ 高 {pct}%",
         "sameAsAverage": "- 持平",
-        "marketAverage": "市场均价"
+        "marketAverage": "市场均价",
+        "marketMarginReference": "坐标参照：Input 市场均价 {price}，对应收益率 {margin}"
       },
       "performance": {
         "title": "链路性能全景对标",
@@ -2087,7 +2088,7 @@
         "default": "没有符合筛选条件的模型。"
       },
       "marginTone": {
-        "high": "太高：当前 {value}，高于自动审批上限 {limit}",
+        "high": "售价高于市场均价：{market}；当前收益率 {value}",
         "low": "太低：当前 {value}，低于平台成本下限 {floor}",
         "muted": "暂无收益率",
         "ok": "合适：当前 {value}，平台下限 {floor}，自动审批上限 {limit}"


### PR DESCRIPTION
## Summary
- Use input market average pricing as the resale margin axis benchmark
- Flag Agione listings when published prices exceed market averages
- Constrain resale platform setup to Agione platform instances and update copy

## Test plan
- [x] git diff --check
- [x] npm run build

Made with [Orca](https://github.com/stablyai/orca) 🐋
