### PR TITLE
Fix meta model catalog normalization

### DIFF
--- a/backend/llm_ops/catalog_maintenance.py
+++ b/backend/llm_ops/catalog_maintenance.py
@@ -185,6 +185,8 @@ def normalize_meta_model_catalog() -> dict[str, int]:
         "linked_records": 0,
     }
     for meta in list(MetaModel.objects.all()):
+        if not is_models_dev_meta_model(meta):
+            continue
         identity = canonical_meta_model_identity(meta.code, meta.name)
         canonical_code = identity["code"]
         canonical_name = identity["name"]
@@ -204,6 +206,8 @@ def normalize_meta_model_catalog() -> dict[str, int]:
                 stats["normalized"] += 1
             continue
         canonical = MetaModel.objects.filter(code=canonical_code).first()
+        if canonical is not None and not is_models_dev_meta_model(canonical):
+            continue
         if canonical is None:
             meta.code = canonical_code
             meta.name = canonical_name
@@ -226,6 +230,11 @@ def normalize_meta_model_catalog() -> dict[str, int]:
         stats["merged"] += 1
     stats["linked_records"] = normalize_model_linked_meta_models()
     return stats
+
+
+def is_models_dev_meta_model(meta_model: MetaModel) -> bool:
+    """Return whether a meta model is managed by models.dev sync."""
+    return bool((meta_model.metadata or {}).get("models_dev"))
 
 
 def normalize_model_linked_meta_models() -> int:
@@ -290,6 +299,14 @@ def merge_meta_model_rows(
     if duplicate.max_output_tokens > canonical.max_output_tokens:
         canonical.max_output_tokens = duplicate.max_output_tokens
         changed_fields.append("max_output_tokens")
+    capabilities = merged_meta_capabilities(canonical, duplicate)
+    if capabilities != dict(canonical.capabilities or {}):
+        canonical.capabilities = capabilities
+        changed_fields.append("capabilities")
+    metadata = merged_meta_metadata(canonical, duplicate)
+    if metadata != dict(canonical.metadata or {}):
+        canonical.metadata = metadata
+        changed_fields.append("metadata")
     if not canonical.owner_code and duplicate.owner_code:
         canonical.owner_code = duplicate.owner_code
         canonical.owner_name = duplicate.owner_name
@@ -304,6 +321,48 @@ def merge_meta_model_rows(
             **{field.name: duplicate}
         ).update(**{field.name: canonical})
     duplicate.delete()
+
+
+def merged_meta_capabilities(
+    canonical: MetaModel,
+    duplicate: MetaModel,
+) -> dict:
+    """Return canonical capabilities enriched from a duplicate row."""
+    capabilities = dict(canonical.capabilities or {})
+    duplicate_capabilities = dict(duplicate.capabilities or {})
+    for key, value in duplicate_capabilities.items():
+        if key == "features":
+            existing_features = capabilities.get("features") or []
+            duplicate_features = value or []
+            capabilities["features"] = list(
+                dict.fromkeys([*existing_features, *duplicate_features])
+            )
+            continue
+        if key not in capabilities:
+            capabilities[key] = value
+    return capabilities
+
+
+def merged_meta_metadata(
+    canonical: MetaModel,
+    duplicate: MetaModel,
+) -> dict:
+    """Return canonical metadata enriched without replacing models.dev."""
+    metadata = dict(canonical.metadata or {})
+    duplicate_metadata = dict(duplicate.metadata or {})
+    duplicate_models_dev = duplicate_metadata.get("models_dev")
+    canonical_models_dev = metadata.get("models_dev")
+    if duplicate_models_dev and duplicate_models_dev != canonical_models_dev:
+        merged_rows = list(metadata.get("merged_models_dev") or [])
+        if duplicate_models_dev not in merged_rows:
+            merged_rows.append(duplicate_models_dev)
+            metadata["merged_models_dev"] = merged_rows
+    for key, value in duplicate_metadata.items():
+        if key == "models_dev":
+            continue
+        if key not in metadata:
+            metadata[key] = value
+    return metadata
 
 
 def cleanup_orphan_meta_models() -> dict[str, int]:

--- a/backend/llm_ops/tests/test_ops_bootstrap.py
+++ b/backend/llm_ops/tests/test_ops_bootstrap.py
@@ -17,7 +17,10 @@ from llm_ops.catalog_maintenance import (
     resolve_orphan_meta_models,
 )
 from llm_ops.collection_services import (
+    AUTO_SYNC_SOURCE_DEFAULTS,
+    OFFICIAL_PROVIDER_CONFIGS,
     SUPPORTED_OFFICIAL_PRICE_SYNC_PROVIDER_CODES,
+    SUPPORTED_OFFICIAL_SOURCE_PROVIDER_CODES,
     reset_official_price_catalog,
     supported_auto_sync_source_options,
     supported_official_provider_options,
@@ -40,6 +43,7 @@ from llm_ops.models import (
     ResalePlatform,
 )
 from llm_ops.periodic_tasks import register_periodic_tasks
+from llm_ops.price_collectors import registered_vendor_price_collector_codes
 
 
 class LLMOpsCatalogStateHelperTests(TestCase):
@@ -97,6 +101,7 @@ class LLMOpsCatalogMaintenanceTests(TestCase):
         meta = MetaModel.objects.create(
             name="DeepSeek R1",
             code="deepseek-r1",
+            metadata={"models_dev": {"id": "deepseek/deepseek-r1"}},
         )
         MetaModel.objects.filter(id=meta.id).update(
             owner_code="aliyun",
@@ -122,6 +127,9 @@ class LLMOpsCatalogMaintenanceTests(TestCase):
             owner_code=provider.code,
             owner_name=provider.name,
             owner_website=provider.website,
+            aliases=["canonical-alias"],
+            capabilities={"features": ["chat"]},
+            metadata={"models_dev": {"id": "deepseek/deepseek-r1"}},
         )
         release = MetaModel.objects.create(
             name="DeepSeek R1 0528",
@@ -129,6 +137,14 @@ class LLMOpsCatalogMaintenanceTests(TestCase):
             owner_code=provider.code,
             owner_name=provider.name,
             owner_website=provider.website,
+            aliases=["release-alias"],
+            capabilities={"features": ["reasoning"]},
+            context_window=128000,
+            max_output_tokens=32000,
+            metadata={
+                "models_dev": {"id": "deepseek/deepseek-r1-0528"},
+                "release": {"date": "2025-05-28"},
+            },
         )
         model = LLMModel.objects.create(
             provider=provider,
@@ -143,9 +159,64 @@ class LLMOpsCatalogMaintenanceTests(TestCase):
         canonical.refresh_from_db()
         self.assertEqual(stats["merged"], 1)
         self.assertEqual(model.meta_model, canonical)
+        self.assertIn("release-alias", canonical.aliases)
+        self.assertEqual(canonical.context_window, 128000)
+        self.assertEqual(canonical.max_output_tokens, 32000)
+        self.assertIn("reasoning", canonical.capabilities["features"])
+        self.assertEqual(
+            canonical.metadata["models_dev"]["id"],
+            "deepseek/deepseek-r1",
+        )
+        self.assertEqual(
+            canonical.metadata["merged_models_dev"][0]["id"],
+            "deepseek/deepseek-r1-0528",
+        )
+        self.assertEqual(canonical.metadata["release"]["date"], "2025-05-28")
         self.assertFalse(
             MetaModel.objects.filter(code="deepseek-r1-0528").exists(),
         )
+
+    def test_normalize_meta_model_catalog_preserves_manual_rows(self):
+        provider = LLMProvider.objects.create(
+            name="DeepSeek",
+            code="deepseek",
+        )
+        online = MetaModel.objects.create(
+            name="DeepSeek R1",
+            code="deepseek-r1",
+            owner_code=provider.code,
+            owner_name=provider.name,
+            owner_website=provider.website,
+            metadata={"models_dev": {"id": "deepseek/deepseek-r1"}},
+        )
+        manual = MetaModel.objects.create(
+            name="Manual DeepSeek R1 0528",
+            code="deepseek-r1-0528",
+            owner_code=provider.code,
+            owner_name=provider.name,
+            owner_website=provider.website,
+            aliases=["manual-alias"],
+            context_window=256000,
+        )
+        model = LLMModel.objects.create(
+            provider=provider,
+            meta_model=manual,
+            name="Manual DeepSeek R1 0528",
+            code="deepseek-r1-0528",
+        )
+
+        stats = normalize_meta_model_catalog()
+
+        model.refresh_from_db()
+        online.refresh_from_db()
+        manual.refresh_from_db()
+        self.assertEqual(stats["merged"], 0)
+        self.assertEqual(model.meta_model, manual)
+        self.assertEqual(manual.code, "deepseek-r1-0528")
+        self.assertEqual(manual.name, "Manual DeepSeek R1 0528")
+        self.assertEqual(manual.aliases, ["manual-alias"])
+        self.assertEqual(manual.context_window, 256000)
+        self.assertEqual(online.aliases, [])
 
     def test_reset_meta_models_canonical_does_not_repopulate(self):
         provider = LLMProvider.objects.create(name="OpenAI", code="openai")
@@ -277,7 +348,7 @@ class LLMOpsOfficialProviderOptionTests(TestCase):
 
         provider_codes = {option["provider_code"] for option in options}
         self.assertEqual(
-            {"aliyun", "azure-openai", "deepseek"},
+            set(SUPPORTED_OFFICIAL_SOURCE_PROVIDER_CODES),
             provider_codes,
         )
         self.assertFalse(LLMProvider.objects.exists())
@@ -286,9 +357,17 @@ class LLMOpsOfficialProviderOptionTests(TestCase):
     def test_auto_sync_source_options_do_not_create_rows(self):
         options = supported_auto_sync_source_options()
 
+        supplier_codes = {
+            code
+            for code in registered_vendor_price_collector_codes()
+            if (
+                code not in OFFICIAL_PROVIDER_CONFIGS
+                and code in AUTO_SYNC_SOURCE_DEFAULTS
+            )
+        }
         provider_codes = {option["provider_code"] for option in options}
         self.assertEqual(
-            {"aliyun", "azure-openai", "deepseek", "siliconflow"},
+            set(SUPPORTED_OFFICIAL_SOURCE_PROVIDER_CODES) | supplier_codes,
             provider_codes,
         )
         self.assertFalse(LLMProvider.objects.exists())


### PR DESCRIPTION
## Summary
- Limit meta model catalog normalization to models.dev-managed rows
- Preserve manually entered meta models and their linked LLM models
- Merge duplicate models.dev metadata and capabilities into canonical rows
- Keep official and supplier option tests aligned with configured collectors

Closes #127

## Test plan
- [x] python3 -m pytest backend/llm_ops/tests/test_ops_bootstrap.py -k 'CatalogMaintenance or OfficialProviderOption'
- [x] git diff --check
- [x] awk line-length check for changed Python files
- [ ] python3 -m black --check backend/llm_ops/catalog_maintenance.py backend/llm_ops/tests/test_ops_bootstrap.py (black not installed)
- [ ] python3 -m flake8 backend/llm_ops/catalog_maintenance.py backend/llm_ops/tests/test_ops_bootstrap.py (flake8 not installed)
- [ ] python3 -m isort --check-only backend/llm_ops/catalog_maintenance.py backend/llm_ops/tests/test_ops_bootstrap.py (isort not installed)

Made with [Orca](https://github.com/stablyai/orca) 🐋
