### PR TITLE
Optimize MetaModel alias lookup cache

### DIFF
--- a/backend/llm_ops/meta_model_lookup.py
+++ b/backend/llm_ops/meta_model_lookup.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+import threading
+from time import monotonic
+
+from django.db import connection
+
+from .models import MetaModel
+
+META_MODEL_LOOKUP_CACHE_TTL_SECONDS = 30.0
+
+
+@dataclass
+class MetaModelLookupCache:
+    """In-process lookup indexes for canonical meta model matching."""
+
+    all_meta: list[MetaModel]
+    alias_index: dict[str, MetaModel]
+    connection_signature: tuple
+    created_at: float
+    name_index: dict[str, MetaModel]
+
+
+_meta_model_cache = threading.local()
+
+
+def invalidate_meta_model_lookup_cache() -> None:
+    """Clear the current thread's cached meta model lookup indexes."""
+    if hasattr(_meta_model_cache, "value"):
+        delattr(_meta_model_cache, "value")
+
+
+def register_meta_model_in_lookup_cache(meta_model: MetaModel) -> None:
+    """Add or refresh one meta model in the current thread's cache."""
+    cached = getattr(_meta_model_cache, "value", None)
+    if cached is None:
+        return
+    if cached.connection_signature[0] != connection.alias:
+        return
+    if is_meta_model_lookup_cache_expired(cached):
+        invalidate_meta_model_lookup_cache()
+        return
+
+    for index, cached_meta in enumerate(cached.all_meta):
+        if cached_meta.pk == meta_model.pk:
+            cached.all_meta[index] = meta_model
+            break
+    else:
+        cached.all_meta.append(meta_model)
+
+    alias_index, name_index = build_meta_model_lookup_indexes(cached.all_meta)
+    cached.alias_index.clear()
+    cached.alias_index.update(alias_index)
+    cached.name_index.clear()
+    cached.name_index.update(name_index)
+
+
+def get_meta_model_lookup_cache() -> MetaModelLookupCache:
+    """Return cached meta model lookup indexes for the current thread."""
+    connection_signature = current_connection_signature()
+    cached = getattr(_meta_model_cache, "value", None)
+    if (
+        cached is not None
+        and is_meta_model_lookup_cache_current(
+            cached,
+            connection_signature,
+        )
+    ):
+        return cached
+
+    all_meta = list(MetaModel.objects.all())
+    alias_index, name_index = build_meta_model_lookup_indexes(all_meta)
+
+    cached = MetaModelLookupCache(
+        all_meta=all_meta,
+        alias_index=alias_index,
+        connection_signature=connection_signature,
+        created_at=monotonic(),
+        name_index=name_index,
+    )
+    _meta_model_cache.value = cached
+    return cached
+
+
+def find_meta_model_by_alias_or_name(
+    *,
+    tokens: list[str],
+    name: str,
+) -> MetaModel | None:
+    """Find a meta model through cached alias and normalized name indexes."""
+    if not tokens and not name:
+        return None
+
+    cache = get_meta_model_lookup_cache()
+    for token in tokens:
+        value = str(token or "").strip()
+        if not value:
+            continue
+        hit = cache.alias_index.get(value)
+        if hit is not None:
+            return hit
+
+    normalized_name = normalize_meta_model_lookup_name(name)
+    if not normalized_name:
+        return None
+    return cache.name_index.get(normalized_name)
+
+
+def normalize_meta_model_lookup_name(value: str | None) -> str:
+    """Normalize a model display name for loose matching."""
+    return re.sub(r"[\s_\-]+", "", str(value or "").strip().lower())
+
+
+def build_meta_model_lookup_indexes(
+    all_meta: list[MetaModel],
+) -> tuple[dict[str, MetaModel], dict[str, MetaModel]]:
+    """Build alias and normalized-name indexes for meta models."""
+    alias_index: dict[str, MetaModel] = {}
+    name_index: dict[str, MetaModel] = {}
+    for meta in all_meta:
+        for alias in meta.aliases or []:
+            value = str(alias or "").strip()
+            if value:
+                alias_index[value] = meta
+
+        normalized_name = normalize_meta_model_lookup_name(meta.name)
+        if normalized_name and normalized_name not in name_index:
+            name_index[normalized_name] = meta
+    return alias_index, name_index
+
+
+def is_meta_model_lookup_cache_current(
+    cached: MetaModelLookupCache,
+    connection_signature: tuple,
+) -> bool:
+    """Return whether the cached indexes are still safe to reuse."""
+    if cached.connection_signature != connection_signature:
+        return False
+    return not is_meta_model_lookup_cache_expired(cached)
+
+
+def is_meta_model_lookup_cache_expired(
+    cached: MetaModelLookupCache,
+) -> bool:
+    """Return whether the cached indexes are older than the TTL."""
+    age = monotonic() - cached.created_at
+    return age > META_MODEL_LOOKUP_CACHE_TTL_SECONDS
+
+
+def current_connection_signature() -> tuple:
+    """Return a cheap signature for the current database transaction scope."""
+    savepoint_ids = tuple(str(value) for value in connection.savepoint_ids)
+    return (connection.alias, connection.in_atomic_block, savepoint_ids)

--- a/backend/llm_ops/models.py
+++ b/backend/llm_ops/models.py
@@ -373,6 +373,17 @@ class MetaModel(models.Model):
                 dict.fromkeys([*update_fields, *changed_fields])
             )
         super().save(*args, **kwargs)
+        from .meta_model_lookup import register_meta_model_in_lookup_cache
+
+        register_meta_model_in_lookup_cache(self)
+
+    def delete(self, *args, **kwargs):
+        """Clear lookup caches when a canonical model is removed."""
+        result = super().delete(*args, **kwargs)
+        from .meta_model_lookup import invalidate_meta_model_lookup_cache
+
+        invalidate_meta_model_lookup_cache()
+        return result
 
     def __str__(self) -> str:
         return self.name

--- a/backend/llm_ops/serializers.py
+++ b/backend/llm_ops/serializers.py
@@ -15,6 +15,7 @@ from .llm_config import (
     get_llm_config_reference,
     get_price_sync_llm_status,
 )
+from .meta_model_lookup import find_meta_model_by_alias_or_name
 from .models import (
     AuditLog,
     ChannelModelPrice,
@@ -563,13 +564,6 @@ def ensure_meta_model_for_price_data(data: dict) -> MetaModel:
     # records this code (or a legacy spelling of it). This
     # keeps the canonical row count to one per release even
     # when multiple price sources disagree on the spelling.
-    #
-    # The lookup is implemented in Python rather than via
-    # ``aliases__contains`` because SQLite (the default dev
-    # backend) does not support the JSON ``contains`` lookup.
-    # The meta-model table is small enough (low hundreds of
-    # rows) that an in-process scan stays well below 5 ms even
-    # on a developer laptop.
     tokens = [
         t
         for t in (
@@ -584,30 +578,10 @@ def ensure_meta_model_for_price_data(data: dict) -> MetaModel:
     ]
     existing = None
     if tokens:
-        all_meta = list(MetaModel.objects.all())
-        alias_index = {
-            alias: meta
-            for meta in all_meta
-            for alias in (meta.aliases or [])
-        }
-        for token in tokens:
-            hit = alias_index.get(token)
-            if hit is not None:
-                existing = hit
-                break
-        # When the reported code/name does not appear in any
-        # alias, fall back to a normalised name match. This
-        # covers the common case where two price sources
-        # disagree on the code spelling (for example
-        # ``deepseek-r1-0528`` vs ``deepseek-r1-250528``)
-        # but agree on the human readable name.
-        if existing is None and name:
-            normalised = name.strip().lower().replace(" ", "")
-            for meta in all_meta:
-                meta_name = (meta.name or "").strip().lower()
-                if meta_name.replace(" ", "") == normalised:
-                    existing = meta
-                    break
+        existing = find_meta_model_by_alias_or_name(
+            tokens=tokens,
+            name=name,
+        )
     if existing is not None:
         merged = list(existing.aliases or [])
         for token in tokens:

--- a/backend/llm_ops/services.py
+++ b/backend/llm_ops/services.py
@@ -10,6 +10,11 @@ from cloud_billing.dashboard import _build_exchange_rate_info
 from django.db import transaction
 from django.utils import timezone
 
+from .meta_model_lookup import (
+    find_meta_model_by_alias_or_name,
+    invalidate_meta_model_lookup_cache as _invalidate_lookup_cache,
+    normalize_meta_model_lookup_name as _normalize_lookup_name,
+)
 from .models import (
     ChannelModelPrice,
     ChannelModelPriceHistory,
@@ -67,6 +72,16 @@ MANUAL_COLLECTION_METHODS = {
     PriceCollectionSource.COLLECTION_METHOD_MANUAL_ENTRY,
     PriceCollectionSource.COLLECTION_METHOD_MANUAL_IMPORT,
 }
+
+
+def invalidate_meta_model_lookup_cache() -> None:
+    """Clear cached meta model lookup indexes for compatibility callers."""
+    _invalidate_lookup_cache()
+
+
+def normalize_meta_model_lookup_name(value: str | None) -> str:
+    """Normalize a model display name for loose matching."""
+    return _normalize_lookup_name(value)
 
 
 @dataclass(frozen=True)
@@ -222,25 +237,10 @@ def match_meta_model_by_alias_or_name(
     if not tokens:
         return None
 
-    all_meta = list(MetaModel.objects.all())
-    alias_index = {
-        alias: meta
-        for meta in all_meta
-        for alias in (meta.aliases or [])
-        if alias
-    }
-    for token in tokens:
-        hit = alias_index.get(token)
-        if hit is not None:
-            return hit
-
-    normalized_name = normalize_meta_model_lookup_name(canonical_name)
-    if not normalized_name:
-        return None
-    for meta in all_meta:
-        if normalize_meta_model_lookup_name(meta.name) == normalized_name:
-            return meta
-    return None
+    return find_meta_model_by_alias_or_name(
+        tokens=tokens,
+        name=canonical_name,
+    )
 
 
 def meta_model_alias_tokens(
@@ -266,11 +266,6 @@ def meta_model_alias_tokens(
         if value and value not in tokens:
             tokens.append(value)
     return tokens
-
-
-def normalize_meta_model_lookup_name(value: str | None) -> str:
-    """Normalize a model display name for loose matching."""
-    return re.sub(r"[\s_\-]+", "", str(value or "").strip().lower())
 
 
 def price_role_for_source(

--- a/backend/llm_ops/tests/test_serializers.py
+++ b/backend/llm_ops/tests/test_serializers.py
@@ -1,7 +1,9 @@
 from decimal import Decimal
 from unittest.mock import patch
 
+from django.db import connection
 from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
 
 from llm_ops.models import (
     LLMModel,
@@ -1000,6 +1002,76 @@ class EnsureMetaModelForPriceDataTests(TestCase):
         )
         self.assertEqual(reused.id, canonical.id)
         self.assertIn("deepseek-r1-250528", reused.aliases)
+
+    def test_repeated_price_data_alias_matches_share_full_table_load(self):
+        from llm_ops import services
+        from llm_ops.serializers import ensure_meta_model_for_price_data
+
+        getattr(services, "invalidate_meta_model_lookup_cache", lambda: None)()
+        canonical = MetaModel.objects.create(
+            name="DeepSeek R1",
+            code="deepseek-r1",
+            owner_code=self.deepseek.code,
+            owner_name=self.deepseek.name,
+            owner_website=self.deepseek.website,
+            aliases=[
+                "deepseek-r1-250528",
+                "DeepSeek R1 0528",
+                "deepseek-r1",
+                "DeepSeek R1",
+            ],
+        )
+        data = {
+            "code": "deepseek-r1-250528",
+            "name": "DeepSeek R1 0528",
+            "provider": self.deepseek,
+        }
+
+        with CaptureQueriesContext(connection) as context:
+            first = ensure_meta_model_for_price_data(data)
+            second = ensure_meta_model_for_price_data(data)
+
+        self.assertEqual(first.id, canonical.id)
+        self.assertEqual(second.id, canonical.id)
+        full_table_queries = [
+            query
+            for query in context.captured_queries
+            if 'FROM "llm_ops_metamodel"' in query["sql"]
+            and " WHERE " not in query["sql"]
+        ]
+        self.assertEqual(len(full_table_queries), 1)
+
+    def test_created_meta_model_updates_lookup_cache_without_reload(self):
+        from llm_ops import services
+        from llm_ops.serializers import ensure_meta_model_for_price_data
+
+        getattr(services, "invalidate_meta_model_lookup_cache", lambda: None)()
+
+        with CaptureQueriesContext(connection) as context:
+            canonical = ensure_meta_model_for_price_data(
+                {
+                    "code": "deepseek-r1-0528",
+                    "name": "DeepSeek R1 0528",
+                    "provider": self.deepseek,
+                }
+            )
+            reused = ensure_meta_model_for_price_data(
+                {
+                    "code": "",
+                    "name": "DeepSeek R1 0528",
+                    "raw_code": "deepseek-r1-250528",
+                    "provider": self.deepseek,
+                }
+            )
+
+        self.assertEqual(reused.id, canonical.id)
+        full_table_queries = [
+            query
+            for query in context.captured_queries
+            if 'FROM "llm_ops_metamodel"' in query["sql"]
+            and " WHERE " not in query["sql"]
+        ]
+        self.assertEqual(len(full_table_queries), 1)
 
     def test_mainstream_online_model_families_have_canonical_owners(self):
         from llm_ops.constants import canonical_owner_for_model_code

--- a/backend/llm_ops/tests/test_services.py
+++ b/backend/llm_ops/tests/test_services.py
@@ -1,7 +1,9 @@
 from decimal import Decimal
 from unittest import mock
 
+from django.db import connection
 from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
 
 from llm_ops.models import (
     ChannelModelPrice,
@@ -22,6 +24,7 @@ from llm_ops.models import (
 from llm_ops.services import (
     calculate_channel_model_cost,
     import_manual_model_prices,
+    match_meta_model_by_alias_or_name,
     price_role_for_source,
     record_channel_model_price_history,
     record_resale_listing_price_history,
@@ -80,6 +83,102 @@ class LLMOpsPricingServiceTests(TestCase):
         )
 
         self.assertEqual(cost, Decimal("28.000000"))
+
+    def test_repeated_meta_model_alias_matches_share_full_table_load(self):
+        from llm_ops import services
+
+        getattr(services, "invalidate_meta_model_lookup_cache", lambda: None)()
+        meta_model = MetaModel.objects.create(
+            name="Alias Family",
+            code="alias-family",
+            aliases=["vendor/alias-family-2024-08-06"],
+        )
+
+        with CaptureQueriesContext(connection) as context:
+            first = match_meta_model_by_alias_or_name(
+                raw_code="vendor/alias-family-2024-08-06",
+                reported_code="alias-family-2024-08-06",
+                reported_name="Alias Family",
+                canonical_code="alias-family",
+                canonical_name="Alias Family",
+                seed_aliases=[],
+            )
+            second = match_meta_model_by_alias_or_name(
+                raw_code="vendor/alias-family-2024-08-06",
+                reported_code="alias-family-2024-08-06",
+                reported_name="Alias Family",
+                canonical_code="alias-family",
+                canonical_name="Alias Family",
+                seed_aliases=[],
+            )
+
+        self.assertEqual(first, meta_model)
+        self.assertEqual(second, meta_model)
+        full_table_queries = [
+            query
+            for query in context.captured_queries
+            if 'FROM "llm_ops_metamodel"' in query["sql"]
+            and " WHERE " not in query["sql"]
+        ]
+        self.assertEqual(len(full_table_queries), 1)
+
+    def test_expired_meta_model_lookup_cache_reloads_table(self):
+        from llm_ops import services
+        from llm_ops.meta_model_lookup import (
+            META_MODEL_LOOKUP_CACHE_TTL_SECONDS,
+        )
+
+        getattr(services, "invalidate_meta_model_lookup_cache", lambda: None)()
+        MetaModel.objects.create(
+            name="Existing Family",
+            code="existing-family",
+            aliases=["existing-family"],
+        )
+
+        with mock.patch(
+            "llm_ops.meta_model_lookup.monotonic",
+            side_effect=[
+                100.0,
+                100.0 + META_MODEL_LOOKUP_CACHE_TTL_SECONDS + 0.01,
+                100.0 + META_MODEL_LOOKUP_CACHE_TTL_SECONDS + 0.02,
+            ],
+        ):
+            with CaptureQueriesContext(connection) as context:
+                missing = match_meta_model_by_alias_or_name(
+                    raw_code="new-family",
+                    reported_code="new-family",
+                    reported_name="New Family",
+                    canonical_code="new-family",
+                    canonical_name="New Family",
+                    seed_aliases=[],
+                )
+                MetaModel.objects.bulk_create(
+                    [
+                        MetaModel(
+                            name="New Family",
+                            code="new-family",
+                            aliases=["new-family"],
+                        )
+                    ]
+                )
+                found = match_meta_model_by_alias_or_name(
+                    raw_code="new-family",
+                    reported_code="new-family",
+                    reported_name="New Family",
+                    canonical_code="new-family",
+                    canonical_name="New Family",
+                    seed_aliases=[],
+                )
+
+        self.assertIsNone(missing)
+        self.assertEqual(found.code, "new-family")
+        full_table_queries = [
+            query
+            for query in context.captured_queries
+            if 'FROM "llm_ops_metamodel"' in query["sql"]
+            and " WHERE " not in query["sql"]
+        ]
+        self.assertEqual(len(full_table_queries), 2)
 
     def test_official_source_is_cloud_hosted_for_third_party_meta_model(
         self,


### PR DESCRIPTION
## Summary
- Add a thread-local MetaModel lookup cache for alias and normalized-name matching.
- Refresh lookup indexes after MetaModel save/delete and bound stale cache reuse with a short TTL.
- Reuse the cached lookup from serializers and services to avoid repeated full-table scans during price ingestion.
- Add query-count regression coverage for repeated lookups, cache updates after creation, and TTL reloads.

Closes #115

## Test plan
- [x] .venv/bin/pytest backend/llm_ops/tests/test_serializers.py::EnsureMetaModelForPriceDataTests backend/llm_ops/tests/test_services.py::LLMOpsPricingServiceTests -q
- [x] .venv/bin/flake8 backend/llm_ops/meta_model_lookup.py backend/llm_ops/models.py backend/llm_ops/serializers.py backend/llm_ops/services.py backend/llm_ops/tests/test_serializers.py backend/llm_ops/tests/test_services.py

Made with [Orca](https://github.com/stablyai/orca) 🐋
