### PR TITLE
Harden models.dev meta model sync

### DIFF
--- a/backend/llm_ops/collection_services.py
+++ b/backend/llm_ops/collection_services.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 import re
 from decimal import Decimal, InvalidOperation
 
+from django.conf import settings
+from django.core.cache import cache
 from django.db import IntegrityError, transaction
 from django.utils import timezone
 
@@ -84,6 +87,8 @@ FULL_CATALOG_PROVIDER_CODES = (
     "baidu",
     "volcengine",
 )
+DEFAULT_MODELS_DEV_SYNC_TIMEOUT = 60
+MODELS_DEV_RESPONSE_CACHE_KEY = "llm_ops:models_dev:last_success_payload"
 CLOUD_PROVIDER_OFFICIAL_CODES = {
     "aliyun",
     "aliyun-wanx",
@@ -1522,18 +1527,24 @@ def collected_model_code_from_value(value: str) -> str:
 
 def sync_meta_models_from_models_dev(
     *,
-    source_url: str = MODELS_DEV_MODELS_URL,
-    timeout: int = 20,
-) -> dict[str, int]:
+    source_url: str | None = None,
+    timeout: int | None = None,
+    fallback_urls: list[str] | tuple[str, ...] | str | None = None,
+) -> dict[str, object]:
     """Fetch models.dev and upsert canonical meta-model identities."""
     from .constants import (
         canonical_meta_model_identity,
     )
 
-    payload = fetch_source_payload(source_url, timeout)
-    source_json = payload.get("json")
-    if not isinstance(source_json, dict):
-        raise ValueError("models.dev source did not return JSON.")
+    resolved_source_url = source_url or MODELS_DEV_MODELS_URL
+    resolved_timeout = models_dev_sync_timeout(timeout)
+    source_json, effective_source_url, used_cache, cached_at = (
+        fetch_models_dev_source_json(
+            source_url=resolved_source_url,
+            timeout=resolved_timeout,
+            fallback_urls=fallback_urls,
+        )
+    )
 
     stats = {
         "models": 0,
@@ -1541,7 +1552,10 @@ def sync_meta_models_from_models_dev(
         "updated": 0,
         "skipped": 0,
         "deleted": 0,
+        "used_cache": int(used_cache),
     }
+    if cached_at:
+        stats["cached_at"] = cached_at
     seen_codes = set()
     with transaction.atomic():
         for model_payload in iter_models_dev_meta_model_payloads(
@@ -1569,12 +1583,156 @@ def sync_meta_models_from_models_dev(
                 code=code,
                 identity=identity,
                 owner=owner,
-                source_url=source_url,
+                source_url=effective_source_url,
             )
             stats["models"] += 1
             stats["created" if created else "updated"] += int(changed)
         stats["deleted"] = cleanup_stale_models_dev_meta_models(seen_codes)
     return stats
+
+
+def models_dev_sync_timeout(timeout: int | None) -> int:
+    """Return the configured timeout for models.dev metadata sync."""
+    if timeout is not None:
+        return max(1, int(timeout))
+    configured = getattr(settings, "LLM_OPS_MODELS_DEV_TIMEOUT", None)
+    if configured in (None, ""):
+        configured = os.getenv("LLM_OPS_MODELS_DEV_TIMEOUT", "")
+    try:
+        return max(1, int(configured))
+    except (TypeError, ValueError):
+        return DEFAULT_MODELS_DEV_SYNC_TIMEOUT
+
+
+def fetch_models_dev_source_json(
+    *,
+    source_url: str,
+    timeout: int,
+    fallback_urls: list[str] | tuple[str, ...] | str | None = None,
+) -> tuple[dict, str, bool, str]:
+    """Fetch models.dev JSON, falling back to mirrors then cache."""
+    errors = []
+    for candidate_url in models_dev_candidate_urls(
+        source_url,
+        fallback_urls,
+    ):
+        try:
+            payload = fetch_source_payload(candidate_url, timeout)
+            source_json = payload.get("json")
+            if not isinstance(source_json, dict):
+                raise ValueError("models.dev source did not return JSON.")
+            cache_models_dev_source_json(source_json, candidate_url)
+            return source_json, candidate_url, False, ""
+        except Exception as exc:
+            errors.append(f"{candidate_url}: {exc}")
+            logger.warning(
+                "llm_ops.models_dev_sync_source_failed",
+                extra={"source_url": candidate_url},
+                exc_info=True,
+            )
+
+    cached = cached_models_dev_source_json()
+    if cached is not None:
+        logger.warning(
+            "llm_ops.models_dev_sync_using_cached_payload",
+            extra={"source_url": cached["source_url"]},
+        )
+        return (
+            cached["json"],
+            cached["source_url"],
+            True,
+            cached["cached_at"],
+        )
+    raise ValueError(
+        "models.dev source did not return JSON and no cache is available: "
+        + "; ".join(errors),
+    )
+
+
+def models_dev_candidate_urls(
+    source_url: str,
+    fallback_urls: list[str] | tuple[str, ...] | str | None,
+) -> list[str]:
+    """Return primary and fallback models.dev URLs without duplicates."""
+    values = [source_url]
+    values.extend(configured_models_dev_fallback_urls(fallback_urls))
+    candidates = []
+    seen = set()
+    for value in values:
+        candidate = str(value or "").strip()
+        if not candidate or candidate in seen:
+            continue
+        seen.add(candidate)
+        candidates.append(candidate)
+    return candidates
+
+
+def configured_models_dev_fallback_urls(
+    fallback_urls: list[str] | tuple[str, ...] | str | None,
+) -> list[str]:
+    """Return explicit or environment-configured models.dev fallback URLs."""
+    if fallback_urls is None:
+        fallback_urls = getattr(
+            settings,
+            "LLM_OPS_MODELS_DEV_FALLBACK_URLS",
+            None,
+        )
+        if fallback_urls in (None, ""):
+            fallback_urls = os.getenv("LLM_OPS_MODELS_DEV_FALLBACK_URLS", "")
+    if isinstance(fallback_urls, str):
+        return [
+            item.strip()
+            for item in fallback_urls.split(",")
+            if item.strip()
+        ]
+    return [
+        str(item).strip()
+        for item in fallback_urls
+        if str(item or "").strip()
+    ]
+
+
+def cache_models_dev_source_json(source_json: dict, source_url: str) -> None:
+    """Store the last successful models.dev response for outage fallback."""
+    try:
+        cache.set(
+            MODELS_DEV_RESPONSE_CACHE_KEY,
+            {
+                "json": source_json,
+                "source_url": source_url,
+                "cached_at": timezone.now().isoformat(),
+            },
+            timeout=None,
+        )
+    except Exception:
+        logger.warning(
+            "llm_ops.models_dev_sync_cache_write_failed",
+            exc_info=True,
+        )
+
+
+def cached_models_dev_source_json() -> dict | None:
+    """Return the cached models.dev payload when it has the expected shape."""
+    try:
+        cached = cache.get(MODELS_DEV_RESPONSE_CACHE_KEY)
+    except Exception:
+        logger.warning(
+            "llm_ops.models_dev_sync_cache_read_failed",
+            exc_info=True,
+        )
+        return None
+    if not isinstance(cached, dict):
+        return None
+    source_json = cached.get("json")
+    source_url = str(cached.get("source_url") or "").strip()
+    cached_at = str(cached.get("cached_at") or "").strip()
+    if not isinstance(source_json, dict) or not source_url:
+        return None
+    return {
+        "json": source_json,
+        "source_url": source_url,
+        "cached_at": cached_at,
+    }
 
 
 def iter_models_dev_meta_model_payloads(source_json: dict):

--- a/backend/llm_ops/models.py
+++ b/backend/llm_ops/models.py
@@ -165,6 +165,11 @@ class PriceCollectionSource(models.Model):
     def _default_collection_method(self):
         if self.source_type == self.SOURCE_TYPE_YUNCE:
             return self.COLLECTION_METHOD_API_SYNC
+        if (
+            self.source_category == self.SOURCE_CATEGORY_OFFICIAL_PROVIDER
+            and self.updates_model_prices
+        ):
+            return self.COLLECTION_METHOD_AUTO_COLLECT
         if self.source_category == self.SOURCE_CATEGORY_SUPPLIER:
             return self.COLLECTION_METHOD_UNKNOWN
         if self.source_category == self.SOURCE_CATEGORY_MANUAL:

--- a/backend/llm_ops/tasks.py
+++ b/backend/llm_ops/tasks.py
@@ -201,6 +201,8 @@ def sync_meta_models_from_models_dev_task(
     self,
     *,
     source_url: str | None = None,
+    timeout: int | None = None,
+    fallback_urls: list[str] | tuple[str, ...] | str | None = None,
 ) -> dict[str, object]:
     """Refresh canonical meta models from models.dev."""
     from .catalog_maintenance import (
@@ -211,7 +213,13 @@ def sync_meta_models_from_models_dev_task(
 
     logger.info("llm_ops.sync_meta_models_from_models_dev start")
     try:
-        kwargs = {"source_url": source_url} if source_url else {}
+        kwargs = {}
+        if source_url:
+            kwargs["source_url"] = source_url
+        if timeout is not None:
+            kwargs["timeout"] = timeout
+        if fallback_urls:
+            kwargs["fallback_urls"] = fallback_urls
         results = sync_meta_models_from_models_dev(**kwargs)
         results["meta_model_normalization"] = normalize_meta_model_catalog()
         results["meta_model_orphan_resolution"] = resolve_orphan_meta_models()

--- a/backend/llm_ops/tests/test_official_collector.py
+++ b/backend/llm_ops/tests/test_official_collector.py
@@ -1,11 +1,13 @@
 import json
 from decimal import Decimal
-from unittest.mock import patch
+from unittest.mock import call, patch
 
-from django.test import TestCase
+from django.core.cache import cache
+from django.test import TestCase, override_settings
 from django.utils import timezone
 
 from llm_ops.collection_services import (
+    MODELS_DEV_RESPONSE_CACHE_KEY,
     ensure_official_model_source,
     ensure_official_source,
     official_model_source_slug as build_official_model_source_slug,
@@ -53,6 +55,7 @@ class MockPricingResponse:
 
 class OfficialCollectionSyncTests(TestCase):
     def setUp(self):
+        cache.delete(MODELS_DEV_RESPONSE_CACHE_KEY)
         self.create_official_sync_fixture()
 
     def create_official_sync_fixture(self):
@@ -779,6 +782,141 @@ class OfficialCollectionSyncTests(TestCase):
         )
         self.assertFalse(
             MetaModel.objects.filter(code="gpt-router-noise").exists(),
+        )
+
+    @patch("llm_ops.collection_services.fetch_source_payload")
+    def test_sync_meta_models_from_models_dev_uses_configured_timeout(
+        self,
+        mock_fetch,
+    ):
+        mock_fetch.return_value = {
+            "json": {
+                "openai/gpt-timeout-test": {
+                    "id": "openai/gpt-timeout-test",
+                    "name": "GPT Timeout Test",
+                },
+            },
+        }
+
+        stats = sync_meta_models_from_models_dev(timeout=45)
+
+        self.assertEqual(stats["models"], 1)
+        mock_fetch.assert_called_once_with(
+            "https://models.dev/models.json",
+            45,
+        )
+        self.assertTrue(
+            MetaModel.objects.filter(code="gpt-timeout-test").exists(),
+        )
+
+    @override_settings(LLM_OPS_MODELS_DEV_TIMEOUT=70)
+    @patch("llm_ops.collection_services.fetch_source_payload")
+    def test_sync_meta_models_from_models_dev_reads_timeout_setting(
+        self,
+        mock_fetch,
+    ):
+        mock_fetch.return_value = {
+            "json": {
+                "openai/gpt-setting-timeout-test": {
+                    "id": "openai/gpt-setting-timeout-test",
+                    "name": "GPT Setting Timeout Test",
+                },
+            },
+        }
+
+        stats = sync_meta_models_from_models_dev()
+
+        self.assertEqual(stats["models"], 1)
+        mock_fetch.assert_called_once_with(
+            "https://models.dev/models.json",
+            70,
+        )
+
+    @patch("llm_ops.collection_services.fetch_source_payload")
+    def test_sync_meta_models_from_models_dev_uses_fallback_url(
+        self,
+        mock_fetch,
+    ):
+        mock_fetch.side_effect = [
+            RuntimeError("primary unavailable"),
+            {
+                "json": {
+                    "openai/gpt-fallback-test": {
+                        "id": "openai/gpt-fallback-test",
+                        "name": "GPT Fallback Test",
+                    },
+                },
+            },
+        ]
+
+        stats = sync_meta_models_from_models_dev(
+            source_url="https://models.dev/models.json",
+            fallback_urls=["https://mirror.example.com/models.json"],
+            timeout=55,
+        )
+
+        self.assertEqual(stats["models"], 1)
+        self.assertEqual(
+            mock_fetch.call_args_list,
+            [
+                call("https://models.dev/models.json", 55),
+                call("https://mirror.example.com/models.json", 55),
+            ],
+        )
+        meta = MetaModel.objects.get(code="gpt-fallback-test")
+        self.assertEqual(
+            meta.metadata["models_dev"]["source_url"],
+            "https://mirror.example.com/models.json",
+        )
+
+    @patch("llm_ops.collection_services.fetch_source_payload")
+    def test_sync_meta_models_from_models_dev_uses_cached_payload(
+        self,
+        mock_fetch,
+    ):
+        mock_fetch.return_value = {
+            "json": {
+                "openai/gpt-cache-test": {
+                    "id": "openai/gpt-cache-test",
+                    "name": "GPT Cache Test",
+                },
+            },
+        }
+        first_stats = sync_meta_models_from_models_dev(timeout=30)
+        mock_fetch.side_effect = RuntimeError("models.dev unavailable")
+
+        second_stats = sync_meta_models_from_models_dev(timeout=30)
+
+        self.assertEqual(first_stats["models"], 1)
+        self.assertEqual(second_stats["models"], 1)
+        self.assertEqual(second_stats["used_cache"], 1)
+        self.assertEqual(
+            MetaModel.objects.filter(code="gpt-cache-test").count(),
+            1,
+        )
+
+    @patch("llm_ops.collection_services.cache.set")
+    @patch("llm_ops.collection_services.fetch_source_payload")
+    def test_sync_meta_models_from_models_dev_ignores_cache_write_failure(
+        self,
+        mock_fetch,
+        mock_cache_set,
+    ):
+        mock_fetch.return_value = {
+            "json": {
+                "openai/gpt-cache-write-test": {
+                    "id": "openai/gpt-cache-write-test",
+                    "name": "GPT Cache Write Test",
+                },
+            },
+        }
+        mock_cache_set.side_effect = RuntimeError("cache unavailable")
+
+        stats = sync_meta_models_from_models_dev(timeout=30)
+
+        self.assertEqual(stats["models"], 1)
+        self.assertTrue(
+            MetaModel.objects.filter(code="gpt-cache-write-test").exists(),
         )
 
     @patch("llm_ops.collectors.official.requests.get")

--- a/backend/llm_ops/tests/test_ops_bootstrap.py
+++ b/backend/llm_ops/tests/test_ops_bootstrap.py
@@ -798,6 +798,8 @@ class LLMOpsPeriodicTasksTests(TestCase):
 
         result = sync_meta_models_from_models_dev_task.run(
             source_url="https://example.com/api.json",
+            timeout=75,
+            fallback_urls=["https://mirror.example.com/models.json"],
         )
 
         self.assertEqual(
@@ -810,6 +812,8 @@ class LLMOpsPeriodicTasksTests(TestCase):
         )
         mock_sync.assert_called_once_with(
             source_url="https://example.com/api.json",
+            timeout=75,
+            fallback_urls=["https://mirror.example.com/models.json"],
         )
         mock_normalize.assert_called_once_with()
         mock_resolve.assert_called_once_with()

--- a/env.sample
+++ b/env.sample
@@ -282,6 +282,17 @@ AZURE_OPENAI_TEMPERATURE=0.7
 LLM_OUTPUT_LANGUAGE=English
 
 # ============================================================================
+# LLM Ops External Source Resilience
+# ============================================================================
+# Timeout in seconds for models.dev meta-model sync.
+LLM_OPS_MODELS_DEV_TIMEOUT=60
+
+# Optional comma-separated fallback URLs for models.dev metadata.
+# Example:
+# LLM_OPS_MODELS_DEV_FALLBACK_URLS=https://mirror.example.com/models.json
+LLM_OPS_MODELS_DEV_FALLBACK_URLS=
+
+# ============================================================================
 # Nginx Port Configuration
 # ============================================================================
 # HTTP port for nginx (default: 10080)


### PR DESCRIPTION
## Summary
- Make models.dev meta-model sync timeout configurable via settings/env and task kwargs
- Add ordered fallback URL support and last-success JSON cache fallback for source outages
- Persist the effective models.dev source URL and expose cache usage metadata in sync stats
- Fill auto-collect defaults for official price sources that update model prices

Closes #128

## Test plan
- [x] python3 -m pytest backend/llm_ops/tests/test_official_collector.py backend/llm_ops/tests/test_ops_bootstrap.py backend/llm_ops/tests/test_serializers.py (105 passed)
- [x] git diff --check
- [ ] python3 -m black --check ... (black module not installed in local Python)
- [ ] python3 -m isort --check-only ... (isort module not installed in local Python)
- [ ] python3 -m flake8 ... (flake8 module not installed in local Python)