### PR TITLE
Fix resale price benchmark color states

### DIFF
--- a/frontend/src/components/llm-ops/ResalePublishingWorkspace.vue
+++ b/frontend/src/components/llm-ops/ResalePublishingWorkspace.vue
@@ -462,6 +462,12 @@
                           dimension.marketAverage
                         )
                       "
+                      :title="
+                        priceDiffTitle(
+                          dimension.priceRaw,
+                          dimension.marketAverage
+                        )
+                      "
                     >
                       {{
                         priceDiffText(
@@ -701,6 +707,7 @@ const {
   normalizeMargin,
   priceDiffAmountText,
   priceDiffClass,
+  priceDiffTitle,
   priceDiffText,
   priceDimensions,
   priceFromMargin,

--- a/frontend/src/composables/useResalePricing.js
+++ b/frontend/src/composables/useResalePricing.js
@@ -6,6 +6,8 @@ import {
   RESALE_PRICE_DIMENSION_SPECS
 } from '@/utils/resalePricing'
 
+const PRICE_COMPARE_EPSILON = 0.00001
+
 export function useResalePricing({
   currencyLabel,
   currencySymbol,
@@ -354,12 +356,12 @@ export function useResalePricing({
     }
     const diff = p - a
     const pct = Math.abs((diff / a) * 100).toFixed(1)
-    if (diff < -0.00001) {
+    if (diff < -PRICE_COMPARE_EPSILON) {
       return t('llmOps.publishingWorkspace.pricing.lowerThanAverage', {
         pct
       })
     }
-    if (diff > 0.00001) {
+    if (diff > PRICE_COMPARE_EPSILON) {
       return t('llmOps.publishingWorkspace.pricing.higherThanAverage', {
         pct
       })
@@ -379,12 +381,23 @@ export function useResalePricing({
   function priceDiffClass(price, avg) {
     const p = Number(price)
     const a = Number(avg)
-    if (!Number.isFinite(p) || !Number.isFinite(a) || a === 0) {
+    if (!Number.isFinite(p) || !Number.isFinite(a) || a <= 0) {
       return 'text-slate-400'
     }
-    if (p < a) return 'text-emerald-600'
-    if (p > a) return 'text-amber-600'
-    return 'text-slate-500'
+    if (p > a + PRICE_COMPARE_EPSILON) return 'text-amber-600'
+    return 'text-emerald-600'
+  }
+
+  function priceDiffTitle(price, avg) {
+    const p = Number(price)
+    const a = Number(avg)
+    if (!Number.isFinite(p) || !Number.isFinite(a) || a <= 0) {
+      return t('llmOps.publishingWorkspace.pricing.priceColorNoBenchmark')
+    }
+    if (p > a + PRICE_COMPARE_EPSILON) {
+      return t('llmOps.publishingWorkspace.pricing.priceColorAboveAverage')
+    }
+    return t('llmOps.publishingWorkspace.pricing.priceColorAtOrBelowAverage')
   }
 
   function priceSpecForItemDimension(dimension) {
@@ -574,6 +587,7 @@ export function useResalePricing({
     normalizeMargin,
     priceDiffAmountText,
     priceDiffClass,
+    priceDiffTitle,
     priceDiffText,
     priceDimensions,
     priceFromMargin,

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -997,6 +997,9 @@
         "lowerThanAverage": "↓ {pct}% lower",
         "higherThanAverage": "↑ {pct}% higher",
         "sameAsAverage": "- Flat",
+        "priceColorNoBenchmark": "No valid market average is available, so this is shown in gray.",
+        "priceColorAboveAverage": "Price > market average, so this is shown in amber as high.",
+        "priceColorAtOrBelowAverage": "Price <= market average, so this is shown in green; matching the market average is acceptable.",
         "marketAverage": "Market average",
         "marketMarginReference": "Axis reference: Input market average {price}, margin {margin}"
       },

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1007,6 +1007,9 @@
         "lowerThanAverage": "↓ 低 {pct}%",
         "higherThanAverage": "↑ 高 {pct}%",
         "sameAsAverage": "- 持平",
+        "priceColorNoBenchmark": "暂无有效市场均价，使用灰色显示。",
+        "priceColorAboveAverage": "售价 > 市场均价，使用黄色提示偏高。",
+        "priceColorAtOrBelowAverage": "售价 <= 市场均价，使用绿色显示；等于市场均价也视为合理。",
         "marketAverage": "市场均价",
         "marketMarginReference": "坐标参照：Input 市场均价 {price}，对应收益率 {margin}"
       },


### PR DESCRIPTION
## Summary
- Treat resale prices at or below the market average as acceptable green states.
- Keep only prices above the market average in amber and invalid benchmarks in gray.
- Add localized tooltip text explaining the color rules.

No linked issue was found for this change.

## Test plan
- [x] npm run build
- [x] node ./node_modules/eslint/bin/eslint.js src/components/llm-ops/ResalePublishingWorkspace.vue src/composables/useResalePricing.js
- [x] git diff --check -- frontend/src/components/llm-ops/ResalePublishingWorkspace.vue frontend/src/composables/useResalePricing.js frontend/src/locales/en.json frontend/src/locales/zh-CN.json
- [ ] npm run lint (blocked: script points --ignore-path to missing frontend/.gitignore; direct full ESLint also reports existing unrelated repository errors)

Made with [Orca](https://github.com/stablyai/orca) 🐋
