### PR TITLE
Add force mode for periodic task registration

### DIFF
--- a/backend/core/management/commands/register_periodic_tasks.py
+++ b/backend/core/management/commands/register_periodic_tasks.py
@@ -19,7 +19,7 @@ from core.periodic_registry import (
 logger = logging.getLogger(__name__)
 
 
-def discover_and_register():
+def discover_and_register(force=False):
     """
     Clear registry, discover each app's periodic_tasks, call
     register_periodic_tasks, then apply registry to django_celery_beat.
@@ -40,21 +40,34 @@ def discover_and_register():
                     f"register_periodic_tasks failed for app {app}: {e}"
                 )
 
-    apply_registry()
+    apply_registry(force=force)
 
 
 class Command(BaseCommand):
     help = (
         "Discover all apps' periodic_tasks.register_periodic_tasks() and "
         "register entries to django_celery_beat without updating existing "
-        "rows."
+        "rows unless --force is provided."
     )
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help=(
+                "Overwrite existing django_celery_beat PeriodicTask rows "
+                "with the code-defined registry values."
+            ),
+        )
+
     def handle(self, *args, **options):
-        discover_and_register()
+        force = options.get("force", False)
+        discover_and_register(force=force)
         count = len(TASK_REGISTRY)
+        mode = "updated" if force else "registered"
         self.stdout.write(
             self.style.SUCCESS(
-                f"Registered {count} periodic task(s) to django_celery_beat; "
+                f"Discovered {count} periodic task(s); {mode} "
+                "django_celery_beat rows."
             )
         )

--- a/backend/core/periodic_registry.py
+++ b/backend/core/periodic_registry.py
@@ -99,7 +99,7 @@ class TaskRegistry:
             "enabled": enabled,
         }
 
-    def _apply_one(self, name, entry):
+    def _apply_one(self, name, entry, force=False):
         from django_celery_beat.models import PeriodicTask, PeriodicTasks
 
         task_name = entry["task"]
@@ -125,7 +125,7 @@ class TaskRegistry:
                 crontab_schedule = _get_or_create_crontab(schedule)
                 interval_schedule = None
 
-        create_defaults = {
+        desired_values = {
             "task": task_name,
             "args": json.dumps(list(args)),
             "kwargs": json.dumps(kwargs),
@@ -133,24 +133,39 @@ class TaskRegistry:
             "enabled": enabled,
         }
         if crontab_schedule is not None:
-            create_defaults["crontab"] = crontab_schedule
-            create_defaults["interval"] = None
+            desired_values["crontab"] = crontab_schedule
+            desired_values["interval"] = None
         else:
-            create_defaults["interval"] = interval_schedule
-            create_defaults["crontab"] = None
+            desired_values["interval"] = interval_schedule
+            desired_values["crontab"] = None
 
         obj, created = PeriodicTask.objects.get_or_create(
-            name=name, defaults=create_defaults
+            name=name, defaults=desired_values
         )
         if not created:
+            if force:
+                update_fields = []
+                for field_name, value in desired_values.items():
+                    setattr(obj, field_name, value)
+                    update_fields.append(field_name)
+
+                for field_name in ("solar", "clocked"):
+                    if hasattr(obj, field_name):
+                        setattr(obj, field_name, None)
+                        update_fields.append(field_name)
+
+                obj.save(update_fields=update_fields)
+                PeriodicTasks.update_changed()
+                return "updated"
+
             logger.debug(
                 "Periodic task already exists, skipping update: %s",
                 name,
             )
-            return False
+            return "skipped"
 
         PeriodicTasks.update_changed()
-        return True
+        return "created"
 
     @staticmethod
     def _ensure_task_module_loaded(task_name):
@@ -171,7 +186,9 @@ class TaskRegistry:
             return True
         if task_name in current_app.tasks:
             return True
-        module_name = task_name.rsplit(".", 1)[0] if "." in task_name else ""
+        module_name = (
+            task_name.rsplit(".", 1)[0] if "." in task_name else ""
+        )
         if not module_name:
             return task_name in current_app.tasks
         try:
@@ -198,7 +215,9 @@ class TaskRegistry:
             # command path runs in a process where those modules may not
             # have been imported yet. Attempt a best-effort import and
             # re-check before declaring the task missing.
-            module_name = task_name.rsplit(".", 1)[0] if "." in task_name else ""
+            module_name = (
+                task_name.rsplit(".", 1)[0] if "." in task_name else ""
+            )
             if module_name:
                 try:
                     __import__(module_name)
@@ -210,11 +229,14 @@ class TaskRegistry:
             # case is the same KeyError that motivated this check.
             return True
 
-    def apply(self):
+    def apply(self, force=False):
         """
         Write all registered entries to django_celery_beat.
 
         Existing rows are skipped so database-side edits are preserved.
+        When ``force`` is true, existing rows are overwritten with the
+        registry definition so operators can restore code-defined
+        schedules after accidental admin-side edits.
         Entries that reference a task name not yet known to the Celery
         app are logged at ERROR level so that missing-task regressions
         show up loudly during ``manage.py register_periodic_tasks``
@@ -234,9 +256,11 @@ class TaskRegistry:
                 )
                 continue
             try:
-                created = self._apply_one(name, entry)
-                if created:
+                result = self._apply_one(name, entry, force=force)
+                if result == "created":
                     logger.debug(f"Registered periodic task: {name}")
+                elif result == "updated":
+                    logger.debug(f"Updated periodic task: {name}")
                 else:
                     logger.debug(f"Skipped existing periodic task: {name}")
             except Exception as e:
@@ -248,7 +272,6 @@ class TaskRegistry:
 TASK_REGISTRY = TaskRegistry()
 
 
-def apply_registry():
+def apply_registry(force=False):
     """Apply the global TASK_REGISTRY to django_celery_beat."""
-    TASK_REGISTRY.apply()
-
+    TASK_REGISTRY.apply(force=force)

--- a/backend/tests/test_core_periodic_registry.py
+++ b/backend/tests/test_core_periodic_registry.py
@@ -1,0 +1,116 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+os.environ.setdefault(
+    "DJANGO_SETTINGS_MODULE",
+    "tests.core_periodic_registry_settings",
+)
+
+import django
+from celery.schedules import crontab
+from django.test import TestCase
+
+django.setup()
+
+from core.periodic_registry import TaskRegistry
+from django_celery_beat.models import CrontabSchedule
+from django_celery_beat.models import PeriodicTask
+
+
+class TaskRegistryForceApplyTests(TestCase):
+    """Periodic registry force mode restores code-defined defaults."""
+
+    def test_existing_task_is_skipped_without_force(self):
+        existing_schedule = CrontabSchedule.objects.create(
+            minute="*",
+            hour="*",
+            day_of_week="*",
+            day_of_month="*",
+            month_of_year="*",
+            timezone="UTC",
+        )
+        PeriodicTask.objects.create(
+            name="llm_ops_model_price_sync_agent",
+            task="legacy.task",
+            crontab=existing_schedule,
+            args=json.dumps(["legacy"]),
+            kwargs=json.dumps({"source_ids": [1]}),
+            queue="legacy",
+            enabled=False,
+        )
+
+        registry = TaskRegistry()
+        registry.add(
+            name="llm_ops_model_price_sync_agent",
+            task="llm_ops.tasks.run_model_price_sync_agent",
+            schedule=crontab(minute="15", hour="1,7,13,19"),
+            kwargs={"source_ids": None, "verify_source": True},
+            queue="backend",
+            enabled=True,
+        )
+
+        registry.apply()
+
+        task = PeriodicTask.objects.get(
+            name="llm_ops_model_price_sync_agent"
+        )
+        self.assertEqual(task.task, "legacy.task")
+        self.assertEqual(task.crontab.minute, "*")
+        self.assertEqual(task.crontab.hour, "*")
+        self.assertEqual(json.loads(task.kwargs), {"source_ids": [1]})
+        self.assertEqual(task.queue, "legacy")
+        self.assertFalse(task.enabled)
+
+    def test_force_updates_existing_task_to_registry_definition(self):
+        existing_schedule = CrontabSchedule.objects.create(
+            minute="*",
+            hour="*",
+            day_of_week="*",
+            day_of_month="*",
+            month_of_year="*",
+            timezone="UTC",
+        )
+        PeriodicTask.objects.create(
+            name="llm_ops_model_price_sync_agent",
+            task="legacy.task",
+            crontab=existing_schedule,
+            args=json.dumps(["legacy"]),
+            kwargs=json.dumps({"source_ids": [1]}),
+            queue="legacy",
+            enabled=False,
+        )
+
+        registry = TaskRegistry()
+        registry.add(
+            name="llm_ops_model_price_sync_agent",
+            task="llm_ops.tasks.run_model_price_sync_agent",
+            schedule=crontab(minute="15", hour="1,7,13,19"),
+            kwargs={"source_ids": None, "verify_source": True},
+            queue="backend",
+            enabled=True,
+        )
+
+        registry.apply(force=True)
+
+        task = PeriodicTask.objects.get(
+            name="llm_ops_model_price_sync_agent"
+        )
+        self.assertEqual(
+            task.task,
+            "llm_ops.tasks.run_model_price_sync_agent",
+        )
+        self.assertEqual(task.crontab.minute, "15")
+        self.assertEqual(task.crontab.hour, "1,7,13,19")
+        self.assertEqual(json.loads(task.args), [])
+        self.assertEqual(
+            json.loads(task.kwargs),
+            {"source_ids": None, "verify_source": True},
+        )
+        self.assertEqual(task.queue, "backend")
+        self.assertTrue(task.enabled)

--- a/backend/tests/test_register_periodic_tasks_command.py
+++ b/backend/tests/test_register_periodic_tasks_command.py
@@ -1,0 +1,43 @@
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+os.environ.setdefault(
+    "DJANGO_SETTINGS_MODULE",
+    "tests.core_periodic_registry_settings",
+)
+
+import django
+
+django.setup()
+
+from core.management.commands.register_periodic_tasks import Command
+
+
+def test_register_periodic_tasks_command_defaults_to_non_force():
+    command = Command()
+
+    with patch(
+        "core.management.commands.register_periodic_tasks."
+        "discover_and_register"
+    ) as discover_and_register:
+        command.handle()
+
+    discover_and_register.assert_called_once_with(force=False)
+
+
+def test_register_periodic_tasks_command_passes_force_option():
+    command = Command()
+
+    with patch(
+        "core.management.commands.register_periodic_tasks."
+        "discover_and_register"
+    ) as discover_and_register:
+        command.handle(force=True)
+
+    discover_and_register.assert_called_once_with(force=True)


### PR DESCRIPTION
## Summary
- Add an explicit `--force` option to `register_periodic_tasks` for restoring code-defined beat schedules.
- Preserve the existing default behavior that skips already-created `PeriodicTask` rows.
- Update the registry apply path to report created, skipped, and updated outcomes.
- Add regression tests for non-force preservation, force overwrite, and command option forwarding.

Closes #129

## Test plan
- [x] `python3 -m pytest backend/tests/test_core_periodic_registry.py backend/tests/test_register_periodic_tasks_command.py`
- [x] `git diff --check`

## Notes
- `uv run pytest ...` was not usable in this checkout because dependency resolution conflicts with `requires-python >=3.8` and `deepagents==0.4.9` requiring Python >=3.11.

Made with [Orca](https://github.com/stablyai/orca) 🐋
