### PR TITLE
Prevent unsafe models.dev stale cleanup

### DIFF
--- a/backend/llm_ops/collection_services.py
+++ b/backend/llm_ops/collection_services.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import re
 from decimal import Decimal, InvalidOperation
 
@@ -56,6 +57,8 @@ from .skill_runner import (
     standard_catalog_to_collected_catalog,
     vendor_pricing_skill_exists,
 )
+
+logger = logging.getLogger(__name__)
 
 SUPPORTED_OFFICIAL_PRICE_SYNC_PROVIDER_CODES = tuple(
     code
@@ -205,6 +208,8 @@ MODELS_DEV_META_SOURCE_PROVIDERS = {
     "zai",
     "zhipuai",
 }
+MODELS_DEV_CLEANUP_MIN_RETAIN_COUNT = 10
+MODELS_DEV_CLEANUP_MAX_DROP_PERCENT = 30
 
 MODELS_DEV_LAB_OWNER_DEFAULTS = {
     "alibaba": ("alibaba", "阿里巴巴", "https://www.alibaba.com/"),
@@ -1632,6 +1637,18 @@ def models_dev_provider_priority(provider_id: str) -> tuple[int, str]:
 
 def cleanup_stale_models_dev_meta_models(active_codes: set[str]) -> int:
     """Delete old online-only meta models outside the accepted source set."""
+    active_count = len(active_codes)
+    tracked_count = count_models_dev_meta_models()
+    if should_skip_models_dev_stale_cleanup(active_count, tracked_count):
+        logger.warning(
+            "llm_ops: skipped models.dev stale cleanup because "
+            "active model count %d is unsafe for %d tracked models.dev "
+            "meta model(s)",
+            active_count,
+            tracked_count,
+        )
+        return 0
+
     deleted = 0
     for meta in MetaModel.objects.all():
         if not (meta.metadata or {}).get("models_dev"):
@@ -1643,6 +1660,33 @@ def cleanup_stale_models_dev_meta_models(active_codes: set[str]) -> int:
         meta.delete()
         deleted += 1
     return deleted
+
+
+def count_models_dev_meta_models() -> int:
+    """Return the number of meta models currently sourced from models.dev."""
+    return sum(
+        1
+        for metadata in MetaModel.objects.values_list("metadata", flat=True)
+        if (metadata or {}).get("models_dev")
+    )
+
+
+def should_skip_models_dev_stale_cleanup(
+    active_count: int,
+    tracked_count: int,
+) -> bool:
+    """Return whether source shrinkage makes stale cleanup unsafe."""
+    if tracked_count <= 0:
+        return False
+    if active_count <= 0:
+        return True
+    if tracked_count < MODELS_DEV_CLEANUP_MIN_RETAIN_COUNT:
+        return False
+    if active_count < MODELS_DEV_CLEANUP_MIN_RETAIN_COUNT:
+        return True
+
+    retained_percent = 100 - MODELS_DEV_CLEANUP_MAX_DROP_PERCENT
+    return active_count * 100 < tracked_count * retained_percent
 
 
 def meta_model_has_business_links(meta_model: MetaModel) -> bool:

--- a/backend/llm_ops/tests/test_official_collector.py
+++ b/backend/llm_ops/tests/test_official_collector.py
@@ -1,3 +1,4 @@
+import json
 from decimal import Decimal
 from unittest.mock import patch
 
@@ -859,27 +860,29 @@ class OfficialCollectionSyncTests(TestCase):
             name="Linked Online Model",
             code="linked-online-model",
         )
-        mock_get.return_value = MockPricingResponse(
-            """
-            {
-              "openai": {
-                "models": {
-                  "openai/gpt-clean-test": {
-                    "id": "openai/gpt-clean-test",
-                    "name": "GPT Clean Test"
-                  }
-                }
-              },
-              "openrouter": {
-                "models": {
-                  "openai/gpt-router-noise": {
-                    "id": "openai/gpt-router-noise",
-                    "name": "GPT Router Noise"
-                  }
-                }
-              }
+        active_models = {
+            f"openai/gpt-clean-test-{number}": {
+                "id": f"openai/gpt-clean-test-{number}",
+                "name": f"GPT Clean Test {number}",
             }
-            """,
+            for number in range(10)
+        }
+        mock_get.return_value = MockPricingResponse(
+            json.dumps(
+                {
+                    "openai": {
+                        "models": active_models,
+                    },
+                    "openrouter": {
+                        "models": {
+                            "openai/gpt-router-noise": {
+                                "id": "openai/gpt-router-noise",
+                                "name": "GPT Router Noise",
+                            },
+                        },
+                    },
+                },
+            ),
             content_type="application/json",
         )
 
@@ -892,8 +895,85 @@ class OfficialCollectionSyncTests(TestCase):
             MetaModel.objects.filter(code="gpt-router-noise").exists(),
         )
         self.assertTrue(
-            MetaModel.objects.filter(code="gpt-clean-test").exists(),
+            MetaModel.objects.filter(code="gpt-clean-test-0").exists(),
         )
+
+    @patch("llm_ops.collectors.official.requests.get")
+    def test_sync_meta_models_from_models_dev_skips_empty_cleanup(
+        self,
+        mock_get,
+    ):
+        stale = MetaModel.objects.create(
+            code="empty-response-stale",
+            name="Empty Response Stale",
+            metadata={
+                "models_dev": {
+                    "id": "openai/empty-response-stale",
+                },
+            },
+        )
+        mock_get.return_value = MockPricingResponse(
+            "{}",
+            content_type="application/json",
+        )
+
+        with self.assertLogs(
+            "llm_ops.collection_services",
+            level="WARNING",
+        ) as logs:
+            stats = sync_meta_models_from_models_dev()
+
+        self.assertEqual(stats["deleted"], 0)
+        self.assertTrue(MetaModel.objects.filter(id=stale.id).exists())
+        self.assertIn("skipped models.dev stale cleanup", logs.output[0])
+
+    @patch("llm_ops.collectors.official.requests.get")
+    def test_sync_meta_models_from_models_dev_skips_large_drop_cleanup(
+        self,
+        mock_get,
+    ):
+        for number in range(12):
+            MetaModel.objects.create(
+                code=f"previous-model-{number}",
+                name=f"Previous Model {number}",
+                metadata={
+                    "models_dev": {
+                        "id": f"openai/previous-model-{number}",
+                    },
+                },
+            )
+        mock_get.return_value = MockPricingResponse(
+            """
+            {
+              "openai": {
+                "models": {
+                  "openai/gpt-partial-test": {
+                    "id": "openai/gpt-partial-test",
+                    "name": "GPT Partial Test"
+                  }
+                }
+              }
+            }
+            """,
+            content_type="application/json",
+        )
+
+        with self.assertLogs(
+            "llm_ops.collection_services",
+            level="WARNING",
+        ) as logs:
+            stats = sync_meta_models_from_models_dev()
+
+        self.assertEqual(stats["deleted"], 0)
+        self.assertEqual(
+            MetaModel.objects.filter(code__startswith="previous-model-")
+            .count(),
+            12,
+        )
+        self.assertTrue(
+            MetaModel.objects.filter(code="gpt-partial-test").exists(),
+        )
+        self.assertIn("skipped models.dev stale cleanup", logs.output[0])
 
     def test_sync_aliyun_official_prices_keeps_cny_currency(self):
         provider = LLMProvider.objects.get(code="aliyun")


### PR DESCRIPTION
## Summary
- Add stale-cleanup safety checks for models.dev meta model sync when active model counts are empty or shrink unexpectedly
- Log a warning and skip deletion instead of removing tracked models.dev meta models during unsafe source shrinkage
- Cover normal cleanup, empty response, and large-drop cases in official collector tests

Closes #126

## Test plan
- [x] python3 -m pytest backend/llm_ops/tests/test_official_collector.py -k models_dev
- [ ] python3 -m black --check backend/llm_ops/collection_services.py backend/llm_ops/tests/test_official_collector.py (black module unavailable in current python3 environment)
- [ ] python3 -m isort --check-only backend/llm_ops/collection_services.py backend/llm_ops/tests/test_official_collector.py (isort module unavailable in current python3 environment)

Made with [Orca](https://github.com/stablyai/orca) 🐋
