### PR TITLE
Fix stale LLM Ops price sync schedules

### DIFF
--- a/backend/llm_ops/global_config.py
+++ b/backend/llm_ops/global_config.py
@@ -219,6 +219,21 @@ def sync_global_config_to_beat(config: LLMOpsGlobalConfig) -> None:
         logger.warning("llm_ops: skipped beat sync due to invalid cron")
         return
 
+    price_task_source_ids = price_sync_task_source_ids(config)
+    price_task_enabled = config.price_collection_enabled
+    if isinstance(price_task_source_ids, list) and not price_task_source_ids:
+        if price_task_enabled:
+            logger.warning(
+                "llm_ops: disabled price sync beat task because selected "
+                "source ids no longer contain supported sources",
+                extra={
+                    "price_collection_source_ids": (
+                        config.price_collection_source_ids
+                    ),
+                },
+            )
+        price_task_enabled = False
+
     PeriodicTask.objects.update_or_create(
         name=META_MODEL_SYNC_TASK_NAME,
         defaults={
@@ -240,13 +255,13 @@ def sync_global_config_to_beat(config: LLMOpsGlobalConfig) -> None:
             "args": json.dumps([]),
             "kwargs": json.dumps(
                 {
-                    "source_ids": price_sync_task_source_ids(config),
+                    "source_ids": price_task_source_ids,
                     "verify_source": True,
                 }
             ),
             "crontab": price_crontab,
             "interval": None,
-            "enabled": config.price_collection_enabled,
+            "enabled": price_task_enabled,
         },
     )
 

--- a/backend/llm_ops/tests/test_global_config.py
+++ b/backend/llm_ops/tests/test_global_config.py
@@ -1,0 +1,63 @@
+import json
+
+from django.test import TestCase
+
+from llm_ops.global_config import sync_global_config_to_beat
+from llm_ops.models import (
+    LLMOpsGlobalConfig,
+    LLMProvider,
+    PriceCollectionSource,
+)
+
+
+class LLMOpsGlobalConfigBeatSyncTests(TestCase):
+    """Global config beat sync must not leave empty enabled tasks."""
+
+    def test_stale_price_source_selection_disables_price_sync_task(self):
+        from django_celery_beat.models import PeriodicTask
+
+        provider = LLMProvider.objects.create(
+            name="Legacy Vendor",
+            code="legacy-vendor",
+        )
+        source = PriceCollectionSource.objects.create(
+            name="Legacy Official",
+            slug="legacy-official",
+            provider=provider,
+            source_category=(
+                PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
+            ),
+            endpoint_url="https://legacy.example.com/pricing/",
+            updates_model_prices=True,
+        )
+        config = LLMOpsGlobalConfig.get_solo()
+        config.price_collection_enabled = True
+        config.price_collection_source_ids = [source.id]
+        config.save()
+
+        with self.assertLogs("llm_ops.global_config", level="WARNING"):
+            sync_global_config_to_beat(config)
+
+        price_task = PeriodicTask.objects.get(
+            name="llm_ops_model_price_sync_agent"
+        )
+        kwargs = json.loads(price_task.kwargs)
+        self.assertEqual(kwargs["source_ids"], [])
+        self.assertFalse(price_task.enabled)
+
+    def test_default_all_sources_keeps_null_task_source_ids_enabled(self):
+        from django_celery_beat.models import PeriodicTask
+
+        config = LLMOpsGlobalConfig.get_solo()
+        config.price_collection_enabled = True
+        config.price_collection_source_ids = []
+        config.save()
+
+        sync_global_config_to_beat(config)
+
+        price_task = PeriodicTask.objects.get(
+            name="llm_ops_model_price_sync_agent"
+        )
+        kwargs = json.loads(price_task.kwargs)
+        self.assertIsNone(kwargs["source_ids"])
+        self.assertTrue(price_task.enabled)

--- a/backend/llm_ops/tests/test_views.py
+++ b/backend/llm_ops/tests/test_views.py
@@ -403,7 +403,7 @@ class LLMOpsViewTests(TestCase):
         )
         self.assertIsNone(json.loads(price_task.kwargs)["source_ids"])
 
-    def test_global_config_stale_sources_write_empty_task_source_ids(self):
+    def test_global_config_stale_sources_disable_price_sync_task(self):
         from django_celery_beat.models import PeriodicTask
 
         provider = LLMProvider.objects.create(
@@ -435,6 +435,7 @@ class LLMOpsViewTests(TestCase):
             name="llm_ops_model_price_sync_agent"
         )
         self.assertEqual(json.loads(price_task.kwargs)["source_ids"], [])
+        self.assertFalse(price_task.enabled)
 
     def test_global_config_blank_secret_clears_existing_secret(self):
         config = LLMOpsGlobalConfig.get_solo()
@@ -523,6 +524,7 @@ class LLMOpsViewTests(TestCase):
             name="llm_ops_model_price_sync_agent"
         )
         self.assertEqual(json.loads(price_task.kwargs)["source_ids"], [])
+        self.assertFalse(price_task.enabled)
 
     def test_global_config_sync_disables_legacy_periodic_task(self):
         from django_celery_beat.models import CrontabSchedule, PeriodicTask


### PR DESCRIPTION
## Summary
- Disable the `llm_ops_model_price_sync_agent` beat task when saved source selections normalize to an empty supported-source list.
- Preserve `source_ids: null` and enabled scheduling for the default all-sources configuration.
- Add regression coverage for stale explicit source selections in the global config sync path and API view tests.

Closes #124

## Test plan
- [x] `python3 -m pytest backend/llm_ops/tests/test_global_config.py`
- [x] `python3 -m compileall -q backend/llm_ops/global_config.py backend/llm_ops/tests/test_global_config.py backend/llm_ops/tests/test_views.py`
- [x] `git diff --check`
- [ ] `python3 -m pytest backend/llm_ops/tests/test_global_config.py backend/llm_ops/tests/test_views.py -k 'global_config'` blocked locally: the active Python environment is missing `drf_spectacular` while importing `llm_ops.views`.