### PR TITLE
Fix missing price sync LLM config handling

### DIFF
--- a/backend/llm_ops/agents/model_price_sync/definition.py
+++ b/backend/llm_ops/agents/model_price_sync/definition.py
@@ -17,7 +17,11 @@ from llm_ops.global_config import (
     price_sync_source_queryset,
     selected_price_collection_sources,
 )
-from llm_ops.llm_config import resolve_price_sync_llm_settings
+from llm_ops.llm_config import (
+    PRICE_SYNC_LLM_NOT_CONFIGURED_MESSAGE,
+    PriceSyncLLMConfigurationError,
+    resolve_price_sync_llm_settings,
+)
 from llm_ops.models import LLMOpsGlobalConfig, PriceCollectionSource
 from llm_ops.source_collectors import (
     collect_price_source,
@@ -285,7 +289,9 @@ def build_llm_ops_agent_model(
         provider = "gemini"
     model_name = str(llm_settings.get("model") or "").strip()
     if not model_name:
-        raise ValueError("LLM Ops price sync Agent model is not configured.")
+        raise PriceSyncLLMConfigurationError(
+            PRICE_SYNC_LLM_NOT_CONFIGURED_MESSAGE
+        )
 
     api_key = llm_settings.get("api_key") or ""
     api_base = llm_settings.get("api_base") or ""

--- a/backend/llm_ops/llm_config.py
+++ b/backend/llm_ops/llm_config.py
@@ -13,6 +13,25 @@ except (ImportError, RuntimeError):
     LLMConfig = None
 
 
+PRICE_SYNC_LLM_NOT_CONFIGURED_MESSAGE = (
+    "LLM Ops price sync Agent model is not configured."
+)
+
+
+class PriceSyncLLMConfigurationError(ValueError):
+    """Raised when the price sync Agent cannot resolve an LLM model."""
+
+
+def is_price_sync_llm_configuration_error(exc: Exception) -> bool:
+    """Return whether an exception is a deterministic LLM config failure."""
+    if isinstance(exc, PriceSyncLLMConfigurationError):
+        return True
+    return (
+        isinstance(exc, ValueError)
+        and PRICE_SYNC_LLM_NOT_CONFIGURED_MESSAGE in str(exc)
+    )
+
+
 def _row_to_reference(row: Any) -> dict[str, str]:
     """Return a stable display reference for an agentcore LLM config."""
     config = getattr(row, "config", {}) or {}
@@ -126,4 +145,29 @@ def resolve_price_sync_llm_settings(
             ),
         },
         "label": model or "Global default",
+    }
+
+
+def get_price_sync_llm_status(
+    preferred_config_uuid: str | None = None,
+) -> dict[str, Any]:
+    """Return operator-facing health for the price sync Agent LLM."""
+    llm_settings = resolve_price_sync_llm_settings(preferred_config_uuid)
+    model = str(llm_settings.get("model") or "").strip()
+    if model:
+        return {
+            "ok": True,
+            "code": "configured",
+            "message": "LLM Ops price sync Agent model is configured.",
+            "source": llm_settings.get("source") or "",
+            "config_uuid": llm_settings.get("config_uuid") or "",
+            "label": llm_settings.get("label") or model,
+        }
+    return {
+        "ok": False,
+        "code": "missing_llm_model",
+        "message": PRICE_SYNC_LLM_NOT_CONFIGURED_MESSAGE,
+        "source": llm_settings.get("source") or "",
+        "config_uuid": llm_settings.get("config_uuid") or "",
+        "label": llm_settings.get("label") or "",
     }

--- a/backend/llm_ops/serializers.py
+++ b/backend/llm_ops/serializers.py
@@ -11,7 +11,10 @@ from .global_config import (
     normalize_source_ids,
     validate_price_collection_source_ids,
 )
-from .llm_config import get_llm_config_reference
+from .llm_config import (
+    get_llm_config_reference,
+    get_price_sync_llm_status,
+)
 from .models import (
     AuditLog,
     ChannelModelPrice,
@@ -254,6 +257,7 @@ class LLMOpsGlobalConfigSerializer(serializers.ModelSerializer):
     """Serializer for singleton LLM operations runtime configuration."""
 
     selected_price_collection_sources = serializers.SerializerMethodField()
+    price_sync_agent_status = serializers.SerializerMethodField()
     price_sync_llm_config = serializers.SerializerMethodField()
 
     class Meta:
@@ -336,6 +340,14 @@ class LLMOpsGlobalConfigSerializer(serializers.ModelSerializer):
         return get_llm_config_reference(
             str(instance.price_sync_llm_config_uuid or "")
         )
+
+    def get_price_sync_agent_status(self, instance):
+        return {
+            "price_collection_enabled": instance.price_collection_enabled,
+            "llm": get_price_sync_llm_status(
+                str(instance.price_sync_llm_config_uuid or "")
+            ),
+        }
 
 
 class AuditLogSerializer(serializers.ModelSerializer):

--- a/backend/llm_ops/tasks.py
+++ b/backend/llm_ops/tasks.py
@@ -16,6 +16,8 @@ import logging
 
 from celery import shared_task
 
+from .llm_config import is_price_sync_llm_configuration_error
+
 logger = logging.getLogger(__name__)
 
 
@@ -50,6 +52,13 @@ def run_model_price_sync_agent(
             source_task_id=getattr(self.request, "id", None),
         )
     except Exception as exc:
+        if is_price_sync_llm_configuration_error(exc):
+            logger.error(
+                "llm_ops.run_model_price_sync_agent configuration error: %s",
+                exc,
+                extra=log_extra,
+            )
+            raise
         logger.exception(
             "llm_ops.run_model_price_sync_agent failed",
             extra=log_extra,

--- a/backend/llm_ops/tests/test_serializers.py
+++ b/backend/llm_ops/tests/test_serializers.py
@@ -29,6 +29,29 @@ from llm_ops.serializers import (
 
 
 class LLMOpsGlobalConfigSerializerTests(TestCase):
+    @patch("llm_ops.serializers.get_price_sync_llm_status")
+    def test_representation_exposes_price_sync_agent_status(self, mock_status):
+        mock_status.return_value = {
+            "ok": False,
+            "code": "missing_llm_model",
+            "message": "LLM Ops price sync Agent model is not configured.",
+            "source": "settings",
+            "config_uuid": "",
+            "label": "",
+        }
+        config = LLMOpsGlobalConfig.get_solo()
+
+        data = LLMOpsGlobalConfigSerializer(config).data
+
+        self.assertEqual(
+            data["price_sync_agent_status"]["llm"]["code"],
+            "missing_llm_model",
+        )
+        self.assertFalse(data["price_sync_agent_status"]["llm"]["ok"])
+        self.assertTrue(
+            data["price_sync_agent_status"]["price_collection_enabled"]
+        )
+
     @patch("llm_ops.models.encryption_service.decrypt")
     def test_plaintext_secret_falls_back_without_decrypt(self, mock_decrypt):
         mock_decrypt.side_effect = AssertionError(

--- a/backend/llm_ops/tests/test_tasks.py
+++ b/backend/llm_ops/tests/test_tasks.py
@@ -1,0 +1,43 @@
+import sys
+from types import ModuleType
+from unittest import mock
+
+from django.test import SimpleTestCase
+
+from llm_ops.llm_config import PRICE_SYNC_LLM_NOT_CONFIGURED_MESSAGE
+from llm_ops.tasks import run_model_price_sync_agent
+
+
+class RunModelPriceSyncAgentTaskTests(SimpleTestCase):
+    """Celery task retry policy for model price sync."""
+
+    def test_missing_llm_config_fails_without_retry(self):
+        agents_module = ModuleType("llm_ops.agents")
+        model_price_sync_module = ModuleType(
+            "llm_ops.agents.model_price_sync"
+        )
+
+        def execute_model_price_sync_agent(**kwargs):
+            raise ValueError(PRICE_SYNC_LLM_NOT_CONFIGURED_MESSAGE)
+
+        model_price_sync_module.execute_model_price_sync_agent = (
+            execute_model_price_sync_agent
+        )
+
+        modules = {
+            "llm_ops.agents": agents_module,
+            "llm_ops.agents.model_price_sync": model_price_sync_module,
+        }
+        with (
+            mock.patch.dict(sys.modules, modules),
+            mock.patch.object(run_model_price_sync_agent, "retry") as retry,
+            self.assertLogs("llm_ops.tasks", level="ERROR") as logs,
+        ):
+            with self.assertRaisesRegex(
+                ValueError,
+                PRICE_SYNC_LLM_NOT_CONFIGURED_MESSAGE,
+            ):
+                run_model_price_sync_agent.run()
+
+        retry.assert_not_called()
+        self.assertIn("configuration error", "\n".join(logs.output))

--- a/frontend/src/components/llm-ops/GlobalConfigPanel.vue
+++ b/frontend/src/components/llm-ops/GlobalConfigPanel.vue
@@ -244,6 +244,18 @@
             {{ t('llmOps.globalConfigPanel.llmConfig.description') }}
           </small>
         </label>
+        <div
+          v-if="priceSyncLLMUnavailable"
+          class="config-warning"
+          role="status"
+        >
+          <strong>
+            {{ t('llmOps.globalConfigPanel.llmConfig.warningTitle') }}
+          </strong>
+          <span>
+            {{ t('llmOps.globalConfigPanel.llmConfig.warningBody') }}
+          </span>
+        </div>
 
         <div class="source-mode-group" role="radiogroup">
           <label
@@ -452,6 +464,13 @@ const llmConfigOptions = computed(() => {
     options.set(selected.uuid, selected)
   }
   return Array.from(options.values())
+})
+
+const priceSyncLLMUnavailable = computed(() => {
+  const status = config.value?.price_sync_agent_status
+  return Boolean(
+    status?.price_collection_enabled && status?.llm?.ok === false
+  )
 })
 
 onMounted(() => {
@@ -947,6 +966,24 @@ function errorMessage(error, fallback) {
   color: #64748b;
   font-size: 0.75rem;
   line-height: 1.5;
+}
+
+.config-warning {
+  background: #fffbeb;
+  border: 1px solid #fcd34d;
+  border-radius: 0.5rem;
+  color: #92400e;
+  display: flex;
+  flex-direction: column;
+  font-size: 0.8125rem;
+  gap: 0.25rem;
+  line-height: 1.5;
+  padding: 0.75rem 0.875rem;
+}
+
+.config-warning strong {
+  color: #78350f;
+  font-size: 0.875rem;
 }
 
 .schedule-editor {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1105,7 +1105,9 @@
       },
       "llmConfig": {
         "default": "Use default active admin LLM config",
-        "description": "Used by the model price sync Agent when it needs LLM-assisted extraction."
+        "description": "Used by the model price sync Agent when it needs LLM-assisted extraction.",
+        "warningBody": "Configure an active LLM before enabling sources that need LLM-assisted extraction. Missing configuration now fails immediately without retry.",
+        "warningTitle": "Price sync Agent LLM is not configured"
       },
       "metaSync": {
         "description": "Sync model providers, model families, and capability tags.",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1115,7 +1115,9 @@
       },
       "llmConfig": {
         "default": "使用默认启用的管理员 LLM 配置",
-        "description": "模型价格同步 Agent 需要 LLM 辅助抽取时使用该配置。"
+        "description": "模型价格同步 Agent 需要 LLM 辅助抽取时使用该配置。",
+        "warningBody": "启用需要 LLM 辅助抽取的数据源前，请先配置可用的 LLM。缺少配置时任务会直接失败，不再自动重试。",
+        "warningTitle": "价格同步 Agent 尚未配置 LLM"
       },
       "metaSync": {
         "description": "同步模型厂商、模型族和能力标签。",


### PR DESCRIPTION
## Summary
- Add a deterministic price sync LLM configuration error path so missing model configuration fails without retry.
- Expose price sync Agent LLM health in the global config serializer.
- Show an operator warning in the LLM Ops global config panel when price collection is enabled but the Agent LLM is not configured.
- Cover serializer status output and task retry behavior with focused tests.

Closes #125

## Test plan
- [x] python3 -m pytest backend/llm_ops/tests/test_serializers.py backend/llm_ops/tests/test_tasks.py
- [x] git diff --check
- [ ] npm --prefix frontend run build (blocked locally: frontend/node_modules is missing, vite command not found)
- [ ] python3 -m black --check targeted backend files (blocked locally: black module is not installed)
- [ ] python3 -m isort --check-only targeted backend files (blocked locally: isort module is not installed)

Made with [Orca](https://github.com/stablyai/orca) 🐋
