### PR TITLE
Optimize LLM Ops model resale decision analysis

### DIFF
--- a/backend/llm_ops/admin.py
+++ b/backend/llm_ops/admin.py
@@ -299,6 +299,10 @@ class ResalePlatformAdmin(admin.ModelAdmin):
         "point_decimal_places",
         "fee_rate",
         "service_fee_rate",
+        "tax_rate",
+        "settlement_rate",
+        "yield_warning",
+        "yield_target",
         "auto_approve_max_margin_rate",
         "is_active",
     )

--- a/backend/llm_ops/collection_services.py
+++ b/backend/llm_ops/collection_services.py
@@ -52,6 +52,7 @@ from .services import (
     normalize_currency,
     price_role_for_source,
     source_owner_type_for_source,
+    sync_dependent_channel_price_items_for_price_items,
     update_aggregated_model_identity,
 )
 from .skill_runner import (
@@ -658,6 +659,7 @@ def sync_official_provider_model_prices(
     )
     run = PriceCollectionRun.objects.create(source=source)
     active_offering_ids: set[int] = set()
+    changed_price_item_ids: set[int] = set()
     stats: dict[str, int | list[str]] = {
         "models": 0,
         "created": 0,
@@ -708,11 +710,14 @@ def sync_official_provider_model_prices(
                     run=run,
                     offering=offering,
                 )
-                sync_model_price_items(
+                price_items = sync_model_price_items(
                     item,
                     source=source,
                     offering=offering,
                     source_url=catalog.source_url,
+                )
+                changed_price_item_ids.update(
+                    price_item.id for price_item in price_items
                 )
                 active_offering_ids.add(offering.id)
                 stats["models"] = int(stats["models"]) + 1
@@ -725,6 +730,10 @@ def sync_official_provider_model_prices(
             stale_stats = close_stale_current_collected_prices(
                 source=source,
                 active_offering_ids=active_offering_ids,
+            )
+            changed_price_item_ids.update(stale_stats["price_item_ids"])
+            channel_sync = sync_dependent_channel_price_items_for_price_items(
+                ModelPriceItem.objects.filter(id__in=changed_price_item_ids),
             )
             source.last_collected_at = timezone.now()
             source_update_fields = ["last_collected_at", "updated_at"]
@@ -748,6 +757,12 @@ def sync_official_provider_model_prices(
                 "skipped_model_codes": skipped_codes,
                 "closed_stale_price_items": stale_stats["price_items"],
                 "closed_stale_history": stale_stats["history"],
+                "channel_model_prices_synced": (
+                    channel_sync["channel_model_prices"]
+                ),
+                "channel_price_items_synced": (
+                    channel_sync["channel_price_items"]
+                ),
             }
             run_metadata.update(catalog_source_fetch_metadata(catalog))
             if standard_catalog is not None:
@@ -3133,6 +3148,7 @@ def close_stale_current_collected_prices(
     if active_offering_ids:
         price_items = price_items.exclude(offering_id__in=active_offering_ids)
         history = history.exclude(offering_id__in=active_offering_ids)
+    closed_price_item_ids = list(price_items.values_list("id", flat=True))
     closed_price_items = price_items.update(
         is_current=False,
         effective_to=now,
@@ -3143,6 +3159,7 @@ def close_stale_current_collected_prices(
     )
     return {
         "price_items": closed_price_items,
+        "price_item_ids": closed_price_item_ids,
         "history": closed_history,
     }
 

--- a/backend/llm_ops/migrations/0007_resaleplatform_fee_config.py
+++ b/backend/llm_ops/migrations/0007_resaleplatform_fee_config.py
@@ -1,0 +1,54 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("llm_ops", "0006_resaleplatform_point_ratio_precision"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="resaleplatform",
+            name="tax_rate",
+            field=models.DecimalField(
+                blank=True,
+                decimal_places=4,
+                default=None,
+                max_digits=8,
+                null=True,
+            ),
+        ),
+        migrations.AddField(
+            model_name="resaleplatform",
+            name="settlement_rate",
+            field=models.DecimalField(
+                blank=True,
+                decimal_places=4,
+                default=None,
+                max_digits=8,
+                null=True,
+            ),
+        ),
+        migrations.AddField(
+            model_name="resaleplatform",
+            name="yield_warning",
+            field=models.DecimalField(
+                blank=True,
+                decimal_places=4,
+                default=None,
+                max_digits=8,
+                null=True,
+            ),
+        ),
+        migrations.AddField(
+            model_name="resaleplatform",
+            name="yield_target",
+            field=models.DecimalField(
+                blank=True,
+                decimal_places=4,
+                default=None,
+                max_digits=8,
+                null=True,
+            ),
+        ),
+    ]

--- a/backend/llm_ops/migrations/0008_performance_indexes.py
+++ b/backend/llm_ops/migrations/0008_performance_indexes.py
@@ -1,0 +1,66 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("llm_ops", "0007_resaleplatform_fee_config"),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name="pricecollectionrun",
+            index=models.Index(
+                fields=["source", "-started_at", "-id"],
+                name="llmops_run_src_start_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="pricecollectionrun",
+            index=models.Index(
+                fields=["status", "-started_at", "-id"],
+                name="llmops_run_status_start_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="resalelisting",
+            index=models.Index(
+                fields=["platform", "is_active"],
+                name="llmops_listing_plat_active_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="resalelisting",
+            index=models.Index(
+                fields=["platform", "publish_status"],
+                name="llmops_listing_plat_pub_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="resalelisting",
+            index=models.Index(
+                fields=["platform", "workflow_status"],
+                name="llmops_listing_plat_flow_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="usagereconciliationrecord",
+            index=models.Index(
+                fields=["status", "-date", "-id"],
+                name="llmops_recon_status_date_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="usagereconciliationrecord",
+            index=models.Index(
+                fields=["model", "-date", "-id"],
+                name="llmops_recon_model_date_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="usagereconciliationrecord",
+            index=models.Index(
+                fields=["channel", "model", "-date"],
+                name="llmops_recon_ch_model_dt_idx",
+            ),
+        ),
+    ]

--- a/backend/llm_ops/models.py
+++ b/backend/llm_ops/models.py
@@ -1677,6 +1677,34 @@ class ResalePlatform(models.Model):
         decimal_places=2,
         default=100,
     )
+    tax_rate = models.DecimalField(
+        max_digits=8,
+        decimal_places=4,
+        null=True,
+        blank=True,
+        default=None,
+    )
+    settlement_rate = models.DecimalField(
+        max_digits=8,
+        decimal_places=4,
+        null=True,
+        blank=True,
+        default=None,
+    )
+    yield_warning = models.DecimalField(
+        max_digits=8,
+        decimal_places=4,
+        null=True,
+        blank=True,
+        default=None,
+    )
+    yield_target = models.DecimalField(
+        max_digits=8,
+        decimal_places=4,
+        null=True,
+        blank=True,
+        default=None,
+    )
     is_active = models.BooleanField(default=True)
     metadata = models.JSONField(blank=True, default=dict)
     notes = models.TextField(blank=True, default="")

--- a/backend/llm_ops/models.py
+++ b/backend/llm_ops/models.py
@@ -950,6 +950,16 @@ class PriceCollectionRun(models.Model):
 
     class Meta:
         ordering = ["-started_at", "-id"]
+        indexes = [
+            models.Index(
+                fields=["source", "-started_at", "-id"],
+                name="llmops_run_src_start_idx",
+            ),
+            models.Index(
+                fields=["status", "-started_at", "-id"],
+                name="llmops_run_status_start_idx",
+            ),
+        ]
 
     def __str__(self) -> str:
         source_name = self.source.name if self.source_id else "Deleted source"
@@ -1849,6 +1859,20 @@ class ResaleListing(models.Model):
             "channel__name",
             "id",
         ]
+        indexes = [
+            models.Index(
+                fields=["platform", "is_active"],
+                name="llmops_listing_plat_active_idx",
+            ),
+            models.Index(
+                fields=["platform", "publish_status"],
+                name="llmops_listing_plat_pub_idx",
+            ),
+            models.Index(
+                fields=["platform", "workflow_status"],
+                name="llmops_listing_plat_flow_idx",
+            ),
+        ]
         constraints = [
             models.UniqueConstraint(
                 fields=["platform", "model", "channel"],
@@ -2109,6 +2133,20 @@ class UsageReconciliationRecord(models.Model):
 
     class Meta:
         ordering = ["-date", "-id"]
+        indexes = [
+            models.Index(
+                fields=["status", "-date", "-id"],
+                name="llmops_recon_status_date_idx",
+            ),
+            models.Index(
+                fields=["model", "-date", "-id"],
+                name="llmops_recon_model_date_idx",
+            ),
+            models.Index(
+                fields=["channel", "model", "-date"],
+                name="llmops_recon_ch_model_dt_idx",
+            ),
+        ]
 
     def __str__(self) -> str:
         return f"{self.date} / {self.channel.name} / {self.model.name}"

--- a/backend/llm_ops/serializers.py
+++ b/backend/llm_ops/serializers.py
@@ -134,6 +134,9 @@ class PriceCollectionSourceSerializer(serializers.ModelSerializer):
         return instance.model_price_items.filter(is_current=True).count()
 
     def get_latest_run_status(self, instance):
+        value = getattr(instance, "latest_run_status", None)
+        if value is not None:
+            return value
         return (
             instance.collection_runs.order_by("-started_at", "-id")
             .values_list("status", flat=True)
@@ -141,9 +144,15 @@ class PriceCollectionSourceSerializer(serializers.ModelSerializer):
         )
 
     def get_model_count(self, instance):
+        value = getattr(instance, "model_count", None)
+        if value is not None:
+            return value
         return instance.models.count()
 
     def get_price_item_count(self, instance):
+        value = getattr(instance, "price_item_count", None)
+        if value is not None:
+            return value
         return instance.model_price_items.count()
 
     def validate(self, attrs):

--- a/backend/llm_ops/serializers.py
+++ b/backend/llm_ops/serializers.py
@@ -1489,6 +1489,34 @@ class ResalePlatformSerializer(serializers.ModelSerializer):
             )
         return value
 
+    def validate_tax_rate(self, value):
+        if value is None:
+            return value
+        if value < Decimal("0") or value >= Decimal("1"):
+            raise serializers.ValidationError("tax_rate must be >= 0 and < 1.")
+        return value
+
+    def validate_settlement_rate(self, value):
+        if value is None:
+            return value
+        if value <= Decimal("0"):
+            raise serializers.ValidationError("settlement_rate must be > 0.")
+        return value
+
+    def validate_yield_warning(self, value):
+        if value is None:
+            return value
+        if value < Decimal("0"):
+            raise serializers.ValidationError("yield_warning must be >= 0.")
+        return value
+
+    def validate_yield_target(self, value):
+        if value is None:
+            return value
+        if value < Decimal("0"):
+            raise serializers.ValidationError("yield_target must be >= 0.")
+        return value
+
     def validate_auto_approve_max_margin_rate(self, value):
         if value < Decimal("0"):
             raise serializers.ValidationError(

--- a/backend/llm_ops/services.py
+++ b/backend/llm_ops/services.py
@@ -8,6 +8,7 @@ import re
 
 from cloud_billing.dashboard import _build_exchange_rate_info
 from django.db import transaction
+from django.db.models import Q
 from django.utils import timezone
 
 from .meta_model_lookup import (
@@ -739,6 +740,12 @@ def import_manual_model_prices(
     changed_price_item_ids = (
         affected_price_item_ids | deactivated_price_item_ids
     )
+    changed_price_items = list(
+        ModelPriceItem.objects.filter(id__in=changed_price_item_ids)
+    )
+    channel_sync = sync_dependent_channel_price_items_for_price_items(
+        changed_price_items,
+    )
     current_price_item_ids = set(
         ModelPriceItem.objects.filter(
             id__in=changed_price_item_ids,
@@ -762,6 +769,7 @@ def import_manual_model_prices(
         "deactivated_price_item_ids": sorted(
             deactivated_price_item_ids - current_price_item_ids,
         ),
+        "channel_price_sync": channel_sync,
     }
 
 
@@ -1460,6 +1468,77 @@ def sync_channel_price_items(
     return items
 
 
+def sync_dependent_channel_price_items_for_price_items(
+    price_items,
+) -> dict[str, int]:
+    """Resync channel prices that derive from changed upstream prices."""
+    references = [
+        price_item_dependency_reference(item) for item in price_items if item
+    ]
+    model_ids = {
+        reference["model_id"]
+        for reference in references
+        if reference["model_id"]
+    }
+    meta_model_ids = {
+        reference["meta_model_id"]
+        for reference in references
+        if reference["meta_model_id"]
+    }
+    source_ids = {
+        reference["source_id"]
+        for reference in references
+        if reference["source_id"]
+    }
+    if not model_ids and not meta_model_ids:
+        return {"channel_model_prices": 0, "channel_price_items": 0}
+
+    model_query = Q()
+    if model_ids:
+        model_query |= Q(model_id__in=model_ids)
+    if meta_model_ids:
+        model_query |= Q(meta_model_id__in=meta_model_ids)
+
+    source_query = Q(price_source__isnull=True)
+    if source_ids:
+        source_query |= Q(price_source_id__in=source_ids)
+
+    prices = list(
+        ChannelModelPrice.objects.filter(model_query)
+        .filter(source_query)
+        .select_related(
+            "channel",
+            "model",
+            "model__meta_model",
+            "price_source",
+        )
+        .order_by("id")
+    )
+    item_count = 0
+    for price in prices:
+        record_channel_model_price_history(price)
+        item_count += len(sync_channel_price_items(price))
+    return {
+        "channel_model_prices": len(prices),
+        "channel_price_items": item_count,
+    }
+
+
+def price_item_dependency_reference(item) -> dict[str, int | None]:
+    """Return stable channel dependency fields for a price item."""
+    if isinstance(item, dict):
+        return {
+            "model_id": item.get("model_id"),
+            "meta_model_id": item.get("meta_model_id"),
+            "source_id": item.get("source_id"),
+        }
+    return {
+        "model_id": getattr(item, "model_id", None),
+        "meta_model_id": getattr(item, "meta_model_id", None),
+        "source_id": getattr(item, "source_id", None),
+    }
+
+
 def channel_price_item_payloads(
     price: ChannelModelPrice,
     *,
@@ -2097,15 +2176,15 @@ _DECISION_PRIORITY = {
 }
 
 
-_DECISION_ACTION_ZH = {
-    DECISION_STATUS_NO_SUPPLY: "去渠道配置",
-    DECISION_STATUS_CURRENCY_UNRESOLVED: "补汇率",
-    DECISION_STATUS_PLATFORM_FEE_UNRESOLVED: "配置平台费用规则",
-    DECISION_STATUS_LOW_YIELD: "复核售价或切换渠道",
-    DECISION_STATUS_NOT_LOWEST_CHANNEL: "评估切换到最低渠道",
-    DECISION_STATUS_UNLISTED: "去挂售",
-    DECISION_STATUS_SINGLE_CHANNEL: "增加备选渠道",
-    DECISION_STATUS_READY: "保持",
+_DECISION_ACTION = {
+    DECISION_STATUS_NO_SUPPLY: "configure_channel",
+    DECISION_STATUS_CURRENCY_UNRESOLVED: "configure_exchange_rate",
+    DECISION_STATUS_PLATFORM_FEE_UNRESOLVED: "configure_platform_fee",
+    DECISION_STATUS_LOW_YIELD: "review_pricing_or_channel",
+    DECISION_STATUS_NOT_LOWEST_CHANNEL: "switch_lowest_channel",
+    DECISION_STATUS_UNLISTED: "publish_listing",
+    DECISION_STATUS_SINGLE_CHANNEL: "add_channel_coverage",
+    DECISION_STATUS_READY: "keep",
 }
 
 
@@ -2265,7 +2344,7 @@ def compute_model_decision(
             status = DECISION_STATUS_READY
         return {
             "decision_status": status,
-            "decision_action": _DECISION_ACTION_ZH[status],
+            "decision_action": _DECISION_ACTION[status],
             "decision_priority": _DECISION_PRIORITY[status],
             "input_yield": input_yield,
             "output_yield": output_yield,
@@ -2283,7 +2362,7 @@ def compute_model_decision(
 
     return {
         "decision_status": status,
-        "decision_action": _DECISION_ACTION_ZH[status],
+        "decision_action": _DECISION_ACTION[status],
         "decision_priority": _DECISION_PRIORITY[status],
         "input_yield": None,
         "output_yield": None,

--- a/backend/llm_ops/services.py
+++ b/backend/llm_ops/services.py
@@ -1032,6 +1032,7 @@ def resolve_channel_model_price(
     model: LLMModel,
     *,
     override: ChannelModelPrice | None = None,
+    source_items: list[ModelPriceItem] | None = None,
     video_resolution: str = "",
 ) -> UnitPrices:
     """Resolve final procurement unit prices after channel overrides."""
@@ -1070,6 +1071,7 @@ def resolve_channel_model_price(
         channel,
         model,
         override=override,
+        source_items=source_items,
     )
     if source_unit_prices:
         input_price = source_unit_prices.input_per_million * ratio
@@ -1159,6 +1161,7 @@ def source_unit_prices_for_channel_model(
     model: LLMModel,
     *,
     override: ChannelModelPrice | None,
+    source_items: list[ModelPriceItem] | None = None,
 ) -> UnitPrices | None:
     """Resolve unit prices from the selected procurement source."""
     if not override:
@@ -1171,7 +1174,9 @@ def source_unit_prices_for_channel_model(
     )
     values = {}
     grouped_items = {}
-    for item in current_model_price_items_for_channel_price(override):
+    if source_items is None:
+        source_items = current_model_price_items_for_channel_price(override)
+    for item in source_items:
         grouped_items.setdefault(item.dimension, []).append(item)
 
     for dimension, items in grouped_items.items():
@@ -2054,3 +2059,240 @@ def decimal_to_string(value) -> str:
     if value is None:
         return ""
     return str(Decimal(str(value)))
+
+
+# ---------------------------------------------------------------------------
+# Model Resale Decision helper
+# ---------------------------------------------------------------------------
+#
+# Compute the canonical decision row used by the LLM Ops Monitor
+# overview page. Inputs are plain dicts (matching SummaryAPIView
+# procurement_rows and ResaleListing payloads). Outputs follow the
+# shape described in docs/llm-ops/overview-refactor.codex.md.
+#
+# No global fallback constants: if any platform fee/yield field is
+# missing, ``platform_fee_unresolved`` is returned and the yield
+# values stay ``None``.
+
+
+DECISION_STATUS_NO_SUPPLY = "no_supply"
+DECISION_STATUS_CURRENCY_UNRESOLVED = "currency_unresolved"
+DECISION_STATUS_PLATFORM_FEE_UNRESOLVED = "platform_fee_unresolved"
+DECISION_STATUS_LOW_YIELD = "low_yield"
+DECISION_STATUS_NOT_LOWEST_CHANNEL = "not_lowest_channel"
+DECISION_STATUS_UNLISTED = "unlisted"
+DECISION_STATUS_SINGLE_CHANNEL = "single_channel"
+DECISION_STATUS_READY = "ready"
+
+
+_DECISION_PRIORITY = {
+    DECISION_STATUS_NO_SUPPLY: 1,
+    DECISION_STATUS_CURRENCY_UNRESOLVED: 2,
+    DECISION_STATUS_PLATFORM_FEE_UNRESOLVED: 3,
+    DECISION_STATUS_LOW_YIELD: 4,
+    DECISION_STATUS_NOT_LOWEST_CHANNEL: 5,
+    DECISION_STATUS_UNLISTED: 6,
+    DECISION_STATUS_SINGLE_CHANNEL: 7,
+    DECISION_STATUS_READY: 8,
+}
+
+
+_DECISION_ACTION_ZH = {
+    DECISION_STATUS_NO_SUPPLY: "去渠道配置",
+    DECISION_STATUS_CURRENCY_UNRESOLVED: "补汇率",
+    DECISION_STATUS_PLATFORM_FEE_UNRESOLVED: "配置平台费用规则",
+    DECISION_STATUS_LOW_YIELD: "复核售价或切换渠道",
+    DECISION_STATUS_NOT_LOWEST_CHANNEL: "评估切换到最低渠道",
+    DECISION_STATUS_UNLISTED: "去挂售",
+    DECISION_STATUS_SINGLE_CHANNEL: "增加备选渠道",
+    DECISION_STATUS_READY: "保持",
+}
+
+
+DECISION_ANOMALY_EVENT_TYPES = {
+    "collection_failed",
+    "source_disabled",
+    "reconciliation_anomaly",
+}
+
+
+def _decimal(value, default=None):
+    """Return Decimal for numeric input, preserving None as None."""
+    if value is None:
+        return default
+    try:
+        return Decimal(str(value))
+    except Exception:  # noqa: BLE001
+        return default
+
+
+def _fee_config_resolved(platform) -> bool:
+    """Return True when every required fee field is non-null."""
+    required = (
+        "fee_rate",
+        "service_fee_rate",
+        "tax_rate",
+        "settlement_rate",
+        "yield_warning",
+    )
+    for attr in required:
+        if getattr(platform, attr, None) is None:
+            return False
+    return True
+
+
+def _compute_yield(retail, cost, platform):
+    """Return (input_yield, output_yield) or (None, None)."""
+    if not _fee_config_resolved(platform):
+        return None, None
+    net_factor = (
+        Decimal("1")
+        - Decimal(str(platform.fee_rate))
+        - Decimal(str(platform.service_fee_rate))
+        - Decimal(str(platform.tax_rate))
+    )
+    settlement = Decimal(str(platform.settlement_rate))
+    if retail is None or cost is None:
+        return None, None
+    if retail == ZERO:
+        if cost > ZERO:
+            return Decimal("-1"), Decimal("-1")
+        return ZERO, ZERO
+    net = retail * net_factor - cost * settlement
+    yield_rate = net / retail if retail else None
+    return yield_rate, yield_rate
+
+
+def compute_model_decision(
+    *,
+    procurement_row,
+    current_listing,
+    platform,
+    data_event_type="updated",
+    last_data_event_at=None,
+):
+    """Build the canonical decision payload for one model row.
+
+    Parameters
+    ----------
+    procurement_row : dict
+        SummaryAPIView procurement row. Must include ``best_channel``,
+        ``options`` (list) and ``requires_currency_conversion``.
+    current_listing : dict or None
+        Currently active listing payload for the selected platform.
+    platform : ResalePlatform or None
+        Selected resale platform used for fee/yield lookup.
+    data_event_type : str
+        ``updated`` | ``collection_failed`` | ``source_disabled`` |
+        ``reconciliation_anomaly`` | ``stale``.
+    last_data_event_at : datetime or None
+        Timestamp of the most recent data event for the row.
+    """
+    best_channel = (procurement_row or {}).get("best_channel") or None
+    options = list((procurement_row or {}).get("options") or [])
+    requires_currency_conversion = bool(
+        (best_channel or {}).get("requires_currency_conversion")
+        or (procurement_row or {}).get(
+            "requires_currency_conversion",
+        )
+    )
+    is_listed = bool(
+        (current_listing or {}).get("is_listed", bool(current_listing))
+    )
+    listing_requires_currency_conversion = bool(
+        (current_listing or {}).get("requires_currency_conversion")
+    )
+
+    if best_channel is None:
+        status = DECISION_STATUS_NO_SUPPLY
+    elif requires_currency_conversion or listing_requires_currency_conversion:
+        status = DECISION_STATUS_CURRENCY_UNRESOLVED
+    elif platform is None or not _fee_config_resolved(platform):
+        status = DECISION_STATUS_PLATFORM_FEE_UNRESOLVED
+    elif is_listed:
+        if "cost_input_price_per_million" in (current_listing or {}):
+            cost_input = _decimal(
+                (current_listing or {}).get(
+                    "cost_input_price_per_million"
+                ),
+            )
+        else:
+            cost_input = _decimal(best_channel.get("input_price_per_million"))
+        if "cost_output_price_per_million" in (current_listing or {}):
+            cost_output = _decimal(
+                (current_listing or {}).get(
+                    "cost_output_price_per_million"
+                ),
+            )
+        else:
+            cost_output = _decimal(
+                best_channel.get("output_price_per_million")
+            )
+        retail_input = _decimal(
+            (current_listing or {}).get(
+                "retail_input_price_per_million"
+            )
+        )
+        retail_output = _decimal(
+            (current_listing or {}).get(
+                "retail_output_price_per_million"
+            )
+        )
+        input_yield, _ = _compute_yield(retail_input, cost_input, platform)
+        _, output_yield = _compute_yield(
+            retail_output, cost_output, platform
+        )
+        yield_warning = Decimal(str(platform.yield_warning))
+        below_warning = (
+            (input_yield is not None and input_yield < yield_warning)
+            or (
+                output_yield is not None
+                and output_yield < yield_warning
+            )
+        )
+        listing_channel_id = (current_listing or {}).get("channel_id")
+        on_lowest = (
+            listing_channel_id is None
+            or listing_channel_id == best_channel.get("channel_id")
+        )
+        if below_warning:
+            status = DECISION_STATUS_LOW_YIELD
+        elif not on_lowest:
+            status = DECISION_STATUS_NOT_LOWEST_CHANNEL
+        elif len(options) <= 1:
+            status = DECISION_STATUS_SINGLE_CHANNEL
+        else:
+            status = DECISION_STATUS_READY
+        return {
+            "decision_status": status,
+            "decision_action": _DECISION_ACTION_ZH[status],
+            "decision_priority": _DECISION_PRIORITY[status],
+            "input_yield": input_yield,
+            "output_yield": output_yield,
+            "data_event_type": data_event_type,
+            "last_data_event_at": (
+                last_data_event_at.isoformat()
+                if last_data_event_at is not None
+                else None
+            ),
+            "is_data_anomaly": data_event_type
+            in DECISION_ANOMALY_EVENT_TYPES,
+        }
+    else:
+        status = DECISION_STATUS_UNLISTED
+
+    return {
+        "decision_status": status,
+        "decision_action": _DECISION_ACTION_ZH[status],
+        "decision_priority": _DECISION_PRIORITY[status],
+        "input_yield": None,
+        "output_yield": None,
+        "data_event_type": data_event_type,
+        "last_data_event_at": (
+            last_data_event_at.isoformat()
+            if last_data_event_at is not None
+            else None
+        ),
+        "is_data_anomaly": data_event_type
+        in DECISION_ANOMALY_EVENT_TYPES,
+    }

--- a/backend/llm_ops/tests/test_serializers.py
+++ b/backend/llm_ops/tests/test_serializers.py
@@ -266,6 +266,41 @@ class ResalePlatformSerializerTests(TestCase):
         self.assertFalse(serializer.is_valid())
         self.assertIn("service_fee_rate", serializer.errors)
 
+    def test_validates_nullable_yield_configuration(self):
+        serializer = ResalePlatformSerializer(
+            data={
+                "name": "Agione Test",
+                "code": "agione-test",
+                "currency": "CNY",
+                "points_per_currency_unit": "100",
+                "tax_rate": None,
+                "settlement_rate": None,
+                "yield_warning": None,
+                "yield_target": None,
+            }
+        )
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+        invalid_serializer = ResalePlatformSerializer(
+            data={
+                "name": "Agione Invalid",
+                "code": "agione-invalid",
+                "currency": "CNY",
+                "points_per_currency_unit": "100",
+                "tax_rate": "1.2",
+                "settlement_rate": "0",
+                "yield_warning": "-0.01",
+                "yield_target": "-0.01",
+            }
+        )
+
+        self.assertFalse(invalid_serializer.is_valid())
+        self.assertIn("tax_rate", invalid_serializer.errors)
+        self.assertIn("settlement_rate", invalid_serializer.errors)
+        self.assertIn("yield_warning", invalid_serializer.errors)
+        self.assertIn("yield_target", invalid_serializer.errors)
+
     def test_rejects_negative_auto_approve_margin(self):
         serializer = ResalePlatformSerializer(
             data={

--- a/backend/llm_ops/tests/test_services.py
+++ b/backend/llm_ops/tests/test_services.py
@@ -32,6 +32,7 @@ from llm_ops.services import (
     resolve_channel_model_price,
     resolve_resale_listing_currency,
     sync_channel_price_items,
+    sync_dependent_channel_price_items_for_price_items,
 )
 
 
@@ -417,6 +418,55 @@ class LLMOpsPricingServiceTests(TestCase):
         self.assertEqual(items[0].base_price_item, supplier_item)
         self.assertEqual(items[0].unit_price, Decimal("1.500000"))
         self.assertEqual(cost, Decimal("1.500000"))
+
+    def test_sync_dependent_channel_items_after_source_price_change(self):
+        supplier_source = PriceCollectionSource.objects.create(
+            name="Supplier A",
+            slug="supplier-a",
+            provider=self.provider,
+            source_category=PriceCollectionSource.SOURCE_CATEGORY_SUPPLIER,
+            currency="USD",
+        )
+        base_item = ModelPriceItem.objects.create(
+            provider=self.provider,
+            model=self.model,
+            source=supplier_source,
+            dimension=ModelPriceItem.DIMENSION_TEXT_INPUT,
+            billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
+            currency="USD",
+            unit_price=Decimal("2.5"),
+            price_fingerprint="supplier-input-v1",
+            is_current=True,
+        )
+        price = ChannelModelPrice.objects.create(
+            channel=self.channel,
+            model=self.model,
+            price_source=supplier_source,
+            settlement_ratio=Decimal("0.8"),
+        )
+        sync_channel_price_items(price)
+        self.assertEqual(
+            ChannelPriceItem.objects.get(is_current=True).unit_price,
+            Decimal("2.000000"),
+        )
+
+        base_item.unit_price = Decimal("3.5")
+        base_item.price_fingerprint = "supplier-input-v2"
+        base_item.save(update_fields=["unit_price", "price_fingerprint"])
+        result = sync_dependent_channel_price_items_for_price_items(
+            [base_item],
+        )
+
+        self.assertEqual(result["channel_model_prices"], 1)
+        self.assertEqual(result["channel_price_items"], 1)
+        self.assertEqual(
+            ChannelPriceItem.objects.get(is_current=True).unit_price,
+            Decimal("2.800000"),
+        )
+        self.assertEqual(
+            ChannelPriceItem.objects.filter(is_current=False).count(),
+            1,
+        )
 
     def test_sync_does_not_fallback_when_selected_source_has_no_items(self):
         official_source = PriceCollectionSource.objects.create(
@@ -876,6 +926,65 @@ class LLMOpsPricingServiceTests(TestCase):
             .values_list("dimension", flat=True)
             .get(),
             ModelPriceItem.DIMENSION_TEXT_OUTPUT,
+        )
+
+    def test_manual_import_resyncs_dependent_channel_prices(self):
+        source = PriceCollectionSource.objects.create(
+            provider=self.provider,
+            name="Supplier Sheet",
+            slug="supplier-sheet-resync",
+            source_category=PriceCollectionSource.SOURCE_CATEGORY_SUPPLIER,
+            currency="USD",
+            updates_model_prices=False,
+        )
+        import_manual_model_prices(
+            source=source,
+            provider=self.provider,
+            rows=[
+                {
+                    "model_code": "gpt-4o",
+                    "model_name": "GPT-4o",
+                    "currency": "USD",
+                    "input_price_per_million": Decimal("1.5"),
+                }
+            ],
+            default_currency="USD",
+            updates_model_prices=False,
+        )
+        price = ChannelModelPrice.objects.create(
+            channel=self.channel,
+            model=self.model,
+            price_source=source,
+            settlement_ratio=Decimal("0.8"),
+        )
+        sync_channel_price_items(price)
+        self.assertEqual(
+            ChannelPriceItem.objects.get(is_current=True).unit_price,
+            Decimal("1.200000"),
+        )
+
+        result = import_manual_model_prices(
+            source=source,
+            provider=self.provider,
+            rows=[
+                {
+                    "model_code": "gpt-4o",
+                    "model_name": "GPT-4o",
+                    "currency": "USD",
+                    "input_price_per_million": Decimal("2.5"),
+                }
+            ],
+            default_currency="USD",
+            updates_model_prices=False,
+        )
+
+        self.assertEqual(
+            result["channel_price_sync"]["channel_model_prices"],
+            1,
+        )
+        self.assertEqual(
+            ChannelPriceItem.objects.get(is_current=True).unit_price,
+            Decimal("2.000000"),
         )
 
     def test_manual_import_keeps_current_rows_when_write_fails(self):

--- a/backend/llm_ops/tests/test_views.py
+++ b/backend/llm_ops/tests/test_views.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
+from django.utils import timezone
 from rest_framework.test import APIClient
 
 from llm_ops.models import (
@@ -3492,6 +3493,663 @@ class LLMOpsViewTests(TestCase):
             100.0,
         )
 
+    def test_summary_decision_fields_for_listed_model(self):
+        from llm_ops.services import compute_model_decision
+        provider = LLMProvider.objects.create(name="Anthropic", code="anthropic")
+        model = LLMModel.objects.create(
+            provider=provider,
+            name="Claude-Test",
+            code="claude-test",
+            input_price_per_million="10",
+            output_price_per_million="30",
+        )
+        channel = ProcurementChannel.objects.create(
+            name="Channel-A",
+            code="channel-a",
+        )
+        platform, _ = ResalePlatform.objects.get_or_create(
+            code="agione-fee",
+            defaults={
+                "name": "Agione Fee",
+                "fee_rate": "0.05",
+                "service_fee_rate": "0.02",
+                "tax_rate": "0.06",
+                "settlement_rate": "0.95",
+                "yield_warning": "0.15",
+            },
+        )
+        ChannelModelPrice.objects.create(
+            channel=channel,
+            model=model,
+            is_listed=True,
+        )
+        self._create_online_listing(
+            platform=platform,
+            model=model,
+            channel=channel,
+            retail_input_price_per_million="30",
+            retail_output_price_per_million="90",
+        )
+        response = self.client.get(
+            reverse("llm-ops-summary"),
+            {"resale_platform": platform.id},
+        )
+        self.assertEqual(response.status_code, 200)
+        diagnostic = response.data["agione"]["diagnostics"][0]
+        for key in (
+            "decision_status",
+            "decision_action",
+            "decision_priority",
+            "yield_metrics",
+            "recommended_channel",
+            "current_listing",
+            "data_event_type",
+            "last_data_event_at",
+            "is_data_anomaly",
+        ):
+            self.assertIn(key, diagnostic)
+        self.assertEqual(diagnostic["decision_status"], "single_channel")
+        self.assertEqual(diagnostic["yield_metrics"]["is_resolved"], True)
+        self.assertEqual(diagnostic["current_listing"]["is_listed"], True)
+        self.assertEqual(diagnostic["data_event_type"], "updated")
+        self.assertEqual(diagnostic["is_data_anomaly"], False)
+        self.assertEqual(
+            compute_model_decision.__name__,
+            "compute_model_decision",
+        )
+
+    def test_summary_decision_treats_auto_listing_as_lowest_channel(self):
+        provider = LLMProvider.objects.create(
+            name="Auto Provider",
+            code="auto-provider",
+        )
+        model = LLMModel.objects.create(
+            provider=provider,
+            name="Auto-Test",
+            code="auto-test",
+            input_price_per_million="10",
+            output_price_per_million="20",
+        )
+        cheap_channel = ProcurementChannel.objects.create(
+            name="Cheap Channel",
+            code="cheap-channel",
+        )
+        backup_channel = ProcurementChannel.objects.create(
+            name="Backup Channel",
+            code="backup-channel",
+        )
+        platform = ResalePlatform.objects.create(
+            code="agione-auto",
+            name="Agione Auto",
+            fee_rate="0.05",
+            service_fee_rate="0.02",
+            tax_rate="0.06",
+            settlement_rate="0.95",
+            yield_warning="0.15",
+        )
+        ChannelModelPrice.objects.create(
+            channel=cheap_channel,
+            model=model,
+            is_listed=True,
+            custom_input_price_per_million="1",
+            custom_output_price_per_million="2",
+        )
+        ChannelModelPrice.objects.create(
+            channel=backup_channel,
+            model=model,
+            is_listed=True,
+            custom_input_price_per_million="3",
+            custom_output_price_per_million="4",
+        )
+        self._create_online_listing(
+            platform=platform,
+            model=model,
+            retail_input_price_per_million="10",
+            retail_output_price_per_million="20",
+        )
+
+        response = self.client.get(
+            reverse("llm-ops-summary"),
+            {"resale_platform": platform.id},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        diagnostic = response.data["agione"]["diagnostics"][0]
+        self.assertTrue(diagnostic["has_lowest_listing"])
+        self.assertEqual(diagnostic["decision_status"], "ready")
+        self.assertIsNone(diagnostic["current_listing"]["channel_id"])
+
+    def test_summary_marks_latest_failed_collection_as_data_anomaly(self):
+        provider = LLMProvider.objects.create(
+            name="Failed Provider",
+            code="failed-provider",
+        )
+        model = LLMModel.objects.create(
+            provider=provider,
+            name="Failed-Test",
+            code="failed-test",
+            input_price_per_million="1",
+            output_price_per_million="2",
+        )
+        channel = ProcurementChannel.objects.create(
+            name="Failed Channel",
+            code="failed-channel",
+        )
+        source = PriceCollectionSource.objects.create(
+            name="Failed Source",
+            slug="failed-source",
+            is_enabled=True,
+        )
+        platform = ResalePlatform.objects.create(
+            code="agione-failed-source",
+            name="Agione Failed Source",
+            fee_rate="0.05",
+            service_fee_rate="0.02",
+            tax_rate="0.06",
+            settlement_rate="0.95",
+            yield_warning="0.15",
+        )
+        ChannelModelPrice.objects.create(
+            channel=channel,
+            model=model,
+            price_source=source,
+            is_listed=True,
+            custom_input_price_per_million="1",
+            custom_output_price_per_million="2",
+        )
+        PriceCollectionRun.objects.create(
+            source=source,
+            status=PriceCollectionRun.STATUS_FAILED,
+            error_message="upstream timeout",
+        )
+        self._create_online_listing(
+            platform=platform,
+            model=model,
+            channel=channel,
+            retail_input_price_per_million="10",
+            retail_output_price_per_million="20",
+        )
+
+        response = self.client.get(
+            reverse("llm-ops-summary"),
+            {"resale_platform": platform.id},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        diagnostic = response.data["agione"]["diagnostics"][0]
+        self.assertEqual(diagnostic["data_event_type"], "collection_failed")
+        self.assertTrue(diagnostic["is_data_anomaly"])
+
+    def test_summary_decision_prefers_lowest_listing_payload(self):
+        provider = LLMProvider.objects.create(
+            name="Multi Listing Provider",
+            code="multi-listing-provider",
+        )
+        model = LLMModel.objects.create(
+            provider=provider,
+            name="Multi-Listing-Test",
+            code="multi-listing-test",
+            input_price_per_million="10",
+            output_price_per_million="20",
+        )
+        backup_channel = ProcurementChannel.objects.create(
+            name="A Backup Channel",
+            code="a-backup-channel",
+        )
+        cheap_channel = ProcurementChannel.objects.create(
+            name="Z Cheap Channel",
+            code="z-cheap-channel",
+        )
+        platform = ResalePlatform.objects.create(
+            code="agione-multi-listing",
+            name="Agione Multi Listing",
+            fee_rate="0.05",
+            service_fee_rate="0.02",
+            tax_rate="0.06",
+            settlement_rate="0.95",
+            yield_warning="0.15",
+        )
+        ChannelModelPrice.objects.create(
+            channel=backup_channel,
+            model=model,
+            is_listed=True,
+            custom_input_price_per_million="5",
+            custom_output_price_per_million="10",
+        )
+        ChannelModelPrice.objects.create(
+            channel=cheap_channel,
+            model=model,
+            is_listed=True,
+            custom_input_price_per_million="1",
+            custom_output_price_per_million="2",
+        )
+        self._create_online_listing(
+            platform=platform,
+            model=model,
+            channel=backup_channel,
+            retail_input_price_per_million="5.5",
+            retail_output_price_per_million="11",
+        )
+        self._create_online_listing(
+            platform=platform,
+            model=model,
+            channel=cheap_channel,
+            retail_input_price_per_million="10",
+            retail_output_price_per_million="20",
+        )
+
+        response = self.client.get(
+            reverse("llm-ops-summary"),
+            {"resale_platform": platform.id},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        diagnostic = response.data["agione"]["diagnostics"][0]
+        self.assertTrue(diagnostic["has_lowest_listing"])
+        self.assertEqual(diagnostic["decision_status"], "ready")
+        self.assertEqual(
+            diagnostic["current_listing"]["channel_id"],
+            cheap_channel.id,
+        )
+
+    def test_summary_ignores_backup_channel_source_anomaly(self):
+        provider = LLMProvider.objects.create(
+            name="Backup Source Provider",
+            code="backup-source-provider",
+        )
+        model = LLMModel.objects.create(
+            provider=provider,
+            name="Backup-Source-Test",
+            code="backup-source-test",
+            input_price_per_million="1",
+            output_price_per_million="2",
+        )
+        best_channel = ProcurementChannel.objects.create(
+            name="Best Source Channel",
+            code="best-source-channel",
+        )
+        backup_channel = ProcurementChannel.objects.create(
+            name="Backup Source Channel",
+            code="backup-source-channel",
+        )
+        healthy_source = PriceCollectionSource.objects.create(
+            name="Healthy Source",
+            slug="healthy-source",
+            is_enabled=True,
+        )
+        failed_source = PriceCollectionSource.objects.create(
+            name="Failed Backup Source",
+            slug="failed-backup-source",
+            is_enabled=True,
+        )
+        platform = ResalePlatform.objects.create(
+            code="agione-backup-source",
+            name="Agione Backup Source",
+            fee_rate="0.05",
+            service_fee_rate="0.02",
+            tax_rate="0.06",
+            settlement_rate="0.95",
+            yield_warning="0.15",
+        )
+        ChannelModelPrice.objects.create(
+            channel=best_channel,
+            model=model,
+            price_source=healthy_source,
+            is_listed=True,
+            custom_input_price_per_million="1",
+            custom_output_price_per_million="2",
+        )
+        ChannelModelPrice.objects.create(
+            channel=backup_channel,
+            model=model,
+            price_source=failed_source,
+            is_listed=True,
+            custom_input_price_per_million="5",
+            custom_output_price_per_million="10",
+        )
+        PriceCollectionRun.objects.create(
+            source=failed_source,
+            status=PriceCollectionRun.STATUS_FAILED,
+            error_message="backup timeout",
+        )
+        self._create_online_listing(
+            platform=platform,
+            model=model,
+            channel=best_channel,
+            retail_input_price_per_million="10",
+            retail_output_price_per_million="20",
+        )
+
+        response = self.client.get(
+            reverse("llm-ops-summary"),
+            {"resale_platform": platform.id},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        diagnostic = response.data["agione"]["diagnostics"][0]
+        self.assertEqual(diagnostic["data_event_type"], "updated")
+        self.assertFalse(diagnostic["is_data_anomaly"])
+
+    def test_summary_decision_platform_fee_unresolved_when_unset(self):
+        provider = LLMProvider.objects.create(name="OpenAI", code="openai")
+        model = LLMModel.objects.create(
+            provider=provider,
+            name="GPT-Fee",
+            code="gpt-fee",
+            input_price_per_million="1",
+            output_price_per_million="2",
+        )
+        channel = ProcurementChannel.objects.create(
+            name="Channel-X",
+            code="channel-x",
+        )
+        platform, _ = ResalePlatform.objects.get_or_create(
+            code="agione-empty",
+            defaults={"name": "Agione Empty"},
+        )
+        ChannelModelPrice.objects.create(
+            channel=channel,
+            model=model,
+            is_listed=True,
+        )
+        self._create_online_listing(
+            platform=platform,
+            model=model,
+            channel=channel,
+            retail_input_price_per_million="1.2",
+            retail_output_price_per_million="2.4",
+        )
+        response = self.client.get(
+            reverse("llm-ops-summary"),
+            {"resale_platform": platform.id},
+        )
+        diagnostic = response.data["agione"]["diagnostics"][0]
+        self.assertEqual(
+            diagnostic["decision_status"],
+            "platform_fee_unresolved",
+        )
+        self.assertIsNone(diagnostic["yield_metrics"]["tax_rate"])
+        self.assertFalse(diagnostic["yield_metrics"]["is_resolved"])
+
+    def test_summary_decision_marks_unconvertible_channel_currency(self):
+        provider = LLMProvider.objects.create(
+            name="Currency Provider",
+            code="currency-provider",
+        )
+        model = LLMModel.objects.create(
+            provider=provider,
+            name="Currency-Test",
+            code="currency-test",
+            input_price_per_million="1",
+            output_price_per_million="2",
+        )
+        channel = ProcurementChannel.objects.create(
+            name="EUR Channel",
+            code="eur-channel",
+            currency="EUR",
+        )
+        cny_channel = ProcurementChannel.objects.create(
+            name="CNY Channel",
+            code="currency-cny-channel",
+            currency="CNY",
+        )
+        platform = ResalePlatform.objects.create(
+            code="agione-currency",
+            name="Agione Currency",
+            fee_rate="0.05",
+            service_fee_rate="0.02",
+            tax_rate="0.06",
+            settlement_rate="0.95",
+            yield_warning="0.15",
+        )
+        ChannelModelPrice.objects.create(
+            channel=channel,
+            model=model,
+            is_listed=True,
+        )
+        ChannelModelPrice.objects.create(
+            channel=cny_channel,
+            model=model,
+            is_listed=True,
+        )
+
+        response = self.client.get(
+            reverse("llm-ops-summary"),
+            {
+                "display_currency": "CNY",
+                "resale_platform": platform.id,
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        diagnostic = response.data["agione"]["diagnostics"][0]
+        self.assertEqual(diagnostic["decision_status"], "currency_unresolved")
+        self.assertEqual(
+            diagnostic["recommended_channel"]["channel_id"],
+            cny_channel.id,
+        )
+        self.assertTrue(diagnostic["requires_currency_conversion"])
+
+    def test_summary_decision_uses_implicit_price_source_for_anomaly(self):
+        provider = LLMProvider.objects.create(
+            name="Implicit Source Provider",
+            code="implicit-source-provider",
+        )
+        model = LLMModel.objects.create(
+            provider=provider,
+            name="Implicit-Source-Test",
+            code="implicit-source-test",
+        )
+        channel = ProcurementChannel.objects.create(
+            name="Implicit Source Channel",
+            code="implicit-source-channel",
+        )
+        source = PriceCollectionSource.objects.create(
+            name="Implicit Disabled Source",
+            slug="implicit-disabled-source",
+            provider=provider,
+            is_enabled=False,
+        )
+        platform = ResalePlatform.objects.create(
+            code="agione-implicit-source",
+            name="Agione Implicit Source",
+            fee_rate="0.05",
+            service_fee_rate="0.02",
+            tax_rate="0.06",
+            settlement_rate="0.95",
+            yield_warning="0.15",
+        )
+        for dimension, unit_price, fingerprint in (
+            (
+                ModelPriceItem.DIMENSION_TEXT_INPUT,
+                "1",
+                "implicit-input",
+            ),
+            (
+                ModelPriceItem.DIMENSION_TEXT_OUTPUT,
+                "2",
+                "implicit-output",
+            ),
+        ):
+            ModelPriceItem.objects.create(
+                source=source,
+                provider=provider,
+                model=model,
+                meta_model=model.meta_model,
+                dimension=dimension,
+                billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
+                currency="USD",
+                unit_price=unit_price,
+                price_fingerprint=fingerprint,
+            )
+        ChannelModelPrice.objects.create(
+            channel=channel,
+            model=model,
+            is_listed=True,
+        )
+
+        response = self.client.get(
+            reverse("llm-ops-summary"),
+            {"resale_platform": platform.id},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        diagnostic = response.data["agione"]["diagnostics"][0]
+        self.assertEqual(diagnostic["data_event_type"], "source_disabled")
+        self.assertTrue(diagnostic["is_data_anomaly"])
+
+    def test_summary_decision_updated_time_uses_channel_price_time(self):
+        provider = LLMProvider.objects.create(
+            name="Updated Provider",
+            code="updated-provider",
+        )
+        model = LLMModel.objects.create(
+            provider=provider,
+            name="Updated-Test",
+            code="updated-test",
+            input_price_per_million="1",
+            output_price_per_million="2",
+        )
+        channel = ProcurementChannel.objects.create(
+            name="Updated Channel",
+            code="updated-channel",
+        )
+        platform = ResalePlatform.objects.create(
+            code="agione-updated",
+            name="Agione Updated",
+            fee_rate="0.05",
+            service_fee_rate="0.02",
+            tax_rate="0.06",
+            settlement_rate="0.95",
+            yield_warning="0.15",
+        )
+        channel_price = ChannelModelPrice.objects.create(
+            channel=channel,
+            model=model,
+            is_listed=True,
+        )
+        old_time = timezone.now().replace(microsecond=0)
+        old_time = old_time - timezone.timedelta(days=2)
+        price_time = old_time + timezone.timedelta(days=1)
+        LLMModel.objects.filter(id=model.id).update(updated_at=old_time)
+        ChannelModelPrice.objects.filter(id=channel_price.id).update(
+            updated_at=price_time,
+        )
+
+        response = self.client.get(
+            reverse("llm-ops-summary"),
+            {"resale_platform": platform.id},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        diagnostic = response.data["agione"]["diagnostics"][0]
+        self.assertEqual(diagnostic["data_event_type"], "updated")
+        self.assertEqual(
+            diagnostic["last_data_event_at"],
+            price_time.isoformat(),
+        )
+
+    def test_summary_decision_current_listing_uses_display_currency(self):
+        provider = LLMProvider.objects.create(
+            name="Display Provider",
+            code="display-provider",
+        )
+        model = LLMModel.objects.create(
+            provider=provider,
+            name="Display-Test",
+            code="display-test",
+            input_price_per_million="1",
+            output_price_per_million="2",
+        )
+        channel = ProcurementChannel.objects.create(
+            name="Display Channel",
+            code="display-channel",
+            currency="CNY",
+        )
+        platform = ResalePlatform.objects.create(
+            code="agione-display",
+            name="Agione Display",
+            fee_rate="0.05",
+            service_fee_rate="0.02",
+            tax_rate="0.06",
+            settlement_rate="0.95",
+            yield_warning="0.15",
+        )
+        ChannelModelPrice.objects.create(
+            channel=channel,
+            model=model,
+            is_listed=True,
+        )
+        self._create_online_listing(
+            platform=platform,
+            model=model,
+            channel=channel,
+            currency="USD",
+            retail_input_price_per_million="10",
+            retail_output_price_per_million="20",
+        )
+
+        response = self.client.get(
+            reverse("llm-ops-summary"),
+            {
+                "display_currency": "CNY",
+                "resale_platform": platform.id,
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        diagnostic = response.data["agione"]["diagnostics"][0]
+        self.assertEqual(diagnostic["current_listing"]["currency"], "CNY")
+
+    def test_summary_decision_yield_config_resolved_with_zero_listing(self):
+        provider = LLMProvider.objects.create(
+            name="Zero Provider",
+            code="zero-provider",
+        )
+        model = LLMModel.objects.create(
+            provider=provider,
+            name="Zero-Test",
+            code="zero-test",
+            input_price_per_million="1",
+            output_price_per_million="2",
+        )
+        channel = ProcurementChannel.objects.create(
+            name="Zero Channel",
+            code="zero-channel",
+        )
+        platform = ResalePlatform.objects.create(
+            code="agione-zero",
+            name="Agione Zero",
+            fee_rate="0.05",
+            service_fee_rate="0.02",
+            tax_rate="0.06",
+            settlement_rate="0.95",
+            yield_warning="0.15",
+        )
+        ChannelModelPrice.objects.create(
+            channel=channel,
+            model=model,
+            is_listed=True,
+        )
+        self._create_online_listing(
+            platform=platform,
+            model=model,
+            channel=channel,
+            retail_input_price_per_million="0",
+            retail_output_price_per_million="0",
+        )
+
+        response = self.client.get(
+            reverse("llm-ops-summary"),
+            {"resale_platform": platform.id},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        diagnostic = response.data["agione"]["diagnostics"][0]
+        self.assertEqual(diagnostic["decision_status"], "low_yield")
+        self.assertEqual(diagnostic["yield_metrics"]["input_yield"], -1.0)
+        self.assertTrue(diagnostic["yield_metrics"]["is_resolved"])
+
     def test_summary_uses_selected_resale_platform(self):
         provider = LLMProvider.objects.create(name="OpenAI", code="openai")
         model = LLMModel.objects.create(
@@ -3654,5 +4312,10 @@ class LLMOpsViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         diagnostic = response.data["agione"]["diagnostics"][0]
         self.assertEqual(diagnostic["status"], "missing_channel")
-        self.assertFalse(diagnostic["is_agione_listed"])
+        self.assertTrue(diagnostic["is_agione_listed"])
+        self.assertEqual(diagnostic["decision_status"], "no_supply")
+        self.assertEqual(
+            diagnostic["current_listing"]["channel_id"],
+            channel.id,
+        )
         self.assertEqual(response.data["listings"], [])

--- a/backend/llm_ops/tests/test_views.py
+++ b/backend/llm_ops/tests/test_views.py
@@ -27,6 +27,7 @@ from llm_ops.models import (
     ResaleListingPriceHistory,
     ResalePlatform,
     ResaleWorkflowConfig,
+    UsageReconciliationRecord,
 )
 from llm_ops.services import sync_channel_price_items
 
@@ -186,6 +187,144 @@ class LLMOpsViewTests(TestCase):
             },
             {"gpt-4o"},
         )
+
+    def test_resale_listing_list_filters_by_platform_and_status(self):
+        provider = LLMProvider.objects.create(name="OpenAI", code="openai")
+        meta_model = MetaModel.objects.create(
+            code="gpt-4o",
+            name="GPT-4o",
+            owner_code="openai",
+            owner_name="OpenAI",
+        )
+        model = LLMModel.objects.create(
+            provider=provider,
+            meta_model=meta_model,
+            name="GPT-4o",
+            code="gpt-4o",
+        )
+        channel = ProcurementChannel.objects.create(
+            name="Primary",
+            code="primary",
+        )
+        agione = ResalePlatform.objects.create(
+            name="Agione",
+            code="agione-filter",
+        )
+        marketplace = ResalePlatform.objects.create(
+            name="Marketplace",
+            code="marketplace-filter",
+        )
+        online_listing = self._create_online_listing(
+            platform=agione,
+            model=model,
+            meta_model=meta_model,
+            channel=channel,
+        )
+        ResaleListing.objects.create(
+            platform=agione,
+            model=model,
+            meta_model=meta_model,
+            channel=None,
+            publish_status=ResaleListing.PUBLISH_NONE,
+            workflow_status=ResaleListing.WORKFLOW_DRAFT,
+        )
+        self._create_online_listing(
+            platform=marketplace,
+            model=model,
+            meta_model=meta_model,
+            channel=channel,
+        )
+
+        response = self.client.get(
+            reverse("resale-listing-list"),
+            {
+                "platform": agione.id,
+                "publish_status": ResaleListing.PUBLISH_ONLINE,
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["id"], online_listing.id)
+
+    def test_reconciliation_list_filters_by_platform_and_status(self):
+        provider = LLMProvider.objects.create(name="OpenAI", code="openai")
+        meta_model = MetaModel.objects.create(
+            code="gpt-4o",
+            name="GPT-4o",
+            owner_code="openai",
+            owner_name="OpenAI",
+        )
+        listed_model = LLMModel.objects.create(
+            provider=provider,
+            meta_model=meta_model,
+            name="GPT-4o",
+            code="gpt-4o",
+        )
+        other_model = LLMModel.objects.create(
+            provider=provider,
+            meta_model=meta_model,
+            name="GPT-4o Mini",
+            code="gpt-4o-mini",
+        )
+        channel = ProcurementChannel.objects.create(
+            name="Primary",
+            code="primary",
+        )
+        agione = ResalePlatform.objects.create(
+            name="Agione",
+            code="agione-reconciliation",
+        )
+        marketplace = ResalePlatform.objects.create(
+            name="Marketplace",
+            code="marketplace-reconciliation",
+        )
+        self._create_online_listing(
+            platform=agione,
+            model=listed_model,
+            meta_model=meta_model,
+            channel=channel,
+        )
+        self._create_online_listing(
+            platform=marketplace,
+            model=other_model,
+            meta_model=meta_model,
+            channel=channel,
+        )
+        target_record = UsageReconciliationRecord.objects.create(
+            date=timezone.localdate(),
+            channel=channel,
+            model=listed_model,
+            meta_model=meta_model,
+            charged_amount=Decimal("12.000000"),
+            expected_amount=Decimal("10.000000"),
+            discrepancy=Decimal("2.000000"),
+            discrepancy_percent=Decimal("20.0000"),
+            status=UsageReconciliationRecord.STATUS_OVERCHARGED,
+        )
+        UsageReconciliationRecord.objects.create(
+            date=timezone.localdate(),
+            channel=channel,
+            model=other_model,
+            meta_model=meta_model,
+            charged_amount=Decimal("8.000000"),
+            expected_amount=Decimal("10.000000"),
+            discrepancy=Decimal("-2.000000"),
+            discrepancy_percent=Decimal("-20.0000"),
+            status=UsageReconciliationRecord.STATUS_UNDERCHARGED,
+        )
+
+        response = self.client.get(
+            reverse("reconciliation-record-list"),
+            {
+                "platform": agione.id,
+                "status": UsageReconciliationRecord.STATUS_OVERCHARGED,
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["id"], target_record.id)
 
     def test_meta_model_owner_summary_reads_current_catalog(self):
         MetaModel.objects.create(
@@ -1024,6 +1163,60 @@ class LLMOpsViewTests(TestCase):
             "0.150000",
         )
         self.assertEqual(audit.changes["unit_price"]["after"], "0.120000")
+
+    def test_model_price_item_update_resyncs_channel_prices(self):
+        provider = LLMProvider.objects.create(name="OpenAI", code="openai")
+        source = PriceCollectionSource.objects.create(
+            name="Supplier Source",
+            slug="supplier-source-resync",
+            provider=provider,
+            source_category=PriceCollectionSource.SOURCE_CATEGORY_SUPPLIER,
+            currency="USD",
+        )
+        model = LLMModel.objects.create(
+            provider=provider,
+            source=source,
+            name="GPT-4o mini",
+            code="gpt-4o-mini",
+        )
+        channel = ProcurementChannel.objects.create(
+            name="Supplier Channel",
+            code="supplier-channel-resync",
+            currency="USD",
+            settlement_ratio=Decimal("0.8"),
+        )
+        item = ModelPriceItem.objects.create(
+            provider=provider,
+            model=model,
+            source=source,
+            dimension=ModelPriceItem.DIMENSION_TEXT_INPUT,
+            billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
+            currency="USD",
+            unit_price=Decimal("1.000000"),
+            price_fingerprint="supplier-input-before",
+        )
+        price = ChannelModelPrice.objects.create(
+            channel=channel,
+            model=model,
+            price_source=source,
+        )
+        sync_channel_price_items(price)
+        self.assertEqual(
+            ChannelPriceItem.objects.get(is_current=True).unit_price,
+            Decimal("0.800000"),
+        )
+
+        response = self.client.patch(
+            reverse("model-price-item-detail", args=[item.id]),
+            {"unit_price": "2.000000"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            ChannelPriceItem.objects.get(is_current=True).unit_price,
+            Decimal("1.600000"),
+        )
 
     def test_model_price_item_can_be_deleted(self):
         provider = LLMProvider.objects.create(name="OpenAI", code="openai")
@@ -3493,6 +3686,55 @@ class LLMOpsViewTests(TestCase):
             100.0,
         )
 
+    def test_summary_monitor_scope_omits_heavy_payloads(self):
+        provider = LLMProvider.objects.create(name="OpenAI", code="openai")
+        model = LLMModel.objects.create(
+            provider=provider,
+            name="GPT-5",
+            code="gpt-5-monitor",
+            input_price_per_million="1",
+            output_price_per_million="2",
+        )
+        channel = ProcurementChannel.objects.create(
+            name="Best Channel",
+            code="best-channel-monitor",
+        )
+        platform, _ = ResalePlatform.objects.get_or_create(
+            code="agione",
+            defaults={"name": "Agione"},
+        )
+        ChannelModelPrice.objects.create(
+            channel=channel,
+            model=model,
+            is_listed=True,
+        )
+        self._create_online_listing(
+            platform=platform,
+            model=model,
+            channel=channel,
+            retail_input_price_per_million="1.2",
+            retail_output_price_per_million="2.4",
+        )
+
+        response = self.client.get(
+            reverse("llm-ops-summary"),
+            {"scope": "monitor"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["procurement"], [])
+        self.assertEqual(response.data["listings"], [])
+        diagnostic = response.data["agione"]["diagnostics"][0]
+        self.assertNotIn("options", diagnostic)
+        self.assertEqual(diagnostic["model_id"], model.id)
+        self.assertEqual(
+            diagnostic["recommended_channel"]["channel_name"],
+            "Best Channel",
+        )
+        self.assertTrue(diagnostic["current_listing"]["is_listed"])
+        self.assertIn("decision_status", diagnostic)
+        self.assertIn("yield_metrics", diagnostic)
+
     def test_summary_decision_fields_for_listed_model(self):
         from llm_ops.services import compute_model_decision
         provider = LLMProvider.objects.create(name="Anthropic", code="anthropic")
@@ -3549,6 +3791,11 @@ class LLMOpsViewTests(TestCase):
         ):
             self.assertIn(key, diagnostic)
         self.assertEqual(diagnostic["decision_status"], "single_channel")
+        self.assertEqual(diagnostic["status_label"], "low_coverage")
+        self.assertEqual(
+            diagnostic["decision_action"],
+            "add_channel_coverage",
+        )
         self.assertEqual(diagnostic["yield_metrics"]["is_resolved"], True)
         self.assertEqual(diagnostic["current_listing"]["is_listed"], True)
         self.assertEqual(diagnostic["data_event_type"], "updated")
@@ -3618,6 +3865,11 @@ class LLMOpsViewTests(TestCase):
         self.assertTrue(diagnostic["has_lowest_listing"])
         self.assertEqual(diagnostic["decision_status"], "ready")
         self.assertIsNone(diagnostic["current_listing"]["channel_id"])
+        self.assertIsNone(diagnostic["current_listing"]["channel_name"])
+        self.assertEqual(
+            diagnostic["current_listing"]["channel_type"],
+            "auto_best",
+        )
 
     def test_summary_marks_latest_failed_collection_as_data_anomaly(self):
         provider = LLMProvider.objects.create(

--- a/backend/llm_ops/views.py
+++ b/backend/llm_ops/views.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 
 from django.db import transaction
-from django.db.models import Count, IntegerField, Max, Q
+from django.db.models import Count, IntegerField, Max, OuterRef, Q, Subquery
 from django.db.models import Value
 from django.utils.text import slugify
 from drf_spectacular.utils import extend_schema
@@ -92,6 +92,7 @@ from .services import (
     resolve_resale_listing_currency,
     selected_price_item_group,
     sync_channel_price_items,
+    sync_dependent_channel_price_items_for_price_items,
 )
 from .source_collectors import source_supports_code_collection
 from .tasks import collect_price_source_prices, run_model_price_sync_agent
@@ -230,15 +231,22 @@ class PriceCollectionSourceViewSet(
                 current_price_item_count=Count(
                     "model_price_items",
                     filter=Q(model_price_items__is_current=True),
+                    distinct=True,
                 ),
                 current_meta_model_count=Count(
                     "model_price_items__meta_model",
                     filter=Q(model_price_items__is_current=True),
                     distinct=True,
                 ),
-            )
-            .prefetch_related(
-                "models__meta_model",
+                latest_run_status=Subquery(
+                    PriceCollectionRun.objects.filter(
+                        source=OuterRef("pk"),
+                    )
+                    .order_by("-started_at", "-id")
+                    .values("status")[:1],
+                ),
+                model_count=Count("models", distinct=True),
+                price_item_count=Count("model_price_items", distinct=True),
             )
         )
         search = self.request.query_params.get("search")
@@ -1017,6 +1025,8 @@ class ModelPriceItemViewSet(
             "sku",
             "offering",
             "source",
+            "source__channel",
+            "source__provider",
         )
         provider = self.request.query_params.get("provider")
         meta_model = self.request.query_params.get("meta_model")
@@ -1081,6 +1091,41 @@ class ModelPriceItemViewSet(
         if page is not None:
             return self.get_paginated_response(serializer.data)
         return Response(serializer.data)
+
+    def perform_update(self, serializer):
+        before = snapshot_instance(serializer.instance)
+        dependency_before = _price_item_dependency_snapshot(
+            serializer.instance,
+        )
+        price_item = serializer.save()
+        sync_dependent_channel_price_items_for_price_items(
+            [dependency_before, price_item],
+        )
+        record_audit_log(
+            request=self.request,
+            action=AuditLog.ACTION_UPDATE,
+            category=self.audit_category,
+            target=price_item,
+            summary=f"Updated model price item {price_item}",
+            before=before,
+            after=snapshot_instance(price_item),
+        )
+
+    def perform_destroy(self, instance):
+        before = snapshot_instance(instance)
+        dependency = _price_item_dependency_snapshot(instance)
+        target_repr = str(instance)
+        with transaction.atomic():
+            instance.delete()
+            sync_dependent_channel_price_items_for_price_items([dependency])
+            record_audit_log(
+                request=self.request,
+                action=AuditLog.ACTION_DELETE,
+                category=self.audit_category,
+                target="llm_ops.ModelPriceItem",
+                summary=f"Deleted model price item {target_repr}",
+                before=before,
+            )
 
 
 class ProcurementChannelViewSet(
@@ -1346,6 +1391,7 @@ class ChannelModelPriceHistoryViewSet(
             "meta_model",
             "model",
             "model__provider",
+            "price_source",
         )
         channel = self.request.query_params.get("channel")
         meta_model = self.request.query_params.get("meta_model")
@@ -1562,12 +1608,21 @@ class ResaleListingViewSet(
         platform = self.request.query_params.get("platform")
         meta_model = self.request.query_params.get("meta_model")
         model = self.request.query_params.get("model")
+        publish_status = self.request.query_params.get("publish_status")
+        workflow_status = self.request.query_params.get("workflow_status")
+        is_active = self.request.query_params.get("is_active")
         if platform:
             queryset = queryset.filter(platform_id=platform)
         if meta_model:
             queryset = queryset.filter(meta_model_id=meta_model)
         if model:
             queryset = queryset.filter(model_id=model)
+        if publish_status:
+            queryset = queryset.filter(publish_status=publish_status)
+        if workflow_status:
+            queryset = queryset.filter(workflow_status=workflow_status)
+        if is_active in {"true", "false"}:
+            queryset = queryset.filter(is_active=is_active == "true")
         return queryset.order_by("platform__name", "model__name", "id")
 
     def perform_create(self, serializer):
@@ -2184,10 +2239,24 @@ class UsageReconciliationRecordViewSet(
         )
         channel = self.request.query_params.get("channel")
         model = self.request.query_params.get("model")
+        status_value = self.request.query_params.get("status")
+        date_from = self.request.query_params.get("date_from")
+        date_to = self.request.query_params.get("date_to")
+        platform = self.request.query_params.get("platform")
         if channel:
             queryset = queryset.filter(channel_id=channel)
         if model:
             queryset = queryset.filter(model_id=model)
+        if status_value:
+            queryset = queryset.filter(status=status_value)
+        if date_from:
+            queryset = queryset.filter(date__gte=date_from)
+        if date_to:
+            queryset = queryset.filter(date__lte=date_to)
+        if platform:
+            queryset = queryset.filter(
+                model__resale_listings__platform_id=platform,
+            ).distinct()
         return queryset.order_by("-date", "-id")
 
 
@@ -2205,6 +2274,14 @@ def _decimal_or_none(value) -> Decimal | None:
     if value is None or value == "":
         return None
     return Decimal(str(value))
+
+
+def _price_item_dependency_snapshot(price_item):
+    return {
+        "model_id": price_item.model_id,
+        "meta_model_id": price_item.meta_model_id,
+        "source_id": price_item.source_id,
+    }
 
 
 def _listing_submit_status(existing: ResaleListing | None) -> dict:
@@ -2704,36 +2781,36 @@ def _diagnostic_status(
     if requires_currency_conversion:
         return {
             "status": "currency_mismatch",
-            "status_label": "需要汇率",
+            "status_label": "currency_mismatch",
             "status_priority": 1,
         }
     if not best_channel:
         return {
             "status": "missing_channel",
-            "status_label": "缺少渠道价",
+            "status_label": "missing_channel",
             "status_priority": 1,
         }
     if not is_agione_listed:
         return {
             "status": "unlisted",
-            "status_label": "未上架",
+            "status_label": "unlisted",
             "status_priority": 2,
         }
     if not has_lowest_listing:
         return {
             "status": "not_lowest",
-            "status_label": "非最低价",
+            "status_label": "not_lowest",
             "status_priority": 3,
         }
     if coverage_count <= 1:
         return {
             "status": "low_coverage",
-            "status_label": "覆盖偏少",
+            "status_label": "low_coverage",
             "status_priority": 4,
         }
     return {
         "status": "ready",
-        "status_label": "就绪",
+        "status_label": "ready",
         "status_priority": 5,
     }
 
@@ -2872,7 +2949,8 @@ def _decision_listing_payload_from_listing(
     channel = listing.channel
     return {
         "channel_id": listing.channel_id,
-        "channel_name": channel.name if channel else "自动最优",
+        "channel_name": channel.name if channel else None,
+        "channel_type": "fixed_channel" if channel else "auto_best",
         "currency": (
             currency_context.display_currency
             if not requires_currency_conversion
@@ -2905,6 +2983,216 @@ def _decision_listing_payload_from_listing(
     }
 
 
+def _summary_listing_rows(
+    *,
+    active_listings,
+    currency_context,
+    overrides,
+    price_item_indexes,
+    rows_by_model,
+    video_resolution,
+):
+    """Build full listing rows for dashboard sections that need them."""
+    listing_rows = []
+    for listing in active_listings:
+        channel = listing.channel
+        row = rows_by_model.get(listing.model_id)
+        options = row["options"] if row else []
+        if channel is None:
+            best_row = row["best_channel"] if row else None
+            if not best_row:
+                continue
+            cost_input = Decimal(
+                str(best_row["original_input_price_per_million"])
+            )
+            cost_output = Decimal(
+                str(best_row["original_output_price_per_million"])
+            )
+            cost_cache_input = Decimal(
+                str(
+                    best_row.get(
+                        "original_cache_input_price_per_million",
+                        "0",
+                    )
+                    or "0"
+                )
+            )
+            cost_currency = (
+                best_row.get("original_currency") or listing.model.currency
+            )
+        else:
+            override = overrides.get((channel.id, listing.model_id))
+            if (
+                not channel.is_active
+                or override is None
+                or not override.is_listed
+            ):
+                continue
+            unit_prices = resolve_channel_model_price(
+                channel,
+                listing.model,
+                override=override,
+                source_items=_indexed_price_items_for_override(
+                    override,
+                    price_item_indexes,
+                ),
+                video_resolution=video_resolution,
+            )
+            cost_input = unit_prices.input_per_million
+            cost_output = unit_prices.output_per_million
+            cost_cache_input = unit_prices.cache_input_per_million
+            cost_currency = resolve_channel_model_currency(
+                channel,
+                listing.model,
+                override=override,
+            )
+        retail_input = listing.retail_input_price_per_million
+        retail_output = listing.retail_output_price_per_million
+        retail_cache_input = listing.retail_cache_input_price_per_million
+        retail_currency = resolve_resale_listing_currency(listing)
+        fee_rate = listing.platform.fee_rate or Decimal("0")
+        cost_input_display = _converted_amount(
+            cost_input,
+            cost_currency,
+            currency_context,
+        )
+        cost_output_display = _converted_amount(
+            cost_output,
+            cost_currency,
+            currency_context,
+        )
+        cost_cache_input_display = _converted_amount(
+            cost_cache_input,
+            cost_currency,
+            currency_context,
+        )
+        retail_input_display = _converted_amount(
+            retail_input,
+            retail_currency,
+            currency_context,
+        )
+        retail_output_display = _converted_amount(
+            retail_output,
+            retail_currency,
+            currency_context,
+        )
+        retail_cache_input_display = _converted_amount(
+            retail_cache_input,
+            retail_currency,
+            currency_context,
+        )
+        requires_currency_conversion = any(
+            value is None
+            for value in (
+                cost_input_display,
+                cost_output_display,
+                cost_cache_input_display,
+                retail_input_display,
+                retail_output_display,
+                retail_cache_input_display,
+            )
+        )
+        if requires_currency_conversion:
+            input_margin = _empty_margin(
+                requires_currency_conversion=True,
+            )
+            output_margin = _empty_margin(
+                requires_currency_conversion=True,
+            )
+        else:
+            input_margin = _gross_margin(
+                retail_input_display,
+                cost_input_display,
+                fee_rate,
+            )
+            output_margin = _gross_margin(
+                retail_output_display,
+                cost_output_display,
+                fee_rate,
+            )
+        listing_rows.append(
+            {
+                "listing_id": listing.id,
+                "platform_id": listing.platform_id,
+                "platform_name": listing.platform.name,
+                "model_id": listing.model_id,
+                "model_name": listing.model.name,
+                "model_code": listing.model.code,
+                "channel_id": listing.channel_id,
+                "channel_name": channel.name if channel else None,
+                "channel_type": "fixed_channel" if channel else "auto_best",
+                "currency": (
+                    currency_context.display_currency
+                    if not requires_currency_conversion
+                    else retail_currency
+                ),
+                "display_currency": currency_context.display_currency,
+                "exchange_rate": _as_float(currency_context.usd_to_cny_rate),
+                "original_currency": retail_currency,
+                "retail_currency": retail_currency,
+                "cost_currency": cost_currency,
+                "requires_currency_conversion": requires_currency_conversion,
+                "updated_at": listing.updated_at,
+                "retail_input_price_per_million": _as_float(
+                    retail_input_display
+                    if retail_input_display is not None
+                    else retail_input
+                ),
+                "retail_output_price_per_million": _as_float(
+                    retail_output_display
+                    if retail_output_display is not None
+                    else retail_output
+                ),
+                "retail_cache_input_price_per_million": _as_float(
+                    retail_cache_input_display
+                    if retail_cache_input_display is not None
+                    else retail_cache_input
+                ),
+                "original_retail_input_price_per_million": (
+                    _as_float(retail_input)
+                ),
+                "original_retail_output_price_per_million": (
+                    _as_float(retail_output)
+                ),
+                "original_retail_cache_input_price_per_million": (
+                    _as_float(retail_cache_input)
+                ),
+                "cost_input_price_per_million": _as_float(
+                    cost_input_display
+                    if cost_input_display is not None
+                    else cost_input
+                ),
+                "cost_output_price_per_million": _as_float(
+                    cost_output_display
+                    if cost_output_display is not None
+                    else cost_output
+                ),
+                "cost_cache_input_price_per_million": _as_float(
+                    cost_cache_input_display
+                    if cost_cache_input_display is not None
+                    else cost_cache_input
+                ),
+                "original_cost_input_price_per_million": _as_float(
+                    cost_input
+                ),
+                "original_cost_output_price_per_million": _as_float(
+                    cost_output
+                ),
+                "original_cost_cache_input_price_per_million": _as_float(
+                    cost_cache_input
+                ),
+                "input_margin": input_margin,
+                "output_margin": output_margin,
+                "option": _listing_option(
+                    listing,
+                    options,
+                    row["best_channel"] if row else None,
+                ),
+            }
+        )
+    return listing_rows
+
+
 class SummaryAPIView(LLMOpsPermissionMixin, APIView):
     """Return dashboard metrics and calculation summaries."""
 
@@ -2927,6 +3215,8 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
         selected_platform_param = (
             request.query_params.get("resale_platform") or ""
         )
+        summary_scope = request.query_params.get("scope") or "full"
+        is_monitor_scope = summary_scope == "monitor"
         currency_context = build_currency_conversion_context(display_currency)
         selected_platform = _selected_resale_platform(selected_platform_param)
 
@@ -3161,7 +3451,6 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
                     "reconciliation_anomaly",
                     reconciliation_row["latest"],
                 )
-        listing_rows = []
         active_listings = list(
             ResaleListing.objects.filter(is_active=True).select_related(
                 "platform",
@@ -3171,207 +3460,18 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
             )
         )
         rows_by_model = {row["model_id"]: row for row in procurement_rows}
-        for listing in active_listings:
-            channel = listing.channel
-            row = rows_by_model.get(listing.model_id)
-            options = row["options"] if row else []
-            if channel is None:
-                best_row = row["best_channel"] if row else None
-                if not best_row:
-                    continue
-                cost_input = Decimal(
-                    str(best_row["original_input_price_per_million"])
-                )
-                cost_output = Decimal(
-                    str(best_row["original_output_price_per_million"])
-                )
-                cost_cache_input = Decimal(
-                    str(
-                        best_row.get(
-                            "original_cache_input_price_per_million",
-                            "0",
-                        )
-                        or "0"
-                    )
-                )
-                cost_currency = (
-                    best_row.get("original_currency") or listing.model.currency
-                )
-            else:
-                override = overrides.get((channel.id, listing.model_id))
-                if (
-                    not channel.is_active
-                    or override is None
-                    or not override.is_listed
-                ):
-                    continue
-                unit_prices = resolve_channel_model_price(
-                    channel,
-                    listing.model,
-                    override=override,
-                    source_items=_indexed_price_items_for_override(
-                        override,
-                        price_item_indexes,
-                    ),
-                    video_resolution=video_resolution,
-                )
-                cost_input = unit_prices.input_per_million
-                cost_output = unit_prices.output_per_million
-                cost_cache_input = unit_prices.cache_input_per_million
-                cost_currency = resolve_channel_model_currency(
-                    channel,
-                    listing.model,
-                    override=override,
-                )
-            retail_input = listing.retail_input_price_per_million
-            retail_output = listing.retail_output_price_per_million
-            retail_cache_input = listing.retail_cache_input_price_per_million
-            retail_currency = resolve_resale_listing_currency(listing)
-            fee_rate = listing.platform.fee_rate or Decimal("0")
-            cost_input_display = _converted_amount(
-                cost_input,
-                cost_currency,
-                currency_context,
+        listing_rows = (
+            []
+            if is_monitor_scope
+            else _summary_listing_rows(
+                active_listings=active_listings,
+                currency_context=currency_context,
+                overrides=overrides,
+                price_item_indexes=price_item_indexes,
+                rows_by_model=rows_by_model,
+                video_resolution=video_resolution,
             )
-            cost_output_display = _converted_amount(
-                cost_output,
-                cost_currency,
-                currency_context,
-            )
-            cost_cache_input_display = _converted_amount(
-                cost_cache_input,
-                cost_currency,
-                currency_context,
-            )
-            retail_input_display = _converted_amount(
-                retail_input,
-                retail_currency,
-                currency_context,
-            )
-            retail_output_display = _converted_amount(
-                retail_output,
-                retail_currency,
-                currency_context,
-            )
-            retail_cache_input_display = _converted_amount(
-                retail_cache_input,
-                retail_currency,
-                currency_context,
-            )
-            requires_currency_conversion = any(
-                value is None
-                for value in (
-                    cost_input_display,
-                    cost_output_display,
-                    cost_cache_input_display,
-                    retail_input_display,
-                    retail_output_display,
-                    retail_cache_input_display,
-                )
-            )
-            if requires_currency_conversion:
-                input_margin = _empty_margin(
-                    requires_currency_conversion=True,
-                )
-                output_margin = _empty_margin(
-                    requires_currency_conversion=True,
-                )
-            else:
-                input_margin = _gross_margin(
-                    retail_input_display,
-                    cost_input_display,
-                    fee_rate,
-                )
-                output_margin = _gross_margin(
-                    retail_output_display,
-                    cost_output_display,
-                    fee_rate,
-                )
-            listing_rows.append(
-                {
-                    "listing_id": listing.id,
-                    "platform_id": listing.platform_id,
-                    "platform_name": listing.platform.name,
-                    "model_id": listing.model_id,
-                    "model_name": listing.model.name,
-                    "model_code": listing.model.code,
-                    "channel_id": listing.channel_id,
-                    "channel_name": (
-                        channel.name if channel else "自动最优"
-                    ),
-                    "currency": (
-                        currency_context.display_currency
-                        if not requires_currency_conversion
-                        else retail_currency
-                    ),
-                    "display_currency": currency_context.display_currency,
-                    "exchange_rate": _as_float(
-                        currency_context.usd_to_cny_rate
-                    ),
-                    "original_currency": retail_currency,
-                    "retail_currency": retail_currency,
-                    "cost_currency": cost_currency,
-                    "requires_currency_conversion": (
-                        requires_currency_conversion
-                    ),
-                    "updated_at": listing.updated_at,
-                    "retail_input_price_per_million": _as_float(
-                        retail_input_display
-                        if retail_input_display is not None
-                        else retail_input
-                    ),
-                    "retail_output_price_per_million": _as_float(
-                        retail_output_display
-                        if retail_output_display is not None
-                        else retail_output
-                    ),
-                    "retail_cache_input_price_per_million": _as_float(
-                        retail_cache_input_display
-                        if retail_cache_input_display is not None
-                        else retail_cache_input
-                    ),
-                    "original_retail_input_price_per_million": (
-                        _as_float(retail_input)
-                    ),
-                    "original_retail_output_price_per_million": (
-                        _as_float(retail_output)
-                    ),
-                    "original_retail_cache_input_price_per_million": (
-                        _as_float(retail_cache_input)
-                    ),
-                    "cost_input_price_per_million": _as_float(
-                        cost_input_display
-                        if cost_input_display is not None
-                        else cost_input
-                    ),
-                    "cost_output_price_per_million": _as_float(
-                        cost_output_display
-                        if cost_output_display is not None
-                        else cost_output
-                    ),
-                    "cost_cache_input_price_per_million": _as_float(
-                        cost_cache_input_display
-                        if cost_cache_input_display is not None
-                        else cost_cache_input
-                    ),
-                    "original_cost_input_price_per_million": (
-                        _as_float(cost_input)
-                    ),
-                    "original_cost_output_price_per_million": (
-                        _as_float(cost_output)
-                    ),
-                    "original_cost_cache_input_price_per_million": (
-                        _as_float(cost_cache_input)
-                    ),
-                    "input_margin": input_margin,
-                    "output_margin": output_margin,
-                    "option": _listing_option(
-                        listing,
-                        options,
-                        row["best_channel"] if row else None,
-                    ),
-                }
-            )
+        )
 
         selected_platform_listing_rows = [
             listing
@@ -3475,6 +3575,7 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
                 current_listing_payload = {
                     "channel_id": listing_payload.get("channel_id"),
                     "channel_name": listing_payload.get("channel_name"),
+                    "channel_type": listing_payload.get("channel_type"),
                     "currency": listing_payload.get("currency"),
                     "retail_input_price_per_million": listing_payload.get(
                         "retail_input_price_per_million"
@@ -3530,24 +3631,36 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
                     selected_platform
                 ),
             }
-            diagnostics.append(
-                {
-                    **row,
-                    "coverage_count": len(options),
-                    "is_agione_listed": bool(active_model_listings),
-                    "has_lowest_listing": has_lowest_listing,
-                    "active_listing_count": len(active_model_listings),
-                    "price_gap": _listing_price_gap(
-                        cheapest_active,
-                        best_channel,
-                    ),
-                    **status_payload,
-                    "recommended_channel": recommended_channel,
-                    "current_listing": current_listing_payload,
-                    "yield_metrics": yield_metrics_payload,
-                    **decision_payload,
-                }
-            )
+            diagnostic = {
+                "model_id": row["model_id"],
+                "model_name": row["model_name"],
+                "model_code": row["model_code"],
+                "meta_model_id": row["meta_model_id"],
+                "meta_model_name": row["meta_model_name"],
+                "meta_model_code": row["meta_model_code"],
+                "provider_name": row["provider_name"],
+                "currency": row["currency"],
+                "requires_currency_conversion": row[
+                    "requires_currency_conversion"
+                ],
+                "coverage_count": len(options),
+                "is_agione_listed": bool(active_model_listings),
+                "has_lowest_listing": has_lowest_listing,
+                "active_listing_count": len(active_model_listings),
+                "price_gap": _listing_price_gap(
+                    cheapest_active,
+                    best_channel,
+                ),
+                **status_payload,
+                "best_channel": recommended_channel,
+                "recommended_channel": recommended_channel,
+                "current_listing": current_listing_payload,
+                "yield_metrics": yield_metrics_payload,
+                **decision_payload,
+            }
+            if not is_monitor_scope:
+                diagnostic = {**row, **diagnostic}
+            diagnostics.append(diagnostic)
 
         diagnostic_counts = {
             "currency_mismatch": 0,
@@ -3621,7 +3734,7 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
                 "point_conversion": _point_conversion_payload(
                     selected_platform,
                 ),
-                "procurement": procurement_rows,
+                "procurement": [] if is_monitor_scope else procurement_rows,
                 "listings": listing_rows,
                 "agione": {
                     "platform_id": (

--- a/backend/llm_ops/views.py
+++ b/backend/llm_ops/views.py
@@ -1,7 +1,8 @@
 from decimal import Decimal
 
 from django.db import transaction
-from django.db.models import Count, IntegerField, Max, Q, Value
+from django.db.models import Count, IntegerField, Max, Q
+from django.db.models import Value
 from django.utils.text import slugify
 from drf_spectacular.utils import extend_schema
 from rest_framework import status, viewsets
@@ -80,13 +81,16 @@ from .serializers import (
 from .services import (
     build_currency_conversion_context,
     calculate_usage_cost,
+    compute_model_decision,
     convert_currency_amount,
+    current_model_price_items_for_channel_price,
     import_manual_model_prices,
     record_channel_model_price_history,
     record_resale_listing_price_history,
     resolve_channel_model_currency,
     resolve_channel_model_price,
     resolve_resale_listing_currency,
+    selected_price_item_group,
     sync_channel_price_items,
 )
 from .source_collectors import source_supports_code_collection
@@ -2191,6 +2195,12 @@ def _as_float(value) -> float:
     return float(value or Decimal("0"))
 
 
+def _as_optional_float(value) -> float | None:
+    if value is None:
+        return None
+    return float(value)
+
+
 def _decimal_or_none(value) -> Decimal | None:
     if value is None or value == "":
         return None
@@ -2541,12 +2551,115 @@ def _select_best_option(options: list[dict]):
         for item in options
         if not item.get("requires_currency_conversion")
     ]
-    if len(comparable_options) != len(options):
-        return None
+    if not comparable_options:
+        return sorted(
+            options,
+            key=lambda item: item["estimated_cost"],
+        )[0]
     return sorted(
         comparable_options,
         key=lambda item: item["estimated_cost"],
     )[0]
+
+
+def _price_source_id_for_override(override, price_items=None):
+    if not override:
+        return None
+    if override.price_source_id:
+        return override.price_source_id
+    if price_items is None:
+        price_items = current_model_price_items_for_channel_price(override)
+    source_ids = [item.source_id for item in price_items if item.source_id]
+    return source_ids[0] if source_ids else None
+
+
+def _price_items_updated_at(price_items):
+    values = [item.updated_at for item in price_items if item.updated_at]
+    return max(values) if values else None
+
+
+def _price_item_indexes(overrides):
+    model_ids = {override.model_id for override in overrides}
+    meta_model_ids = {
+        override.model.meta_model_id
+        for override in overrides
+        if override.model.meta_model_id
+    }
+    model_rows = list(
+        ModelPriceItem.objects.filter(
+            model_id__in=model_ids,
+            is_current=True,
+        )
+        .select_related("model", "offering", "sku", "source")
+        .order_by("model_id", "source_id", "dimension", "tier_start", "id")
+    )
+    meta_rows = list(
+        ModelPriceItem.objects.filter(
+            meta_model_id__in=meta_model_ids,
+            is_current=True,
+            unit_price__gt=Decimal("0"),
+        )
+        .select_related("model", "offering", "sku", "source")
+        .order_by(
+            "meta_model_id",
+            "source_id",
+            "dimension",
+            "tier_start",
+            "id",
+        )
+    )
+
+    model_any = {}
+    model_by_source = {}
+    for item in model_rows:
+        model_any.setdefault(item.model_id, []).append(item)
+        model_by_source.setdefault(
+            (item.model_id, item.source_id),
+            [],
+        ).append(item)
+
+    meta_any = {}
+    meta_by_source = {}
+    for item in meta_rows:
+        meta_any.setdefault(item.meta_model_id, []).append(item)
+        meta_by_source.setdefault(
+            (item.meta_model_id, item.source_id),
+            [],
+        ).append(item)
+
+    return {
+        "model_any": model_any,
+        "model_by_source": model_by_source,
+        "meta_any": meta_any,
+        "meta_by_source": meta_by_source,
+    }
+
+
+def _indexed_price_items_for_override(override, indexes):
+    if not override:
+        return []
+    if override.price_source_id:
+        rows = indexes["model_by_source"].get(
+            (override.model_id, override.price_source_id),
+            [],
+        )
+        if rows:
+            return selected_price_item_group(rows, model=override.model)
+        rows = indexes["meta_by_source"].get(
+            (override.model.meta_model_id, override.price_source_id),
+            [],
+        )
+        if rows:
+            return selected_price_item_group(rows, model=override.model)
+        return []
+
+    rows = indexes["model_any"].get(override.model_id, [])
+    if rows:
+        return selected_price_item_group(rows, model=override.model)
+    rows = indexes["meta_any"].get(override.model.meta_model_id, [])
+    if rows:
+        return selected_price_item_group(rows, model=override.model)
+    return []
 
 
 def _has_procurement_text_price(unit_prices) -> bool:
@@ -2625,6 +2738,173 @@ def _diagnostic_status(
     }
 
 
+_DATA_EVENT_PRIORITY = {
+    "reconciliation_anomaly": 1,
+    "collection_failed": 2,
+    "source_disabled": 3,
+}
+
+_REQUIRED_YIELD_CONFIG_FIELDS = (
+    "fee_rate",
+    "service_fee_rate",
+    "tax_rate",
+    "settlement_rate",
+    "yield_warning",
+)
+
+
+def _prefer_data_event(current, candidate) -> bool:
+    if current is None:
+        return True
+    current_at = current.get("at")
+    candidate_at = candidate.get("at")
+    if current_at and candidate_at and current_at != candidate_at:
+        return candidate_at > current_at
+    if candidate_at and not current_at:
+        return True
+    if current_at and not candidate_at:
+        return False
+    return _DATA_EVENT_PRIORITY.get(
+        candidate["type"],
+        0,
+    ) > _DATA_EVENT_PRIORITY.get(current["type"], 0)
+
+
+def _set_model_data_event(events_by_model, model_id, event_type, event_at):
+    candidate = {"type": event_type, "at": event_at}
+    current = events_by_model.get(model_id)
+    if _prefer_data_event(current, candidate):
+        events_by_model[model_id] = candidate
+
+
+def _latest_datetime(*values):
+    valid_values = [value for value in values if value is not None]
+    if not valid_values:
+        return None
+    return max(valid_values)
+
+
+def _platform_yield_config_resolved(platform) -> bool:
+    if platform is None:
+        return False
+    return all(
+        getattr(platform, field_name, None) is not None
+        for field_name in _REQUIRED_YIELD_CONFIG_FIELDS
+    )
+
+
+def _best_channel_price_updated_at(
+    overrides,
+    best_channel,
+    model_id,
+    source_run_at_by_source=None,
+):
+    if not best_channel:
+        return None
+    channel_id = best_channel.get("channel_id")
+    override = overrides.get((channel_id, model_id))
+    source_id = best_channel.get("price_source_id")
+    source_run_at = None
+    if source_id and source_run_at_by_source:
+        source_run_at = source_run_at_by_source.get(source_id)
+    return _latest_datetime(
+        override.updated_at if override else None,
+        best_channel.get("price_updated_at"),
+        source_run_at,
+    )
+
+
+def _decision_listing_payload(listing_payloads, best_channel):
+    if not listing_payloads:
+        return None
+    if best_channel:
+        best_channel_id = best_channel.get("channel_id")
+        for payload in listing_payloads:
+            channel_id = payload.get("channel_id")
+            if channel_id is None or channel_id == best_channel_id:
+                return payload
+    return listing_payloads[0]
+
+
+def _decision_listing_payload_from_listing(
+    listing,
+    *,
+    row,
+    currency_context,
+):
+    retail_currency = resolve_resale_listing_currency(listing)
+    retail_input = listing.retail_input_price_per_million
+    retail_output = listing.retail_output_price_per_million
+    retail_cache_input = listing.retail_cache_input_price_per_million
+    retail_input_display = _converted_amount(
+        retail_input,
+        retail_currency,
+        currency_context,
+    )
+    retail_output_display = _converted_amount(
+        retail_output,
+        retail_currency,
+        currency_context,
+    )
+    retail_cache_input_display = _converted_amount(
+        retail_cache_input,
+        retail_currency,
+        currency_context,
+    )
+    option = _listing_option(
+        listing,
+        row["options"] if row else [],
+        row["best_channel"] if row else None,
+    )
+    requires_currency_conversion = any(
+        value is None
+        for value in (
+            retail_input_display,
+            retail_output_display,
+            retail_cache_input_display,
+        )
+    )
+    if option:
+        requires_currency_conversion = (
+            requires_currency_conversion
+            or option.get("requires_currency_conversion", False)
+        )
+    channel = listing.channel
+    return {
+        "channel_id": listing.channel_id,
+        "channel_name": channel.name if channel else "自动最优",
+        "currency": (
+            currency_context.display_currency
+            if not requires_currency_conversion
+            else retail_currency
+        ),
+        "retail_input_price_per_million": _as_float(
+            retail_input_display
+            if retail_input_display is not None
+            else retail_input
+        ),
+        "retail_output_price_per_million": _as_float(
+            retail_output_display
+            if retail_output_display is not None
+            else retail_output
+        ),
+        "retail_cache_input_price_per_million": _as_float(
+            retail_cache_input_display
+            if retail_cache_input_display is not None
+            else retail_cache_input
+        ),
+        "cost_input_price_per_million": (
+            option.get("input_price_per_million") if option else None
+        ),
+        "cost_output_price_per_million": (
+            option.get("output_price_per_million") if option else None
+        ),
+        "requires_currency_conversion": requires_currency_conversion,
+        "updated_at": listing.updated_at,
+        "is_listed": True,
+    }
+
+
 class SummaryAPIView(LLMOpsPermissionMixin, APIView):
     """Return dashboard metrics and calculation summaries."""
 
@@ -2655,6 +2935,9 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
             .select_related("meta_model", "provider")
             .order_by("provider__name", "name", "id")
         )
+        model_updated_at_by_id = {
+            model.id: model.updated_at for model in models
+        }
         channels = list(
             ProcurementChannel.objects.filter(is_active=True).order_by(
                 "name",
@@ -2666,8 +2949,14 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
             for item in ChannelModelPrice.objects.select_related(
                 "channel",
                 "model",
+                "model__meta_model",
+                "price_source",
             )
         }
+        listed_overrides = [
+            override for override in overrides.values() if override.is_listed
+        ]
+        price_item_indexes = _price_item_indexes(listed_overrides)
 
         procurement_rows = []
         for model in models:
@@ -2676,10 +2965,15 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
                 override = overrides.get((channel.id, model.id))
                 if not override or not override.is_listed:
                     continue
+                price_items = _indexed_price_items_for_override(
+                    override,
+                    price_item_indexes,
+                )
                 unit_prices = resolve_channel_model_price(
                     channel,
                     model,
                     override=override,
+                    source_items=price_items,
                     video_resolution=video_resolution,
                 )
                 if not _has_procurement_text_price(unit_prices):
@@ -2697,6 +2991,11 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
                 option = {
                     "channel_id": channel.id,
                     "channel_name": channel.name,
+                    "price_source_id": _price_source_id_for_override(
+                        override,
+                        price_items,
+                    ),
+                    "price_updated_at": _price_items_updated_at(price_items),
                     "currency": currency,
                     "input_price_per_million": _as_float(
                         unit_prices.input_per_million
@@ -2742,10 +3041,13 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
                     item["estimated_cost"],
                 )
             )
-            requires_currency_conversion = any(
-                item.get("requires_currency_conversion") for item in options
-            )
             best = _select_best_option(options) if options else None
+            requires_currency_conversion = bool(
+                any(
+                    item.get("requires_currency_conversion")
+                    for item in options
+                )
+            )
             procurement_rows.append(
                 {
                     "model_id": model.id,
@@ -2764,6 +3066,101 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
                 }
             )
 
+        data_events_by_model = {}
+        source_model_ids = {}
+        best_channel_ids_by_model = {}
+        for row in procurement_rows:
+            best_channel = row["best_channel"]
+            if not best_channel:
+                continue
+            model_id = row["model_id"]
+            channel_id = best_channel["channel_id"]
+            best_channel_ids_by_model[model_id] = channel_id
+            source_id = best_channel.get("price_source_id")
+            if not source_id:
+                continue
+            source_model_ids.setdefault(
+                source_id,
+                set(),
+            ).add(model_id)
+        price_sources_by_id = {}
+        if source_model_ids:
+            price_sources_by_id = {
+                source.id: source
+                for source in PriceCollectionSource.objects.filter(
+                    id__in=source_model_ids,
+                )
+            }
+        for source_id, model_ids in source_model_ids.items():
+            source = price_sources_by_id.get(source_id)
+            if not source or source.is_enabled:
+                continue
+            for model_id in model_ids:
+                _set_model_data_event(
+                    data_events_by_model,
+                    model_id,
+                    "source_disabled",
+                    source.updated_at,
+                )
+        latest_source_run_at_by_source = {}
+        if source_model_ids:
+            latest_started_rows = (
+                PriceCollectionRun.objects.filter(
+                    source_id__in=source_model_ids,
+                )
+                .values("source_id")
+                .annotate(latest_started_at=Max("started_at"))
+            )
+            latest_started_at_values = [
+                row["latest_started_at"]
+                for row in latest_started_rows
+                if row["latest_started_at"]
+            ]
+            latest_runs_by_source = {}
+            latest_run_candidates = PriceCollectionRun.objects.filter(
+                source_id__in=source_model_ids,
+                started_at__in=latest_started_at_values,
+            ).order_by("source_id", "-started_at", "-id")
+            for run in latest_run_candidates:
+                latest_runs_by_source.setdefault(run.source_id, run)
+            for run in latest_runs_by_source.values():
+                latest_source_run_at_by_source[run.source_id] = (
+                    run.finished_at or run.started_at
+                )
+                if run.status != PriceCollectionRun.STATUS_FAILED:
+                    continue
+                for model_id in source_model_ids.get(run.source_id, set()):
+                    _set_model_data_event(
+                        data_events_by_model,
+                        model_id,
+                        "collection_failed",
+                        run.finished_at or run.started_at,
+                    )
+        if best_channel_ids_by_model:
+            reconciliation_rows = (
+                UsageReconciliationRecord.objects.exclude(
+                    status=UsageReconciliationRecord.STATUS_PERFECT,
+                )
+                .filter(
+                    model_id__in=best_channel_ids_by_model,
+                    channel_id__in=set(best_channel_ids_by_model.values()),
+                )
+                .values("model_id", "channel_id")
+                .annotate(latest=Max("updated_at"))
+            )
+            for reconciliation_row in reconciliation_rows:
+                model_id = reconciliation_row["model_id"]
+                if (
+                    best_channel_ids_by_model.get(model_id)
+                    != reconciliation_row["channel_id"]
+                ):
+                    continue
+                _set_model_data_event(
+                    data_events_by_model,
+                    model_id,
+                    "reconciliation_anomaly",
+                    reconciliation_row["latest"],
+                )
         listing_rows = []
         active_listings = list(
             ResaleListing.objects.filter(is_active=True).select_related(
@@ -2773,17 +3170,10 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
                 "channel",
             )
         )
-        valid_active_listings = []
+        rows_by_model = {row["model_id"]: row for row in procurement_rows}
         for listing in active_listings:
             channel = listing.channel
-            row = next(
-                (
-                    procurement_row
-                    for procurement_row in procurement_rows
-                    if procurement_row["model_id"] == listing.model_id
-                ),
-                None,
-            )
+            row = rows_by_model.get(listing.model_id)
             options = row["options"] if row else []
             if channel is None:
                 best_row = row["best_channel"] if row else None
@@ -2819,6 +3209,10 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
                     channel,
                     listing.model,
                     override=override,
+                    source_items=_indexed_price_items_for_override(
+                        override,
+                        price_item_indexes,
+                    ),
                     video_resolution=video_resolution,
                 )
                 cost_input = unit_prices.input_per_million
@@ -2829,8 +3223,6 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
                     listing.model,
                     override=override,
                 )
-            valid_active_listings.append(listing)
-
             retail_input = listing.retail_input_price_per_million
             retail_output = listing.retail_output_price_per_million
             retail_cache_input = listing.retail_cache_input_price_per_million
@@ -2922,6 +3314,7 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
                     "requires_currency_conversion": (
                         requires_currency_conversion
                     ),
+                    "updated_at": listing.updated_at,
                     "retail_input_price_per_million": _as_float(
                         retail_input_display
                         if retail_input_display is not None
@@ -2982,7 +3375,7 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
 
         selected_platform_listing_rows = [
             listing
-            for listing in valid_active_listings
+            for listing in active_listings
             if (
                 selected_platform
                 and listing.platform_id == selected_platform.id
@@ -2994,6 +3387,20 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
                 listing.model_id,
                 [],
             ).append(listing)
+        selected_platform_listing_payloads_by_model = {}
+        for listing in selected_platform_listing_rows:
+            if not selected_platform:
+                continue
+            row = rows_by_model.get(listing.model_id)
+            payload = _decision_listing_payload_from_listing(
+                listing,
+                row=row,
+                currency_context=currency_context,
+            )
+            selected_platform_listing_payloads_by_model.setdefault(
+                listing.model_id,
+                [],
+            ).append(payload)
 
         diagnostics = []
         for row in procurement_rows:
@@ -3030,6 +3437,99 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
                     "requires_currency_conversion"
                 ],
             )
+            listing_payloads = selected_platform_listing_payloads_by_model.get(
+                row["model_id"],
+                [],
+            )
+            listing_payload = _decision_listing_payload(
+                listing_payloads,
+                best_channel,
+            )
+            data_event = data_events_by_model.get(row["model_id"], {})
+            last_data_event_at = data_event.get("at")
+            if last_data_event_at is None:
+                last_data_event_at = _latest_datetime(
+                    _best_channel_price_updated_at(
+                        overrides,
+                        best_channel,
+                        row["model_id"],
+                        latest_source_run_at_by_source,
+                    ),
+                    (
+                        listing_payload.get("updated_at")
+                        if listing_payload
+                        else None
+                    ),
+                    model_updated_at_by_id.get(row["model_id"]),
+                )
+            decision_payload = compute_model_decision(
+                procurement_row=row,
+                current_listing=listing_payload,
+                platform=selected_platform,
+                data_event_type=data_event.get("type", "updated"),
+                last_data_event_at=last_data_event_at,
+            )
+            recommended_channel = best_channel or None
+            current_listing_payload = None
+            if listing_payload:
+                current_listing_payload = {
+                    "channel_id": listing_payload.get("channel_id"),
+                    "channel_name": listing_payload.get("channel_name"),
+                    "currency": listing_payload.get("currency"),
+                    "retail_input_price_per_million": listing_payload.get(
+                        "retail_input_price_per_million"
+                    ),
+                    "retail_output_price_per_million": listing_payload.get(
+                        "retail_output_price_per_million"
+                    ),
+                    "retail_cache_input_price_per_million": (
+                        listing_payload.get(
+                            "retail_cache_input_price_per_million",
+                        )
+                    ),
+                    "is_listed": True,
+                }
+            yield_metrics_payload = {
+                "fee_rate": _as_optional_float(
+                    selected_platform.fee_rate
+                    if selected_platform
+                    else None
+                ),
+                "service_fee_rate": _as_optional_float(
+                    selected_platform.service_fee_rate
+                    if selected_platform
+                    else None
+                ),
+                "tax_rate": _as_optional_float(
+                    selected_platform.tax_rate
+                    if selected_platform
+                    else None
+                ),
+                "settlement_rate": _as_optional_float(
+                    selected_platform.settlement_rate
+                    if selected_platform
+                    else None
+                ),
+                "yield_warning": _as_optional_float(
+                    selected_platform.yield_warning
+                    if selected_platform
+                    else None
+                ),
+                "yield_target": _as_optional_float(
+                    selected_platform.yield_target
+                    if selected_platform
+                    else None
+                ),
+                "input_yield": _as_optional_float(
+                    decision_payload.get("input_yield")
+                ),
+                "output_yield": _as_optional_float(
+                    decision_payload.get("output_yield")
+                ),
+                "is_resolved": _platform_yield_config_resolved(
+                    selected_platform
+                ),
+            }
             diagnostics.append(
                 {
                     **row,
@@ -3042,6 +3542,10 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
                         best_channel,
                     ),
                     **status_payload,
+                    "recommended_channel": recommended_channel,
+                    "current_listing": current_listing_payload,
+                    "yield_metrics": yield_metrics_payload,
+                    **decision_payload,
                 }
             )
 

--- a/docs/llm-ops/overview-refactor.codex.md
+++ b/docs/llm-ops/overview-refactor.codex.md
@@ -1,0 +1,177 @@
+# LLM Ops Overview Refactor — Codex Brief
+
+## Status: Aligned with repo reality (post-clarification)
+
+This brief supersedes earlier drafts. It reflects the current
+`ResalePlatform` schema (already has `fee_rate`, `service_fee_rate`)
+and the operator decision that all newly added fee/yield fields are
+nullable with no global fallback.
+
+## Objective
+
+Refactor the LLM Ops Monitor overview page into a single
+"模型挂售决策表" worktable. Remove duplicate status views, drop the
+drawer on the overview page, and route row clicks to the Resale
+Publishing Workspace.
+
+## Root Cause
+
+The overview page is organized by data objects (KPI, provider
+matrix, channel coverage, focus table, channel matrix, risk board)
+instead of by operator decisions. Status, action and margin are
+recomputed in multiple components with inconsistent ordering and no
+recommended action. Margin thresholds are global (10%) instead of
+per-platform fee configuration.
+
+## Scope
+
+- `backend/llm_ops/models.py` — `ResalePlatform` field additions
+- `backend/llm_ops/migrations/0007_resaleplatform_fee_config.py` — new migration
+- `backend/llm_ops/services.py` — `compute_model_decision` helper
+- `backend/llm_ops/views.py` — `SummaryAPIView` canonical output
+- `backend/llm_ops/tests/test_views.py` — decision field assertions
+- `frontend/src/composables/useLLMOpsMonitor.js` — decision row factory
+- `frontend/src/components/llm-ops/LLMOpsMonitorDashboard.vue` — collapsed page
+- `frontend/src/pages/LLMOps.vue` — remove overview drawer reference
+- `frontend/src/locales/zh-CN.json`, `frontend/src/locales/en.json` — i18n
+
+Out of scope: changes to legacy management commands, new routes,
+new engine or registry layer.
+
+## Required Architecture / Logic
+
+### 1. ResalePlatform schema addition
+
+Add four DecimalFields, all `null=True, blank=True, default=None`,
+matching `fee_rate` precision (`max_digits=8, decimal_places=4`):
+
+- `tax_rate`
+- `settlement_rate`
+- `yield_warning`
+- `yield_target`
+
+`fee_rate` and `service_fee_rate` already exist; do not duplicate.
+
+### 2. SummaryAPIView canonical output
+
+For each model row emit:
+
+- `recommended_channel` — `{channel_id, channel_name, currency, input_price_per_million, output_price_per_million, cache_input_price_per_million, estimated_cost}`
+- `current_listing` — `{channel_id, channel_name, currency, retail_input_price_per_million, retail_output_price_per_million, retail_cache_input_price_per_million, is_listed}`
+- `yield_metrics` — `{fee_rate, service_fee_rate, tax_rate, settlement_rate, yield_warning, yield_target, input_yield, output_yield, is_resolved}`
+- `decision_status` (enum, see priority list)
+- `decision_action` (string, see mapping)
+- `last_data_event_at` (datetime)
+- `data_event_type` (enum: `updated` | `collection_failed` | `source_disabled` | `reconciliation_anomaly` | `stale`)
+
+### 3. Yield calculation
+
+Per-platform, no global fallback. Implementation rule:
+
+- If any of `fee_rate`, `service_fee_rate`, `tax_rate`, `settlement_rate`, `yield_warning` is null on the selected `ResalePlatform`, set `yield_metrics.is_resolved = false`, `input_yield = null`, `output_yield = null`, and `decision_status = platform_fee_unresolved`.
+- When resolved, compute net yield per dimension:
+  `net_yield = (retail * (1 - fee_rate - service_fee_rate - tax_rate) - cost * settlement_rate) / retail`
+  `cost` here uses `recommended_channel.cost` or, when `current_listing.is_listed` is true, the actual listing channel cost.
+- `low_yield` fires when `input_yield < yield_warning` or `output_yield < yield_warning`.
+
+### 4. Decision status priority (highest to lowest)
+
+1. `no_supply` — best_channel missing
+2. `currency_unresolved` — best_channel present but display currency conversion failed
+3. `platform_fee_unresolved` — `yield_metrics.is_resolved = false`
+4. `low_yield` — listed and yield below warning
+5. `not_lowest_channel` — listed but listing.channel_id != best_channel.channel_id
+6. `unlisted` — best_channel present and not listed
+7. `single_channel` — options.length == 1
+8. `ready` — all checks pass
+
+### 5. decision_action mapping
+
+| status | action text (zh-CN) |
+|---|---|
+| `no_supply` | 去渠道配置 |
+| `currency_unresolved` | 补汇率 |
+| `platform_fee_unresolved` | 配置平台费用规则 |
+| `low_yield` | 复核售价或切换渠道 |
+| `not_lowest_channel` | 评估切换到最低渠道 |
+| `unlisted` | 去挂售 |
+| `single_channel` | 增加备选渠道 |
+| `ready` | 保持 |
+
+### 6. Sort order
+
+1. decision_status priority asc
+2. |input_yield| desc (lowest yield first; null treated as 0)
+3. last_data_event_at asc (oldest first)
+4. provider_name asc
+
+### 7. KPI strip collapse to 4 cards
+
+- `pending_listing` — count of `decision_status == unlisted`
+- `missing_channel` — count of `decision_status == no_supply`
+- `low_yield` — count of `decision_status == low_yield`
+- `data_anomaly` — count where `data_event_type in {collection_failed, source_disabled, reconciliation_anomaly, stale}`
+
+Remove cards for: total channels, total models, providers, active listings, channel coverage rate, ready_models percentage.
+
+### 8. Overview page composition (LLMOpsMonitorDashboard.vue)
+
+- Top: four KPI cards in one row.
+- Body: decision table only.
+- Removed from this page: provider matrix, channel coverage module, listing risk board, collection health panel, any drawer/modal trigger.
+
+### 9. Row click navigation
+
+- Row binds to `model_id`.
+- Click navigates to `ResalePublishingWorkspace` scoped to that model.
+- Workspace decides edit vs create mode based on `current_listing.is_listed`.
+- `ResalePublishingDrawer` reference is removed from overview page only. Other call sites may keep it.
+
+### 10. Locale keys (zh-CN + en)
+
+- `decision.status.<status>` for all 8 statuses
+- `decision.action.<key>` for all 8 actions
+- `overview.kpi.{pendingListing,missingChannel,lowYield,dataAnomaly}.{label,hint}`
+- `overview.table.columns.{model,provider,coverage,recommended,recommendedPrice,currentListing,currentPrice,inputYield,outputYield,status,action,lastUpdate,dataEventType}`
+
+### 11. Data anomaly rule
+
+- `data_event_type = updated` — never counted into data_anomaly
+- `collection_failed` — count when latest CollectionRun for the price source feeding the model has status in {failed}
+- `source_disabled` — count when PriceCollectionSource for the best_channel has is_enabled = false
+- `reconciliation_anomaly` — count when UsageReconciliationRecord exists for this channel+model with status != STATUS_PERFECT
+- `stale` — reserved for future source-level cadence support. Do not
+  infer stale from a global fixed threshold; without a source cadence,
+  avoid emitting this event to prevent false data anomaly KPI counts.
+
+## Acceptance Tests
+
+1. Overview page renders only KPI strip (4 cards) and decision table.
+2. Each decision row contains all canonical fields.
+3. no_supply rows appear first.
+4. platform_fee_unresolved rows appear before low_yield.
+5. low_yield rows appear after platform_fee_unresolved but before not_lowest_channel.
+6. data_event_type=updated does NOT increase data_anomaly.
+7. data_event_type in {collection_failed, source_disabled, reconciliation_anomaly} increases data_anomaly; stale is reserved until source cadence is modeled.
+8. Clicking a decision row opens ResalePublishingWorkspace for that model; no drawer opens on overview.
+9. i18n keys present in both locales.
+10. SummaryAPIView returns canonical decision fields; backend test asserts presence.
+
+## Attempt Rule
+
+max 3 attempts per failure mode. Stop and report on fourth root cause.
+
+## Completion Rule
+
+- All acceptance tests pass.
+- No duplicate riskRows/lowMarginRows computation in frontend.
+- Overview page no longer references ResalePublishingDrawer.
+- Decision status logic exists in one helper: `llm_ops.services.compute_model_decision`.
+- i18n keys present in both locales.
+
+## Boundary
+
+- Do not modify ResalePlatform fields beyond the four additions.
+- Do not introduce a new engine or registry.
+- Do not modify legacy management commands.
+- Do not change non-overview LLM Ops pages except ResalePublishingWorkspace (only to accept incoming model_id scope).

--- a/frontend/src/components/llm-ops/AgioneListingStatusBoard.vue
+++ b/frontend/src/components/llm-ops/AgioneListingStatusBoard.vue
@@ -439,7 +439,8 @@ const rows = useAgioneListingRows({
   selectedTrendModelIdRef: unusedModelId,
   selectedTrendChannelIdRef: unusedChannelId,
   trendProfitRateRef: unusedProfitRate,
-  pointConversionRef: toRef(props, 'pointConversion')
+  pointConversionRef: toRef(props, 'pointConversion'),
+  t
 })
 
 const {

--- a/frontend/src/components/llm-ops/AgioneListingStatusBoard.vue
+++ b/frontend/src/components/llm-ops/AgioneListingStatusBoard.vue
@@ -208,6 +208,7 @@
             <tr
               v-for="row in paginatedListingRows"
               :key="row.status_listing?.id || 'model-' + row.model.id"
+              :class="{ 'listing-row-focused': isFocusedRow(row) }"
               class="cursor-default"
             >
               <td class="table-cell">
@@ -353,7 +354,7 @@
 <script setup>
 import '@/components/llm-ops/agioneListingStatusBoard.css'
 
-import { ref, toRef } from 'vue'
+import { ref, toRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { llmOpsApi } from '@/api/llmOps'
@@ -404,6 +405,10 @@ const props = defineProps({
   exchangeRate: {
     type: Number,
     default: 7.15
+  },
+  focusModelId: {
+    type: [String, Number],
+    default: null
   }
 })
 
@@ -492,6 +497,14 @@ const {
   visibleListingRows
 })
 
+watch(
+  () => [props.focusModelId, visibleListingRows.value.length],
+  () => {
+    focusListingModel()
+  },
+  { immediate: true }
+)
+
 const { exportFormat, exportListings } = useAgioneListingExport({
   activeListingChannelLabel,
   exportableRows,
@@ -535,6 +548,26 @@ function isWorkflowTransition(kind) {
 
 function openWorkspace(modelId, kind) {
   emit('open-workspace', { modelId, kind })
+}
+
+function focusListingModel() {
+  const modelId = props.focusModelId
+  if (!modelId) return
+  const row = visibleListingRows.value.find(
+    (item) => String(item.model?.id) === String(modelId)
+  )
+  const model =
+    row?.model ||
+    props.models.find((item) => String(item.id) === String(modelId))
+  if (!model) return
+  listingStatusFilter.value = 'all'
+  searchQuery.value = rows.modelDisplayName(model) || model.code || ''
+}
+
+function isFocusedRow(row) {
+  return (
+    props.focusModelId && String(row.model?.id) === String(props.focusModelId)
+  )
 }
 
 function actionPayloadForRows(targetRows, action = null) {

--- a/frontend/src/components/llm-ops/ChannelModal.vue
+++ b/frontend/src/components/llm-ops/ChannelModal.vue
@@ -17,10 +17,14 @@
               Channel
             </p>
             <h3 class="mt-2 text-lg font-semibold text-slate-900">
-              {{ form.id ? '编辑转发渠道' : '新建转发渠道' }}
+              {{
+                form.id
+                  ? t('llmOps.channelModal.editTitle')
+                  : t('llmOps.channelModal.createTitle')
+              }}
             </h3>
             <p class="mt-1 text-sm text-slate-500">
-              渠道用于配置可采购/转发模型的供应入口和默认结算规则。
+              {{ t('llmOps.channelModal.description') }}
             </p>
           </div>
           <button
@@ -29,7 +33,7 @@
             :disabled="saving"
             @click="close"
           >
-            关闭
+            {{ t('common.close') }}
           </button>
         </div>
       </div>
@@ -38,43 +42,49 @@
       >
         <section class="form-section">
           <div class="section-heading">
-            <h4>基础信息</h4>
-            <p>用于识别渠道，以及记录后续对接接口的入口。</p>
+            <h4>{{ t('llmOps.channelModal.basicTitle') }}</h4>
+            <p>{{ t('llmOps.channelModal.basicHint') }}</p>
           </div>
           <div class="grid gap-4 md:grid-cols-2">
             <label class="field-group">
-              <span class="field-label">渠道显示名称</span>
+              <span class="field-label">
+                {{ t('llmOps.channelModal.fields.name') }}
+              </span>
               <input
                 v-model="form.name"
                 class="field"
-                placeholder="例如：生产转发渠道"
+                :placeholder="t('llmOps.channelModal.placeholders.name')"
                 required
               />
               <span class="field-help">
-                展示在渠道列表、模型转发关系和价格对比中的名称。
+                {{ t('llmOps.channelModal.help.name') }}
               </span>
             </label>
             <label class="field-group">
-              <span class="field-label">渠道标识</span>
+              <span class="field-label">
+                {{ t('llmOps.channelModal.fields.code') }}
+              </span>
               <input
                 v-model="form.code"
                 class="field"
-                placeholder="例如：prod-forwarding-channel"
+                :placeholder="t('llmOps.channelModal.placeholders.code')"
                 required
               />
               <span class="field-help">
-                系统唯一标识，建议使用小写英文、数字和短横线。
+                {{ t('llmOps.channelModal.help.code') }}
               </span>
             </label>
             <label class="field-group md:col-span-2">
-              <span class="field-label">转发 API Base URL</span>
+              <span class="field-label">
+                {{ t('llmOps.channelModal.fields.apiEndpoint') }}
+              </span>
               <input
                 v-model="form.api_endpoint"
                 class="field"
-                placeholder="例如：https://llm.example.com/v1"
+                :placeholder="t('llmOps.channelModal.placeholders.apiEndpoint')"
               />
               <span class="field-help">
-                渠道提供的模型转发接口地址；暂无接口时可先留空。
+                {{ t('llmOps.channelModal.help.apiEndpoint') }}
               </span>
             </label>
           </div>
@@ -82,22 +92,26 @@
 
         <section class="form-section">
           <div class="section-heading">
-            <h4>结算规则</h4>
-            <p>作为该渠道模型的默认采购价规则，单个模型仍可覆盖。</p>
+            <h4>{{ t('llmOps.channelModal.settlementTitle') }}</h4>
+            <p>{{ t('llmOps.channelModal.settlementHint') }}</p>
           </div>
           <div class="grid gap-4 md:grid-cols-2">
             <label class="field-group">
-              <span class="field-label">默认结算币种</span>
+              <span class="field-label">
+                {{ t('llmOps.channelModal.fields.currency') }}
+              </span>
               <CompactSelect
                 v-model="form.currency"
                 :options="currencyOptions"
               />
               <span class="field-help">
-                渠道默认采购币种；单个模型可在模型管理中覆盖。
+                {{ t('llmOps.channelModal.help.currency') }}
               </span>
             </label>
             <label class="field-group">
-              <span class="field-label">默认采购折扣比例</span>
+              <span class="field-label">
+                {{ t('llmOps.channelModal.fields.settlementRatio') }}
+              </span>
               <div class="relative">
                 <input
                   v-model="settlementRatioPercent"
@@ -105,12 +119,14 @@
                   min="0.01"
                   step="0.01"
                   type="number"
-                  placeholder="例如：85"
+                  :placeholder="
+                    t('llmOps.channelModal.placeholders.settlementRatio')
+                  "
                 />
                 <span class="field-suffix">%</span>
               </div>
               <span class="field-help">
-                采购价 = 价格源价格 × 折扣比例；85% 表示按 0.85 倍采购。
+                {{ t('llmOps.channelModal.help.settlementRatio') }}
               </span>
             </label>
           </div>
@@ -118,18 +134,20 @@
 
         <section class="form-section">
           <div class="section-heading">
-            <h4>补充信息</h4>
-            <p>记录合同、账期或模型覆盖限制。</p>
+            <h4>{{ t('llmOps.channelModal.notesTitle') }}</h4>
+            <p>{{ t('llmOps.channelModal.notesHint') }}</p>
           </div>
           <label class="field-group">
-            <span class="field-label">运营备注</span>
+            <span class="field-label">
+              {{ t('llmOps.channelModal.fields.notes') }}
+            </span>
             <textarea
               v-model="form.notes"
               class="field min-h-20 resize-none"
-              placeholder="例如：合同折扣、结算周期、特殊限制"
+              :placeholder="t('llmOps.channelModal.placeholders.notes')"
             />
             <span class="field-help">
-              可记录账期、限流、合同折扣、模型覆盖范围等信息。
+              {{ t('llmOps.channelModal.help.notes') }}
             </span>
           </label>
         </section>
@@ -144,7 +162,11 @@
             <span class="status-switch-dot" />
           </span>
           <span class="text-sm text-slate-700">
-            {{ form.is_active ? '渠道已启用' : '渠道已停用' }}
+            {{
+              form.is_active
+                ? t('llmOps.channelModal.enabled')
+                : t('llmOps.channelModal.disabled')
+            }}
           </span>
         </label>
         <div class="modal-footer-actions">
@@ -154,7 +176,7 @@
             :disabled="saving"
             @click="close"
           >
-            取消
+            {{ t('common.cancel') }}
           </button>
           <button
             class="btn-primary btn-action-save"
@@ -162,7 +184,13 @@
             :disabled="saving"
           >
             <span class="icon-mark" />
-            {{ saving ? '保存中' : form.id ? '保存修改' : '创建渠道' }}
+            {{
+              saving
+                ? t('common.saving')
+                : form.id
+                  ? t('llmOps.channelModal.saveChanges')
+                  : t('llmOps.channelModal.createChannel')
+            }}
           </button>
         </div>
       </div>
@@ -172,6 +200,8 @@
 
 <script setup>
 import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
 import { llmOpsApi } from '@/api/llmOps'
 import CompactSelect from '@/components/llm-ops/CompactSelect.vue'
 
@@ -187,6 +217,7 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['close', 'saved'])
+const { t } = useI18n()
 
 const form = ref(defaults())
 const saving = ref(false)

--- a/frontend/src/components/llm-ops/ChannelModelDrawer.vue
+++ b/frontend/src/components/llm-ops/ChannelModelDrawer.vue
@@ -26,14 +26,14 @@
           </div>
           <div class="flex flex-wrap items-center justify-end gap-2">
             <span v-if="hasUnsavedChanges" class="dirty-badge">
-              未保存变更
+              {{ t('llmOps.channelModelDrawer.unsaved') }}
             </span>
             <button
               type="button"
               class="btn-secondary btn-action-cancel"
               @click="close"
             >
-              关闭
+              {{ t('common.close') }}
             </button>
             <button
               type="button"
@@ -42,7 +42,9 @@
               @click="save"
             >
               <span class="icon-mark" :class="saving ? 'animate-spin' : ''" />
-              {{ saving ? '保存中' : saveButtonLabel }}
+              {{
+                saving ? t('llmOps.channelModelDrawer.saving') : saveButtonLabel
+              }}
             </button>
           </div>
         </div>
@@ -52,19 +54,34 @@
         <div class="panel space-y-4">
           <div class="flex flex-col gap-3 xl:flex-row xl:items-start">
             <div class="min-w-0 flex-1">
-              <h4 class="text-sm font-semibold text-slate-900">添加渠道模型</h4>
+              <h4 class="text-sm font-semibold text-slate-900">
+                {{ t('llmOps.channelModelDrawer.addTitle') }}
+              </h4>
               <p class="mt-1 text-xs leading-5 text-slate-500">
-                先选择元模型，再指定该渠道实际使用的上游供货源。
-                添加后默认启用，可在下方设置成本规则和固定成本价。
+                {{ t('llmOps.channelModelDrawer.addDescription') }}
               </p>
             </div>
             <div class="flex flex-wrap gap-2 text-xs text-slate-500">
               <span class="summary-pill">
-                已配置 {{ managedRows.length }}
+                {{
+                  t('llmOps.channelModelDrawer.configuredCount', {
+                    count: managedRows.length
+                  })
+                }}
               </span>
-              <span class="summary-pill"> 已启用 {{ listedCount }} </span>
               <span class="summary-pill">
-                可添加 {{ availableModelCount }}
+                {{
+                  t('llmOps.channelModelDrawer.enabledCount', {
+                    count: listedCount
+                  })
+                }}
+              </span>
+              <span class="summary-pill">
+                {{
+                  t('llmOps.channelModelDrawer.availableCount', {
+                    count: availableModelCount
+                  })
+                }}
               </span>
             </div>
           </div>
@@ -73,19 +90,27 @@
             <div class="add-model-main">
               <div class="add-grid">
                 <div class="form-field">
-                  <label class="field-label">元模型厂商</label>
+                  <label class="field-label">
+                    {{ t('llmOps.channelModelDrawer.metaVendor') }}
+                  </label>
                   <CompactSelect
                     v-model="selectedVendorKey"
                     :options="vendorOptions"
-                    placeholder="先选择元模型厂商"
+                    :placeholder="
+                      t('llmOps.channelModelDrawer.selectMetaVendor')
+                    "
                     searchable
-                    search-placeholder="搜索厂商"
+                    :search-placeholder="
+                      t('llmOps.channelModelDrawer.searchVendor')
+                    "
                     @change="handleVendorChange"
                   />
                 </div>
 
                 <div class="form-field model-select-field">
-                  <label class="field-label">选择元模型</label>
+                  <label class="field-label">
+                    {{ t('llmOps.channelModelDrawer.selectMetaModel') }}
+                  </label>
                   <div ref="modelDropdownRef" class="searchable-select">
                     <button
                       class="searchable-trigger"
@@ -98,16 +123,22 @@
                           v-if="selectedModelCount"
                           class="block truncate font-medium text-slate-800"
                         >
-                          已选 {{ selectedModelCount }} 个元模型
+                          {{
+                            t('llmOps.channelModelDrawer.selectedMetaModels', {
+                              count: selectedModelCount
+                            })
+                          }}
                         </span>
                         <span
                           v-else-if="!selectedVendorKey"
                           class="block truncate text-slate-400"
                         >
-                          先选择元模型厂商
+                          {{ t('llmOps.channelModelDrawer.selectMetaVendor') }}
                         </span>
                         <span v-else class="block truncate text-slate-400">
-                          搜索并选择元模型
+                          {{
+                            t('llmOps.channelModelDrawer.searchAndSelectModel')
+                          }}
                         </span>
                       </span>
                       <span class="dropdown-caret">⌄</span>
@@ -118,14 +149,25 @@
                         ref="modelSearchInput"
                         v-model="modelSearch"
                         class="searchable-input"
-                        placeholder="名称 / code / 模态"
+                        :placeholder="
+                          t('llmOps.channelModelDrawer.modelSearchPlaceholder')
+                        "
                         @keydown.escape="closeModelDropdown"
                       />
                       <div class="searchable-meta">
                         <span>
-                          {{ availableModelGroups.length }} 个可添加元模型
+                          {{
+                            t('llmOps.channelModelDrawer.addableMetaModels', {
+                              count: availableModelGroups.length
+                            })
+                          }}
                           <template v-if="selectedModelCount">
-                            · 已选 {{ selectedModelCount }}
+                            ·
+                            {{
+                              t('llmOps.channelModelDrawer.selectedShort', {
+                                count: selectedModelCount
+                              })
+                            }}
                           </template>
                         </span>
                         <span class="searchable-meta-actions">
@@ -133,13 +175,15 @@
                             type="button"
                             @click.stop="selectVisibleModels"
                           >
-                            全选当前结果
+                            {{
+                              t('llmOps.channelModelDrawer.selectAllVisible')
+                            }}
                           </button>
                           <button
                             type="button"
                             @click.stop="clearSelectedModels"
                           >
-                            清空
+                            {{ t('common.clear') }}
                           </button>
                         </span>
                       </div>
@@ -189,7 +233,7 @@
                           v-if="!availableModelOptions.length"
                           class="searchable-empty"
                         >
-                          没有匹配的可添加模型
+                          {{ t('llmOps.channelModelDrawer.noMatchedModels') }}
                         </div>
                       </div>
                     </div>
@@ -198,7 +242,9 @@
 
                 <div class="inline-cost-grid">
                   <div class="form-field">
-                    <label class="field-label">成本规则</label>
+                    <label class="field-label">
+                      {{ t('llmOps.channelModelDrawer.costRule') }}
+                    </label>
                     <CompactSelect
                       v-model="newDraft.price_mode"
                       :options="priceModeOptions"
@@ -207,12 +253,18 @@
                   </div>
 
                   <div class="form-field">
-                    <label class="field-label">配置值</label>
+                    <label class="field-label">
+                      {{ t('llmOps.channelModelDrawer.configValue') }}
+                    </label>
                     <div
                       v-if="newDraft.price_mode === 'channel_default'"
                       class="readonly-field cost-value-readonly"
                     >
-                      <span class="truncate">渠道默认折扣</span>
+                      <span class="truncate">
+                        {{
+                          t('llmOps.channelModelDrawer.channelDefaultDiscount')
+                        }}
+                      </span>
                       <strong>
                         {{ ratioPercent(props.channel?.settlement_ratio, 1) }}
                       </strong>
@@ -246,7 +298,7 @@
                           class="field compact-field text-right"
                           step="0.000001"
                           type="number"
-                          placeholder="可选"
+                          :placeholder="t('common.optional')"
                         />
                       </label>
                       <div
@@ -256,18 +308,23 @@
                         "
                         class="fixed-price-note"
                       >
-                        当前模型的图片等特殊计价维度暂不支持在渠道配置中手动覆盖，
-                        会使用上游价格或折扣后的渠道成本价。
+                        {{
+                          t(
+                            'llmOps.channelModelDrawer.unsupportedFixedPriceNote'
+                          )
+                        }}
                       </div>
                       <div
                         v-else-if="!selectedCostModel"
                         class="fixed-price-note"
                       >
-                        先选择元模型，再配置固定成本价。
+                        {{ t('llmOps.channelModelDrawer.selectModelForFixed') }}
                       </div>
                     </div>
                     <div v-else class="readonly-field">
-                      <span class="truncate">跟随成本规则</span>
+                      <span class="truncate">
+                        {{ t('llmOps.channelModelDrawer.followCostRule') }}
+                      </span>
                     </div>
                   </div>
                 </div>
@@ -279,11 +336,13 @@
               >
                 <div class="batch-selection-head">
                   <div>
-                    <p>已选模型</p>
-                    <span>为每个元模型指定实际使用的渠道上游。</span>
+                    <p>{{ t('llmOps.channelModelDrawer.selectedModels') }}</p>
+                    <span>
+                      {{ t('llmOps.channelModelDrawer.selectedModelsHint') }}
+                    </span>
                   </div>
                   <button type="button" @click="clearSelectedModels">
-                    清空选择
+                    {{ t('llmOps.channelModelDrawer.clearSelection') }}
                   </button>
                 </div>
                 <div class="batch-selection-list">
@@ -302,31 +361,49 @@
                         selectedProviderByModelKey[item.group.key] || ''
                       "
                       :options="item.options"
-                      placeholder="选择渠道上游"
+                      :placeholder="
+                        t('llmOps.channelModelDrawer.selectChannelUpstream')
+                      "
                       searchable
-                      search-placeholder="搜索上游 / 币种 / 类型"
+                      :search-placeholder="
+                        t('llmOps.channelModelDrawer.searchUpstream')
+                      "
                       @change="
                         (value) =>
                           selectBatchPriceSourceModel(item.group.key, value)
                       "
                     />
                     <div v-else class="readonly-field">
-                      <span class="truncate">无可用上游</span>
+                      <span class="truncate">
+                        {{ t('llmOps.channelModelDrawer.noAvailableUpstream') }}
+                      </span>
                     </div>
                     <div v-if="item.model" class="batch-price-preview">
                       <span>
-                        上游 {{ batchUpstreamPriceSummary(item.model) }}
+                        {{
+                          t('llmOps.channelModelDrawer.upstreamSummary', {
+                            value: batchUpstreamPriceSummary(item.model)
+                          })
+                        }}
                       </span>
                       <strong>
-                        成本
                         {{
-                          batchPendingDraftPriceSummary(newDraft, item.model)
+                          t('llmOps.channelModelDrawer.costSummary', {
+                            value: batchPendingDraftPriceSummary(
+                              newDraft,
+                              item.model
+                            )
+                          })
                         }}
                       </strong>
                     </div>
                     <div v-else class="batch-price-preview muted">
-                      <span>待选择渠道上游</span>
-                      <strong>选择后显示价格</strong>
+                      <span>
+                        {{ t('llmOps.channelModelDrawer.pendingUpstream') }}
+                      </span>
+                      <strong>
+                        {{ t('llmOps.channelModelDrawer.priceAfterSelection') }}
+                      </strong>
                     </div>
                   </div>
                 </div>
@@ -334,7 +411,9 @@
             </div>
 
             <div class="channel-performance-panel">
-              <p class="channel-performance-title">模型转发能力</p>
+              <p class="channel-performance-title">
+                {{ t('llmOps.channelModelDrawer.forwardingCapability') }}
+              </p>
               <div class="channel-performance-grid">
                 <label
                   v-for="field in performanceFields"
@@ -358,18 +437,28 @@
           <div v-if="selectedModelOptions.length" class="pending-association">
             <div class="pending-main">
               <p class="truncate text-sm font-semibold text-slate-900">
-                已选 {{ selectedModelCount }} 个元模型
+                {{
+                  t('llmOps.channelModelDrawer.selectedMetaModels', {
+                    count: selectedModelCount
+                  })
+                }}
               </p>
               <p class="mt-1 truncate text-xs text-slate-500">
-                {{ selectedResolvedCount }} 个已指定上游
+                {{
+                  t('llmOps.channelModelDrawer.resolvedUpstreamCount', {
+                    count: selectedResolvedCount
+                  })
+                }}
               </p>
             </div>
             <div class="pending-price-compact">
-              <span>成本规则</span>
+              <span>{{ t('llmOps.channelModelDrawer.costRule') }}</span>
               <strong>{{ newDraftRuleSummary }}</strong>
             </div>
             <div class="pending-price-compact">
-              <span>转发能力</span>
+              <span>{{
+                t('llmOps.channelModelDrawer.forwardingCapability')
+              }}</span>
               <strong>{{ newDraftPerformanceSummary }}</strong>
             </div>
             <button
@@ -378,7 +467,11 @@
               :disabled="!canAddSelectedModels"
               @click="addSelectedModels"
             >
-              批量添加 {{ selectedModelCount }} 个模型
+              {{
+                t('llmOps.channelModelDrawer.batchAddModels', {
+                  count: selectedModelCount
+                })
+              }}
             </button>
           </div>
         </div>
@@ -387,7 +480,9 @@
           <input
             v-model="search"
             class="field compact-field"
-            placeholder="搜索已配置元模型、code 或上游来源"
+            :placeholder="
+              t('llmOps.channelModelDrawer.configuredSearchPlaceholder')
+            "
           />
         </div>
 
@@ -395,7 +490,11 @@
           <div class="table-toolbar">
             <div class="min-w-0">
               <h3 class="panel-title">
-                已配置元模型（{{ filteredRows.length }}）
+                {{
+                  t('llmOps.channelModelDrawer.configuredMetaModelsTitle', {
+                    count: filteredRows.length
+                  })
+                }}
               </h3>
               <div
                 v-if="changeSummaryLabels.length"
@@ -419,8 +518,10 @@
               >
                 {{
                   configuredRowsExpanded
-                    ? '收起'
-                    : `显示全部 ${filteredRows.length}`
+                    ? t('common.collapse')
+                    : t('llmOps.channelModelDrawer.showAll', {
+                        count: filteredRows.length
+                      })
                 }}
               </button>
             </div>
@@ -447,7 +548,7 @@
                 </div>
                 <OperationIconButton
                   icon="remove"
-                  label="移除"
+                  :label="t('common.remove')"
                   tone="danger"
                   @click="removeRow(row)"
                 />
@@ -473,22 +574,22 @@
 
               <div class="channel-model-summary-list">
                 <div class="channel-model-price-summary">
-                  <span>价格</span>
+                  <span>{{ t('llmOps.channelModelDrawer.price') }}</span>
                   <strong>
-                    <em>规则</em>
+                    <em>{{ t('llmOps.channelModelDrawer.rule') }}</em>
                     {{ priceRuleSummary(row) }}
                   </strong>
                   <strong>
-                    <em>成本</em>
+                    <em>{{ t('llmOps.channelModelDrawer.cost') }}</em>
                     {{ compactCostSummary(row) }}
                   </strong>
                   <strong>
-                    <em>上游</em>
+                    <em>{{ t('llmOps.channelModelDrawer.upstream') }}</em>
                     {{ upstreamPriceSummary(row.model) }}
                   </strong>
                 </div>
                 <div class="channel-model-ability-summary">
-                  <span>能力</span>
+                  <span>{{ t('llmOps.channelModelDrawer.capability') }}</span>
                   <strong
                     v-for="item in performanceSummaryItems(row)"
                     :key="item.label"
@@ -500,11 +601,15 @@
               </div>
 
               <details class="channel-model-detail">
-                <summary>配置详情</summary>
+                <summary>
+                  {{ t('llmOps.channelModelDrawer.configDetails') }}
+                </summary>
 
                 <div class="mt-3 grid gap-2 sm:grid-cols-2">
                   <div class="card-field">
-                    <span>上游价格</span>
+                    <span>{{
+                      t('llmOps.channelModelDrawer.upstreamPrice')
+                    }}</span>
                     <div class="mt-1 space-y-1 font-mono">
                       <p
                         v-for="item in providerPriceSummary(row.model)"
@@ -516,7 +621,9 @@
                     </div>
                   </div>
                   <div class="card-field">
-                    <span>渠道成本价</span>
+                    <span>{{
+                      t('llmOps.channelModelDrawer.channelCost')
+                    }}</span>
                     <div
                       v-if="row.priceItems?.length"
                       class="mt-1 flex flex-wrap gap-1"
@@ -533,7 +640,7 @@
                       </span>
                     </div>
                     <span v-else class="mt-1 block text-xs text-slate-400">
-                      保存后自动生成
+                      {{ t('llmOps.channelModelDrawer.generatedAfterSave') }}
                     </span>
                   </div>
                 </div>
@@ -585,14 +692,16 @@
                       class="field compact-field text-right"
                       step="0.000001"
                       type="number"
-                      placeholder="可选"
+                      :placeholder="t('common.optional')"
                     />
                   </label>
                   <span
                     v-if="!customPriceFields(row.model).length"
                     class="text-xs text-slate-400"
                   >
-                    当前模型暂不支持手动覆盖固定成本价。
+                    {{
+                      t('llmOps.channelModelDrawer.fixedOverrideUnsupported')
+                    }}
                   </span>
                 </div>
 
@@ -616,7 +725,7 @@
               </details>
             </article>
             <div v-if="!filteredRows.length" class="empty-card">
-              还没有配置模型，请先从上方添加。
+              {{ t('llmOps.channelModelDrawer.emptyConfigured') }}
             </div>
             <button
               v-if="hiddenConfiguredRowCount"
@@ -624,7 +733,11 @@
               class="show-more-card"
               @click="configuredRowsExpanded = true"
             >
-              还有 {{ hiddenConfiguredRowCount }} 个模型，点击显示全部
+              {{
+                t('llmOps.channelModelDrawer.hiddenModels', {
+                  count: hiddenConfiguredRowCount
+                })
+              }}
             </button>
           </div>
 
@@ -639,11 +752,21 @@
               </colgroup>
               <thead>
                 <tr>
-                  <th class="table-head">模型</th>
-                  <th class="table-head">上游</th>
-                  <th class="table-head">价格</th>
-                  <th class="table-head">能力</th>
-                  <th class="table-head action-col text-center">操作</th>
+                  <th class="table-head">
+                    {{ t('llmOps.fields.model') }}
+                  </th>
+                  <th class="table-head">
+                    {{ t('llmOps.channelModelDrawer.upstream') }}
+                  </th>
+                  <th class="table-head">
+                    {{ t('llmOps.channelModelDrawer.price') }}
+                  </th>
+                  <th class="table-head">
+                    {{ t('llmOps.channelModelDrawer.capability') }}
+                  </th>
+                  <th class="table-head action-col text-center">
+                    {{ t('common.actions') }}
+                  </th>
                 </tr>
               </thead>
               <tbody>
@@ -692,15 +815,15 @@
                   <td class="table-cell">
                     <div class="price-cell">
                       <p>
-                        <em>规则</em>
+                        <em>{{ t('llmOps.channelModelDrawer.rule') }}</em>
                         <strong>{{ priceRuleSummary(row) }}</strong>
                       </p>
                       <span>
-                        <em>成本</em>
+                        <em>{{ t('llmOps.channelModelDrawer.cost') }}</em>
                         <strong>{{ compactCostSummary(row) }}</strong>
                       </span>
                       <span>
-                        <em>上游</em>
+                        <em>{{ t('llmOps.channelModelDrawer.upstream') }}</em>
                         <strong>{{ upstreamPriceSummary(row.model) }}</strong>
                       </span>
                     </div>
@@ -728,7 +851,7 @@
                     <div class="flex items-center justify-center">
                       <OperationIconButton
                         icon="remove"
-                        label="移除"
+                        :label="t('common.remove')"
                         tone="danger"
                         @click="removeRow(row)"
                       />
@@ -742,13 +865,17 @@
                       class="link-btn"
                       @click="configuredRowsExpanded = true"
                     >
-                      还有 {{ hiddenConfiguredRowCount }} 个模型，点击显示全部
+                      {{
+                        t('llmOps.channelModelDrawer.hiddenModels', {
+                          count: hiddenConfiguredRowCount
+                        })
+                      }}
                     </button>
                   </td>
                 </tr>
                 <tr v-if="!filteredRows.length">
                   <td class="table-cell text-slate-500" colspan="5">
-                    还没有配置模型，请先从上方添加。
+                    {{ t('llmOps.channelModelDrawer.emptyConfigured') }}
                   </td>
                 </tr>
               </tbody>
@@ -764,6 +891,7 @@
 import '@/components/llm-ops/channelModelDrawer.css'
 
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import { llmOpsApi } from '@/api/llmOps'
 import {
@@ -820,6 +948,7 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['close', 'refresh', 'saved'])
+const { t } = useI18n()
 
 const search = ref('')
 const selectedVendorKey = ref('')
@@ -836,11 +965,20 @@ const saving = ref(false)
 const pendingRefresh = ref(false)
 const recentlyAddedModelId = ref(null)
 
-const priceModeOptions = [
-  { label: '默认折扣', value: 'channel_default' },
-  { label: '折扣比例', value: 'discount' },
-  { label: '固定成本价', value: 'fixed' }
-]
+const priceModeOptions = computed(() => [
+  {
+    label: t('llmOps.channelModelDrawer.priceMode.channelDefault'),
+    value: 'channel_default'
+  },
+  {
+    label: t('llmOps.channelModelDrawer.priceMode.discount'),
+    value: 'discount'
+  },
+  {
+    label: t('llmOps.channelModelDrawer.priceMode.fixed'),
+    value: 'fixed'
+  }
+])
 
 const channelCurrency = computed(() =>
   String(props.channel?.currency || 'USD').toUpperCase()
@@ -867,7 +1005,8 @@ const {
   channelCurrency,
   drafts,
   getChannel: () => props.channel,
-  getModelSourceCategory: (model) => modelSourceCategory(model)
+  getModelSourceCategory: (model) => modelSourceCategory(model),
+  t
 })
 
 const {
@@ -894,7 +1033,8 @@ const {
 } = useChannelModelPricing({
   customPriceFields,
   normalizeSearch,
-  props
+  props,
+  t
 })
 
 const changeSummary = computed(() => summarizeDraftChanges())
@@ -906,16 +1046,38 @@ const hasUnsavedChanges = computed(() =>
 const changeSummaryLabels = computed(() => {
   const summary = changeSummary.value
   return [
-    summary.added ? `新增 ${summary.added}` : '',
-    summary.modified ? `改成本 ${summary.modified}` : '',
-    summary.enabled ? `启用 ${summary.enabled}` : '',
-    summary.disabled ? `停用 ${summary.disabled}` : '',
-    summary.removed ? `移除 ${summary.removed}` : ''
+    summary.added
+      ? t('llmOps.channelModelDrawer.changeAdded', {
+          count: summary.added
+        })
+      : '',
+    summary.modified
+      ? t('llmOps.channelModelDrawer.changeModified', {
+          count: summary.modified
+        })
+      : '',
+    summary.enabled
+      ? t('llmOps.channelModelDrawer.changeEnabled', {
+          count: summary.enabled
+        })
+      : '',
+    summary.disabled
+      ? t('llmOps.channelModelDrawer.changeDisabled', {
+          count: summary.disabled
+        })
+      : '',
+    summary.removed
+      ? t('llmOps.channelModelDrawer.changeRemoved', {
+          count: summary.removed
+        })
+      : ''
   ].filter(Boolean)
 })
 
 const saveButtonLabel = computed(() =>
-  hasUnsavedChanges.value ? '保存变更' : '暂无变更'
+  hasUnsavedChanges.value
+    ? t('llmOps.channelModelDrawer.saveChanges')
+    : t('llmOps.channelModelDrawer.noChanges')
 )
 
 const baseAvailableModels = computed(() =>
@@ -975,7 +1137,8 @@ const {
   metaModelById,
   modalityLabel,
   modelSourceCategory,
-  sourceCategoryLabel
+  sourceCategoryLabel,
+  t
 })
 
 const {
@@ -1012,7 +1175,8 @@ const {
   selectedModelKeys,
   selectedProviderByModelKey,
   selectedVendorKey,
-  sourceCategoryBadge
+  sourceCategoryBadge,
+  t
 })
 
 const {
@@ -1040,7 +1204,8 @@ const {
   ratioPercent,
   ratioToPercentInput,
   recentlyAddedModelId,
-  selectedResolvedModels
+  selectedResolvedModels,
+  t
 })
 
 const {
@@ -1107,7 +1272,7 @@ function reset() {
 function close() {
   if (
     hasUnsavedChanges.value &&
-    !window.confirm('当前有未保存的模型配置变更，确定关闭抽屉吗？')
+    !window.confirm(t('llmOps.channelModelDrawer.closeConfirm'))
   ) {
     return
   }

--- a/frontend/src/components/llm-ops/ChannelPriceMatrixPanel.vue
+++ b/frontend/src/components/llm-ops/ChannelPriceMatrixPanel.vue
@@ -5,16 +5,18 @@
         class="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between"
       >
         <div>
-          <h3 class="panel-title">渠道横向比价矩阵</h3>
+          <h3 class="panel-title">
+            {{ t('llmOps.channelPriceMatrixPanel.title') }}
+          </h3>
           <p class="mt-1 text-xs text-slate-500">
-            按模型比较各渠道采购价格、最低价命中和覆盖缺口。
+            {{ t('llmOps.channelPriceMatrixPanel.subtitle') }}
           </p>
         </div>
         <div class="flex flex-col gap-2 sm:flex-row">
           <input
             v-model="keyword"
             class="llm-ops-input h-9 w-full sm:w-64"
-            placeholder="搜索模型或厂商"
+            :placeholder="t('llmOps.channelPriceMatrixPanel.searchPlaceholder')"
             type="search"
           />
           <CompactSelect
@@ -40,7 +42,9 @@
         <table class="data-table min-w-[980px]">
           <thead>
             <tr>
-              <th class="table-head sticky left-0 z-10 bg-white">模型</th>
+              <th class="table-head sticky left-0 z-10 bg-white">
+                {{ t('llmOps.fields.model') }}
+              </th>
               <th
                 v-for="channel in visibleChannels"
                 :key="channel.id"
@@ -48,8 +52,12 @@
               >
                 {{ channel.name }}
               </th>
-              <th class="table-head text-right">覆盖</th>
-              <th class="table-head">最低价渠道</th>
+              <th class="table-head text-right">
+                {{ t('llmOps.channelPriceMatrixPanel.columns.coverage') }}
+              </th>
+              <th class="table-head">
+                {{ t('llmOps.channelPriceMatrixPanel.columns.lowestChannel') }}
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -83,7 +91,9 @@
                 <span v-if="row.best_channel" class="status-pill success">
                   {{ row.best_channel.channel_name }}
                 </span>
-                <span v-else class="status-pill danger">缺渠道价</span>
+                <span v-else class="status-pill danger">
+                  {{ t('llmOps.channelPriceMatrixPanel.status.missing') }}
+                </span>
               </td>
             </tr>
             <tr v-if="!filteredRows.length">
@@ -91,7 +101,7 @@
                 class="table-cell text-slate-500"
                 :colspan="visibleChannels.length + 3"
               >
-                当前筛选条件下没有模型。
+                {{ t('llmOps.channelPriceMatrixPanel.empty') }}
               </td>
             </tr>
           </tbody>
@@ -103,6 +113,7 @@
 
 <script setup>
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import { asArray } from '@/utils/llmOpsPagination'
 
@@ -113,14 +124,24 @@ const props = defineProps({
   channels: { type: Array, default: () => [] }
 })
 
+const { t } = useI18n()
 const keyword = ref('')
 const statusFilter = ref('all')
-const statusFilterOptions = [
-  { label: '全部状态', value: 'all' },
-  { label: '缺渠道价', value: 'missing' },
-  { label: '单渠道覆盖', value: 'single' },
-  { label: '多渠道覆盖', value: 'ready' }
-]
+const statusFilterOptions = computed(() => [
+  { label: t('llmOps.channelPriceMatrixPanel.filters.all'), value: 'all' },
+  {
+    label: t('llmOps.channelPriceMatrixPanel.filters.missing'),
+    value: 'missing'
+  },
+  {
+    label: t('llmOps.channelPriceMatrixPanel.filters.single'),
+    value: 'single'
+  },
+  {
+    label: t('llmOps.channelPriceMatrixPanel.filters.ready'),
+    value: 'ready'
+  }
+])
 
 const rows = computed(() => asArray(props.summary.agione?.diagnostics))
 const visibleChannels = computed(() =>
@@ -156,24 +177,26 @@ const metrics = computed(() => {
   const missing = rows.value.filter((row) => !row.best_channel).length
   return [
     {
-      label: '模型总数',
+      label: t('llmOps.channelPriceMatrixPanel.metrics.total.label'),
       value: total,
-      hint: '参与渠道比价的活跃模型'
+      hint: t('llmOps.channelPriceMatrixPanel.metrics.total.hint')
     },
     {
-      label: '有渠道价',
+      label: t('llmOps.channelPriceMatrixPanel.metrics.covered.label'),
       value: covered,
-      hint: `覆盖率 ${percentage(covered, total)}%`
+      hint: t('llmOps.channelPriceMatrixPanel.metrics.covered.hint', {
+        percent: percentage(covered, total)
+      })
     },
     {
-      label: '单渠道风险',
+      label: t('llmOps.channelPriceMatrixPanel.metrics.single.label'),
       value: single,
-      hint: '只有一个采购渠道，缺少备选'
+      hint: t('llmOps.channelPriceMatrixPanel.metrics.single.hint')
     },
     {
-      label: '缺渠道价',
+      label: t('llmOps.channelPriceMatrixPanel.metrics.missing.label'),
       value: missing,
-      hint: '无法计算采购成本'
+      hint: t('llmOps.channelPriceMatrixPanel.metrics.missing.hint')
     }
   ]
 })

--- a/frontend/src/components/llm-ops/CollectionHealthPanel.vue
+++ b/frontend/src/components/llm-ops/CollectionHealthPanel.vue
@@ -14,9 +14,11 @@
     <div class="panel overflow-hidden p-0">
       <div class="table-toolbar">
         <div>
-          <h3 class="panel-title">采集健康度看板</h3>
+          <h3 class="panel-title">
+            {{ t('llmOps.collectionHealthPanel.title') }}
+          </h3>
           <p class="mt-1 text-xs text-slate-500">
-            按价格源查看最近采集、连续失败和数据新鲜度。
+            {{ t('llmOps.collectionHealthPanel.subtitle') }}
           </p>
         </div>
       </div>
@@ -24,13 +26,29 @@
         <table class="data-table">
           <thead>
             <tr>
-              <th class="table-head">价格源</th>
-              <th class="table-head">类型</th>
-              <th class="table-head">最近状态</th>
-              <th class="table-head text-right">成功率</th>
-              <th class="table-head text-right">连续失败</th>
-              <th class="table-head">最近采集</th>
-              <th class="table-head">健康状态</th>
+              <th class="table-head">
+                {{ t('llmOps.collectionHealthPanel.columns.source') }}
+              </th>
+              <th class="table-head">
+                {{ t('llmOps.collectionHealthPanel.columns.type') }}
+              </th>
+              <th class="table-head">
+                {{ t('llmOps.collectionHealthPanel.columns.latestStatus') }}
+              </th>
+              <th class="table-head text-right">
+                {{ t('llmOps.collectionHealthPanel.columns.successRate') }}
+              </th>
+              <th class="table-head text-right">
+                {{
+                  t('llmOps.collectionHealthPanel.columns.consecutiveFailures')
+                }}
+              </th>
+              <th class="table-head">
+                {{ t('llmOps.collectionHealthPanel.columns.lastCollected') }}
+              </th>
+              <th class="table-head">
+                {{ t('llmOps.collectionHealthPanel.columns.health') }}
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -64,7 +82,7 @@
             </tr>
             <tr v-if="!sourceRows.length">
               <td class="table-cell text-slate-500" colspan="7">
-                暂无价格源。
+                {{ t('llmOps.collectionHealthPanel.empty') }}
               </td>
             </tr>
           </tbody>
@@ -76,6 +94,8 @@
 
 <script setup>
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
 import {
   priceSourceCollectionMethod,
   priceSourceCollectionMethodLabel
@@ -85,6 +105,8 @@ const props = defineProps({
   sources: { type: Array, default: () => [] },
   runs: { type: Array, default: () => [] }
 })
+
+const { t } = useI18n()
 
 const sourceRows = computed(() =>
   props.sources
@@ -139,31 +161,33 @@ const metrics = computed(() => {
   ).length
   return [
     {
-      label: '价格源总数',
+      label: t('llmOps.collectionHealthPanel.metrics.total.label'),
       value: total,
       badge: `${percentage(healthy, total)}%`,
-      hint: '启用的官方、供应商和手工价格源',
+      hint: t('llmOps.collectionHealthPanel.metrics.total.hint'),
       tone: healthy === total && total ? 'good' : 'warn'
     },
     {
-      label: '健康价格源',
+      label: t('llmOps.collectionHealthPanel.metrics.healthy.label'),
       value: healthy,
-      badge: '正常',
-      hint: '最近一次采集成功且未超过新鲜度窗口',
+      badge: t('llmOps.collectionHealthPanel.badges.normal'),
+      hint: t('llmOps.collectionHealthPanel.metrics.healthy.hint'),
       tone: healthy ? 'good' : 'warn'
     },
     {
-      label: '采集失败',
+      label: t('llmOps.collectionHealthPanel.metrics.failed.label'),
       value: failed,
-      badge: failed ? '需处理' : '正常',
-      hint: '最近任务失败或存在连续失败',
+      badge: failed
+        ? t('llmOps.collectionHealthPanel.badges.needsHandling')
+        : t('llmOps.collectionHealthPanel.badges.normal'),
+      hint: t('llmOps.collectionHealthPanel.metrics.failed.hint'),
       tone: failed ? 'danger' : 'good'
     },
     {
-      label: '数据过期',
+      label: t('llmOps.collectionHealthPanel.metrics.stale.label'),
       value: stale,
-      badge: '7天阈值',
-      hint: '最近采集时间超过 7 天',
+      badge: t('llmOps.collectionHealthPanel.badges.sevenDayThreshold'),
+      hint: t('llmOps.collectionHealthPanel.metrics.stale.hint'),
       tone: stale ? 'warn' : 'good'
     }
   ]
@@ -191,12 +215,28 @@ function isStale(value) {
 }
 
 function healthState({ enabled, stale, failures, latestStatus }) {
-  if (!enabled) return { label: '已停用', tone: 'info' }
-  if (failures > 0 || latestStatus === 'failed') {
-    return { label: '采集失败', tone: 'danger' }
+  if (!enabled) {
+    return {
+      label: t('llmOps.collectionHealthPanel.health.disabled'),
+      tone: 'info'
+    }
   }
-  if (stale) return { label: '数据过期', tone: 'warn' }
-  return { label: '健康', tone: 'success' }
+  if (failures > 0 || latestStatus === 'failed') {
+    return {
+      label: t('llmOps.collectionHealthPanel.health.failed'),
+      tone: 'danger'
+    }
+  }
+  if (stale) {
+    return {
+      label: t('llmOps.collectionHealthPanel.health.stale'),
+      tone: 'warn'
+    }
+  }
+  return {
+    label: t('llmOps.collectionHealthPanel.health.healthy'),
+    tone: 'success'
+  }
 }
 
 function healthRank(tone) {
@@ -205,17 +245,33 @@ function healthRank(tone) {
 
 function sourceCategoryLabel(source) {
   const method = priceSourceCollectionMethod(source)
-  return priceSourceCollectionMethodLabel(method)
+  return priceSourceCollectionMethodLabel(method, collectionMethodLabels())
 }
 
 function statusLabel(status) {
   return (
     {
-      succeeded: '成功',
-      failed: '失败',
-      running: '运行中'
-    }[status] || '暂无'
+      succeeded: t('llmOps.collectionHealthPanel.runStatus.succeeded'),
+      failed: t('llmOps.collectionHealthPanel.runStatus.failed'),
+      running: t('llmOps.collectionHealthPanel.runStatus.running')
+    }[status] || t('llmOps.collectionHealthPanel.runStatus.none')
   )
+}
+
+function collectionMethodLabels() {
+  return {
+    auto_collect: t(
+      'llmOps.collectionHealthPanel.collectionMethod.autoCollect'
+    ),
+    api_sync: t('llmOps.collectionHealthPanel.collectionMethod.apiSync'),
+    manual_entry: t(
+      'llmOps.collectionHealthPanel.collectionMethod.manualEntry'
+    ),
+    manual_import: t(
+      'llmOps.collectionHealthPanel.collectionMethod.manualImport'
+    ),
+    unknown: t('llmOps.collectionHealthPanel.collectionMethod.unknown')
+  }
 }
 
 function statusTone(status) {

--- a/frontend/src/components/llm-ops/CollectionRunLogPanel.vue
+++ b/frontend/src/components/llm-ops/CollectionRunLogPanel.vue
@@ -292,11 +292,17 @@ const statusOptions = computed(() => [
 const categoryOptions = computed(() => [
   { label: t('llmOps.taskLogs.categories.all'), value: '' },
   {
-    label: priceSourceCollectionMethodLabel('auto_collect'),
+    label: priceSourceCollectionMethodLabel(
+      'auto_collect',
+      collectionMethodLabels()
+    ),
     value: 'auto'
   },
   {
-    label: priceSourceCollectionMethodLabel('manual_entry'),
+    label: priceSourceCollectionMethodLabel(
+      'manual_entry',
+      collectionMethodLabels()
+    ),
     value: 'manual'
   },
   { label: t('llmOps.taskLogs.categories.unknown'), value: 'unknown' }
@@ -457,11 +463,33 @@ function statusTone(status) {
 
 function categoryLabel(category) {
   const labels = {
-    auto: priceSourceCollectionMethodLabel('auto_collect'),
-    manual: priceSourceCollectionMethodLabel('manual_entry'),
+    auto: priceSourceCollectionMethodLabel(
+      'auto_collect',
+      collectionMethodLabels()
+    ),
+    manual: priceSourceCollectionMethodLabel(
+      'manual_entry',
+      collectionMethodLabels()
+    ),
     unknown: t('llmOps.taskLogs.categories.unknown')
   }
   return labels[category] || labels.unknown
+}
+
+function collectionMethodLabels() {
+  return {
+    auto_collect: t(
+      'llmOps.collectionHealthPanel.collectionMethod.autoCollect'
+    ),
+    api_sync: t('llmOps.collectionHealthPanel.collectionMethod.apiSync'),
+    manual_entry: t(
+      'llmOps.collectionHealthPanel.collectionMethod.manualEntry'
+    ),
+    manual_import: t(
+      'llmOps.collectionHealthPanel.collectionMethod.manualImport'
+    ),
+    unknown: t('llmOps.collectionHealthPanel.collectionMethod.unknown')
+  }
 }
 
 function categoryTone(category) {

--- a/frontend/src/components/llm-ops/LLMOpsMonitorDashboard.vue
+++ b/frontend/src/components/llm-ops/LLMOpsMonitorDashboard.vue
@@ -1,207 +1,43 @@
 <template>
   <section class="space-y-6">
-    <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
-      <div v-for="item in kpiCards" :key="item.label" class="kpi-card">
-        <div class="flex items-start justify-between gap-3">
-          <div>
-            <p class="text-xs font-medium text-slate-500">
-              {{ item.label }}
-            </p>
-            <p class="kpi-value mt-2 text-2xl font-semibold">
-              {{ item.value }}
-            </p>
-          </div>
-          <span :class="['kpi-tone', item.tone]">
-            {{ item.badge }}
-          </span>
+    <div class="kpi-decision-groups">
+      <div
+        v-for="group in groupedKpiCards"
+        :key="group.key"
+        class="kpi-decision-group"
+      >
+        <div class="kpi-decision-group-head">
+          <span class="kpi-decision-group-mark" :class="group.markClass" />
+          <span>{{ group.label }}</span>
         </div>
-        <div class="mt-3 h-1.5 overflow-hidden rounded-full bg-slate-200">
-          <div
-            class="h-full rounded-full"
-            :class="item.barClass"
-            :style="{ width: `${item.progress}%` }"
-          />
-        </div>
-        <p class="mt-2 text-xs text-slate-500">
-          {{ item.hint }}
-        </p>
-      </div>
-    </div>
-
-    <div class="grid gap-4 xl:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
-      <div class="panel space-y-4">
-        <div class="flex items-center justify-between gap-3">
-          <div>
-            <p
-              class="text-xs font-semibold uppercase tracking-[0.18em] text-agione-600"
-            >
-              Action Queue
-            </p>
-            <h3 class="mt-2 text-lg font-semibold text-slate-900">
-              {{ t('llmOps.monitor.actionQueueTitle') }}
-            </h3>
-          </div>
-          <button
-            type="button"
-            class="btn-secondary btn-action-view"
-            @click="$emit('navigate', 'reseller')"
-          >
-            {{ t('llmOps.actions.goResale') }}
-          </button>
-        </div>
-        <div class="space-y-3">
-          <button
-            v-for="item in actionItems"
-            :key="item.label"
-            type="button"
-            class="action-row"
-            @click="$emit('navigate', item.section)"
-          >
-            <span :class="['action-dot', item.tone]" />
-            <span class="min-w-0 flex-1">
-              <span class="block text-sm font-medium text-slate-900">
-                {{ item.label }}
-              </span>
-              <span class="mt-1 block text-xs text-slate-500">
-                {{ item.hint }}
-              </span>
-            </span>
-            <span class="font-mono text-lg font-semibold text-slate-900">
-              {{ item.value }}
-            </span>
-          </button>
-        </div>
-      </div>
-
-      <div class="panel space-y-4">
         <div
-          class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+          class="grid gap-3"
+          :class="group.items.length > 1 ? 'md:grid-cols-2' : 'md:grid-cols-1'"
         >
-          <div>
-            <p
-              class="text-xs font-semibold uppercase tracking-[0.18em] text-agione-600"
-            >
-              Channel Coverage
-            </p>
-            <h3 class="mt-2 text-lg font-semibold text-slate-900">
-              {{ t('llmOps.monitor.channelCoverageTitle') }}
-            </h3>
-          </div>
-          <span class="text-sm text-slate-500">
-            {{
-              t('llmOps.monitor.channelCount', {
-                count: operationalChannelCount
-              })
-            }}
-          </span>
-        </div>
-        <div class="space-y-3">
-          <div
-            v-for="channel in channelCoverageRows"
-            :key="channel.id"
-            class="coverage-row"
-          >
-            <div class="flex items-center justify-between gap-4">
+          <div v-for="item in group.items" :key="item.key" class="kpi-card">
+            <div class="flex items-start justify-between gap-3">
               <div class="min-w-0">
-                <p class="truncate text-sm font-medium text-slate-900">
-                  {{ channel.name }}
+                <p class="text-xs font-medium text-slate-500">
+                  {{ item.label }}
                 </p>
-                <p class="mt-1 text-xs text-slate-500">
-                  {{
-                    t('llmOps.monitor.channelCoverageMeta', {
-                      covered: channel.covered,
-                      best: channel.best_count
-                    })
-                  }}
+                <p class="kpi-value mt-2 text-2xl font-semibold">
+                  {{ item.value }}
                 </p>
               </div>
-              <span class="font-mono text-sm text-slate-700">
-                {{ channel.coverage_rate }}%
+              <span :class="['kpi-tone', item.tone]">
+                {{ item.badge }}
               </span>
             </div>
-            <div class="mt-2 h-2 overflow-hidden rounded-full bg-slate-100">
+            <div class="mt-3 h-1.5 overflow-hidden rounded-full bg-slate-200">
               <div
-                class="h-full rounded-full bg-agione-500"
-                :style="{ width: `${channel.coverage_rate}%` }"
+                class="h-full rounded-full transition-all"
+                :class="item.barClass"
+                :style="{ width: `${item.progress}%` }"
               />
             </div>
-          </div>
-          <div
-            v-if="!channelCoverageRows.length"
-            class="rounded-lg border border-dashed border-slate-200 bg-slate-50 px-4 py-6 text-center text-sm text-slate-500"
-          >
-            {{ t('llmOps.monitor.emptyChannelCoverage') }}
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <div class="panel space-y-4">
-      <div
-        class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
-      >
-        <div>
-          <p
-            class="text-xs font-semibold uppercase tracking-[0.18em] text-agione-600"
-          >
-            Provider Matrix
-          </p>
-          <h3 class="mt-2 text-lg font-semibold text-slate-900">
-            {{ t('llmOps.monitor.providerMatrixTitle') }}
-          </h3>
-        </div>
-        <button
-          type="button"
-          class="btn-secondary btn-action-config"
-          @click="$emit('navigate', 'providers')"
-        >
-          {{ t('llmOps.actions.manageProviders') }}
-        </button>
-      </div>
-      <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-        <div
-          v-for="provider in providerCoverageRows"
-          :key="provider.name"
-          class="provider-card"
-        >
-          <div class="flex items-start justify-between gap-3">
-            <div class="min-w-0">
-              <p class="truncate text-sm font-semibold text-slate-900">
-                {{ provider.name }}
-              </p>
-              <p class="mt-1 text-xs text-slate-500">
-                {{
-                  t('llmOps.monitor.modelCount', {
-                    count: provider.model_count
-                  })
-                }}
-              </p>
-            </div>
-            <span
-              :class="provider.ready_rate >= 80 ? 'badge-ok' : 'badge-muted'"
-            >
-              {{ provider.ready_rate }}%
-            </span>
-          </div>
-          <div class="mt-3 space-y-2">
-            <div class="metric-line">
-              <span>{{ t('llmOps.monitor.channelCoverage') }}</span>
-              <strong>{{ provider.procured_count }}</strong>
-            </div>
-            <div class="metric-line">
-              <span>{{ t('llmOps.monitor.agioneListed') }}</span>
-              <strong>{{ provider.listed_count }}</strong>
-            </div>
-            <div class="metric-line">
-              <span>{{ t('llmOps.monitor.todo') }}</span>
-              <strong>{{ provider.todo_count }}</strong>
-            </div>
-          </div>
-          <div class="mt-3 h-1.5 overflow-hidden rounded-full bg-slate-100">
-            <div
-              class="h-full rounded-full bg-emerald-500"
-              :style="{ width: `${provider.ready_rate}%` }"
-            />
+            <p class="mt-2 text-xs text-slate-500">
+              {{ item.hint }}
+            </p>
           </div>
         </div>
       </div>
@@ -211,65 +47,82 @@
       <div class="table-toolbar">
         <div>
           <h3 class="panel-title">
-            {{ t('llmOps.monitor.focusTableTitle') }}
+            {{ t('llmOps.overview.decisionTable.title') }}
           </h3>
           <p class="mt-1 text-xs text-slate-500">
-            {{ t('llmOps.monitor.focusTableSubtitle') }}
+            {{ t('llmOps.overview.decisionTable.subtitle') }}
           </p>
         </div>
         <div class="flex flex-col gap-2 sm:flex-row">
           <CompactSelect
-            v-model="simulationChannelModel"
-            :options="simulationChannelOptions"
-            class-name="w-36"
-            size="sm"
-          />
-          <CompactSelect
             v-model="simulationStatusModel"
             :options="simulationStatusOptions"
-            class-name="w-32"
+            class-name="w-40"
             size="sm"
           />
         </div>
       </div>
       <div class="overflow-x-auto">
-        <table class="data-table">
+        <table class="data-table decision-table">
           <thead>
             <tr>
-              <th class="table-head">{{ t('llmOps.fields.model') }}</th>
-              <th class="table-head">{{ t('llmOps.fields.provider') }}</th>
-              <th class="table-head text-right">
-                {{ t('llmOps.monitor.channelCoverage') }}
+              <th class="table-head w-10" />
+              <th class="table-head">
+                {{ t('llmOps.overview.columns.model') }}
               </th>
               <th class="table-head">
-                {{
-                  simulationChannel
-                    ? t('llmOps.monitor.filteredChannel')
-                    : t('llmOps.monitor.lowestProcurementChannel')
-                }}
+                {{ t('llmOps.overview.columns.provider') }}
+              </th>
+              <th class="table-head text-right">
+                {{ t('llmOps.overview.columns.coverage') }}
               </th>
               <th class="table-head">
-                {{ currentPlatformListingLabel }}
+                {{ t('llmOps.overview.columns.recommended') }}
+              </th>
+              <th class="table-head">
+                {{ t('llmOps.overview.columns.currentListing') }}
               </th>
               <th class="table-head text-right">
-                {{
-                  simulationChannel
-                    ? t('llmOps.price.input')
-                    : t('llmOps.price.lowestInput')
-                }}
+                {{ t('llmOps.overview.columns.purchasePrice') }}
               </th>
               <th class="table-head text-right">
-                {{
-                  simulationChannel
-                    ? t('llmOps.price.output')
-                    : t('llmOps.price.lowestOutput')
-                }}
+                {{ t('llmOps.overview.columns.listingPrice') }}
               </th>
-              <th class="table-head">{{ t('llmOps.fields.status') }}</th>
+              <th class="table-head text-right">
+                {{ t('llmOps.overview.columns.inputYield') }}
+              </th>
+              <th class="table-head text-right">
+                {{ t('llmOps.overview.columns.outputYield') }}
+              </th>
+              <th class="table-head">
+                {{ t('llmOps.overview.columns.action') }}
+              </th>
+              <th class="table-head">
+                {{ t('llmOps.overview.columns.lastUpdate') }}
+              </th>
             </tr>
           </thead>
           <tbody>
-            <tr v-for="row in monitorTableRows" :key="row.model_id">
+            <tr
+              v-for="row in monitorTableRows"
+              :key="row.model_id"
+              :aria-label="rowAriaLabel(row)"
+              :class="['decision-row', rowClass(row)]"
+              class="cursor-pointer transition"
+              role="button"
+              tabindex="0"
+              @click="handleRowClick(row)"
+              @keydown.enter="handleRowClick(row)"
+              @keydown.space.prevent="handleRowClick(row)"
+            >
+              <td class="table-cell">
+                <span
+                  :class="['status-icon', row.status_tone]"
+                  :title="statusTitle(row)"
+                >
+                  {{ statusGlyph(row.decision_status) }}
+                </span>
+              </td>
               <td class="table-cell">
                 <p class="font-medium text-slate-900">
                   {{ row.model_name }}
@@ -286,47 +139,103 @@
                 {{ row.coverage_count }} / {{ operationalChannelCount }}
               </td>
               <td class="table-cell">
-                {{
-                  row.display_channel?.channel_name ||
-                  t('llmOps.status.noSupply')
-                }}
+                <span v-if="row.recommended_channel?.channel_name">
+                  {{ row.recommended_channel.channel_name }}
+                </span>
+                <span v-else class="text-slate-400">-</span>
               </td>
               <td class="table-cell">
-                <span
-                  :class="row.is_agione_listed ? 'badge-ok' : 'badge-muted'"
-                >
+                <span v-if="row.current_listing?.is_listed" class="badge-ok">
                   {{
-                    row.is_agione_listed
-                      ? t('llmOps.status.listed')
-                      : t('llmOps.status.unlisted')
+                    row.current_listing.channel_name ||
+                    t('llmOps.status.listed')
                   }}
                 </span>
+                <span v-else class="badge-muted">
+                  {{ t('llmOps.status.unlisted') }}
+                </span>
+              </td>
+              <td class="table-cell text-right font-mono text-xs">
+                <div v-if="procurementPriceRows(row).length" class="price-pair">
+                  <span
+                    v-for="price in procurementPriceRows(row)"
+                    :key="price.label"
+                    class="price-pair-row"
+                  >
+                    <span class="price-pair-label">{{ price.label }}</span>
+                    <span>{{ price.value }}</span>
+                  </span>
+                </div>
+                <span v-else class="text-slate-400">-</span>
+              </td>
+              <td class="table-cell text-right font-mono text-xs">
+                <div v-if="listingPriceRows(row).length" class="price-pair">
+                  <span
+                    v-for="price in listingPriceRows(row)"
+                    :key="price.label"
+                    class="price-pair-row"
+                  >
+                    <span class="price-pair-label">{{ price.label }}</span>
+                    <span>{{ price.value }}</span>
+                  </span>
+                </div>
+                <span v-else class="text-slate-400">-</span>
               </td>
               <td class="table-cell text-right font-mono">
-                {{
-                  money(
-                    row.display_channel?.input_price_per_million,
-                    row.display_channel?.currency
-                  )
-                }}
+                {{ percent(row.input_yield) }}
               </td>
               <td class="table-cell text-right font-mono">
-                {{
-                  money(
-                    row.display_channel?.output_price_per_million,
-                    row.display_channel?.currency
-                  )
-                }}
+                {{ percent(row.output_yield) }}
               </td>
               <td class="table-cell">
-                <span :class="['status-pill', row.status_tone]">
-                  {{ row.status_label }}
-                </span>
+                <div class="decision-action-cell">
+                  <span :class="['status-pill', row.status_tone]">
+                    {{ actionLabel(row) }}
+                  </span>
+                  <div class="decision-hover-panel" role="status">
+                    <div class="decision-hover-title">
+                      {{ statusTitle(row) }}
+                    </div>
+                    <div class="decision-hover-grid">
+                      <span>{{ t('llmOps.overview.hover.action') }}</span>
+                      <strong>{{ actionLabel(row) }}</strong>
+                      <span>{{ t('llmOps.overview.hover.recommended') }}</span>
+                      <strong>{{
+                        channelText(row.recommended_channel)
+                      }}</strong>
+                      <span>{{ t('llmOps.overview.hover.current') }}</span>
+                      <strong>{{ currentListingText(row) }}</strong>
+                      <span>{{
+                        t('llmOps.overview.hover.purchasePrice')
+                      }}</span>
+                      <strong>{{
+                        priceSummary(procurementPriceRows(row))
+                      }}</strong>
+                      <span>{{ t('llmOps.overview.hover.listingPrice') }}</span>
+                      <strong>{{ priceSummary(listingPriceRows(row)) }}</strong>
+                      <span>{{ t('llmOps.overview.hover.yield') }}</span>
+                      <strong>{{ yieldSummary(row) }}</strong>
+                    </div>
+                  </div>
+                </div>
+              </td>
+              <td class="table-cell text-xs text-slate-500">
+                <div class="flex flex-col gap-1">
+                  <span :title="absoluteTime(row.last_data_event_at)">
+                    {{ relativeTime(row.last_data_event_at) }}
+                  </span>
+                  <span
+                    v-if="row.data_event_type"
+                    :class="['event-pill', eventTone(row.data_event_type)]"
+                  >
+                    {{ eventLabel(row.data_event_type) }}
+                  </span>
+                </div>
               </td>
             </tr>
             <tr v-if="!monitorTableRows.length">
-              <td class="table-cell text-slate-500" colspan="8">
-                {{ t('llmOps.monitor.emptyFocusRows') }}
+              <td class="table-cell text-slate-500" colspan="12">
+                {{ emptyMessage }}
               </td>
             </tr>
           </tbody>
@@ -343,75 +252,483 @@ import { useI18n } from 'vue-i18n'
 import CompactSelect from '@/components/llm-ops/CompactSelect.vue'
 
 const props = defineProps({
-  actionItems: {
-    type: Array,
-    required: true
-  },
-  channelCoverageRows: {
-    type: Array,
-    required: true
-  },
-  currentPlatformListingLabel: {
-    type: String,
-    required: true
-  },
-  kpiCards: {
-    type: Array,
-    required: true
-  },
-  monitorModelSubtitle: {
-    type: Function,
-    required: true
-  },
-  monitorTableRows: {
-    type: Array,
-    required: true
-  },
-  money: {
-    type: Function,
-    required: true
-  },
-  operationalChannelCount: {
-    type: Number,
-    required: true
-  },
-  providerCoverageRows: {
-    type: Array,
-    required: true
-  },
-  simulationChannel: {
-    type: [String, Number],
-    default: ''
-  },
-  simulationChannelOptions: {
-    type: Array,
-    required: true
-  },
-  simulationStatus: {
-    type: String,
-    required: true
-  },
-  simulationStatusOptions: {
-    type: Array,
-    required: true
-  }
+  kpiCards: { type: Array, required: true },
+  monitorModelSubtitle: { type: Function, required: true },
+  monitorTableRows: { type: Array, required: true },
+  operationalChannelCount: { type: Number, required: true },
+  simulationStatus: { type: String, required: true },
+  simulationStatusOptions: { type: Array, required: true }
 })
 
-const emit = defineEmits([
-  'navigate',
-  'update:simulationChannel',
-  'update:simulationStatus'
-])
+const emit = defineEmits(['navigateToWorkspace', 'update:simulationStatus'])
 
 const { t } = useI18n()
-
-const simulationChannelModel = computed({
-  get: () => props.simulationChannel,
-  set: (value) => emit('update:simulationChannel', value)
-})
 
 const simulationStatusModel = computed({
   get: () => props.simulationStatus,
   set: (value) => emit('update:simulationStatus', value)
 })
+
+const emptyMessage = computed(() => {
+  if (props.simulationStatus === 'all') {
+    return t('llmOps.overview.emptyDecisionRows')
+  }
+  if (props.simulationStatus === 'priority') {
+    return t('llmOps.overview.emptyDecisionAllReady')
+  }
+  return t('llmOps.overview.emptyDecisionFiltered')
+})
+
+const KPI_GROUP_ORDER = ['supply', 'yield', 'data']
+const KPI_GROUP_MARKS = {
+  supply: 'mark-supply',
+  yield: 'mark-yield',
+  data: 'mark-data'
+}
+
+const groupedKpiCards = computed(() =>
+  KPI_GROUP_ORDER.map((key) => ({
+    key,
+    label: kpiGroupLabel(key),
+    markClass: KPI_GROUP_MARKS[key],
+    items: props.kpiCards.filter((item) => item.group === key)
+  })).filter((group) => group.items.length)
+)
+
+function handleRowClick(row) {
+  emit('navigateToWorkspace', {
+    autoListing: Boolean(
+      row.current_listing?.is_listed && row.current_listing.channel_id === null
+    ),
+    modelId: row.model_id
+  })
+}
+
+function percent(value) {
+  if (value === null || value === undefined || value === '') return '-'
+  const num = Number(value) * 100
+  return `${num.toFixed(1)}%`
+}
+
+const STATUS_GLYPHS = {
+  no_supply: '!',
+  currency_unresolved: '?',
+  platform_fee_unresolved: '⚙',
+  low_yield: '¥',
+  not_lowest_channel: '↧',
+  unlisted: '+',
+  single_channel: '◐',
+  ready: '✓'
+}
+
+function statusGlyph(status) {
+  return STATUS_GLYPHS[status] || '·'
+}
+
+function statusTitle(row) {
+  const key = `llmOps.decision.status.${row.decision_status || 'ready'}`
+  return t(key)
+}
+
+function rowAriaLabel(row) {
+  return `${row.model_name || ''} ${statusTitle(row)} ${actionLabel(row)}`.trim()
+}
+
+function rowClass(row) {
+  const statusClass = `decision-row-${row.decision_status || 'ready'}`
+  return row.is_data_anomaly
+    ? `${statusClass} decision-row-data_anomaly`
+    : statusClass
+}
+
+function channelText(channel) {
+  if (!channel) return '-'
+  return channel.channel_name || '-'
+}
+
+function currentListingText(row) {
+  if (!row.current_listing?.is_listed) return t('llmOps.status.unlisted')
+  const listing = row.current_listing
+  return listing.channel_name || t('llmOps.status.listed')
+}
+
+function procurementPriceRows(row) {
+  const channel = row.recommended_channel
+  if (!channel) return []
+  return [
+    priceRow(
+      t('llmOps.price.input'),
+      channel.input_price_per_million,
+      channel.currency
+    ),
+    priceRow(
+      t('llmOps.price.output'),
+      channel.output_price_per_million,
+      channel.currency
+    )
+  ]
+}
+
+function listingPriceRows(row) {
+  const listing = row.current_listing
+  if (!listing?.is_listed) return []
+  return [
+    priceRow(
+      t('llmOps.price.input'),
+      listing.retail_input_price_per_million,
+      listing.currency
+    ),
+    priceRow(
+      t('llmOps.price.output'),
+      listing.retail_output_price_per_million,
+      listing.currency
+    )
+  ]
+}
+
+function priceRow(label, value, currency) {
+  return {
+    label,
+    value: formatPrice(value, currency)
+  }
+}
+
+function formatPrice(value, currency) {
+  if (value === null || value === undefined || value === '') return '-'
+  const numberValue = Number(value)
+  if (!Number.isFinite(numberValue)) return '-'
+  return `${currency || ''} ${numberValue.toFixed(4)}`.trim()
+}
+
+function priceSummary(rows) {
+  if (!rows.length) return '-'
+  return rows.map((row) => `${row.label}: ${row.value}`).join(' / ')
+}
+
+function yieldSummary(row) {
+  return `${percent(row.input_yield)} / ${percent(row.output_yield)}`
+}
+
+const GROUP_LABELS = {
+  supply: 'llmOps.overview.kpiGroup.supply',
+  yield: 'llmOps.overview.kpiGroup.yield',
+  data: 'llmOps.overview.kpiGroup.data'
+}
+
+function kpiGroupLabel(group) {
+  return t(GROUP_LABELS[group] || GROUP_LABELS.supply)
+}
+
+const DECISION_ACTION_LABELS = {
+  no_supply: 'llmOps.decision.action.configureChannel',
+  currency_unresolved: 'llmOps.decision.action.configureExchange',
+  platform_fee_unresolved: 'llmOps.decision.action.configurePlatformFee',
+  low_yield: 'llmOps.decision.action.reviewMargin',
+  not_lowest_channel: 'llmOps.decision.action.switchLowestChannel',
+  unlisted: 'llmOps.decision.action.publishToPlatform',
+  single_channel: 'llmOps.decision.action.addChannelCoverage',
+  ready: 'llmOps.decision.action.keep'
+}
+
+function actionLabel(row) {
+  const status = row.decision_status || 'ready'
+  return t(DECISION_ACTION_LABELS[status] || DECISION_ACTION_LABELS.ready)
+}
+
+const EVENT_LABELS = {
+  updated: 'llmOps.overview.event.updated',
+  collection_failed: 'llmOps.overview.event.collectionFailed',
+  source_disabled: 'llmOps.overview.event.sourceDisabled',
+  reconciliation_anomaly: 'llmOps.overview.event.reconciliationAnomaly',
+  stale: 'llmOps.overview.event.stale'
+}
+
+const EVENT_TONES = {
+  updated: 'event-pill-muted',
+  collection_failed: 'event-pill-danger',
+  source_disabled: 'event-pill-warn',
+  reconciliation_anomaly: 'event-pill-warn',
+  stale: 'event-pill-info'
+}
+
+function eventLabel(type) {
+  return t(EVENT_LABELS[type] || EVENT_LABELS.updated)
+}
+
+function eventTone(type) {
+  return EVENT_TONES[type] || 'event-pill-muted'
+}
+
+function absoluteTime(value) {
+  if (!value) return '-'
+  return new Date(value).toLocaleString()
+}
+
+function relativeTime(value) {
+  if (!value) return '-'
+  const target = new Date(value).getTime()
+  if (!Number.isFinite(target)) return '-'
+  const diffMs = Date.now() - target
+  if (diffMs < 0) return t('llmOps.overview.time.justNow')
+  const sec = Math.floor(diffMs / 1000)
+  if (sec < 60) return t('llmOps.overview.time.secondsAgo', { count: sec })
+  const min = Math.floor(sec / 60)
+  if (min < 60) return t('llmOps.overview.time.minutesAgo', { count: min })
+  const hr = Math.floor(min / 60)
+  if (hr < 24) return t('llmOps.overview.time.hoursAgo', { count: hr })
+  const day = Math.floor(hr / 24)
+  if (day < 30) return t('llmOps.overview.time.daysAgo', { count: day })
+  return absoluteTime(value)
+}
 </script>
+
+<style scoped>
+.kpi-decision-groups {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr);
+  gap: 1rem;
+}
+.kpi-decision-group {
+  min-width: 0;
+}
+.kpi-decision-group-head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+  color: var(--ui-text-muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.kpi-decision-group-mark {
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 9999px;
+  background: var(--ui-color-primary);
+}
+.kpi-decision-group-mark.mark-supply {
+  background: var(--ui-color-primary);
+}
+.kpi-decision-group-mark.mark-yield {
+  background: var(--ui-color-warning);
+}
+.kpi-decision-group-mark.mark-data {
+  background: var(--ui-color-info);
+}
+.status-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 9999px;
+  font-weight: 700;
+  font-size: 0.7rem;
+  background: var(--ui-color-primary-subtle);
+  color: var(--ui-color-primary);
+  border: 1px solid var(--ui-border-soft);
+}
+.status-icon.danger {
+  background: var(--ui-color-destructive-subtle);
+  color: var(--ui-color-destructive);
+}
+.status-icon.warn {
+  background: var(--ui-color-warning-subtle);
+  color: var(--ui-color-warning);
+}
+.status-icon.success {
+  background: var(--ui-color-success-subtle);
+  color: var(--ui-color-success);
+}
+.status-icon.info {
+  background: var(--ui-color-info-subtle);
+  color: var(--ui-color-info);
+}
+.event-pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 9999px;
+  padding: 0 0.5rem;
+  height: 1.25rem;
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  border: 1px solid var(--ui-border-soft);
+  background: var(--ui-bg-muted);
+  color: var(--ui-text-secondary);
+}
+.event-pill-muted {
+  background: var(--ui-bg-muted);
+  color: var(--ui-text-muted);
+}
+.event-pill-danger {
+  background: var(--ui-color-destructive-subtle);
+  color: var(--ui-color-destructive);
+  border-color: rgba(225, 29, 72, 0.2);
+}
+.event-pill-warn {
+  background: var(--ui-color-warning-subtle);
+  color: var(--ui-color-warning);
+  border-color: rgba(217, 119, 6, 0.2);
+}
+.event-pill-info {
+  background: var(--ui-color-info-subtle);
+  color: var(--ui-color-info);
+  border-color: rgba(37, 99, 235, 0.2);
+}
+.decision-table tbody tr {
+  border-bottom: 1px solid var(--ui-border-soft);
+}
+.decision-row {
+  position: relative;
+  outline: none;
+}
+.decision-row::before {
+  content: '';
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 0.2rem;
+  background: transparent;
+}
+.decision-row:hover,
+.decision-row:focus-visible {
+  background: var(--ui-bg-subtle);
+}
+.decision-row:focus-visible {
+  box-shadow: inset 0 0 0 2px rgba(95, 78, 207, 0.28);
+}
+.decision-row-no_supply,
+.decision-row-low_yield {
+  background: rgba(255, 241, 242, 0.42);
+}
+.decision-row-no_supply::before,
+.decision-row-low_yield::before {
+  background: var(--ui-color-destructive);
+}
+.decision-row-no_supply > td:first-child,
+.decision-row-low_yield > td:first-child {
+  box-shadow: inset 0.2rem 0 0 var(--ui-color-destructive);
+}
+.decision-row-platform_fee_unresolved,
+.decision-row-currency_unresolved,
+.decision-row-single_channel {
+  background: rgba(239, 246, 255, 0.42);
+}
+.decision-row-platform_fee_unresolved::before,
+.decision-row-currency_unresolved::before,
+.decision-row-single_channel::before {
+  background: var(--ui-color-info);
+}
+.decision-row-platform_fee_unresolved > td:first-child,
+.decision-row-currency_unresolved > td:first-child,
+.decision-row-single_channel > td:first-child {
+  box-shadow: inset 0.2rem 0 0 var(--ui-color-info);
+}
+.decision-row-not_lowest_channel,
+.decision-row-unlisted {
+  background: rgba(255, 251, 235, 0.5);
+}
+.decision-row-not_lowest_channel::before,
+.decision-row-unlisted::before {
+  background: var(--ui-color-warning);
+}
+.decision-row-not_lowest_channel > td:first-child,
+.decision-row-unlisted > td:first-child {
+  box-shadow: inset 0.2rem 0 0 var(--ui-color-warning);
+}
+.decision-row-data_anomaly > td:first-child {
+  box-shadow: inset 0.2rem 0 0 var(--ui-color-destructive);
+}
+.price-pair {
+  display: inline-flex;
+  min-width: 7.5rem;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+.price-pair-row {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.45rem;
+  white-space: nowrap;
+}
+.price-pair-label {
+  color: var(--ui-text-muted);
+  font-family: inherit;
+}
+.decision-action-cell {
+  position: relative;
+  display: inline-flex;
+}
+.decision-hover-panel {
+  position: absolute;
+  z-index: 20;
+  top: calc(100% + 0.5rem);
+  right: 0;
+  width: min(22rem, calc(100vw - 2rem));
+  padding: 0.75rem;
+  border: 1px solid var(--ui-border-default);
+  border-radius: 0.5rem;
+  background: var(--ui-bg-card);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.16);
+  opacity: 0;
+  transform: translateY(-0.25rem);
+  pointer-events: none;
+  transition:
+    opacity 0.16s ease,
+    transform 0.16s ease;
+}
+.decision-row:hover .decision-hover-panel,
+.decision-row:focus-within .decision-hover-panel {
+  opacity: 1;
+  transform: translateY(0);
+}
+.decision-hover-title {
+  margin-bottom: 0.5rem;
+  color: var(--ui-text-primary);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+.decision-hover-grid {
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  gap: 0.35rem 0.75rem;
+  color: var(--ui-text-muted);
+  font-size: 0.75rem;
+}
+.decision-hover-grid strong {
+  min-width: 0;
+  color: var(--ui-text-primary);
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.badge-ok {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 0.5rem;
+  background: var(--ui-color-success-subtle);
+  color: var(--ui-color-success);
+  padding: 0.125rem 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+.badge-muted {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 0.5rem;
+  background: var(--ui-bg-muted);
+  color: var(--ui-text-muted);
+  padding: 0.125rem 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+@media (max-width: 1024px) {
+  .kpi-decision-groups {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/frontend/src/components/llm-ops/LLMOpsMonitorDashboard.vue
+++ b/frontend/src/components/llm-ops/LLMOpsMonitorDashboard.vue
@@ -140,16 +140,13 @@
               </td>
               <td class="table-cell">
                 <span v-if="row.recommended_channel?.channel_name">
-                  {{ row.recommended_channel.channel_name }}
+                  {{ channelText(row.recommended_channel) }}
                 </span>
                 <span v-else class="text-slate-400">-</span>
               </td>
               <td class="table-cell">
                 <span v-if="row.current_listing?.is_listed" class="badge-ok">
-                  {{
-                    row.current_listing.channel_name ||
-                    t('llmOps.status.listed')
-                  }}
+                  {{ currentListingText(row) }}
                 </span>
                 <span v-else class="badge-muted">
                   {{ t('llmOps.status.unlisted') }}
@@ -343,12 +340,18 @@ function rowClass(row) {
 
 function channelText(channel) {
   if (!channel) return '-'
+  if (channel.channel_type === 'auto_best' || channel.channel_id === null) {
+    return t('llmOps.channel.autoBest')
+  }
   return channel.channel_name || '-'
 }
 
 function currentListingText(row) {
   if (!row.current_listing?.is_listed) return t('llmOps.status.unlisted')
   const listing = row.current_listing
+  if (listing.channel_type === 'auto_best' || listing.channel_id === null) {
+    return t('llmOps.channel.autoBest')
+  }
   return listing.channel_name || t('llmOps.status.listed')
 }
 

--- a/frontend/src/components/llm-ops/ListingRiskPanel.vue
+++ b/frontend/src/components/llm-ops/ListingRiskPanel.vue
@@ -11,9 +11,9 @@
     <div class="panel overflow-hidden p-0">
       <div class="table-toolbar">
         <div>
-          <h3 class="panel-title">挂售利润风险榜</h3>
+          <h3 class="panel-title">{{ t('llmOps.listingRisk.title') }}</h3>
           <p class="mt-1 text-xs text-slate-500">
-            聚合低毛利、非最低采购、未挂售和币种换算风险。
+            {{ t('llmOps.listingRisk.subtitle') }}
           </p>
         </div>
         <CompactSelect
@@ -27,12 +27,24 @@
         <table class="data-table">
           <thead>
             <tr>
-              <th class="table-head">模型</th>
-              <th class="table-head">风险类型</th>
-              <th class="table-head text-right">Input 毛利</th>
-              <th class="table-head text-right">Output 毛利</th>
-              <th class="table-head">当前渠道</th>
-              <th class="table-head">建议动作</th>
+              <th class="table-head">
+                {{ t('llmOps.listingRisk.columns.model') }}
+              </th>
+              <th class="table-head">
+                {{ t('llmOps.listingRisk.columns.risk') }}
+              </th>
+              <th class="table-head text-right">
+                {{ t('llmOps.listingRisk.columns.inputMargin') }}
+              </th>
+              <th class="table-head text-right">
+                {{ t('llmOps.listingRisk.columns.outputMargin') }}
+              </th>
+              <th class="table-head">
+                {{ t('llmOps.listingRisk.columns.channel') }}
+              </th>
+              <th class="table-head">
+                {{ t('llmOps.listingRisk.columns.action') }}
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -63,7 +75,7 @@
             </tr>
             <tr v-if="!filteredRows.length">
               <td class="table-cell text-slate-500" colspan="6">
-                当前筛选条件下没有风险项。
+                {{ t('llmOps.listingRisk.empty') }}
               </td>
             </tr>
           </tbody>
@@ -75,6 +87,7 @@
 
 <script setup>
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import { asArray } from '@/utils/llmOpsPagination'
 
@@ -84,14 +97,18 @@ const props = defineProps({
   summary: { type: Object, default: () => ({}) }
 })
 
+const { t, te } = useI18n()
 const riskFilter = ref('all')
-const riskFilterOptions = [
-  { label: '全部风险', value: 'all' },
-  { label: '低毛利', value: 'margin' },
-  { label: '非最低价', value: 'not_lowest' },
-  { label: '未挂售', value: 'unlisted' },
-  { label: '需要汇率', value: 'currency_mismatch' }
-]
+const riskFilterOptions = computed(() => [
+  { label: t('llmOps.listingRisk.filters.all'), value: 'all' },
+  { label: t('llmOps.listingRisk.risk.margin'), value: 'margin' },
+  { label: t('llmOps.listingRisk.risk.not_lowest'), value: 'not_lowest' },
+  { label: t('llmOps.listingRisk.risk.unlisted'), value: 'unlisted' },
+  {
+    label: t('llmOps.listingRisk.risk.currency_mismatch'),
+    value: 'currency_mismatch'
+  }
+])
 
 const diagnosticRows = computed(() =>
   asArray(props.summary.agione?.diagnostics)
@@ -120,7 +137,7 @@ const riskRows = computed(() => {
       tone: statusTone(row.status),
       input_margin: null,
       output_margin: null,
-      channel_name: row.best_channel?.channel_name || '',
+      channel_name: channelDisplayName(row.best_channel),
       action: actionText(row.status)
     })
   })
@@ -134,12 +151,12 @@ const riskRows = computed(() => {
       model_name: listing.model_name,
       provider_name: listing.platform_name,
       risk: 'margin',
-      risk_label: '低毛利',
+      risk_label: t('llmOps.listingRisk.risk.margin'),
       tone: 'danger',
       input_margin: inputMargin,
       output_margin: outputMargin,
-      channel_name: listing.channel_name,
-      action: '复核售价、服务费率或采购渠道'
+      channel_name: channelDisplayName(listing),
+      action: t('llmOps.listingRisk.actions.margin')
     })
   })
   return rows.sort((left, right) => riskRank(left.risk) - riskRank(right.risk))
@@ -152,24 +169,24 @@ const filteredRows = computed(() => {
 
 const metrics = computed(() => [
   {
-    label: '风险总数',
+    label: t('llmOps.listingRisk.metrics.total.label'),
     value: riskRows.value.length,
-    hint: '当前平台可见的挂售和采购风险'
+    hint: t('llmOps.listingRisk.metrics.total.hint')
   },
   {
-    label: '低毛利',
+    label: t('llmOps.listingRisk.metrics.margin.label'),
     value: riskRows.value.filter((row) => row.risk === 'margin').length,
-    hint: 'Input 或 Output 毛利低于 10%'
+    hint: t('llmOps.listingRisk.metrics.margin.hint')
   },
   {
-    label: '非最低价',
+    label: t('llmOps.listingRisk.metrics.notLowest.label'),
     value: riskRows.value.filter((row) => row.risk === 'not_lowest').length,
-    hint: '已挂售但未使用最低采购渠道'
+    hint: t('llmOps.listingRisk.metrics.notLowest.hint')
   },
   {
-    label: '未挂售',
+    label: t('llmOps.listingRisk.metrics.unlisted.label'),
     value: riskRows.value.filter((row) => row.risk === 'unlisted').length,
-    hint: '已有供应但未进入当前平台'
+    hint: t('llmOps.listingRisk.metrics.unlisted.hint')
   }
 ])
 
@@ -179,14 +196,8 @@ function isLowMargin(value) {
 }
 
 function statusLabel(status) {
-  return (
-    {
-      currency_mismatch: '需要汇率',
-      missing_channel: '缺渠道价',
-      unlisted: '未挂售',
-      not_lowest: '非最低价'
-    }[status] || status
-  )
+  const key = `llmOps.listingRisk.risk.${status}`
+  return te(key) ? t(key) : status
 }
 
 function statusTone(status) {
@@ -201,14 +212,8 @@ function statusTone(status) {
 }
 
 function actionText(status) {
-  return (
-    {
-      currency_mismatch: '补充汇率后重新比较采购价',
-      missing_channel: '先为模型配置至少一个渠道采购价',
-      unlisted: '进入挂售工作台创建平台上架记录',
-      not_lowest: '评估切换到最低采购渠道'
-    }[status] || '复核状态'
-  )
+  const key = `llmOps.listingRisk.actions.${status}`
+  return te(key) ? t(key) : t('llmOps.listingRisk.actions.fallback')
 }
 
 function riskRank(status) {
@@ -226,5 +231,13 @@ function riskRank(status) {
 function percent(value) {
   if (value === null || value === undefined || value === '') return '-'
   return `${(Number(value) * 100).toFixed(2)}%`
+}
+
+function channelDisplayName(value) {
+  if (!value) return ''
+  if (value.channel_type === 'auto_best' || value.channel_id === null) {
+    return t('llmOps.channel.autoBest')
+  }
+  return value.channel_name || ''
 }
 </script>

--- a/frontend/src/components/llm-ops/ManualPriceImportModal.vue
+++ b/frontend/src/components/llm-ops/ManualPriceImportModal.vue
@@ -290,7 +290,8 @@ const sourceOptions = computed(() => [
         source.provider_name ||
         '',
       badge: priceSourceCollectionMethodLabel(
-        priceSourceCollectionMethod(source)
+        priceSourceCollectionMethod(source),
+        collectionMethodLabels()
       )
     }))
 ])
@@ -308,7 +309,8 @@ const selectedSourceProvider = computed(() => {
 })
 const sourceCategoryLabel = computed(() =>
   priceSourceCollectionMethodLabel(
-    priceSourceCollectionMethod(selectedSource.value)
+    priceSourceCollectionMethod(selectedSource.value),
+    collectionMethodLabels()
   )
 )
 const sourceStatusText = computed(() => {
@@ -583,6 +585,22 @@ function modalityLabel(value) {
     video: t('llmOps.manualPriceImport.modalities.video')
   }
   return labels[value] || value || labels.text
+}
+
+function collectionMethodLabels() {
+  return {
+    auto_collect: t(
+      'llmOps.collectionHealthPanel.collectionMethod.autoCollect'
+    ),
+    api_sync: t('llmOps.collectionHealthPanel.collectionMethod.apiSync'),
+    manual_entry: t(
+      'llmOps.collectionHealthPanel.collectionMethod.manualEntry'
+    ),
+    manual_import: t(
+      'llmOps.collectionHealthPanel.collectionMethod.manualImport'
+    ),
+    unknown: t('llmOps.collectionHealthPanel.collectionMethod.unknown')
+  }
 }
 </script>
 

--- a/frontend/src/components/llm-ops/MetaModelManagement.vue
+++ b/frontend/src/components/llm-ops/MetaModelManagement.vue
@@ -257,7 +257,7 @@
                 <tbody>
                   <tr v-if="drawerLoading">
                     <td class="table-cell text-slate-500" colspan="5">
-                      加载中...
+                      {{ t('common.loading') }}
                     </td>
                   </tr>
                   <tr v-for="item in paginatedVendorMetaRows" :key="item.id">
@@ -622,7 +622,12 @@ async function fetchOwnerSummary() {
     const response = await llmOpsApi.listMetaModelOwnerSummary()
     ownerRows.value = paginationResults(paginationPayload(response))
   } catch (error) {
-    showError(errorMessage(error, '加载元模型厂商汇总失败。'))
+    showError(
+      errorMessage(
+        error,
+        t('llmOps.metaModelManagement.errors.loadOwnerSummary')
+      )
+    )
   } finally {
     ownerSummaryLoading.value = false
   }
@@ -654,7 +659,9 @@ async function fetchVendorMetaModels() {
   } catch (error) {
     drawerRows.value = []
     drawerTotal.value = 0
-    showError(errorMessage(error, '加载元模型明细失败。'))
+    showError(
+      errorMessage(error, t('llmOps.metaModelManagement.errors.loadDetails'))
+    )
   } finally {
     drawerLoading.value = false
   }

--- a/frontend/src/components/llm-ops/MetaModelModal.vue
+++ b/frontend/src/components/llm-ops/MetaModelModal.vue
@@ -17,10 +17,14 @@
               Meta Model
             </p>
             <h3 class="mt-2 text-lg font-semibold text-slate-900">
-              {{ form.id ? '编辑元模型' : '新建元模型' }}
+              {{
+                form.id
+                  ? t('llmOps.metaModelModal.editTitle')
+                  : t('llmOps.metaModelModal.createTitle')
+              }}
             </h3>
             <p class="mt-1 text-sm leading-6 text-slate-500">
-              元模型用于把不同价格源中的同一模型身份归一到厂商、能力和版本。
+              {{ t('llmOps.metaModelModal.description') }}
             </p>
           </div>
           <button
@@ -29,7 +33,7 @@
             :disabled="saving"
             @click="close"
           >
-            关闭
+            {{ t('common.close') }}
           </button>
         </div>
       </div>
@@ -39,31 +43,37 @@
       >
         <section class="form-section">
           <div class="section-heading">
-            <h4>模型身份</h4>
-            <p>用于跨官方、供应商和人工价格源归并模型。</p>
+            <h4>{{ t('llmOps.metaModelModal.identityTitle') }}</h4>
+            <p>{{ t('llmOps.metaModelModal.identityHint') }}</p>
           </div>
           <div class="grid gap-4 md:grid-cols-2">
             <label class="field-group">
-              <span class="field-label">显示名称</span>
+              <span class="field-label">
+                {{ t('llmOps.metaModelModal.fields.name') }}
+              </span>
               <input
                 v-model="form.name"
                 class="field"
-                placeholder="例如：GPT-4o mini"
+                :placeholder="t('llmOps.metaModelModal.placeholders.name')"
                 required
               />
             </label>
             <label class="field-group">
-              <span class="field-label">模型标识 Code</span>
+              <span class="field-label">
+                {{ t('llmOps.metaModelModal.fields.code') }}
+              </span>
               <input
                 v-model="form.code"
                 class="field font-mono disabled:bg-slate-50 disabled:text-slate-400"
                 :disabled="Boolean(form.id)"
-                placeholder="例如：gpt-4o-mini"
+                :placeholder="t('llmOps.metaModelModal.placeholders.code')"
                 required
               />
             </label>
             <label class="field-group">
-              <span class="field-label">模型归属方</span>
+              <span class="field-label">
+                {{ t('llmOps.metaModelModal.fields.owner') }}
+              </span>
               <CompactSelect
                 v-model="form.owner_code"
                 :options="ownerOptions"
@@ -71,7 +81,9 @@
               />
             </label>
             <label class="field-group">
-              <span class="field-label">状态</span>
+              <span class="field-label">
+                {{ t('llmOps.metaModelModal.fields.status') }}
+              </span>
               <CompactSelect
                 v-model="form.status"
                 :options="statusOptions"
@@ -83,20 +95,24 @@
 
         <section class="form-section">
           <div class="section-heading">
-            <h4>分类与能力</h4>
-            <p>用于运营筛选、渠道规划和模型可用性展示。</p>
+            <h4>{{ t('llmOps.metaModelModal.capabilityTitle') }}</h4>
+            <p>{{ t('llmOps.metaModelModal.capabilityHint') }}</p>
           </div>
           <div class="grid gap-4 md:grid-cols-2">
             <label class="field-group">
-              <span class="field-label">模型家族</span>
+              <span class="field-label">
+                {{ t('llmOps.metaModelModal.fields.family') }}
+              </span>
               <input
                 v-model="form.family"
                 class="field"
-                placeholder="例如：GPT-4o"
+                :placeholder="t('llmOps.metaModelModal.placeholders.family')"
               />
             </label>
             <label class="field-group">
-              <span class="field-label">模态</span>
+              <span class="field-label">
+                {{ t('llmOps.metaModelModal.fields.modality') }}
+              </span>
               <CompactSelect
                 v-model="form.modality"
                 :options="modalityOptions"
@@ -104,16 +120,22 @@
               />
             </label>
             <label class="field-group">
-              <span class="field-label">能力标签</span>
+              <span class="field-label">
+                {{ t('llmOps.metaModelModal.fields.features') }}
+              </span>
               <input
                 v-model="form.feature_text"
                 class="field"
                 placeholder="chat, vision, tool_calling"
               />
-              <span class="field-help">英文逗号分隔。</span>
+              <span class="field-help">
+                {{ t('llmOps.metaModelModal.featureHelp') }}
+              </span>
             </label>
             <label class="field-group">
-              <span class="field-label">上下文窗口</span>
+              <span class="field-label">
+                {{ t('llmOps.metaModelModal.fields.contextWindow') }}
+              </span>
               <input
                 v-model.number="form.context_window"
                 class="field"
@@ -122,7 +144,9 @@
               />
             </label>
             <label class="field-group">
-              <span class="field-label">最大输出 Token</span>
+              <span class="field-label">
+                {{ t('llmOps.metaModelModal.fields.maxOutputTokens') }}
+              </span>
               <input
                 v-model.number="form.max_output_tokens"
                 class="field"
@@ -135,16 +159,18 @@
 
         <section class="form-section">
           <div class="section-heading">
-            <h4>别名</h4>
-            <p>别名用于从采集结果中匹配同一元模型身份。</p>
+            <h4>{{ t('llmOps.metaModelModal.aliasTitle') }}</h4>
+            <p>{{ t('llmOps.metaModelModal.aliasHint') }}</p>
           </div>
           <div class="grid gap-4">
             <label class="field-group">
-              <span class="field-label">别名</span>
+              <span class="field-label">
+                {{ t('llmOps.metaModelModal.fields.aliases') }}
+              </span>
               <textarea
                 v-model="form.alias_text"
                 class="field min-h-24 resize-none font-mono"
-                placeholder="每行一个别名，例如 GPT-4o mini"
+                :placeholder="t('llmOps.metaModelModal.placeholders.aliases')"
               />
             </label>
           </div>
@@ -152,8 +178,8 @@
 
         <section class="form-section">
           <div class="section-heading">
-            <h4>元数据</h4>
-            <p>可记录采集来源、官方页面标识或运营备注，必须是 JSON 对象。</p>
+            <h4>{{ t('llmOps.metaModelModal.metadataTitle') }}</h4>
+            <p>{{ t('llmOps.metaModelModal.metadataHint') }}</p>
           </div>
           <textarea
             v-model="form.metadata_text"
@@ -173,8 +199,8 @@
         <span v-else class="modal-footer-status modal-footer-note">
           {{
             form.id
-              ? '保存后会影响关联模型的展示身份。'
-              : '创建后可绑定到模型 SKU。'
+              ? t('llmOps.metaModelModal.editNote')
+              : t('llmOps.metaModelModal.createNote')
           }}
         </span>
         <div class="modal-footer-actions">
@@ -184,7 +210,7 @@
             :disabled="saving"
             @click="close"
           >
-            取消
+            {{ t('common.cancel') }}
           </button>
           <button
             class="btn-primary btn-action-save"
@@ -192,7 +218,11 @@
             :disabled="saving"
           >
             <span class="icon-mark" :class="saving ? 'animate-spin' : ''" />
-            {{ form.id ? '保存修改' : '创建元模型' }}
+            {{
+              form.id
+                ? t('llmOps.metaModelModal.saveChanges')
+                : t('llmOps.metaModelModal.createMetaModel')
+            }}
           </button>
         </div>
       </div>
@@ -202,6 +232,8 @@
 
 <script setup>
 import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
 import { llmOpsApi } from '@/api/llmOps'
 import CompactSelect from '@/components/llm-ops/CompactSelect.vue'
 
@@ -225,6 +257,7 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['close', 'saved'])
+const { t } = useI18n()
 
 const form = ref(defaults())
 const saving = ref(false)
@@ -244,7 +277,9 @@ const modalityOptions = [
 ]
 
 const ownerOptions = computed(() => {
-  const options = [{ value: '', label: '未绑定' }]
+  const options = [
+    { value: '', label: t('llmOps.metaModelModal.ownerUnbound') }
+  ]
   const seen = new Set([''])
   props.metaModels.forEach((model) => {
     pushOwnerOption(options, seen, model.owner_code, model.owner_name)
@@ -337,7 +372,10 @@ async function save() {
     form.value = defaults()
     emit('saved')
   } catch (error) {
-    saveError.value = errorMessage(error, '元模型保存失败，请稍后重试。')
+    saveError.value = errorMessage(
+      error,
+      t('llmOps.metaModelModal.errors.saveFailed')
+    )
   } finally {
     saving.value = false
   }
@@ -348,10 +386,10 @@ function normalizePayload(payload) {
   try {
     metadata = payload.metadata_text ? JSON.parse(payload.metadata_text) : {}
   } catch (_error) {
-    throw new Error('元数据必须是合法 JSON 对象。')
+    throw new Error(t('llmOps.metaModelModal.errors.invalidMetadataJson'))
   }
   if (!metadata || Array.isArray(metadata) || typeof metadata !== 'object') {
-    throw new Error('元数据必须是 JSON 对象。')
+    throw new Error(t('llmOps.metaModelModal.errors.metadataObject'))
   }
 
   const aliases = String(payload.alias_text || '')

--- a/frontend/src/components/llm-ops/ModelWorkbenchPanel.vue
+++ b/frontend/src/components/llm-ops/ModelWorkbenchPanel.vue
@@ -3,9 +3,11 @@
     <div class="panel">
       <div class="grid gap-4 lg:grid-cols-[minmax(0,1fr)_320px]">
         <div>
-          <h3 class="panel-title">模型详情工作台</h3>
+          <h3 class="panel-title">
+            {{ t('llmOps.modelWorkbenchPanel.title') }}
+          </h3>
           <p class="mt-1 text-xs text-slate-500">
-            集中查看单个模型的官方价格、渠道采购、挂售状态和对账记录。
+            {{ t('llmOps.modelWorkbenchPanel.subtitle') }}
           </p>
         </div>
         <CompactSelect
@@ -20,7 +22,9 @@
 
     <div v-if="selectedModel" class="grid gap-4 xl:grid-cols-4">
       <div class="kpi-card">
-        <p class="text-xs font-medium text-slate-500">元模型</p>
+        <p class="text-xs font-medium text-slate-500">
+          {{ t('llmOps.modelWorkbenchPanel.kpi.metaModel') }}
+        </p>
         <p class="mt-2 text-lg font-semibold text-slate-900">
           {{ selectedModel.meta_model_name || '-' }}
         </p>
@@ -29,48 +33,64 @@
         </p>
       </div>
       <div class="kpi-card">
-        <p class="text-xs font-medium text-slate-500">渠道覆盖</p>
+        <p class="text-xs font-medium text-slate-500">
+          {{ t('llmOps.modelWorkbenchPanel.kpi.channelCoverage') }}
+        </p>
         <p class="kpi-value mt-2 text-2xl font-semibold">
           {{ selectedDiagnostic?.coverage_count || 0 }}
         </p>
-        <p class="mt-2 text-xs text-slate-500">可用采购渠道数量</p>
+        <p class="mt-2 text-xs text-slate-500">
+          {{ t('llmOps.modelWorkbenchPanel.kpi.channelCoverageHint') }}
+        </p>
       </div>
       <div class="kpi-card">
-        <p class="text-xs font-medium text-slate-500">挂售链路</p>
+        <p class="text-xs font-medium text-slate-500">
+          {{ t('llmOps.modelWorkbenchPanel.kpi.listingLinks') }}
+        </p>
         <p class="kpi-value mt-2 text-2xl font-semibold">
           {{ modelListings.length }}
         </p>
-        <p class="mt-2 text-xs text-slate-500">当前平台及其他平台记录</p>
+        <p class="mt-2 text-xs text-slate-500">
+          {{ t('llmOps.modelWorkbenchPanel.kpi.listingLinksHint') }}
+        </p>
       </div>
       <div class="kpi-card">
-        <p class="text-xs font-medium text-slate-500">对账异常</p>
+        <p class="text-xs font-medium text-slate-500">
+          {{ t('llmOps.modelWorkbenchPanel.kpi.reconciliationAnomalies') }}
+        </p>
         <p class="kpi-value mt-2 text-2xl font-semibold">
           {{ anomalyRecords.length }}
         </p>
-        <p class="mt-2 text-xs text-slate-500">非 perfect 的对账记录</p>
+        <p class="mt-2 text-xs text-slate-500">
+          {{ t('llmOps.modelWorkbenchPanel.kpi.reconciliationAnomaliesHint') }}
+        </p>
       </div>
     </div>
 
     <div class="grid gap-4 xl:grid-cols-2">
       <div class="panel overflow-hidden p-0">
         <div class="table-toolbar">
-          <h3 class="panel-title">标准价格项</h3>
+          <h3 class="panel-title">
+            {{ t('llmOps.modelWorkbenchPanel.standardPrices') }}
+          </h3>
         </div>
         <MiniTable
-          :columns="['维度', '价格', '来源']"
+          :columns="officialColumns"
           :rows="officialRows"
-          empty-text="暂无标准价格项。"
+          :empty-text="t('llmOps.modelWorkbenchPanel.emptyStandardPrices')"
         />
       </div>
 
       <div class="panel overflow-hidden p-0">
         <div class="table-toolbar">
-          <h3 class="panel-title">渠道采购价</h3>
+          <h3 class="panel-title">
+            {{ t('llmOps.modelWorkbenchPanel.channelPrices') }}
+          </h3>
         </div>
         <MiniTable
-          :columns="['渠道', '维度', '价格']"
+          :columns="channelColumns"
           :rows="channelRows"
-          empty-text="暂无渠道价格项。"
+          :empty-text="t('llmOps.modelWorkbenchPanel.emptyChannelPrices')"
         />
       </div>
     </div>
@@ -78,23 +98,29 @@
     <div class="grid gap-4 xl:grid-cols-2">
       <div class="panel overflow-hidden p-0">
         <div class="table-toolbar">
-          <h3 class="panel-title">挂售记录</h3>
+          <h3 class="panel-title">
+            {{ t('llmOps.modelWorkbenchPanel.listingRecords') }}
+          </h3>
         </div>
         <MiniTable
-          :columns="['平台', '渠道', '状态']"
+          :columns="listingColumns"
           :rows="listingRows"
-          empty-text="暂无挂售记录。"
+          :empty-text="t('llmOps.modelWorkbenchPanel.emptyListingRecords')"
         />
       </div>
 
       <div class="panel overflow-hidden p-0">
         <div class="table-toolbar">
-          <h3 class="panel-title">对账记录</h3>
+          <h3 class="panel-title">
+            {{ t('llmOps.modelWorkbenchPanel.reconciliationRecords') }}
+          </h3>
         </div>
         <MiniTable
-          :columns="['日期', '渠道', '差异']"
+          :columns="reconciliationColumns"
           :rows="reconciliationRows"
-          empty-text="暂无对账记录。"
+          :empty-text="
+            t('llmOps.modelWorkbenchPanel.emptyReconciliationRecords')
+          "
         />
       </div>
     </div>
@@ -103,6 +129,7 @@
 
 <script setup>
 import { computed, defineComponent, h, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import CompactSelect from './CompactSelect.vue'
 
@@ -110,7 +137,7 @@ const MiniTable = defineComponent({
   props: {
     columns: { type: Array, default: () => [] },
     rows: { type: Array, default: () => [] },
-    emptyText: { type: String, default: '暂无数据。' }
+    emptyText: { type: String, default: '' }
   },
   setup(props) {
     return () =>
@@ -171,7 +198,32 @@ const props = defineProps({
   records: { type: Array, default: () => [] }
 })
 
+const { t } = useI18n()
 const selectedModelId = ref('')
+
+const officialColumns = computed(() => [
+  t('llmOps.modelWorkbenchPanel.columns.dimension'),
+  t('llmOps.modelWorkbenchPanel.columns.price'),
+  t('llmOps.modelWorkbenchPanel.columns.source')
+])
+
+const channelColumns = computed(() => [
+  t('llmOps.modelWorkbenchPanel.columns.channel'),
+  t('llmOps.modelWorkbenchPanel.columns.dimension'),
+  t('llmOps.modelWorkbenchPanel.columns.price')
+])
+
+const listingColumns = computed(() => [
+  t('llmOps.modelWorkbenchPanel.columns.platform'),
+  t('llmOps.modelWorkbenchPanel.columns.channel'),
+  t('llmOps.modelWorkbenchPanel.columns.status')
+])
+
+const reconciliationColumns = computed(() => [
+  t('llmOps.modelWorkbenchPanel.columns.date'),
+  t('llmOps.modelWorkbenchPanel.columns.channel'),
+  t('llmOps.modelWorkbenchPanel.columns.variance')
+])
 
 const diagnostics = computed(() => props.summary.agione?.diagnostics || [])
 const modelOptions = computed(() =>
@@ -259,8 +311,11 @@ const channelRows = computed(() =>
 
 const listingRows = computed(() =>
   modelListings.value.map((listing) => [
-    listing.platform_name || `平台 ${listing.platform}`,
-    listing.channel_name || '自动最优',
+    listing.platform_name ||
+      t('llmOps.modelWorkbenchPanel.platformFallback', {
+        id: listing.platform
+      }),
+    channelDisplayName(listing),
     `${workflowLabel(listing.workflow_status)} / ${publishLabel(
       listing.publish_status
     )}`
@@ -284,17 +339,24 @@ function channelName(channelId) {
   )
 }
 
+function channelDisplayName(value) {
+  if (value.channel_type === 'auto_best' || value.channel === null) {
+    return t('llmOps.channel.autoBest')
+  }
+  return value.channel_name || channelName(value.channel)
+}
+
 function dimensionLabel(value) {
   return (
     {
-      text_input: '文本输入',
-      text_output: '文本输出',
-      cache_input: '缓存输入',
-      image_output: '图片输出',
-      audio_input: '音频输入',
-      audio_output: '音频输出',
-      video_input: '视频输入',
-      video_output: '视频输出'
+      text_input: t('llmOps.modelWorkbenchPanel.dimension.textInput'),
+      text_output: t('llmOps.modelWorkbenchPanel.dimension.textOutput'),
+      cache_input: t('llmOps.modelWorkbenchPanel.dimension.cacheInput'),
+      image_output: t('llmOps.modelWorkbenchPanel.dimension.imageOutput'),
+      audio_input: t('llmOps.modelWorkbenchPanel.dimension.audioInput'),
+      audio_output: t('llmOps.modelWorkbenchPanel.dimension.audioOutput'),
+      video_input: t('llmOps.modelWorkbenchPanel.dimension.videoInput'),
+      video_output: t('llmOps.modelWorkbenchPanel.dimension.videoOutput')
     }[value] || value
   )
 }
@@ -302,15 +364,23 @@ function dimensionLabel(value) {
 function workflowLabel(value) {
   return (
     {
-      draft: '草稿',
-      pending_publish: '待发布',
-      online: '在线',
-      update_draft: '更新草稿',
-      pending_update: '待更新',
-      pending_offline: '待下架',
-      offline_exception: '下架异常',
-      offline: '已下架',
-      deleted: '已删除'
+      draft: t('llmOps.modelWorkbenchPanel.workflowStatus.draft'),
+      pending_publish: t(
+        'llmOps.modelWorkbenchPanel.workflowStatus.pendingPublish'
+      ),
+      online: t('llmOps.modelWorkbenchPanel.workflowStatus.online'),
+      update_draft: t('llmOps.modelWorkbenchPanel.workflowStatus.updateDraft'),
+      pending_update: t(
+        'llmOps.modelWorkbenchPanel.workflowStatus.pendingUpdate'
+      ),
+      pending_offline: t(
+        'llmOps.modelWorkbenchPanel.workflowStatus.pendingOffline'
+      ),
+      offline_exception: t(
+        'llmOps.modelWorkbenchPanel.workflowStatus.offlineException'
+      ),
+      offline: t('llmOps.modelWorkbenchPanel.workflowStatus.offline'),
+      deleted: t('llmOps.modelWorkbenchPanel.workflowStatus.deleted')
     }[value] || value
   )
 }
@@ -318,10 +388,10 @@ function workflowLabel(value) {
 function publishLabel(value) {
   return (
     {
-      none: '未发布',
-      online: '已发布',
-      offline: '已下架',
-      deleted: '已删除'
+      none: t('llmOps.modelWorkbenchPanel.publishStatus.none'),
+      online: t('llmOps.modelWorkbenchPanel.publishStatus.online'),
+      offline: t('llmOps.modelWorkbenchPanel.publishStatus.offline'),
+      deleted: t('llmOps.modelWorkbenchPanel.publishStatus.deleted')
     }[value] || value
   )
 }

--- a/frontend/src/components/llm-ops/PriceChangePanel.vue
+++ b/frontend/src/components/llm-ops/PriceChangePanel.vue
@@ -11,9 +11,11 @@
     <div class="panel overflow-hidden p-0">
       <div class="table-toolbar">
         <div>
-          <h3 class="panel-title">价格变化看板</h3>
+          <h3 class="panel-title">
+            {{ t('llmOps.priceChangePanel.title') }}
+          </h3>
           <p class="mt-1 text-xs text-slate-500">
-            汇总渠道采购价、挂售价和标准价格项的最近变化。
+            {{ t('llmOps.priceChangePanel.subtitle') }}
           </p>
         </div>
         <CompactSelect
@@ -27,12 +29,20 @@
         <table class="data-table">
           <thead>
             <tr>
-              <th class="table-head">对象</th>
-              <th class="table-head">类型</th>
+              <th class="table-head">
+                {{ t('llmOps.priceChangePanel.columns.object') }}
+              </th>
+              <th class="table-head">
+                {{ t('llmOps.priceChangePanel.columns.type') }}
+              </th>
               <th class="table-head text-right">Input</th>
               <th class="table-head text-right">Output</th>
-              <th class="table-head">币种</th>
-              <th class="table-head">时间</th>
+              <th class="table-head">
+                {{ t('llmOps.priceChangePanel.columns.currency') }}
+              </th>
+              <th class="table-head">
+                {{ t('llmOps.priceChangePanel.columns.time') }}
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -57,7 +67,7 @@
             </tr>
             <tr v-if="!filteredRows.length">
               <td class="table-cell text-slate-500" colspan="6">
-                暂无价格变化记录。
+                {{ t('llmOps.priceChangePanel.empty') }}
               </td>
             </tr>
           </tbody>
@@ -69,6 +79,7 @@
 
 <script setup>
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import CompactSelect from './CompactSelect.vue'
 
@@ -78,22 +89,27 @@ const props = defineProps({
   priceItems: { type: Array, default: () => [] }
 })
 
+const { t } = useI18n()
 const typeFilter = ref('all')
-const typeFilterOptions = [
-  { label: '全部价格', value: 'all' },
-  { label: '渠道采购价', value: 'channel' },
-  { label: '平台挂售价', value: 'listing' },
-  { label: '标准价格项', value: 'official' }
-]
+const typeFilterOptions = computed(() => [
+  { label: t('llmOps.priceChangePanel.filters.all'), value: 'all' },
+  { label: t('llmOps.priceChangePanel.types.channel'), value: 'channel' },
+  { label: t('llmOps.priceChangePanel.types.listing'), value: 'listing' },
+  { label: t('llmOps.priceChangePanel.types.official'), value: 'official' }
+])
 
 const changeRows = computed(() => {
   const channelRows = props.channelHistory.map((item) => ({
     key: `channel-${item.id}`,
     type: 'channel',
-    type_label: '渠道采购价',
+    type_label: t('llmOps.priceChangePanel.types.channel'),
     tone: 'info',
-    name: item.model_name || `模型 ${item.model}`,
-    context: item.channel_name || `渠道 ${item.channel}`,
+    name:
+      item.model_name ||
+      t('llmOps.priceChangePanel.fallback.model', { id: item.model }),
+    context:
+      item.channel_name ||
+      t('llmOps.priceChangePanel.fallback.channel', { id: item.channel }),
     input: item.input_price_per_million,
     output: item.output_price_per_million,
     currency: item.currency,
@@ -102,10 +118,16 @@ const changeRows = computed(() => {
   const listingRows = props.listingHistory.map((item) => ({
     key: `listing-${item.id}`,
     type: 'listing',
-    type_label: '平台挂售价',
+    type_label: t('llmOps.priceChangePanel.types.listing'),
     tone: 'warn',
-    name: item.model_name || `模型 ${item.model}`,
-    context: item.platform_name || `平台 ${item.platform}`,
+    name:
+      item.model_name ||
+      t('llmOps.priceChangePanel.fallback.model', { id: item.model }),
+    context:
+      item.platform_name ||
+      t('llmOps.priceChangePanel.fallback.platform', {
+        id: item.platform
+      }),
     input: item.retail_input_price_per_million,
     output: item.retail_output_price_per_million,
     currency: item.currency,
@@ -125,19 +147,19 @@ const filteredRows = computed(() => {
 
 const metrics = computed(() => [
   {
-    label: '渠道价历史',
+    label: t('llmOps.priceChangePanel.metrics.channelHistory.label'),
     value: props.channelHistory.length,
-    hint: '采购渠道价格版本记录'
+    hint: t('llmOps.priceChangePanel.metrics.channelHistory.hint')
   },
   {
-    label: '挂售价历史',
+    label: t('llmOps.priceChangePanel.metrics.listingHistory.label'),
     value: props.listingHistory.length,
-    hint: '平台挂售价格版本记录'
+    hint: t('llmOps.priceChangePanel.metrics.listingHistory.hint')
   },
   {
-    label: '标准价格项',
+    label: t('llmOps.priceChangePanel.metrics.officialItems.label'),
     value: props.priceItems.length,
-    hint: '当前标准价格维度数量'
+    hint: t('llmOps.priceChangePanel.metrics.officialItems.hint')
   }
 ])
 
@@ -145,9 +167,11 @@ function recentOfficialRows() {
   return props.priceItems.slice(0, 80).map((item) => ({
     key: `official-${item.id}`,
     type: 'official',
-    type_label: '标准价格项',
+    type_label: t('llmOps.priceChangePanel.types.official'),
     tone: 'success',
-    name: item.model_name || `模型 ${item.model}`,
+    name:
+      item.model_name ||
+      t('llmOps.priceChangePanel.fallback.model', { id: item.model }),
     context: dimensionLabel(item.dimension),
     input: item.dimension === 'text_input' ? item.unit_price : null,
     output: item.dimension === 'text_output' ? item.unit_price : null,
@@ -159,14 +183,14 @@ function recentOfficialRows() {
 function dimensionLabel(value) {
   return (
     {
-      text_input: '文本输入',
-      text_output: '文本输出',
-      cache_input: '缓存输入',
-      image_output: '图片输出',
-      audio_input: '音频输入',
-      audio_output: '音频输出',
-      video_input: '视频输入',
-      video_output: '视频输出'
+      text_input: t('llmOps.priceChangePanel.dimension.textInput'),
+      text_output: t('llmOps.priceChangePanel.dimension.textOutput'),
+      cache_input: t('llmOps.priceChangePanel.dimension.cacheInput'),
+      image_output: t('llmOps.priceChangePanel.dimension.imageOutput'),
+      audio_input: t('llmOps.priceChangePanel.dimension.audioInput'),
+      audio_output: t('llmOps.priceChangePanel.dimension.audioOutput'),
+      video_input: t('llmOps.priceChangePanel.dimension.videoInput'),
+      video_output: t('llmOps.priceChangePanel.dimension.videoOutput')
     }[value] || value
   )
 }

--- a/frontend/src/components/llm-ops/ProviderManagement.vue
+++ b/frontend/src/components/llm-ops/ProviderManagement.vue
@@ -177,7 +177,7 @@
                 <div class="provider-actions">
                   <OperationIconButton
                     icon="edit"
-                    label="编辑价格源"
+                    :label="t('llmOps.providerManagement.actions.editSource')"
                     :disabled="!provider.primary_source"
                     @click.stop="
                       editSourceFromProvider(provider.primary_source)
@@ -186,7 +186,9 @@
                   <OperationIconButton
                     v-if="provider.primary_source?.can_manual_entry"
                     icon="manual"
-                    label="配置模型价格"
+                    :label="
+                      t('llmOps.providerManagement.actions.configureModelPrice')
+                    "
                     tone="primary"
                     @click.stop="
                       openManualEntryFromProvider(provider.primary_source)
@@ -206,7 +208,7 @@
                     icon="collect"
                     :label="
                       provider.primary_source?.collect_action_label ||
-                      '同步价格'
+                      t('llmOps.providerManagement.actions.syncPrice')
                     "
                     :disabled="
                       !provider.primary_source.is_enabled ||
@@ -218,7 +220,9 @@
                   <OperationIconButton
                     v-if="canOfficialResetSource(provider.primary_source)"
                     icon="reset"
-                    label="重置官方价格"
+                    :label="
+                      t('llmOps.providerManagement.actions.resetOfficialPrice')
+                    "
                     tone="danger"
                     @click.stop="
                       openOfficialResetModal(provider.primary_source)
@@ -226,7 +230,7 @@
                   />
                   <OperationIconButton
                     icon="delete"
-                    label="删除价格源"
+                    :label="t('llmOps.providerManagement.actions.deleteSource')"
                     tone="danger"
                     :disabled="
                       !provider.primary_source ||
@@ -271,9 +275,11 @@
         <div class="modal-header">
           <div>
             <p class="modal-eyebrow">Official Price Reset</p>
-            <h3 class="modal-title">重置官方价格数据</h3>
+            <h3 class="modal-title">
+              {{ t('llmOps.providerManagement.officialReset.title') }}
+            </h3>
             <p class="modal-desc">
-              清理历史 seed / 同步写入的官方价格脏数据，并重新同步官方价格。
+              {{ t('llmOps.providerManagement.officialReset.description') }}
             </p>
           </div>
           <button
@@ -282,20 +288,24 @@
             :disabled="officialResetBusy"
             @click="closeOfficialResetModal"
           >
-            关闭
+            {{ t('common.close') }}
           </button>
         </div>
 
         <div class="reset-modal-body">
           <label class="field-group">
-            <span class="field-label">清理范围</span>
+            <span class="field-label">
+              {{ t('llmOps.providerManagement.officialReset.scope') }}
+            </span>
             <select
               v-model="officialResetScope"
               class="field-input"
               :disabled="officialResetBusy || officialResetScopeLocked"
               @change="officialResetPreview = null"
             >
-              <option value="all">全部官方来源</option>
+              <option value="all">
+                {{ t('llmOps.providerManagement.officialReset.allSources') }}
+              </option>
               <option
                 v-for="option in officialResetProviderOptions"
                 :key="option.code"
@@ -317,14 +327,16 @@
             </div>
           </div>
           <p v-else class="reset-empty">
-            先预览清理范围，再执行重置。平台会保留手工价格、供货商价格和渠道配置。
+            {{ t('llmOps.providerManagement.officialReset.emptyPreview') }}
           </p>
 
           <div
             v-if="officialResetLegacySources.length"
             class="reset-legacy-list"
           >
-            <p>将删除的历史模型级来源</p>
+            <p>
+              {{ t('llmOps.providerManagement.officialReset.legacySources') }}
+            </p>
             <div>
               <span v-for="slug in officialResetLegacySources" :key="slug">
                 {{ slug }}
@@ -340,7 +352,11 @@
             :disabled="officialResetBusy"
             @click="previewOfficialReset"
           >
-            {{ officialResetPreviewing ? '预览中...' : '预览影响' }}
+            {{
+              officialResetPreviewing
+                ? t('llmOps.providerManagement.officialReset.previewing')
+                : t('llmOps.providerManagement.officialReset.preview')
+            }}
           </button>
           <button
             type="button"
@@ -348,7 +364,11 @@
             :disabled="!officialResetPreview || officialResetBusy"
             @click="executeOfficialReset"
           >
-            {{ officialResetExecuting ? '重置中...' : '确认重置并同步' }}
+            {{
+              officialResetExecuting
+                ? t('llmOps.providerManagement.officialReset.executing')
+                : t('llmOps.providerManagement.officialReset.execute')
+            }}
           </button>
         </div>
       </section>
@@ -501,14 +521,38 @@ const officialResetBusy = computed(
 const officialResetPreviewItems = computed(() => {
   const stats = officialResetPreview.value?.stats || {}
   return [
-    { label: '匹配来源', value: stats.sources_matched || 0 },
-    { label: '保留真实来源', value: stats.provider_sources_kept || 0 },
-    { label: '删除历史来源', value: stats.legacy_sources_deleted || 0 },
-    { label: '重置模型', value: stats.models_reset || 0 },
-    { label: '删除价格项', value: stats.price_items_deleted || 0 },
-    { label: '删除快照', value: stats.snapshots_deleted || 0 },
-    { label: '删除历史', value: stats.history_deleted || 0 },
-    { label: '删除运行记录', value: stats.runs_deleted || 0 }
+    {
+      label: t('llmOps.providerManagement.officialReset.stats.sourcesMatched'),
+      value: stats.sources_matched || 0
+    },
+    {
+      label: t('llmOps.providerManagement.officialReset.stats.sourcesKept'),
+      value: stats.provider_sources_kept || 0
+    },
+    {
+      label: t('llmOps.providerManagement.officialReset.stats.legacySources'),
+      value: stats.legacy_sources_deleted || 0
+    },
+    {
+      label: t('llmOps.providerManagement.officialReset.stats.modelsReset'),
+      value: stats.models_reset || 0
+    },
+    {
+      label: t('llmOps.providerManagement.officialReset.stats.priceItems'),
+      value: stats.price_items_deleted || 0
+    },
+    {
+      label: t('llmOps.providerManagement.officialReset.stats.snapshots'),
+      value: stats.snapshots_deleted || 0
+    },
+    {
+      label: t('llmOps.providerManagement.officialReset.stats.history'),
+      value: stats.history_deleted || 0
+    },
+    {
+      label: t('llmOps.providerManagement.officialReset.stats.runs'),
+      value: stats.runs_deleted || 0
+    }
   ]
 })
 
@@ -573,7 +617,12 @@ async function loadSelectedProviderPriceItems(
   } catch (error) {
     selectedProviderPriceItems.value = []
     selectedProviderTotal.value = 0
-    showError(errorMessage(error, '加载价格源明细失败。'))
+    showError(
+      errorMessage(
+        error,
+        t('llmOps.providerManagement.errors.loadSourceDetail')
+      )
+    )
   } finally {
     selectedProviderLoading.value = false
   }
@@ -617,7 +666,12 @@ async function previewOfficialReset() {
     )
     officialResetPreview.value = apiPayload(response)
   } catch (error) {
-    showError(errorMessage(error, '预览官方价格重置范围失败。'))
+    showError(
+      errorMessage(
+        error,
+        t('llmOps.providerManagement.errors.previewOfficialReset')
+      )
+    )
   } finally {
     officialResetPreviewing.value = false
   }
@@ -626,7 +680,7 @@ async function previewOfficialReset() {
 async function executeOfficialReset() {
   if (!officialResetPreview.value) return
   const confirmed = window.confirm(
-    '确认清理所选官方价格数据并重新同步？该操作会删除官方价格项、采集快照和历史模型级来源。'
+    t('llmOps.providerManagement.officialReset.confirm')
   )
   if (!confirmed) return
 
@@ -641,14 +695,19 @@ async function executeOfficialReset() {
     const payload = apiPayload(response)
     const stats = payload.stats || {}
     showSuccess(
-      `官方价格已重置并同步：删除价格项 ${stats.price_items_deleted || 0}，重置模型 ${stats.models_reset || 0}`
+      t('llmOps.providerManagement.messages.officialResetSuccess', {
+        priceItems: stats.price_items_deleted || 0,
+        models: stats.models_reset || 0
+      })
     )
     showOfficialResetModal.value = false
     officialResetPreview.value = null
     officialResetScopeLocked.value = false
     emit('refresh')
   } catch (error) {
-    showError(errorMessage(error, '重置官方价格失败。'))
+    showError(
+      errorMessage(error, t('llmOps.providerManagement.errors.officialReset'))
+    )
   } finally {
     officialResetExecuting.value = false
   }
@@ -687,7 +746,12 @@ async function ensurePriceEntryCatalogLoaded() {
   try {
     await Promise.all(requests)
   } catch (error) {
-    showError(errorMessage(error, '加载手工录价模型目录失败。'))
+    showError(
+      errorMessage(
+        error,
+        t('llmOps.providerManagement.errors.loadManualEntryCatalog')
+      )
+    )
   }
 }
 

--- a/frontend/src/components/llm-ops/ProviderModal.vue
+++ b/frontend/src/components/llm-ops/ProviderModal.vue
@@ -17,10 +17,14 @@
               Provider
             </p>
             <h3 class="mt-2 text-lg font-semibold text-slate-900">
-              {{ form.id ? '编辑模型厂商' : '新建模型厂商' }}
+              {{
+                form.id
+                  ? t('llmOps.providerModal.editTitle')
+                  : t('llmOps.providerModal.createTitle')
+              }}
             </h3>
             <p class="mt-1 text-sm leading-6 text-slate-500">
-              模型厂商由系统适配，页面只维护展示名称、价格采集地址和运营备注。
+              {{ t('llmOps.providerModal.description') }}
             </p>
           </div>
           <button
@@ -29,7 +33,7 @@
             :disabled="saving"
             @click="close"
           >
-            关闭
+            {{ t('common.close') }}
           </button>
         </div>
       </div>
@@ -39,33 +43,37 @@
       >
         <section class="form-section">
           <div class="section-heading">
-            <h4>基础信息</h4>
-            <p>用于在模型定价、渠道发布和 Agione 挂售中识别厂商。</p>
+            <h4>{{ t('llmOps.providerModal.basicTitle') }}</h4>
+            <p>{{ t('llmOps.providerModal.basicHint') }}</p>
           </div>
           <div class="grid gap-4 md:grid-cols-2">
             <label class="field-group">
-              <span class="field-label">厂商显示名称</span>
+              <span class="field-label">
+                {{ t('llmOps.providerModal.fields.name') }}
+              </span>
               <input
                 v-model="form.name"
                 class="field"
-                placeholder="例如：OpenAI"
+                :placeholder="t('llmOps.providerModal.placeholders.name')"
                 required
               />
               <span class="field-help">
-                展示在厂商列表、模型详情和运营总览中的名称。
+                {{ t('llmOps.providerModal.help.name') }}
               </span>
             </label>
             <label class="field-group">
-              <span class="field-label">厂商标识 Code</span>
+              <span class="field-label">
+                {{ t('llmOps.providerModal.fields.code') }}
+              </span>
               <input
                 v-model="form.code"
                 class="field font-mono disabled:bg-slate-50 disabled:text-slate-400"
                 :disabled="Boolean(form.id)"
-                placeholder="例如：openai"
+                :placeholder="t('llmOps.providerModal.placeholders.code')"
                 required
               />
               <span class="field-help">
-                系统适配标识，已创建厂商不建议修改。
+                {{ t('llmOps.providerModal.help.code') }}
               </span>
             </label>
           </div>
@@ -73,21 +81,24 @@
 
         <section class="form-section">
           <div class="section-heading">
-            <h4>价格采集地址</h4>
-            <p>只影响该厂商绑定的模型价格源，不修改厂商官网或 API 接入地址。</p>
+            <h4>{{ t('llmOps.providerModal.priceSourceTitle') }}</h4>
+            <p>{{ t('llmOps.providerModal.priceSourceHint') }}</p>
           </div>
           <label class="field-group">
-            <span class="field-label">价格源地址</span>
+            <span class="field-label">
+              {{ t('llmOps.providerModal.fields.priceSourceEndpoint') }}
+            </span>
             <input
               v-model="form.price_source_endpoint_url"
               class="field"
-              placeholder="例如：https://models.dev/api.json"
+              :placeholder="
+                t('llmOps.providerModal.placeholders.priceSourceEndpoint')
+              "
               type="url"
               :disabled="!form.primary_source_id"
             />
             <span class="field-help">
-              可填写厂商官方价格页，或使用 https://models.dev/api.json
-              作为聚合价格数据源；停用状态请在模型价格源列表中维护。
+              {{ t('llmOps.providerModal.help.priceSourceEndpoint') }}
             </span>
           </label>
           <a
@@ -106,21 +117,27 @@
             class="mt-2 truncate text-xs text-slate-400"
             :title="form.website"
           >
-            厂商官网 / 接入地址：{{ form.website }}
+            {{
+              t('llmOps.providerModal.websitePrefix', {
+                website: form.website
+              })
+            }}
           </p>
         </section>
 
         <section class="form-section">
           <div class="section-heading">
-            <h4>运营备注</h4>
-            <p>记录价格口径、采集限制或厂商适配说明。</p>
+            <h4>{{ t('llmOps.providerModal.notesTitle') }}</h4>
+            <p>{{ t('llmOps.providerModal.notesHint') }}</p>
           </div>
           <label class="field-group">
-            <span class="field-label">备注</span>
+            <span class="field-label">
+              {{ t('llmOps.providerModal.fields.notes') }}
+            </span>
             <textarea
               v-model="form.notes"
               class="field min-h-24 resize-none"
-              placeholder="例如：价格页更新频率、特殊模型口径、待补充采集适配"
+              :placeholder="t('llmOps.providerModal.placeholders.notes')"
             />
           </label>
         </section>
@@ -134,7 +151,11 @@
               <span class="status-switch-dot" />
             </span>
             <span class="text-sm text-slate-700">
-              {{ form.is_active ? '厂商已启用' : '厂商已停用' }}
+              {{
+                form.is_active
+                  ? t('llmOps.providerModal.enabled')
+                  : t('llmOps.providerModal.disabled')
+              }}
             </span>
           </label>
           <p
@@ -151,7 +172,7 @@
             :disabled="saving"
             @click="close"
           >
-            取消
+            {{ t('common.cancel') }}
           </button>
           <button
             class="btn-primary btn-action-save"
@@ -159,7 +180,11 @@
             :disabled="saving"
           >
             <span class="icon-mark" :class="saving ? 'animate-spin' : ''" />
-            {{ form.id ? '保存修改' : '创建厂商' }}
+            {{
+              form.id
+                ? t('llmOps.providerModal.saveChanges')
+                : t('llmOps.providerModal.createProvider')
+            }}
           </button>
         </div>
       </div>
@@ -169,6 +194,8 @@
 
 <script setup>
 import { ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
 import { llmOpsApi } from '@/api/llmOps'
 
 const props = defineProps({
@@ -183,6 +210,7 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['close', 'saved'])
+const { t } = useI18n()
 
 const form = ref(defaults())
 const saving = ref(false)
@@ -262,8 +290,8 @@ async function save() {
     emit('saved')
   } catch (error) {
     saveError.value = providerSaved
-      ? errorMessage(error, '厂商已保存，但价格源地址保存失败，请重试。')
-      : errorMessage(error, '模型厂商保存失败，请稍后重试。')
+      ? errorMessage(error, t('llmOps.providerModal.errors.sourceSaveFailed'))
+      : errorMessage(error, t('llmOps.providerModal.errors.saveFailed'))
   } finally {
     saving.value = false
   }

--- a/frontend/src/components/llm-ops/ProviderPricingDrawer.vue
+++ b/frontend/src/components/llm-ops/ProviderPricingDrawer.vue
@@ -27,7 +27,7 @@
             class="btn-secondary btn-action-cancel"
             @click="$emit('close')"
           >
-            关闭
+            {{ t('common.close') }}
           </button>
         </div>
       </div>
@@ -35,39 +35,59 @@
       <div class="space-y-5 px-5 py-5">
         <div class="grid gap-3 md:grid-cols-5">
           <div class="rounded-lg bg-slate-50 px-3 py-2">
-            <p class="text-xs text-slate-500">模型数量</p>
+            <p class="text-xs text-slate-500">
+              {{ t('llmOps.providerPricingDrawer.modelCount') }}
+            </p>
             <p class="mt-1 font-mono text-sm text-slate-800">
               {{ models.length }}
             </p>
           </div>
           <div class="rounded-lg bg-slate-50 px-3 py-2">
-            <p class="text-xs text-slate-500">已定价模型</p>
+            <p class="text-xs text-slate-500">
+              {{ t('llmOps.providerPricingDrawer.pricedModelCount') }}
+            </p>
             <p class="mt-1 font-mono text-sm text-slate-800">
               {{ pricedModelCount }}
             </p>
           </div>
           <div class="rounded-lg bg-slate-50 px-3 py-2">
-            <p class="text-xs text-slate-500">模型价格源</p>
+            <p class="text-xs text-slate-500">
+              {{ t('llmOps.providerPricingDrawer.modelPriceSources') }}
+            </p>
             <p class="mt-1 font-mono text-sm text-slate-800">
               {{ sourceRows.length }}
             </p>
           </div>
           <div class="rounded-lg bg-slate-50 px-3 py-2">
-            <p class="text-xs text-slate-500">价格结构</p>
+            <p class="text-xs text-slate-500">
+              {{ t('llmOps.providerPricingDrawer.priceStructure') }}
+            </p>
             <p class="mt-1 text-sm text-slate-800">
-              原厂 {{ officialModelCount }} · 云托管
-              {{ cloudHostedModelCount }} · 外部 {{ externalModelCount }}
+              {{
+                t('llmOps.providerPricingDrawer.priceStructureSummary', {
+                  official: officialModelCount,
+                  cloud: cloudHostedModelCount,
+                  external: externalModelCount
+                })
+              }}
             </p>
           </div>
           <div class="rounded-lg bg-slate-50 px-3 py-2">
-            <p class="text-xs text-slate-500">价格来源</p>
+            <p class="text-xs text-slate-500">
+              {{ t('llmOps.providerPricingDrawer.priceSource') }}
+            </p>
             <div v-if="primarySource" class="mt-1 min-w-0">
               <div class="min-w-0">
                 <p class="truncate text-sm font-medium text-slate-900">
                   {{ primarySource.name }}
                 </p>
                 <p class="mt-1 truncate font-mono text-xs text-slate-400">
-                  {{ primarySource.slug }} · {{ sourceRows.length }} 个来源
+                  {{
+                    t('llmOps.providerPricingDrawer.sourceSummary', {
+                      slug: primarySource.slug,
+                      count: sourceRows.length
+                    })
+                  }}
                 </p>
                 <a
                   v-if="primarySource.endpoint_url"
@@ -88,9 +108,11 @@
         <div class="panel overflow-hidden p-0">
           <div class="table-toolbar">
             <div>
-              <h3 class="panel-title">服务商模型价格</h3>
+              <h3 class="panel-title">
+                {{ t('llmOps.providerPricingDrawer.title') }}
+              </h3>
               <p class="mt-1 text-xs text-slate-500">
-                按模型汇总输入、输出、缓存等核心价格，减少逐维度展开带来的噪音。
+                {{ t('llmOps.providerPricingDrawer.subtitle') }}
               </p>
             </div>
             <div
@@ -99,9 +121,15 @@
               <input
                 v-model="search"
                 class="field-input"
-                placeholder="搜索模型、来源或 code"
+                :placeholder="
+                  t('llmOps.providerPricingDrawer.searchPlaceholder')
+                "
               />
-              <div class="filter-tabs" role="tablist" aria-label="来源类型">
+              <div
+                class="filter-tabs"
+                role="tablist"
+                :aria-label="t('llmOps.providerPricingDrawer.sourceType')"
+              >
                 <button
                   v-for="option in categoryFilterOptions"
                   :key="option.value"
@@ -130,10 +158,16 @@
               </colgroup>
               <thead>
                 <tr>
-                  <th class="table-head">模型</th>
-                  <th class="table-head">来源类型</th>
-                  <th class="table-head">价格摘要</th>
-                  <th class="table-head">更新时间</th>
+                  <th class="table-head">{{ t('llmOps.fields.model') }}</th>
+                  <th class="table-head">
+                    {{ t('llmOps.providerPricingDrawer.sourceType') }}
+                  </th>
+                  <th class="table-head">
+                    {{ t('llmOps.providerPricingDrawer.priceSummary') }}
+                  </th>
+                  <th class="table-head">
+                    {{ t('llmOps.providerPricingDrawer.updatedAt') }}
+                  </th>
                 </tr>
               </thead>
               <tbody>
@@ -166,7 +200,9 @@
                         {{ item.value }}
                       </span>
                     </div>
-                    <span v-else class="text-xs text-slate-400">暂无价格</span>
+                    <span v-else class="text-xs text-slate-400">
+                      {{ t('llmOps.providerPricingDrawer.noPrice') }}
+                    </span>
                   </td>
                   <td class="table-cell">
                     {{ formatDateTime(row.updated_at) }}
@@ -174,7 +210,7 @@
                 </tr>
                 <tr v-if="!filteredModelRows.length">
                   <td class="table-cell text-slate-500" colspan="4">
-                    当前服务商还没有模型定价记录。
+                    {{ t('llmOps.providerPricingDrawer.empty') }}
                   </td>
                 </tr>
               </tbody>
@@ -189,6 +225,8 @@
 <script setup>
 import '@/components/llm-ops/providerPricingDrawer.css'
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
 import {
   canCollectPriceSource,
   canManualEntryPriceSource,
@@ -197,7 +235,6 @@ import {
   normalizePriceSourceCategory as businessSourceCategory,
   officialProviderCodeFromSlug as baseOfficialProviderCodeFromSlug,
   preferredPriceSource,
-  priceSourceCategoryLabel as sourceCategoryLabel,
   priceSourceCategoryRank as categoryRank,
   priceSourceGroupKey as basePriceSourceGroupKey,
   priceSourceTone as sourceTone
@@ -240,6 +277,7 @@ const props = defineProps({
   }
 })
 
+const { t } = useI18n()
 const search = ref('')
 const categoryFilter = ref('all')
 
@@ -250,19 +288,31 @@ const modelRows = computed(() =>
 const categoryFilterOptions = computed(() => {
   const counts = sourceCategoryCounts(modelRows.value)
   return [
-    { value: 'all', label: '全部来源', count: modelRows.value.length },
+    {
+      value: 'all',
+      label: t('llmOps.providerPricingDrawer.allSources'),
+      count: modelRows.value.length
+    },
     {
       value: 'official_provider',
-      label: '原厂',
+      label: sourceCategoryLabel('official_provider'),
       count: counts.official_provider || 0
     },
     {
       value: 'cloud_hosted',
-      label: '云托管',
+      label: sourceCategoryLabel('cloud_hosted'),
       count: counts.cloud_hosted || 0
     },
-    { value: 'supplier', label: '供货商', count: counts.supplier || 0 },
-    { value: 'manual', label: '人工', count: counts.manual || 0 }
+    {
+      value: 'supplier',
+      label: sourceCategoryLabel('supplier'),
+      count: counts.supplier || 0
+    },
+    {
+      value: 'manual',
+      label: sourceCategoryLabel('manual'),
+      count: counts.manual || 0
+    }
   ]
 })
 
@@ -403,7 +453,7 @@ function buildModelRow(model, items, source = null, sourceKey = 'source') {
       items[0]?.source_name ||
       model.source_name ||
       resolvedSource.name ||
-      '未绑定价格源',
+      t('llmOps.providerPricingDrawer.unboundPriceSource'),
     source_url:
       items[0]?.source_endpoint_url ||
       model.source_endpoint_url ||
@@ -552,9 +602,21 @@ function isProviderOfficialSource(source) {
 function aggregateSourceName(source) {
   const providerName = source.provider_name || props.provider?.name || ''
   if (!isLegacyOfficialModelSource(source)) {
-    return source?.name || (providerName ? `${providerName} 官方价格` : '-')
+    return (
+      source?.name ||
+      (providerName
+        ? t('llmOps.providerPricingDrawer.officialPriceName', {
+            provider: providerName
+          })
+        : '-')
+    )
   }
-  return `${providerName || source.provider_code || '服务商'} 官方价格`
+  return t('llmOps.providerPricingDrawer.officialPriceName', {
+    provider:
+      providerName ||
+      source.provider_code ||
+      t('llmOps.providerPricingDrawer.providerFallback')
+  })
 }
 
 function aggregateSourceSlug(source) {
@@ -574,25 +636,33 @@ function officialProviderCodeFromSlug(source) {
 
 function dimensionLabel(dimension) {
   const labels = {
-    text_input: '文本输入',
-    text_output: '文本输出',
-    cache_input: '缓存输入',
-    image_input: '图片输入',
-    image_output: '图片输出',
-    audio_input: '音频输入',
-    audio_output: '音频输出',
-    video_input: '视频输入',
-    video_output: '视频输出'
+    text_input: t('llmOps.providerPricingDrawer.dimension.textInput'),
+    text_output: t('llmOps.providerPricingDrawer.dimension.textOutput'),
+    cache_input: t('llmOps.providerPricingDrawer.dimension.cacheInput'),
+    image_input: t('llmOps.providerPricingDrawer.dimension.imageInput'),
+    image_output: t('llmOps.providerPricingDrawer.dimension.imageOutput'),
+    audio_input: t('llmOps.providerPricingDrawer.dimension.audioInput'),
+    audio_output: t('llmOps.providerPricingDrawer.dimension.audioOutput'),
+    video_input: t('llmOps.providerPricingDrawer.dimension.videoInput'),
+    video_output: t('llmOps.providerPricingDrawer.dimension.videoOutput')
   }
   return labels[dimension] || dimension || '-'
 }
 
 function tokenPricingItems(model) {
   return [
-    priceItem('输入 / 1M', model.input_price_per_million, model.currency),
-    priceItem('输出 / 1M', model.output_price_per_million, model.currency),
     priceItem(
-      '缓存输入 / 1M',
+      t('llmOps.providerPricingDrawer.legacyPrice.input1m'),
+      model.input_price_per_million,
+      model.currency
+    ),
+    priceItem(
+      t('llmOps.providerPricingDrawer.legacyPrice.output1m'),
+      model.output_price_per_million,
+      model.currency
+    ),
+    priceItem(
+      t('llmOps.providerPricingDrawer.legacyPrice.cacheInput1m'),
       model.cache_input_price_per_million,
       model.currency
     )
@@ -602,12 +672,12 @@ function tokenPricingItems(model) {
 function audioPricingItems(model) {
   return [
     priceItem(
-      '音频输入 / 秒',
+      t('llmOps.providerPricingDrawer.legacyPrice.audioInputSecond'),
       model.audio_input_price_per_second,
       model.currency
     ),
     priceItem(
-      '音频输出 / 秒',
+      t('llmOps.providerPricingDrawer.legacyPrice.audioOutputSecond'),
       model.audio_output_price_per_second,
       model.currency
     )
@@ -617,7 +687,7 @@ function audioPricingItems(model) {
 function imagePricingItems(model) {
   return [
     priceItem(
-      '图片输出 / 张',
+      t('llmOps.providerPricingDrawer.legacyPrice.imageOutputImage'),
       model.image_output_price_per_image,
       model.currency
     )
@@ -627,12 +697,12 @@ function imagePricingItems(model) {
 function videoPricingItems(model) {
   const items = [
     priceItem(
-      '视频输入 / 秒',
+      t('llmOps.providerPricingDrawer.legacyPrice.videoInputSecond'),
       model.video_input_price_per_second,
       model.currency
     ),
     priceItem(
-      '视频输出 / 秒',
+      t('llmOps.providerPricingDrawer.legacyPrice.videoOutputSecond'),
       model.video_output_price_per_second,
       model.currency
     )
@@ -640,8 +710,20 @@ function videoPricingItems(model) {
   const resolutionItems = Object.entries(model.video_resolution_prices || {})
     .slice(0, 2)
     .flatMap(([resolution, price]) => [
-      priceItem(`${resolution} 输入`, price?.input, model.currency),
-      priceItem(`${resolution} 输出`, price?.output, model.currency)
+      priceItem(
+        t('llmOps.providerPricingDrawer.legacyPrice.resolutionInput', {
+          resolution
+        }),
+        price?.input,
+        model.currency
+      ),
+      priceItem(
+        t('llmOps.providerPricingDrawer.legacyPrice.resolutionOutput', {
+          resolution
+        }),
+        price?.output,
+        model.currency
+      )
     ])
     .filter(Boolean)
   return [...items, ...resolutionItems]
@@ -664,20 +746,32 @@ function currentPriceItemSummary(item) {
 
 function compactDimensionLabel(dimension, billingUnit) {
   const labels = {
-    text_input: '输入',
-    text_output: '输出',
-    cache_input: '缓存',
-    image_input: '图入',
-    image_output: '图出',
-    audio_input: '音入',
-    audio_output: '音出',
-    video_input: '视入',
-    video_output: '视出'
+    text_input: t('llmOps.providerPricingDrawer.compactDimension.input'),
+    text_output: t('llmOps.providerPricingDrawer.compactDimension.output'),
+    cache_input: t('llmOps.providerPricingDrawer.compactDimension.cache'),
+    image_input: t('llmOps.providerPricingDrawer.compactDimension.imageInput'),
+    image_output: t(
+      'llmOps.providerPricingDrawer.compactDimension.imageOutput'
+    ),
+    audio_input: t('llmOps.providerPricingDrawer.compactDimension.audioInput'),
+    audio_output: t(
+      'llmOps.providerPricingDrawer.compactDimension.audioOutput'
+    ),
+    video_input: t('llmOps.providerPricingDrawer.compactDimension.videoInput'),
+    video_output: t('llmOps.providerPricingDrawer.compactDimension.videoOutput')
   }
   const base = labels[dimension] || dimensionLabel(dimension)
-  if (billingUnit === 'per_image') return `${base}/张`
-  if (billingUnit === 'per_second') return `${base}/秒`
-  if (billingUnit === 'per_generation') return `${base}/次`
+  if (billingUnit === 'per_image') {
+    return t('llmOps.providerPricingDrawer.billingUnit.perImage', { base })
+  }
+  if (billingUnit === 'per_second') {
+    return t('llmOps.providerPricingDrawer.billingUnit.perSecond', { base })
+  }
+  if (billingUnit === 'per_generation') {
+    return t('llmOps.providerPricingDrawer.billingUnit.perGeneration', {
+      base
+    })
+  }
   return base
 }
 
@@ -772,12 +866,25 @@ function hasImagePrice(model) {
 
 function modalityLabel(modality) {
   const labels = {
-    text: '文本',
-    audio: '音频',
-    video: '视频',
-    multimodal: '多模态'
+    text: t('llmOps.providerPricingDrawer.modality.text'),
+    audio: t('llmOps.providerPricingDrawer.modality.audio'),
+    video: t('llmOps.providerPricingDrawer.modality.video'),
+    multimodal: t('llmOps.providerPricingDrawer.modality.multimodal')
   }
   return labels[modality] || modality || '-'
+}
+
+function sourceCategoryLabel(category) {
+  const labels = {
+    official_provider: t(
+      'llmOps.providerPricingDrawer.sourceCategory.officialProvider'
+    ),
+    cloud_hosted: t('llmOps.providerPricingDrawer.sourceCategory.cloudHosted'),
+    supplier: t('llmOps.providerPricingDrawer.sourceCategory.supplier'),
+    manual: t('llmOps.providerPricingDrawer.sourceCategory.manual'),
+    unknown: t('llmOps.providerPricingDrawer.sourceCategory.unknown')
+  }
+  return labels[category] || labels.unknown
 }
 
 function formatDateTime(value) {

--- a/frontend/src/components/llm-ops/ResalePlatformModal.vue
+++ b/frontend/src/components/llm-ops/ResalePlatformModal.vue
@@ -180,6 +180,51 @@
               />
             </label>
             <label class="field-group">
+              <span class="field-label">税费率（%）</span>
+              <input
+                v-model="form.tax_rate"
+                class="field"
+                min="0"
+                max="99.99"
+                step="0.01"
+                type="number"
+                placeholder="留空表示未配置"
+              />
+            </label>
+            <label class="field-group">
+              <span class="field-label">结算比例（%）</span>
+              <input
+                v-model="form.settlement_rate"
+                class="field"
+                min="0"
+                step="0.01"
+                type="number"
+                placeholder="例如：95"
+              />
+            </label>
+            <label class="field-group">
+              <span class="field-label">收益率预警线（%）</span>
+              <input
+                v-model="form.yield_warning"
+                class="field"
+                min="0"
+                step="0.01"
+                type="number"
+                placeholder="例如：15"
+              />
+            </label>
+            <label class="field-group">
+              <span class="field-label">目标收益率（%）</span>
+              <input
+                v-model="form.yield_target"
+                class="field"
+                min="0"
+                step="0.01"
+                type="number"
+                placeholder="例如：25"
+              />
+            </label>
+            <label class="field-group">
               <span class="field-label">免审最高收益率（%）</span>
               <input
                 v-model="form.auto_approve_max_margin_rate"
@@ -371,6 +416,10 @@ function defaults() {
     currency: 'CNY',
     fee_rate: '3',
     service_fee_rate: '0',
+    tax_rate: '',
+    settlement_rate: '',
+    yield_warning: '',
+    yield_target: '',
     auto_approve_max_margin_rate: '100',
     point_name: '积分',
     points_per_currency_unit: '100.00',
@@ -392,6 +441,10 @@ function platformToForm(platform) {
     environment: platform.environment || 'production',
     fee_rate: percentFromRatio(platform.fee_rate),
     service_fee_rate: percentFromRatio(platform.service_fee_rate),
+    tax_rate: optionalPercentFromRatio(platform.tax_rate),
+    settlement_rate: optionalPercentFromRatio(platform.settlement_rate),
+    yield_warning: optionalPercentFromRatio(platform.yield_warning),
+    yield_target: optionalPercentFromRatio(platform.yield_target),
     points_per_currency_unit: formatDecimal(
       platform.points_per_currency_unit,
       2
@@ -420,6 +473,18 @@ function ratioFromPercent(value) {
   return Number((numberValue / 100).toFixed(6))
 }
 
+function optionalPercentFromRatio(value) {
+  if (value === null || value === undefined || value === '') return ''
+  return percentFromRatio(value)
+}
+
+function optionalRatioFromPercent(value) {
+  if (value === null || value === undefined || value === '') return null
+  const numberValue = Number(value)
+  if (!Number.isFinite(numberValue)) return null
+  return Number((numberValue / 100).toFixed(6))
+}
+
 function normalizePayload(payload) {
   const clean = { ...payload }
   clean.platform_type = 'agione'
@@ -436,6 +501,10 @@ function normalizePayload(payload) {
   )
   clean.fee_rate = ratioFromPercent(clean.fee_rate)
   clean.service_fee_rate = ratioFromPercent(clean.service_fee_rate)
+  clean.tax_rate = optionalRatioFromPercent(clean.tax_rate)
+  clean.settlement_rate = optionalRatioFromPercent(clean.settlement_rate)
+  clean.yield_warning = optionalRatioFromPercent(clean.yield_warning)
+  clean.yield_target = optionalRatioFromPercent(clean.yield_target)
   clean.point_decimal_places = normalizePointDecimalPlaces(
     clean.point_decimal_places
   )

--- a/frontend/src/components/llm-ops/ResalePlatformModal.vue
+++ b/frontend/src/components/llm-ops/ResalePlatformModal.vue
@@ -18,10 +18,14 @@
               Resale Platform
             </p>
             <h3 class="mt-2 text-lg font-semibold text-slate-900">
-              {{ form.id ? '编辑挂售平台' : '新建挂售平台' }}
+              {{
+                form.id
+                  ? t('llmOps.resalePlatformModal.editTitle')
+                  : t('llmOps.resalePlatformModal.createTitle')
+              }}
             </h3>
             <p class="mt-1 text-sm text-slate-500">
-              配置 Agione 平台实例、区域、接口、抽佣、免审收益率和积分规则。
+              {{ t('llmOps.resalePlatformModal.description') }}
             </p>
           </div>
           <button
@@ -30,7 +34,7 @@
             :disabled="saving"
             @click="close"
           >
-            关闭
+            {{ t('common.close') }}
           </button>
         </div>
       </div>
@@ -40,44 +44,54 @@
       >
         <section class="form-section">
           <div class="section-heading">
-            <h4>平台信息</h4>
-            <p>用于区分 Agione 上架平台实例和后续接口适配。</p>
+            <h4>{{ t('llmOps.resalePlatformModal.platformInfo') }}</h4>
+            <p>{{ t('llmOps.resalePlatformModal.platformInfoHint') }}</p>
           </div>
           <div class="grid gap-4 md:grid-cols-2">
             <label class="field-group">
-              <span class="field-label">平台名称</span>
+              <span class="field-label">
+                {{ t('llmOps.resalePlatformModal.fields.name') }}
+              </span>
               <input
                 v-model="form.name"
                 class="field"
-                placeholder="例如：Agione 主平台"
+                :placeholder="t('llmOps.resalePlatformModal.placeholders.name')"
                 required
               />
             </label>
             <label class="field-group">
-              <span class="field-label">平台标识</span>
+              <span class="field-label">
+                {{ t('llmOps.resalePlatformModal.fields.code') }}
+              </span>
               <input
                 v-model="form.code"
                 class="field"
-                placeholder="例如：agione-main"
+                :placeholder="t('llmOps.resalePlatformModal.placeholders.code')"
                 required
               />
             </label>
             <label class="field-group">
-              <span class="field-label">平台类型</span>
+              <span class="field-label">
+                {{ t('llmOps.resalePlatformModal.fields.platformType') }}
+              </span>
               <CompactSelect
                 v-model="form.platform_type"
                 :options="platformTypeOptions"
               />
             </label>
             <label class="field-group">
-              <span class="field-label">环境</span>
+              <span class="field-label">
+                {{ t('llmOps.resalePlatformModal.fields.environment') }}
+              </span>
               <CompactSelect
                 v-model="form.environment"
                 :options="environmentOptions"
               />
             </label>
             <label class="field-group">
-              <span class="field-label">区域</span>
+              <span class="field-label">
+                {{ t('llmOps.resalePlatformModal.fields.region') }}
+              </span>
               <CompactSelect
                 v-model="form.region_code"
                 :options="regionOptions"
@@ -85,15 +99,21 @@
               />
             </label>
             <label class="field-group">
-              <span class="field-label">区域名称</span>
+              <span class="field-label">
+                {{ t('llmOps.resalePlatformModal.fields.regionName') }}
+              </span>
               <input
                 v-model="form.region_name"
                 class="field"
-                placeholder="例如：新加坡"
+                :placeholder="
+                  t('llmOps.resalePlatformModal.placeholders.regionName')
+                "
               />
             </label>
             <label class="field-group">
-              <span class="field-label">官网地址</span>
+              <span class="field-label">
+                {{ t('llmOps.resalePlatformModal.fields.website') }}
+              </span>
               <input
                 v-model="form.website"
                 class="field"
@@ -102,7 +122,9 @@
               />
             </label>
             <label class="field-group">
-              <span class="field-label">API 接入地址</span>
+              <span class="field-label">
+                {{ t('llmOps.resalePlatformModal.fields.apiEndpoint') }}
+              </span>
               <input
                 v-model="form.api_endpoint"
                 autocomplete="off"
@@ -120,7 +142,9 @@
               />
             </label>
             <label class="field-group md:col-span-2">
-              <span class="field-label">平台 API Key</span>
+              <span class="field-label">
+                {{ t('llmOps.resalePlatformModal.fields.apiKey') }}
+              </span>
               <input
                 v-model="form.api_key"
                 autocomplete="off"
@@ -131,12 +155,14 @@
                 data-bwignore="true"
                 data-form-type="other"
                 data-lpignore="true"
-                placeholder="用于挂售接口鉴权"
+                :placeholder="
+                  t('llmOps.resalePlatformModal.placeholders.apiKey')
+                "
                 spellcheck="false"
                 type="text"
               />
               <span class="field-help">
-                用于调用挂售平台接口执行上架、改价和下架操作。
+                {{ t('llmOps.resalePlatformModal.apiKeyHint') }}
               </span>
             </label>
           </div>
@@ -144,19 +170,23 @@
 
         <section class="form-section">
           <div class="section-heading">
-            <h4>结算与积分</h4>
-            <p>用于挂售页将平台上架价换算为积分。</p>
+            <h4>{{ t('llmOps.resalePlatformModal.settlementTitle') }}</h4>
+            <p>{{ t('llmOps.resalePlatformModal.settlementHint') }}</p>
           </div>
           <div class="grid gap-4 md:grid-cols-2">
             <label class="field-group">
-              <span class="field-label">平台货币</span>
+              <span class="field-label">
+                {{ t('llmOps.resalePlatformModal.fields.currency') }}
+              </span>
               <CompactSelect
                 v-model="form.currency"
                 :options="currencyOptions"
               />
             </label>
             <label class="field-group">
-              <span class="field-label">平台抽佣比例（%）</span>
+              <span class="field-label">
+                {{ t('llmOps.resalePlatformModal.fields.feeRate') }}
+              </span>
               <input
                 v-model="form.fee_rate"
                 class="field"
@@ -164,11 +194,15 @@
                 max="99.99"
                 step="0.01"
                 type="number"
-                placeholder="例如：3"
+                :placeholder="
+                  t('llmOps.resalePlatformModal.placeholders.feeRate')
+                "
               />
             </label>
             <label class="field-group">
-              <span class="field-label">服务费率（%）</span>
+              <span class="field-label">
+                {{ t('llmOps.resalePlatformModal.fields.serviceFeeRate') }}
+              </span>
               <input
                 v-model="form.service_fee_rate"
                 class="field"
@@ -176,11 +210,15 @@
                 max="99.99"
                 step="0.01"
                 type="number"
-                placeholder="例如：10"
+                :placeholder="
+                  t('llmOps.resalePlatformModal.placeholders.serviceFeeRate')
+                "
               />
             </label>
             <label class="field-group">
-              <span class="field-label">税费率（%）</span>
+              <span class="field-label">
+                {{ t('llmOps.resalePlatformModal.fields.taxRate') }}
+              </span>
               <input
                 v-model="form.tax_rate"
                 class="field"
@@ -188,81 +226,119 @@
                 max="99.99"
                 step="0.01"
                 type="number"
-                placeholder="留空表示未配置"
+                :placeholder="
+                  t('llmOps.resalePlatformModal.placeholders.optionalRate')
+                "
               />
             </label>
             <label class="field-group">
-              <span class="field-label">结算比例（%）</span>
+              <span class="field-label">
+                {{ t('llmOps.resalePlatformModal.fields.settlementRate') }}
+              </span>
               <input
                 v-model="form.settlement_rate"
                 class="field"
                 min="0"
                 step="0.01"
                 type="number"
-                placeholder="例如：95"
+                :placeholder="
+                  t('llmOps.resalePlatformModal.placeholders.settlementRate')
+                "
               />
             </label>
             <label class="field-group">
-              <span class="field-label">收益率预警线（%）</span>
+              <span class="field-label">
+                {{ t('llmOps.resalePlatformModal.fields.yieldWarning') }}
+              </span>
               <input
                 v-model="form.yield_warning"
                 class="field"
                 min="0"
                 step="0.01"
                 type="number"
-                placeholder="例如：15"
+                :placeholder="
+                  t('llmOps.resalePlatformModal.placeholders.yieldWarning')
+                "
               />
             </label>
             <label class="field-group">
-              <span class="field-label">目标收益率（%）</span>
+              <span class="field-label">
+                {{ t('llmOps.resalePlatformModal.fields.yieldTarget') }}
+              </span>
               <input
                 v-model="form.yield_target"
                 class="field"
                 min="0"
                 step="0.01"
                 type="number"
-                placeholder="例如：25"
+                :placeholder="
+                  t('llmOps.resalePlatformModal.placeholders.yieldTarget')
+                "
               />
             </label>
             <label class="field-group">
-              <span class="field-label">免审最高收益率（%）</span>
+              <span class="field-label">
+                {{
+                  t('llmOps.resalePlatformModal.fields.autoApproveMaxMargin')
+                }}
+              </span>
               <input
                 v-model="form.auto_approve_max_margin_rate"
                 class="field"
                 min="0"
                 step="0.01"
                 type="number"
-                placeholder="例如：20"
+                :placeholder="
+                  t(
+                    'llmOps.resalePlatformModal.placeholders.autoApproveMaxMargin'
+                  )
+                "
               />
             </label>
             <label class="field-group">
-              <span class="field-label">积分名称</span>
+              <span class="field-label">
+                {{ t('llmOps.resalePlatformModal.fields.pointName') }}
+              </span>
               <input
                 v-model="form.point_name"
                 class="field"
-                placeholder="积分"
+                :placeholder="
+                  t('llmOps.resalePlatformModal.placeholders.pointName')
+                "
               />
             </label>
             <label class="field-group">
-              <span class="field-label">积分兑换比例（每 1 平台货币）</span>
+              <span class="field-label">
+                {{
+                  t('llmOps.resalePlatformModal.fields.pointsPerCurrencyUnit')
+                }}
+              </span>
               <input
                 v-model="form.points_per_currency_unit"
                 class="field"
                 min="0.01"
                 step="0.01"
                 type="number"
-                placeholder="例如：100.00"
+                :placeholder="
+                  t(
+                    'llmOps.resalePlatformModal.placeholders.pointsPerCurrencyUnit'
+                  )
+                "
               />
             </label>
             <label class="field-group">
-              <span class="field-label">积分舍入方式</span>
+              <span class="field-label">
+                {{ t('llmOps.resalePlatformModal.fields.roundingMode') }}
+              </span>
               <CompactSelect
                 v-model="form.point_rounding_mode"
                 :options="roundingModeOptions"
               />
             </label>
             <label class="field-group">
-              <span class="field-label">保留小数位</span>
+              <span class="field-label">
+                {{ t('llmOps.resalePlatformModal.fields.decimalPlaces') }}
+              </span>
               <CompactSelect
                 v-model="form.point_decimal_places"
                 :options="decimalPlaceOptions"
@@ -273,13 +349,13 @@
 
         <section class="form-section">
           <div class="section-heading">
-            <h4>扩展元数据</h4>
-            <p>记录租户、渠道、账号、结算口径等平台特有信息。</p>
+            <h4>{{ t('llmOps.resalePlatformModal.metadataTitle') }}</h4>
+            <p>{{ t('llmOps.resalePlatformModal.metadataHint') }}</p>
           </div>
           <textarea
             v-model="form.metadata_text"
             class="field min-h-28 resize-none font-mono text-xs leading-5"
-            placeholder='例如：{"tenant_id":"tenant-001","channel":"direct"}'
+            :placeholder="t('llmOps.resalePlatformModal.placeholders.metadata')"
             :aria-invalid="Boolean(metadataError)"
           />
           <p v-if="metadataError" class="field-error">
@@ -289,13 +365,13 @@
 
         <section class="form-section">
           <div class="section-heading">
-            <h4>备注</h4>
-            <p>记录平台差异、合同口径或接口限制。</p>
+            <h4>{{ t('llmOps.resalePlatformModal.notesTitle') }}</h4>
+            <p>{{ t('llmOps.resalePlatformModal.notesHint') }}</p>
           </div>
           <textarea
             v-model="form.notes"
             class="field min-h-20 resize-none"
-            placeholder="例如：积分倍率来源、结算周期、接口适配状态"
+            :placeholder="t('llmOps.resalePlatformModal.placeholders.notes')"
           />
         </section>
       </div>
@@ -307,7 +383,11 @@
             <span class="status-switch-dot" />
           </span>
           <span class="text-sm text-slate-700">
-            {{ form.is_active ? '平台已启用' : '平台已停用' }}
+            {{
+              form.is_active
+                ? t('llmOps.resalePlatformModal.enabled')
+                : t('llmOps.resalePlatformModal.disabled')
+            }}
           </span>
         </label>
         <div class="modal-footer-actions">
@@ -317,7 +397,7 @@
             :disabled="saving"
             @click="close"
           >
-            取消
+            {{ t('common.cancel') }}
           </button>
           <button
             class="btn-primary btn-action-save"
@@ -325,7 +405,13 @@
             :disabled="saving"
           >
             <span class="icon-mark" :class="saving ? 'animate-spin' : ''" />
-            {{ saving ? '保存中' : form.id ? '保存修改' : '创建平台' }}
+            {{
+              saving
+                ? t('common.saving')
+                : form.id
+                  ? t('llmOps.resalePlatformModal.saveChanges')
+                  : t('llmOps.resalePlatformModal.createPlatform')
+            }}
           </button>
         </div>
       </div>
@@ -334,7 +420,9 @@
 </template>
 
 <script setup>
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
 import { llmOpsApi } from '@/api/llmOps'
 import CompactSelect from '@/components/llm-ops/CompactSelect.vue'
 
@@ -350,6 +438,7 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['close', 'saved'])
+const { t } = useI18n()
 
 const form = ref(defaults())
 const saving = ref(false)
@@ -358,38 +447,62 @@ const currencyOptions = [
   { label: 'USD', value: 'USD' }
 ]
 const platformTypeOptions = [{ label: 'Agione', value: 'agione' }]
-const environmentOptions = [
-  { label: '生产', value: 'production' },
-  { label: '预发', value: 'staging' },
-  { label: '沙箱', value: 'sandbox' },
-  { label: '测试', value: 'test' }
-]
-const regionOptions = [
-  { label: '全球 / 默认', value: '' },
-  { label: '中国大陆', value: 'cn' },
-  { label: '华北', value: 'cn-north' },
-  { label: '华东', value: 'cn-east' },
-  { label: '华南', value: 'cn-south' },
-  { label: '香港', value: 'cn-hongkong' },
-  { label: '新加坡', value: 'ap-southeast-1' },
-  { label: '日本', value: 'ap-northeast-1' },
-  { label: '美国东部', value: 'us-east-1' },
-  { label: '欧洲西部', value: 'eu-west-1' }
-]
-const roundingModeOptions = [
-  { label: '四舍五入', value: 'half_up' },
-  { label: '向上舍入', value: 'up' },
-  { label: '向下舍入', value: 'down' }
-]
-const decimalPlaceOptions = [
-  { label: '0 位', value: 0 },
-  { label: '1 位', value: 1 },
-  { label: '2 位', value: 2 },
-  { label: '3 位', value: 3 },
-  { label: '4 位', value: 4 },
-  { label: '5 位', value: 5 },
-  { label: '6 位', value: 6 }
-]
+const environmentOptions = computed(() => [
+  {
+    label: t('llmOps.resalePlatform.environments.production'),
+    value: 'production'
+  },
+  { label: t('llmOps.resalePlatform.environments.staging'), value: 'staging' },
+  { label: t('llmOps.resalePlatform.environments.sandbox'), value: 'sandbox' },
+  { label: t('llmOps.resalePlatform.environments.test'), value: 'test' }
+])
+const regionOptions = computed(() => [
+  { label: t('llmOps.resalePlatformModal.regions.global'), value: '' },
+  { label: t('llmOps.resalePlatformModal.regions.cn'), value: 'cn' },
+  {
+    label: t('llmOps.resalePlatformModal.regions.cnNorth'),
+    value: 'cn-north'
+  },
+  {
+    label: t('llmOps.resalePlatformModal.regions.cnEast'),
+    value: 'cn-east'
+  },
+  {
+    label: t('llmOps.resalePlatformModal.regions.cnSouth'),
+    value: 'cn-south'
+  },
+  {
+    label: t('llmOps.resalePlatformModal.regions.cnHongkong'),
+    value: 'cn-hongkong'
+  },
+  {
+    label: t('llmOps.resalePlatformModal.regions.apSoutheast1'),
+    value: 'ap-southeast-1'
+  },
+  {
+    label: t('llmOps.resalePlatformModal.regions.apNortheast1'),
+    value: 'ap-northeast-1'
+  },
+  {
+    label: t('llmOps.resalePlatformModal.regions.usEast1'),
+    value: 'us-east-1'
+  },
+  {
+    label: t('llmOps.resalePlatformModal.regions.euWest1'),
+    value: 'eu-west-1'
+  }
+])
+const roundingModeOptions = computed(() => [
+  { label: t('llmOps.resalePlatformModal.rounding.halfUp'), value: 'half_up' },
+  { label: t('llmOps.resalePlatformModal.rounding.up'), value: 'up' },
+  { label: t('llmOps.resalePlatformModal.rounding.down'), value: 'down' }
+])
+const decimalPlaceOptions = computed(() =>
+  Array.from({ length: 7 }, (_, value) => ({
+    label: t('llmOps.resalePlatformModal.decimalPlaces', { count: value }),
+    value
+  }))
+)
 const metadataError = ref('')
 
 watch(
@@ -421,7 +534,7 @@ function defaults() {
     yield_warning: '',
     yield_target: '',
     auto_approve_max_margin_rate: '100',
-    point_name: '积分',
+    point_name: t('llmOps.resalePlatformModal.defaultPointName'),
     points_per_currency_unit: '100.00',
     point_rounding_mode: 'half_up',
     point_decimal_places: 0,
@@ -540,10 +653,10 @@ function parseMetadata(value) {
   try {
     parsed = JSON.parse(text)
   } catch {
-    throw new Error('扩展元数据不是有效的 JSON。')
+    throw new Error(t('llmOps.resalePlatformModal.errors.invalidMetadataJson'))
   }
   if (!parsed || Array.isArray(parsed) || typeof parsed !== 'object') {
-    throw new Error('扩展元数据必须是 JSON 对象。')
+    throw new Error(t('llmOps.resalePlatformModal.errors.metadataObject'))
   }
   return parsed
 }
@@ -569,14 +682,21 @@ async function save() {
     emit('saved')
   } catch (error) {
     if (error instanceof SyntaxError) {
-      metadataError.value = '扩展元数据不是有效的 JSON。'
+      metadataError.value = t(
+        'llmOps.resalePlatformModal.errors.invalidMetadataJson'
+      )
       return
     }
-    if (error?.message === '扩展元数据不是有效的 JSON。') {
+    if (
+      error?.message ===
+      t('llmOps.resalePlatformModal.errors.invalidMetadataJson')
+    ) {
       metadataError.value = error.message
       return
     }
-    if (error?.message === '扩展元数据必须是 JSON 对象。') {
+    if (
+      error?.message === t('llmOps.resalePlatformModal.errors.metadataObject')
+    ) {
       metadataError.value = error.message
       return
     }

--- a/frontend/src/components/llm-ops/ResalePublishingWorkspace.vue
+++ b/frontend/src/components/llm-ops/ResalePublishingWorkspace.vue
@@ -566,6 +566,10 @@ const props = defineProps({
     type: [String, Number],
     default: null
   },
+  initialAutoListing: {
+    type: Boolean,
+    default: false
+  },
   agionePlatform: {
     type: Object,
     default: null
@@ -780,6 +784,7 @@ const workspaceHasChanges = computed(() =>
 watch(
   [
     () => props.initialModelId,
+    () => props.initialAutoListing,
     () => metaModelRows.value.length,
     () => props.models.length,
     () => props.listings.length
@@ -879,16 +884,17 @@ function hydrateInitialModel() {
 
 function hydrateInitialListings(initialModelId) {
   const platformId = String(selectedPlatform.value?.id || '')
+  const autoListing = props.initialAutoListing
+    ? findAutoListing(initialModelId, platformId)
+    : null
   const nextState = { ...chainState.value }
   chainRows.value
     .filter((row) => String(row.modelId) === String(initialModelId))
     .forEach((row) => {
-      const listing = (props.listings || []).find(
-        (item) =>
-          String(item.model) === String(initialModelId) &&
-          String(item.channel) === String(row.channelId) &&
-          (!platformId || String(item.platform) === platformId)
-      )
+      const listing =
+        autoListing && row.isLowest
+          ? autoListing
+          : listingForChannel(initialModelId, row.channelId, platformId)
       if (!listing) return
       const priceIn = convertToDisplay(
         listing.retail_input_price_per_million,
@@ -904,6 +910,7 @@ function hydrateInitialListings(initialModelId) {
       )
       nextState[row.uniqueId] = {
         ...nextState[row.uniqueId],
+        listingChannelId: autoListing && row.isLowest ? null : row.channelId,
         selected: true,
         currency: currencyLabel.value.toUpperCase(),
         priceInRaw:
@@ -923,6 +930,24 @@ function hydrateInitialListings(initialModelId) {
     })
   chainState.value = nextState
   syncSelectedChain()
+}
+
+function findAutoListing(modelId, platformId) {
+  return (props.listings || []).find(
+    (item) =>
+      String(item.model) === String(modelId) &&
+      (item.channel === null || item.channel === undefined) &&
+      (!platformId || String(item.platform) === platformId)
+  )
+}
+
+function listingForChannel(modelId, channelId, platformId) {
+  return (props.listings || []).find(
+    (item) =>
+      String(item.model) === String(modelId) &&
+      String(item.channel) === String(channelId) &&
+      (!platformId || String(item.platform) === platformId)
+  )
 }
 
 function onMarginInput(row, event) {
@@ -1044,12 +1069,17 @@ function comparablePrice(value, options = {}) {
 
 function listingForRow(row) {
   const platformId = String(selectedPlatform.value?.id || '')
-  return (props.listings || []).find(
-    (item) =>
-      String(item.model) === String(row.modelId) &&
-      String(item.channel) === String(row.channelId) &&
-      (!platformId || String(item.platform) === platformId)
+  const state = getChainState(row.uniqueId)
+  const channelId = Object.prototype.hasOwnProperty.call(
+    state,
+    'listingChannelId'
   )
+    ? state.listingChannelId
+    : row.channelId
+  if (channelId === null) {
+    return findAutoListing(row.modelId, platformId)
+  }
+  return listingForChannel(row.modelId, channelId, platformId)
 }
 
 function baselineForRow(row) {
@@ -1095,7 +1125,7 @@ function workspacePayload() {
     supplierId: form.value.supplierId,
     hasChanges: workspaceHasChanges.value,
     listings: selectedChainRows.value.map((row) => ({
-      channelId: row.channelId,
+      channelId: payloadChannelId(row),
       metaModelId: row.metaModelId,
       modelId: row.modelId,
       currency: currencyLabel.value.toUpperCase(),
@@ -1107,6 +1137,14 @@ function workspacePayload() {
       hasChanges: listingRowHasChanges(row)
     }))
   }
+}
+
+function payloadChannelId(row) {
+  const state = getChainState(row.uniqueId)
+  if (Object.prototype.hasOwnProperty.call(state, 'listingChannelId')) {
+    return state.listingChannelId
+  }
+  return row.channelId
 }
 
 function emitChange() {

--- a/frontend/src/components/llm-ops/SourcePriceDrawer.vue
+++ b/frontend/src/components/llm-ops/SourcePriceDrawer.vue
@@ -133,7 +133,7 @@
               <tbody>
                 <tr v-if="loading">
                   <td class="table-cell text-slate-500" colspan="3">
-                    加载中...
+                    {{ t('common.loading') }}
                   </td>
                 </tr>
                 <template v-for="row in filteredModelRows" :key="row.key">
@@ -218,7 +218,7 @@
                 :disabled="page <= 1 || loading"
                 @click="$emit('page-change', page - 1)"
               >
-                上一页
+                {{ t('common.previous') }}
               </button>
               <button
                 class="btn-secondary pagination-btn"
@@ -226,7 +226,7 @@
                 :disabled="page >= totalPages || loading"
                 @click="$emit('page-change', page + 1)"
               >
-                下一页
+                {{ t('common.next') }}
               </button>
             </div>
           </div>

--- a/frontend/src/components/llm-ops/agioneListingStatusBoard.css
+++ b/frontend/src/components/llm-ops/agioneListingStatusBoard.css
@@ -1154,6 +1154,11 @@
   vertical-align: middle;
 }
 
+.agione-listing-status-board .listing-row-focused {
+  background: #f5f3ff;
+  box-shadow: inset 0.2rem 0 0 #5f4ecf;
+}
+
 .agione-listing-status-board .row-actions {
   display: flex;
   align-items: center;

--- a/frontend/src/composables/useAgioneListingRows.js
+++ b/frontend/src/composables/useAgioneListingRows.js
@@ -28,7 +28,8 @@ export function useAgioneListingRows({
   selectedTrendModelIdRef,
   selectedTrendChannelIdRef,
   trendProfitRateRef,
-  pointConversionRef
+  pointConversionRef,
+  t
 }) {
   const listingRows = computed(() => {
     const procurementByModel = new Map(
@@ -197,14 +198,26 @@ export function useAgioneListingRows({
     }
     if (model.modality === 'audio') {
       return [
-        { key: 'audio_input', label: '音频输入' },
-        { key: 'audio_output', label: '音频输出' }
+        {
+          key: 'audio_input',
+          label: t('llmOps.publishingWorkspace.metrics.audioInput')
+        },
+        {
+          key: 'audio_output',
+          label: t('llmOps.publishingWorkspace.metrics.audioOutput')
+        }
       ]
     }
     if (model.modality === 'video') {
       return [
-        { key: 'video_input', label: '视频输入' },
-        { key: 'video_output', label: '视频输出' }
+        {
+          key: 'video_input',
+          label: t('llmOps.publishingWorkspace.metrics.videoInput')
+        },
+        {
+          key: 'video_output',
+          label: t('llmOps.publishingWorkspace.metrics.videoOutput')
+        }
       ]
     }
     if (
@@ -213,9 +226,15 @@ export function useAgioneListingRows({
       model.image_output_price_per_image !== ''
     ) {
       return [
-        { key: 'input', label: '输入价' },
-        { key: 'output', label: '输出价' },
-        { key: 'image_output', label: '图片输出' }
+        { key: 'input', label: t('llmOps.publishingWorkspace.metrics.input') },
+        {
+          key: 'output',
+          label: t('llmOps.publishingWorkspace.metrics.output')
+        },
+        {
+          key: 'image_output',
+          label: t('llmOps.publishingWorkspace.metrics.imageOutput')
+        }
       ]
     }
     return tokenMetricOptions()
@@ -240,7 +259,7 @@ export function useAgioneListingRows({
         const fallbackValue = metricValues[0]?.value ?? null
         return {
           ...option,
-          label: option.channel_name || '渠道',
+          label: option.channel_name || t('llmOps.channel.fallback'),
           metric_values: metricValues,
           metric_price: primaryValue ?? fallbackValue,
           value: primaryValue ?? fallbackValue,
@@ -260,13 +279,13 @@ export function useAgioneListingRows({
 
   const trendChannelSelectOptions = computed(() =>
     trendChannelOptions.value.map((option) => ({
-      label: option.channel_name || '未命名渠道',
+      label: option.channel_name || t('llmOps.channel.unnamed'),
       value: option.channel_id,
       description: metricPriceSummary(option.metric_values),
       badge:
         String(option.channel_id) ===
         String(lowestChannelPrice.value?.channel_id)
-          ? '最低'
+          ? t('llmOps.publishingWorkspace.supply.lowest')
           : '',
       searchText: [
         option.channel_name,
@@ -280,12 +299,17 @@ export function useAgioneListingRows({
 
   const trendModelOptions = computed(() => [
     {
-      label: '选择模型',
+      label: t('llmOps.publishingWorkspace.modelSelect.label'),
       value: '',
-      description: `${actionableTrendRows.value.length} 个可决策模型 · ${unavailableTrendRows.value.length} 个待配置渠道`
+      description: t('llmOps.publishingWorkspace.modelSelect.description', {
+        actionable: actionableTrendRows.value.length,
+        unavailable: unavailableTrendRows.value.length
+      })
     },
     {
-      label: `可选模型（已配置渠道 ${actionableTrendRows.value.length}）`,
+      label: t('llmOps.publishingWorkspace.modelSelect.actionableGroup', {
+        count: actionableTrendRows.value.length
+      }),
       value: '__group_actionable_models',
       type: 'group'
     },
@@ -293,7 +317,10 @@ export function useAgioneListingRows({
     ...(unavailableTrendRows.value.length
       ? [
           {
-            label: `不可选模型（暂无渠道 ${unavailableTrendRows.value.length}）`,
+            label: t(
+              'llmOps.publishingWorkspace.modelSelect.unavailableGroup',
+              { count: unavailableTrendRows.value.length }
+            ),
             value: '__group_unavailable_models',
             type: 'group'
           }
@@ -302,7 +329,7 @@ export function useAgioneListingRows({
     ...unavailableTrendRows.value.map((row) => ({
       ...trendModelOption(row),
       disabled: true,
-      badge: '需配置渠道'
+      badge: t('llmOps.publishingWorkspace.modelSelect.needsChannel')
     }))
   ])
 
@@ -357,8 +384,8 @@ export function useAgioneListingRows({
       return {
         ...option,
         key: `channel-${option.channel_id}`,
-        label: option.channel_name || '未命名渠道',
-        channel_name: option.channel_name || '未命名渠道',
+        label: option.channel_name || t('llmOps.channel.unnamed'),
+        channel_name: option.channel_name || t('llmOps.channel.unnamed'),
         cost_value: costValue,
         cost_summary: metricPriceSummary(option.metric_values),
         cost_breakdown_summary: metricCostBreakdownSummary(
@@ -375,10 +402,10 @@ export function useAgioneListingRows({
           String(unref(selectedTrendChannelIdRef)),
         gap_label:
           gapValue > 0
-            ? `高 ${money(
-                gapValue,
-                selectedTrendCurrency.value
-              )} · ${gapPercent.toFixed(1)}%`
+            ? t('llmOps.publishingWorkspace.supply.higherCost', {
+                amount: money(gapValue, selectedTrendCurrency.value),
+                percent: gapPercent.toFixed(1)
+              })
             : ''
       }
     })
@@ -416,46 +443,65 @@ export function useAgioneListingRows({
   )
 
   const trendPrimaryActionLabel = computed(() => {
-    if (selectedOptionIsListed.value) return '更新价格'
-    return '追加上架'
+    if (selectedOptionIsListed.value) {
+      return t('llmOps.publishingWorkspace.actions.updatePrice')
+    }
+    return t('llmOps.publishingWorkspace.actions.appendListing')
   })
 
   const trendActionHint = computed(() => {
-    if (!selectedTrendOption.value) return '先选择采购渠道后再生成上架价格。'
+    if (!selectedTrendOption.value) {
+      return t('llmOps.publishingWorkspace.actions.selectChannelFirst')
+    }
     if (selectedOptionIsListed.value && selectedOptionIsLowest.value) {
-      return '当前渠道已经上架且是最低采购渠道，可直接更新收益率后的售价。'
+      return t('llmOps.publishingWorkspace.actions.updateLowestListedHint')
     }
     if (selectedOptionIsListed.value) {
-      return '当前渠道已经上架，本次操作会更新该渠道的挂售价格。'
+      return t('llmOps.publishingWorkspace.actions.updateListedHint')
     }
     if (canSwitchTrendListing.value) {
-      return '追加会保留现有渠道；切换会下架同平台其他渠道，仅保留当前渠道。'
+      return t('llmOps.publishingWorkspace.actions.switchAvailableHint')
     }
-    return '追加会新增当前渠道的挂售价格，不会影响已有上架渠道。'
+    return t('llmOps.publishingWorkspace.actions.appendListingHint')
   })
 
   const selectedDecisionStatusLabel = computed(() => {
-    if (!selectedTrendOption.value) return '未选择渠道'
-    if (selectedOptionIsListed.value && selectedOptionIsLowest.value) {
-      return '已上架最低价'
+    if (!selectedTrendOption.value) {
+      return t('llmOps.publishingWorkspace.decision.noChannelSelected')
     }
-    if (selectedOptionIsListed.value) return '当前已上架'
-    if (selectedOptionIsLowest.value) return '最低采购价'
-    return '非最低采购价'
+    if (selectedOptionIsListed.value && selectedOptionIsLowest.value) {
+      return t('llmOps.publishingWorkspace.decision.listedLowest')
+    }
+    if (selectedOptionIsListed.value) {
+      return t('llmOps.publishingWorkspace.decision.currentlyListed')
+    }
+    if (selectedOptionIsLowest.value) {
+      return t('llmOps.publishingWorkspace.decision.lowestProcurement')
+    }
+    return t('llmOps.publishingWorkspace.decision.notLowestProcurement')
   })
 
   const selectedPlanLabel = computed(() => {
-    if (!selectedTrendOption.value) return '未选择'
-    if (selectedOptionIsListed.value && selectedOptionIsLowest.value) {
-      return '已上架最低源'
+    if (!selectedTrendOption.value) {
+      return t('llmOps.publishingWorkspace.plan.notSelected')
     }
-    if (selectedOptionIsListed.value) return '已上架'
-    if (selectedOptionIsLowest.value) return '最低采购渠道'
-    return '非最低源'
+    if (selectedOptionIsListed.value && selectedOptionIsLowest.value) {
+      return t('llmOps.publishingWorkspace.plan.listedLowestSource')
+    }
+    if (selectedOptionIsListed.value) {
+      return t('llmOps.publishingWorkspace.plan.listed')
+    }
+    if (selectedOptionIsLowest.value) {
+      return t('llmOps.publishingWorkspace.plan.lowestProcurementChannel')
+    }
+    return t('llmOps.publishingWorkspace.plan.notLowestSource')
   })
 
   const pointFormulaLabel = computed(() => {
-    return unref(pointConversionRef)?.formula_label || '未配置'
+    return (
+      unref(pointConversionRef)?.formula_label ||
+      t('llmOps.publishingWorkspace.fallback.notConfigured')
+    )
   })
 
   function listingOption(listing, lowestOption, options) {
@@ -526,9 +572,12 @@ export function useAgioneListingRows({
 
   function tokenMetricOptions() {
     return [
-      { key: 'input', label: '输入价' },
-      { key: 'cache_input', label: '缓存输入价' },
-      { key: 'output', label: '输出价' }
+      { key: 'input', label: t('llmOps.publishingWorkspace.metrics.input') },
+      {
+        key: 'cache_input',
+        label: t('llmOps.publishingWorkspace.metrics.cacheInput')
+      },
+      { key: 'output', label: t('llmOps.publishingWorkspace.metrics.output') }
     ]
   }
 
@@ -666,7 +715,10 @@ export function useAgioneListingRows({
     const listings = asArray(row?.active_listings)
     if (!listings.length) return '-'
     return listings
-      .map((listing) => listing.channel_name || '未指定渠道')
+      .map(
+        (listing) =>
+          listing.channel_name || t?.('llmOps.channel.unspecified') || '-'
+      )
       .filter(Boolean)
       .join(' / ')
   }
@@ -703,7 +755,8 @@ export function useAgioneListingRows({
           unref(pointConversionRef)
         )
         return `${item.label} ${points} ${
-          unref(pointConversionRef)?.point_name || '积分'
+          unref(pointConversionRef)?.point_name ||
+          t('llmOps.publishingWorkspace.fallback.points')
         }`
       })
       .filter(Boolean)
@@ -730,7 +783,9 @@ export function useAgioneListingRows({
     return [
       modelNameIncludesVendor(name, vendorName) ? '' : vendorName,
       code,
-      row.source_count ? `${row.source_count} 个价格源` : ''
+      row.source_count
+        ? t('llmOps.monitor.sourceCount', { count: row.source_count })
+        : ''
     ]
       .filter(Boolean)
       .join(' / ')
@@ -761,16 +816,24 @@ export function useAgioneListingRows({
       value: row.key,
       description: [
         modelCodeDescription(row.model),
-        row.source_count > 1 ? `${row.source_count} 个价格源` : '',
-        row.options.length ? `${row.options.length} 个采购渠道` : '暂无采购渠道'
+        row.source_count > 1
+          ? t?.('llmOps.monitor.sourceCount', {
+              count: row.source_count
+            }) || ''
+          : '',
+        row.options.length
+          ? t?.('llmOps.monitor.procurementChannelCount', {
+              count: row.options.length
+            }) || ''
+          : t?.('llmOps.monitor.noProcurementChannels') || ''
       ]
         .filter(Boolean)
         .join(' · '),
       badge: row.is_listed
         ? row.has_lowest_listing
-          ? '已上架'
-          : '待处理'
-        : '未上架',
+          ? t?.('llmOps.status.listed') || ''
+          : t?.('llmOps.status.needsHandling') || ''
+        : t?.('llmOps.status.unlisted') || '',
       searchText: [
         modelDisplayName(row.model),
         row.model.code,

--- a/frontend/src/composables/useChannelModelDisplay.js
+++ b/frontend/src/composables/useChannelModelDisplay.js
@@ -11,8 +11,11 @@ export function useChannelModelDisplay({
   metaModelById,
   modalityLabel,
   modelSourceCategory,
-  sourceCategoryLabel
+  sourceCategoryLabel,
+  t
 }) {
+  const translate = typeof t === 'function' ? t : (key) => key
+
   function metaModelForSourceModel(model) {
     const metaId = String(model?.meta_model || '').trim()
     if (metaId && metaModelById.value.has(metaId)) {
@@ -36,7 +39,11 @@ export function useChannelModelDisplay({
   }
 
   function metaModelVendorName(group) {
-    return group.ownerName || group.ownerCode || '未归属厂商'
+    return (
+      group.ownerName ||
+      group.ownerCode ||
+      translate('llmOps.channelModelDrawer.unassignedVendor')
+    )
   }
 
   function stripModelNamespace(value) {
@@ -92,7 +99,7 @@ export function useChannelModelDisplay({
       hasKnownSourceCategory(modelSourceCategory(model))
         ? sourceCategoryLabel(modelSourceCategory(model))
         : null,
-      model.currency || '默认币种'
+      model.currency || translate('llmOps.channelModelDrawer.defaultCurrency')
     ]
       .filter(Boolean)
       .join(' · ')
@@ -103,7 +110,11 @@ export function useChannelModelDisplay({
     if (normalizeSearch(option.code) !== normalizeSearch(option.name)) {
       parts.push(option.code)
     }
-    parts.push(`${option.providerCount} 个上游价格源`)
+    parts.push(
+      translate('llmOps.channelModelDrawer.upstreamSourceCount', {
+        count: option.providerCount
+      })
+    )
     return parts.filter(Boolean).join(' · ')
   }
 

--- a/frontend/src/composables/useChannelModelDrafts.js
+++ b/frontend/src/composables/useChannelModelDrafts.js
@@ -7,42 +7,55 @@ const customPriceKeys = [
   'custom_video_output_price_per_second'
 ]
 
-const performanceFields = [
+const performanceFieldDefinitions = [
   {
     key: 'tpm_limit',
-    label: 'TPM',
-    shortLabel: 'TPM',
-    placeholder: '每分钟 Token',
+    labelKey: 'llmOps.channelModelDrawer.performance.tpm',
+    shortLabelKey: 'llmOps.channelModelDrawer.performance.tpmShort',
+    placeholderKey: 'llmOps.channelModelDrawer.performance.tpmPlaceholder',
     shortPlaceholder: 'Token/min',
-    title: '每分钟 Token 上限'
+    titleKey: 'llmOps.channelModelDrawer.performance.tpmTitle'
   },
   {
     key: 'rpm_limit',
-    label: 'RPM',
-    shortLabel: 'RPM',
-    placeholder: '每分钟请求',
+    labelKey: 'llmOps.channelModelDrawer.performance.rpm',
+    shortLabelKey: 'llmOps.channelModelDrawer.performance.rpmShort',
+    placeholderKey: 'llmOps.channelModelDrawer.performance.rpmPlaceholder',
     shortPlaceholder: 'Req/min',
-    title: '每分钟请求上限'
+    titleKey: 'llmOps.channelModelDrawer.performance.rpmTitle'
   },
   {
     key: 'latency_ms',
-    label: '延迟(ms)',
-    shortLabel: '延迟',
-    placeholder: '毫秒',
+    labelKey: 'llmOps.channelModelDrawer.performance.latency',
+    shortLabelKey: 'llmOps.channelModelDrawer.performance.latencyShort',
+    placeholderKey: 'llmOps.channelModelDrawer.performance.latencyPlaceholder',
     shortPlaceholder: 'ms',
-    title: '渠道平均延迟，单位毫秒'
+    titleKey: 'llmOps.channelModelDrawer.performance.latencyTitle'
   }
 ]
 
-const performanceFieldKeys = performanceFields.map((field) => field.key)
+const performanceFieldKeys = performanceFieldDefinitions.map(
+  (field) => field.key
+)
 
 export function useChannelModelDrafts({
   baselineDrafts,
   channelCurrency,
   drafts,
   getChannel,
-  getModelSourceCategory
+  getModelSourceCategory,
+  t
 }) {
+  const translate = typeof t === 'function' ? t : (key) => key
+  const performanceFields = performanceFieldDefinitions.map((field) => ({
+    key: field.key,
+    label: translate(field.labelKey),
+    shortLabel: translate(field.shortLabelKey),
+    placeholder: translate(field.placeholderKey),
+    shortPlaceholder: field.shortPlaceholder,
+    title: translate(field.titleKey)
+  }))
+
   function emptyNewDraft() {
     return {
       model: '',
@@ -219,11 +232,17 @@ export function useChannelModelDrafts({
   function priceRuleSummary(row) {
     const channel = getChannel()
     const draft = row?.draft || {}
-    if (draft.price_mode === 'fixed') return '固定成本价'
-    if (draft.price_mode === 'discount') {
-      return `折扣 ${ratioPercent(draft.settlement_ratio)}`
+    if (draft.price_mode === 'fixed') {
+      return translate('llmOps.channelModelDrawer.priceRule.fixed')
     }
-    return `默认折扣 ${ratioPercent(channel?.settlement_ratio, 1)}`
+    if (draft.price_mode === 'discount') {
+      return translate('llmOps.channelModelDrawer.priceRule.discount', {
+        value: ratioPercent(draft.settlement_ratio)
+      })
+    }
+    return translate('llmOps.channelModelDrawer.priceRule.defaultDiscount', {
+      value: ratioPercent(channel?.settlement_ratio, 1)
+    })
   }
 
   function costCurrencyTitle(currency) {
@@ -231,9 +250,13 @@ export function useChannelModelDrafts({
       .trim()
       .toUpperCase()
     if (value) {
-      return `成本价保存为 ${value}；页面价格按全局显示货币换算。`
+      return translate('llmOps.channelModelDrawer.costCurrencyFixed', {
+        currency: value
+      })
     }
-    return `成本价跟随渠道结算币种 ${channelCurrency.value} 保存；页面价格按全局显示货币换算。`
+    return translate('llmOps.channelModelDrawer.costCurrencyChannelDefault', {
+      currency: channelCurrency.value
+    })
   }
 
   function normalizePayload(payload, nullableFields = []) {
@@ -299,13 +322,17 @@ export function useChannelModelDrafts({
       return [
         {
           key: 'custom_audio_input_price_per_second',
-          label: '音频输入 / 秒',
-          shortLabel: '音入'
+          label: translate('llmOps.channelModelDrawer.priceField.audioInput'),
+          shortLabel: translate(
+            'llmOps.channelModelDrawer.priceField.audioInputShort'
+          )
         },
         {
           key: 'custom_audio_output_price_per_second',
-          label: '音频输出 / 秒',
-          shortLabel: '音出'
+          label: translate('llmOps.channelModelDrawer.priceField.audioOutput'),
+          shortLabel: translate(
+            'llmOps.channelModelDrawer.priceField.audioOutputShort'
+          )
         }
       ]
     }
@@ -313,13 +340,17 @@ export function useChannelModelDrafts({
       return [
         {
           key: 'custom_video_input_price_per_second',
-          label: '视频输入 / 秒',
-          shortLabel: '视入'
+          label: translate('llmOps.channelModelDrawer.priceField.videoInput'),
+          shortLabel: translate(
+            'llmOps.channelModelDrawer.priceField.videoInputShort'
+          )
         },
         {
           key: 'custom_video_output_price_per_second',
-          label: '视频输出 / 秒',
-          shortLabel: '视出'
+          label: translate('llmOps.channelModelDrawer.priceField.videoOutput'),
+          shortLabel: translate(
+            'llmOps.channelModelDrawer.priceField.videoOutputShort'
+          )
         }
       ]
     }
@@ -329,13 +360,17 @@ export function useChannelModelDrafts({
     return [
       {
         key: 'custom_input_price_per_million',
-        label: '文本输入 / 百万 tokens',
-        shortLabel: '文入'
+        label: translate('llmOps.channelModelDrawer.priceField.textInput'),
+        shortLabel: translate(
+          'llmOps.channelModelDrawer.priceField.textInputShort'
+        )
       },
       {
         key: 'custom_output_price_per_million',
-        label: '文本输出 / 百万 tokens',
-        shortLabel: '文出'
+        label: translate('llmOps.channelModelDrawer.priceField.textOutput'),
+        shortLabel: translate(
+          'llmOps.channelModelDrawer.priceField.textOutputShort'
+        )
       }
     ]
   }

--- a/frontend/src/composables/useChannelModelNewDraft.js
+++ b/frontend/src/composables/useChannelModelNewDraft.js
@@ -17,26 +17,44 @@ export function useChannelModelNewDraft({
   ratioPercent,
   ratioToPercentInput,
   recentlyAddedModelId,
-  selectedResolvedModels
+  selectedResolvedModels,
+  t
 }) {
+  const translate = typeof t === 'function' ? t : (key) => key
   const newDraft = ref(emptyNewDraft())
 
   const currencyOptions = computed(() => [
     {
-      label: '使用渠道默认币种',
+      label: translate('llmOps.channelModelDrawer.currency.useChannelDefault'),
       value: '',
-      description: `保存为 ${channelCurrency.value}`
+      description: translate('llmOps.channelModelDrawer.currency.savedAs', {
+        currency: channelCurrency.value
+      })
     },
-    { label: 'CNY', value: 'CNY', description: '固定保存为人民币' },
-    { label: 'USD', value: 'USD', description: '固定保存为美元' }
+    {
+      label: 'CNY',
+      value: 'CNY',
+      description: translate('llmOps.channelModelDrawer.currency.fixedCny')
+    },
+    {
+      label: 'USD',
+      value: 'USD',
+      description: translate('llmOps.channelModelDrawer.currency.fixedUsd')
+    }
   ])
 
   const newDraftRuleSummary = computed(() => {
     if (newDraft.value.price_mode === 'discount') {
-      return `折扣 ${ratioPercent(newDraft.value.settlement_ratio)}`
+      return translate('llmOps.channelModelDrawer.priceRule.discount', {
+        value: ratioPercent(newDraft.value.settlement_ratio)
+      })
     }
-    if (newDraft.value.price_mode === 'fixed') return '固定成本价'
-    return `默认折扣 ${ratioPercent(props.channel?.settlement_ratio, 1)}`
+    if (newDraft.value.price_mode === 'fixed') {
+      return translate('llmOps.channelModelDrawer.priceRule.fixed')
+    }
+    return translate('llmOps.channelModelDrawer.priceRule.defaultDiscount', {
+      value: ratioPercent(props.channel?.settlement_ratio, 1)
+    })
   })
 
   const newDraftPerformanceSummary = computed(() => {

--- a/frontend/src/composables/useChannelModelPricing.js
+++ b/frontend/src/composables/useChannelModelPricing.js
@@ -1,8 +1,11 @@
 export function useChannelModelPricing({
   customPriceFields,
   normalizeSearch,
-  props
+  props,
+  t
 }) {
+  const translate = typeof t === 'function' ? t : (key) => key
+
   function convertCurrencyAmount(value, sourceCurrency = 'USD') {
     if (value === null || value === undefined || value === '') return null
     const source = String(sourceCurrency || '').toUpperCase()
@@ -46,7 +49,9 @@ export function useChannelModelPricing({
 
   function moneyOrStatus(value, currency = 'USD') {
     if (value === null || value === undefined || value === '') return '-'
-    if (Number(value) === 0) return '缺价格'
+    if (Number(value) === 0) {
+      return translate('llmOps.channelModelDrawer.missingPrice')
+    }
     return money(value, currency)
   }
 
@@ -61,7 +66,9 @@ export function useChannelModelPricing({
       )
     }
     const previewItems = draftPricePreview(row?.draft, row?.model)
-    if (!previewItems.length) return '成本待生成'
+    if (!previewItems.length) {
+      return translate('llmOps.channelModelDrawer.pendingCostGeneration')
+    }
     return priceSummaryText(
       previewItems.map((item) => ({
         label: previewPriceLabel(item.label),
@@ -137,7 +144,7 @@ export function useChannelModelPricing({
         value: draft.rpm_limit || '-'
       },
       {
-        label: '延迟',
+        label: translate('llmOps.channelModelDrawer.performance.latencyShort'),
         value: draft.latency_ms ? `${draft.latency_ms}ms` : '-'
       }
     ]
@@ -153,9 +160,9 @@ export function useChannelModelPricing({
       return money(item.value, item.currency)
     }
     if (isNotApplicablePrice(item, model)) {
-      return '不适用'
+      return translate('llmOps.channelModelDrawer.notApplicable')
     }
-    return '缺价格'
+    return translate('llmOps.channelModelDrawer.missingPrice')
   }
 
   function summaryPriceText(item, model) {
@@ -168,9 +175,9 @@ export function useChannelModelPricing({
       return priceNumberText(item, model, 2)
     }
     if (isNotApplicablePrice(item, model)) {
-      return '不适用'
+      return translate('llmOps.channelModelDrawer.notApplicable')
     }
-    return '缺价格'
+    return translate('llmOps.channelModelDrawer.missingPrice')
   }
 
   function fixedNumber(value, digits = 4) {
@@ -193,20 +200,23 @@ export function useChannelModelPricing({
       return fixedNumber(displayValue, digits)
     }
     if (isNotApplicablePrice(item, model)) {
-      return '不适用'
+      return translate('llmOps.channelModelDrawer.notApplicable')
     }
     return fixedNumber(0, digits)
   }
 
   function isNotApplicablePrice(item, model) {
     const code = String(model?.code || '').toLowerCase()
-    const label = String(item?.label || '')
-    if (code.includes('embedding') && label.includes('出')) {
+    const label = String(item?.label || '').toLowerCase()
+    if (
+      code.includes('embedding') &&
+      (label.includes('out') || label.includes('output'))
+    ) {
       return true
     }
     if (
       Number(model?.image_output_price_per_image || 0) > 0 &&
-      (label.includes('文本入') || label.includes('文本出'))
+      (label.includes('input') || label.includes('output'))
     ) {
       return true
     }
@@ -362,24 +372,20 @@ export function useChannelModelPricing({
   }
 
   function previewPriceLabel(label) {
-    const normalized = String(label || '').replace('预估', '')
+    const normalized = String(label || '').trim()
     const labels = {
-      文入: 'Input',
-      文出: 'Output',
-      缓存: 'Cache',
-      音入: 'Audio In',
-      音出: 'Audio Out',
-      视入: 'Video In',
-      视出: 'Video Out',
-      图入: 'Image In',
-      图出: 'Image Out',
-      文本入: 'Input',
-      文本出: 'Output',
-      图片出: 'Image Out',
-      音频入: 'Audio In',
-      音频出: 'Audio Out',
-      视频入: 'Video In',
-      视频出: 'Video Out'
+      [translate('llmOps.channelModelDrawer.priceField.textInputShort')]:
+        'Input',
+      [translate('llmOps.channelModelDrawer.priceField.textOutputShort')]:
+        'Output',
+      [translate('llmOps.channelModelDrawer.priceField.audioInputShort')]:
+        'Audio In',
+      [translate('llmOps.channelModelDrawer.priceField.audioOutputShort')]:
+        'Audio Out',
+      [translate('llmOps.channelModelDrawer.priceField.videoInputShort')]:
+        'Video In',
+      [translate('llmOps.channelModelDrawer.priceField.videoOutputShort')]:
+        'Video Out'
     }
     return labels[normalized] || normalized || '-'
   }
@@ -402,7 +408,9 @@ export function useChannelModelPricing({
     if (!model) return ''
     if (providerPriceItemsForModel(model).length) return ''
     if (model.last_price_updated_at) return ''
-    if (model.source_name || model.source_endpoint_url) return '源未入库'
+    if (model.source_name || model.source_endpoint_url) {
+      return translate('llmOps.channelModelDrawer.sourceNotIngested')
+    }
     return ''
   }
 
@@ -430,7 +438,7 @@ export function useChannelModelPricing({
   function fixedPricePreview(draft, model, currency) {
     return customPriceFields(model)
       .map((field) => ({
-        label: `${field.shortLabel}预估`,
+        label: field.shortLabel,
         value: draft[field.key],
         currency
       }))
@@ -448,7 +456,7 @@ export function useChannelModelPricing({
           currency
         )
         return {
-          label: `${item.label}预估`,
+          label: item.label,
           value: baseAmount === null ? null : baseAmount * ratio,
           currency,
           missingReason: item.missingReason || ''
@@ -481,12 +489,18 @@ export function useChannelModelPricing({
   }
 
   function upstreamSourceLabel(model) {
-    if (!model) return '未绑定上游'
-    return model.source_name || model.provider_name || '未绑定上游'
+    if (!model) return translate('llmOps.channelModelDrawer.unboundUpstream')
+    return (
+      model.source_name ||
+      model.provider_name ||
+      translate('llmOps.channelModelDrawer.unboundUpstream')
+    )
   }
 
   function purchaseSourceLabel(model) {
-    if (!model) return '未选择渠道上游'
+    if (!model) {
+      return translate('llmOps.channelModelDrawer.noUpstreamSelected')
+    }
     return upstreamSourceLabel(model)
   }
 
@@ -506,12 +520,17 @@ export function useChannelModelPricing({
 
   function sourceCategoryLabel(category) {
     const labels = {
-      official_provider: '原厂',
-      supplier: '供货商',
-      manual: '人工',
-      unknown: '未标记类型'
+      official_provider: translate(
+        'llmOps.channelModelDrawer.sourceCategory.officialProvider'
+      ),
+      supplier: translate('llmOps.channelModelDrawer.sourceCategory.supplier'),
+      manual: translate('llmOps.channelModelDrawer.sourceCategory.manual'),
+      unknown: translate('llmOps.channelModelDrawer.sourceCategory.unknown')
     }
-    return labels[category] || '未标记类型'
+    return (
+      labels[category] ||
+      translate('llmOps.channelModelDrawer.sourceCategory.unknown')
+    )
   }
 
   function sourceCategoryBadge(category) {
@@ -544,22 +563,23 @@ export function useChannelModelPricing({
 
   function comparisonTitle(item) {
     if (item.comparison_status === 'unknown') {
-      return (
-        '已按全局显示货币换算展示；缺少同维度上游基准价时，' +
-        '暂无法判断高低。'
-      )
+      return translate('llmOps.channelModelDrawer.comparisonUnknown')
     }
     const delta = item.delta_amount || 0
     const percent = item.delta_percent || 0
-    return `较上游价格 ${item.currency} ${Number(delta).toFixed(4)} / ${Number(percent).toFixed(2)}%`
+    return translate('llmOps.channelModelDrawer.comparisonDelta', {
+      currency: item.currency,
+      delta: Number(delta).toFixed(4),
+      percent: Number(percent).toFixed(2)
+    })
   }
 
   function modalityLabel(modality) {
     const labels = {
-      text: '文本',
-      audio: '音频',
-      video: '视频',
-      multimodal: '多模态'
+      text: translate('llmOps.channelModelDrawer.modality.text'),
+      audio: translate('llmOps.channelModelDrawer.modality.audio'),
+      video: translate('llmOps.channelModelDrawer.modality.video'),
+      multimodal: translate('llmOps.channelModelDrawer.modality.multimodal')
     }
     return labels[modality] || modality || '-'
   }

--- a/frontend/src/composables/useChannelModelSelection.js
+++ b/frontend/src/composables/useChannelModelSelection.js
@@ -19,8 +19,11 @@ export function useChannelModelSelection({
   selectedModelKeys,
   selectedProviderByModelKey,
   selectedVendorKey,
-  sourceCategoryBadge
+  sourceCategoryBadge,
+  t
 }) {
+  const translate = typeof t === 'function' ? t : (key) => key
+
   const candidateMetaModelGroups = computed(() => {
     const groups = new Map()
     baseAvailableModels.value.forEach((model) => {
@@ -73,7 +76,9 @@ export function useChannelModelSelection({
       .map((vendor) => ({
         label: vendor.label,
         value: vendor.value,
-        description: `${vendor.count} 个可添加元模型`
+        description: translate('llmOps.channelModelDrawer.vendorAddableCount', {
+          count: vendor.count
+        })
       }))
       .sort((left, right) => left.label.localeCompare(right.label))
   })

--- a/frontend/src/composables/useLLMOpsData.js
+++ b/frontend/src/composables/useLLMOpsData.js
@@ -1,4 +1,5 @@
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import { llmOpsApi } from '@/api/llmOps'
 import { useToast } from '@/composables/useToast'
@@ -16,9 +17,12 @@ import {
 } from '@/utils/llmOpsPagination'
 
 const PRICE_HISTORY_PAGE_SIZE = 120
+const RUN_LOG_PAGE_SIZE = 120
+const RECONCILIATION_PAGE_SIZE = 120
 const supportedDisplayCurrencies = new Set(['CNY', 'USD'])
 
 export function useLLMOpsData() {
+  const { t } = useI18n()
   const { showError } = useToast()
   const loading = ref(false)
   const backgroundLoading = ref(false)
@@ -88,7 +92,7 @@ export function useLLMOpsData() {
       const [channelRes, platformRes, summaryRes] = await Promise.all([
         fetchList(llmOpsApi.listChannels),
         fetchList(llmOpsApi.listResalePlatforms),
-        llmOpsApi.getSummary(summaryParams())
+        llmOpsApi.getSummary(summaryParams('monitor'))
       ])
       channels.value = asArray(extract(channelRes))
       resalePlatforms.value = asArray(extract(platformRes))
@@ -109,7 +113,7 @@ export function useLLMOpsData() {
       summaryRes
     ] = await Promise.all([
       fetchList(llmOpsApi.listCollectionSources),
-      fetchList(llmOpsApi.listCollectionRuns),
+      fetchRecentCollectionRuns(),
       fetchList(llmOpsApi.listProviders),
       fetchList(llmOpsApi.listMetaModels),
       shouldLoadModels ? fetchList(llmOpsApi.listModels) : Promise.resolve([]),
@@ -151,7 +155,7 @@ export function useLLMOpsData() {
       secondaryDataLoaded.value = true
     } catch (error) {
       if (!silent) {
-        showError(errorMessage(error, '加载 LLM Ops 扩展数据失败。'))
+        showError(errorMessage(error, t('llmOps.dataErrors.loadSecondary')))
       }
     } finally {
       backgroundLoading.value = false
@@ -173,18 +177,23 @@ export function useLLMOpsData() {
       return
     }
     if (section === 'channels') {
-      await Promise.all([refreshChannelPricingData(), refreshModelPriceItems()])
+      await Promise.all([
+        refreshChannelPricingData(),
+        refreshModelPriceItems(),
+        refreshSummary()
+      ])
       return
     }
     if (section === 'channelMatrix') {
-      await refreshChannelPricingData()
+      await Promise.all([refreshChannelPricingData(), refreshSummary()])
       return
     }
     if (section === 'reseller' || section === 'listingRisk') {
       await Promise.all([
         refreshChannelPricingData(),
         refreshModelPriceItems(),
-        refreshResaleListings()
+        refreshResaleListings(),
+        refreshSummary()
       ])
       return
     }
@@ -193,7 +202,8 @@ export function useLLMOpsData() {
         refreshModelPriceItems(),
         refreshChannelPricingData(),
         refreshResaleListings(),
-        refreshReconciliationRecords()
+        refreshReconciliationRecords(),
+        refreshSummary()
       ])
       return
     }
@@ -224,8 +234,13 @@ export function useLLMOpsData() {
     modelPriceItems.value = asArray(items)
   }
 
-  async function refreshResaleListings() {
-    listings.value = asArray(await fetchList(llmOpsApi.listResaleListings))
+  async function refreshResaleListings(
+    platformId = selectedResalePlatformId.value
+  ) {
+    const params = platformId ? { platform: platformId } : {}
+    listings.value = asArray(
+      await fetchList(llmOpsApi.listResaleListings, params)
+    )
   }
 
   function preloadResalePublishingData() {
@@ -245,13 +260,15 @@ export function useLLMOpsData() {
     }
 
     Promise.all(tasks).catch((error) => {
-      showError(errorMessage(error, '加载发布工作台数据失败。'))
+      showError(errorMessage(error, t('llmOps.dataErrors.loadPublishing')))
     })
   }
 
   async function refreshReconciliationRecords() {
     records.value = asArray(
-      await fetchList(llmOpsApi.listReconciliationRecords)
+      await fetchFirstPage(llmOpsApi.listReconciliationRecords, {
+        page_size: RECONCILIATION_PAGE_SIZE
+      })
     )
   }
 
@@ -275,8 +292,15 @@ export function useLLMOpsData() {
         fetchList(llmOpsApi.listChannelPriceItems, {
           is_current: 'true'
         }),
-        fetchList(llmOpsApi.listResaleListings),
-        fetchList(llmOpsApi.listReconciliationRecords),
+        fetchList(
+          llmOpsApi.listResaleListings,
+          selectedResalePlatformId.value
+            ? { platform: selectedResalePlatformId.value }
+            : {}
+        ),
+        fetchFirstPage(llmOpsApi.listReconciliationRecords, {
+          page_size: RECONCILIATION_PAGE_SIZE
+        }),
         llmOpsApi.getSummary(summaryParams())
       ])
     channelPrices.value = asArray(prices)
@@ -289,7 +313,7 @@ export function useLLMOpsData() {
   async function refreshCollectionRuns() {
     const [sourceData, runData] = await Promise.all([
       fetchList(llmOpsApi.listCollectionSources),
-      fetchList(llmOpsApi.listCollectionRuns)
+      fetchRecentCollectionRuns()
     ])
     sources.value = sourceData
     collectionRuns.value = runData
@@ -300,7 +324,7 @@ export function useLLMOpsData() {
       const [sourceData, runData, providerData, summaryRes] = await Promise.all(
         [
           fetchList(llmOpsApi.listCollectionSources),
-          fetchList(llmOpsApi.listCollectionRuns),
+          fetchRecentCollectionRuns(),
           fetchList(llmOpsApi.listProviders),
           llmOpsApi.getSummary(summaryParams())
         ]
@@ -310,7 +334,7 @@ export function useLLMOpsData() {
       providers.value = asArray(providerData)
       summary.value = normalizeSummary(extract(summaryRes))
     } catch (error) {
-      showError(errorMessage(error, '刷新价格源数据失败。'))
+      showError(errorMessage(error, t('llmOps.dataErrors.refreshProviders')))
     }
   }
 
@@ -325,7 +349,7 @@ export function useLLMOpsData() {
       metaModels.value = asArray(metaModelData)
       summary.value = normalizeSummary(extract(summaryRes))
     } catch (error) {
-      showError(errorMessage(error, '刷新元模型数据失败。'))
+      showError(errorMessage(error, t('llmOps.dataErrors.refreshMetaModels')))
     }
   }
 
@@ -339,10 +363,10 @@ export function useLLMOpsData() {
       channels.value = asArray(channelData)
       summary.value = normalizeSummary(extract(summaryRes))
       refreshResaleListings().catch((error) => {
-        showError(errorMessage(error, '刷新转售列表失败。'))
+        showError(errorMessage(error, t('llmOps.dataErrors.refreshListings')))
       })
     } catch (error) {
-      showError(errorMessage(error, '刷新渠道数据失败。'))
+      showError(errorMessage(error, t('llmOps.dataErrors.refreshChannels')))
     }
   }
 
@@ -350,7 +374,12 @@ export function useLLMOpsData() {
     try {
       const [platformData, listingData, summaryRes] = await Promise.all([
         fetchList(llmOpsApi.listResalePlatforms),
-        fetchList(llmOpsApi.listResaleListings),
+        fetchList(
+          llmOpsApi.listResaleListings,
+          selectedResalePlatformId.value
+            ? { platform: selectedResalePlatformId.value }
+            : {}
+        ),
         llmOpsApi.getSummary(summaryParams())
       ])
       resalePlatforms.value = asArray(platformData)
@@ -358,7 +387,7 @@ export function useLLMOpsData() {
       summary.value = normalizeSummary(extract(summaryRes))
       await loadResaleWorkflowConfig()
     } catch (error) {
-      showError(errorMessage(error, '刷新转售平台数据失败。'))
+      showError(errorMessage(error, t('llmOps.dataErrors.refreshPlatforms')))
     }
   }
 
@@ -379,15 +408,22 @@ export function useLLMOpsData() {
     }
   }
 
-  async function refreshSummary() {
-    const summaryRes = await llmOpsApi.getSummary(summaryParams())
+  async function refreshSummary(scope = 'full') {
+    const summaryRes = await llmOpsApi.getSummary(summaryParams(scope))
     summary.value = normalizeSummary(extract(summaryRes))
   }
 
-  function summaryParams() {
+  async function fetchRecentCollectionRuns() {
+    return fetchFirstPage(llmOpsApi.listCollectionRuns, {
+      page_size: RUN_LOG_PAGE_SIZE
+    })
+  }
+
+  function summaryParams(scope = 'full') {
     return {
       display_currency: displayCurrency.value,
-      resale_platform: selectedResalePlatformId.value || ''
+      resale_platform: selectedResalePlatformId.value || '',
+      scope
     }
   }
 
@@ -416,6 +452,7 @@ export function useLLMOpsData() {
     providers,
     records,
     refreshAll,
+    refreshChannelPricingData,
     refreshChannelManagementData,
     refreshCollectionRuns,
     refreshCoreData,

--- a/frontend/src/composables/useLLMOpsData.js
+++ b/frontend/src/composables/useLLMOpsData.js
@@ -78,10 +78,25 @@ export function useLLMOpsData() {
       loading.value = false
     }
 
-    refreshSecondaryData({ force: true, silent: true })
+    if (DATA_HEAVY_SECTIONS.has(section)) {
+      refreshSecondaryData({ force: true, silent: true })
+    }
   }
 
   async function refreshCoreData(section) {
+    if (section === 'monitor') {
+      const [channelRes, platformRes, summaryRes] = await Promise.all([
+        fetchList(llmOpsApi.listChannels),
+        fetchList(llmOpsApi.listResalePlatforms),
+        llmOpsApi.getSummary(summaryParams())
+      ])
+      channels.value = asArray(extract(channelRes))
+      resalePlatforms.value = asArray(extract(platformRes))
+      summary.value = normalizeSummary(extract(summaryRes))
+      await loadResaleWorkflowConfig()
+      return
+    }
+
     const shouldLoadModels = !LIGHT_CORE_SECTIONS.has(section)
     const [
       sourceRes,

--- a/frontend/src/composables/useLLMOpsMonitor.js
+++ b/frontend/src/composables/useLLMOpsMonitor.js
@@ -68,7 +68,7 @@ export function useLLMOpsMonitor({ channels, procurementRows, summary }) {
         output_yield: row.yield_metrics?.output_yield ?? null,
         data_event_type: row.data_event_type || 'updated',
         last_data_event_at: row.last_data_event_at || null,
-        status_label: row.decision_action || '',
+        status_label: '',
         status_tone: decisionTone(decisionStatus),
         status_priority: row.decision_priority || 8
       }

--- a/frontend/src/composables/useLLMOpsMonitor.js
+++ b/frontend/src/composables/useLLMOpsMonitor.js
@@ -3,565 +3,198 @@ import { useI18n } from 'vue-i18n'
 
 import { asArray, asObject } from '@/utils/llmOpsPagination'
 
-const monitorStatusLabelKeys = {
-  currency_mismatch: 'llmOps.status.currencyMismatch',
-  low_coverage: 'llmOps.status.lowCoverage',
-  missing_channel: 'llmOps.status.missingChannel',
-  not_lowest: 'llmOps.status.notLowest',
-  ready: 'llmOps.status.readyShort',
-  unlisted: 'llmOps.status.unlisted'
-}
-
-export function useLLMOpsMonitor({
-  agionePlatform,
-  channels,
-  collectionRuns,
-  listings,
-  models,
-  procurementRows,
-  providerCollectionSources,
-  summary
-}) {
+export function useLLMOpsMonitor({ channels, procurementRows, summary }) {
   const { t } = useI18n()
 
-  const simulationChannel = ref('')
   const simulationStatus = ref('priority')
 
   const simulationStatusOptions = computed(() => [
     { label: t('llmOps.filters.priority'), value: 'priority' },
     { label: t('llmOps.filters.allModels'), value: 'all' },
-    { label: t('llmOps.status.currencyMismatch'), value: 'currency_mismatch' },
-    { label: t('llmOps.status.missingChannel'), value: 'missing_channel' },
-    { label: t('llmOps.status.unlisted'), value: 'unlisted' },
-    { label: t('llmOps.status.ready'), value: 'ready' }
-  ])
-
-  const simulationChannelOptions = computed(() => [
-    { label: t('llmOps.filters.allChannels'), value: '' },
-    ...asArray(channels.value).map((channel) => ({
-      label: channel.name,
-      value: channel.id
-    }))
+    { label: t('llmOps.decision.status.no_supply'), value: 'no_supply' },
+    {
+      label: t('llmOps.decision.status.currency_unresolved'),
+      value: 'currency_unresolved'
+    },
+    {
+      label: t('llmOps.decision.status.platform_fee_unresolved'),
+      value: 'platform_fee_unresolved'
+    },
+    { label: t('llmOps.decision.status.low_yield'), value: 'low_yield' },
+    {
+      label: t('llmOps.decision.status.not_lowest_channel'),
+      value: 'not_lowest_channel'
+    },
+    { label: t('llmOps.decision.status.unlisted'), value: 'unlisted' },
+    {
+      label: t('llmOps.decision.status.single_channel'),
+      value: 'single_channel'
+    },
+    { label: t('llmOps.decision.status.ready'), value: 'ready' }
   ])
 
   const agioneDiagnostics = computed(() =>
     asArray(summary.value.agione?.diagnostics)
   )
   const summaryKpis = computed(() => asObject(summary.value.kpis))
-  const diagnosticCounts = computed(() =>
-    asObject(summary.value.agione?.diagnostic_counts)
-  )
 
-  const activeModels = computed(() =>
-    asArray(models.value).filter((model) => model.is_active !== false)
-  )
-
-  const activeModelIds = computed(
-    () => new Set(activeModels.value.map((model) => String(model.id)))
-  )
-
-  const operationalModelCount = computed(() =>
-    numberOrFallback(summaryKpis.value.active_models, activeModels.value.length)
-  )
   const operationalChannelCount = computed(() =>
     numberOrFallback(
       summaryKpis.value.active_channels,
       asArray(channels.value).length
     )
   )
-  const enabledPriceSourceCount = computed(() =>
-    numberOrFallback(
-      summaryKpis.value.enabled_price_sources,
-      asArray(providerCollectionSources.value).length
-    )
-  )
-  const reconciliationAnomalyCount = computed(() =>
-    numberOrFallback(summaryKpis.value.reconciliation_anomalies, 0)
-  )
-
-  const agioneListingRows = computed(() => {
-    const agioneId = agionePlatform.value?.id
-    if (!agioneId) return []
-    return asArray(listings.value).filter(
-      (listing) =>
-        listing.is_active !== false &&
-        String(listing.platform) === String(agioneId)
-    )
-  })
-
-  const agioneListingModelIds = computed(() => {
-    return new Set(
-      agioneListingRows.value
-        .filter((listing) => activeModelIds.value.has(String(listing.model)))
-        .map((listing) => String(listing.model))
-    )
-  })
-
-  const agioneListingsByModel = computed(() => {
-    const rowsByModel = new Map()
-    agioneListingRows.value.forEach((listing) => {
-      const key = String(listing.model)
-      const rows = rowsByModel.get(key) || []
-      rows.push(listing)
-      rowsByModel.set(key, rows)
-    })
-    return rowsByModel
-  })
 
   const enrichedProcurementRows = computed(() =>
     (agioneDiagnostics.value.length
       ? agioneDiagnostics.value
       : procurementRows.value
     ).map((row) => {
-      if (row.status) {
-        const options = asArray(row.options)
-        return {
-          ...row,
-          best_channel: row.best_channel || null,
-          display_channel: row.best_channel || null,
-          coverage_count: row.coverage_count ?? options.length,
-          is_agione_listed: Boolean(row.is_agione_listed),
-          has_lowest_listing: Boolean(row.has_lowest_listing),
-          requires_currency_conversion: Boolean(
-            row.requires_currency_conversion
-          ),
-          status_priority: row.status_priority || 5,
-          status_label: localizedMonitorStatusLabel(row.status),
-          status_tone: monitorStatusTone(row.status)
-        }
-      }
       const options = asArray(row.options)
       const bestChannel = row.best_channel || null
-      const coverageCount = options.length
-      const agioneListings =
-        agioneListingsByModel.value.get(String(row.model_id)) || []
-      const isAgioneListed = agioneListingModelIds.value.has(
-        String(row.model_id)
-      )
-      const hasLowestListing = agioneListings.some((listing) =>
-        isLowestListing(listing, bestChannel, options)
-      )
-      const status = resolveMonitorStatus({
-        bestChannel,
-        coverageCount,
-        isAgioneListed,
-        hasLowestListing,
-        requiresCurrencyConversion: row.requires_currency_conversion || false
-      })
+      const decisionStatus = row.decision_status || 'ready'
       return {
         ...row,
         best_channel: bestChannel,
         display_channel: bestChannel,
-        coverage_count: coverageCount,
-        is_agione_listed: isAgioneListed,
-        has_lowest_listing: hasLowestListing,
-        requires_currency_conversion: row.requires_currency_conversion || false,
-        ...status
+        coverage_count: row.coverage_count ?? options.length,
+        is_agione_listed: Boolean(row.is_agione_listed),
+        has_lowest_listing: Boolean(row.has_lowest_listing),
+        requires_currency_conversion: Boolean(row.requires_currency_conversion),
+        decision_status: decisionStatus,
+        decision_action: row.decision_action || '',
+        decision_priority: row.decision_priority || 8,
+        input_yield: row.yield_metrics?.input_yield ?? null,
+        output_yield: row.yield_metrics?.output_yield ?? null,
+        data_event_type: row.data_event_type || 'updated',
+        last_data_event_at: row.last_data_event_at || null,
+        status_label: row.decision_action || '',
+        status_tone: decisionTone(decisionStatus),
+        status_priority: row.decision_priority || 8
       }
     })
   )
 
-  const localListedCount = computed(() => agioneListingModelIds.value.size)
-  const listedCount = computed(() =>
-    numberOrFallback(
-      summaryKpis.value.current_platform_listed_models,
-      localListedCount.value
-    )
-  )
-  const procuredCount = computed(
-    () => enrichedProcurementRows.value.filter((row) => row.best_channel).length
-  )
-  const missingChannelRows = computed(() =>
-    enrichedProcurementRows.value.filter((row) => !row.best_channel)
-  )
-  const currencyMismatchRows = computed(() =>
-    enrichedProcurementRows.value.filter(
-      (row) => row.requires_currency_conversion
-    )
-  )
-  const unlistedRows = computed(() =>
-    enrichedProcurementRows.value.filter((row) => !row.is_agione_listed)
-  )
-  const readyRows = computed(() =>
-    enrichedProcurementRows.value.filter((row) => row.status_priority === 5)
-  )
-  const nonLowestRows = computed(() =>
-    enrichedProcurementRows.value.filter(
-      (row) =>
-        row.best_channel && row.is_agione_listed && !row.has_lowest_listing
-    )
-  )
-  const lowCoverageRows = computed(() =>
-    enrichedProcurementRows.value.filter((row) => row.status_priority === 4)
-  )
-  const readyCount = computed(() =>
-    numberOrFallback(summaryKpis.value.ready_models, readyRows.value.length)
-  )
-  const missingChannelCount = computed(() =>
-    numberOrFallback(
-      diagnosticCounts.value.missing_channel,
-      missingChannelRows.value.length
-    )
-  )
-  const currencyMismatchCount = computed(() =>
-    numberOrFallback(
-      diagnosticCounts.value.currency_mismatch,
-      currencyMismatchRows.value.length
-    )
-  )
-  const unlistedCount = computed(() =>
-    numberOrFallback(diagnosticCounts.value.unlisted, unlistedRows.value.length)
-  )
-  const nonLowestCount = computed(() =>
-    numberOrFallback(
-      diagnosticCounts.value.not_lowest,
-      nonLowestRows.value.length
-    )
-  )
-  const lowCoverageCount = computed(() =>
-    numberOrFallback(
-      diagnosticCounts.value.low_coverage,
-      lowCoverageRows.value.length
-    )
-  )
-
-  const currentPlatformListingLabel = computed(() => {
-    const platformName =
-      summary.value.agione?.platform_name ||
-      agionePlatform.value?.name ||
-      'Agione'
-    return t('llmOps.monitor.platformListed', { platform: platformName })
-  })
-
   const kpiCards = computed(() => {
-    const modelCount = operationalModelCount.value
-    const channelCount = operationalChannelCount.value
-    const procurementRate = percentage(procuredCount.value, modelCount)
-    const listingRate = percentage(listedCount.value, modelCount)
-    const readyRate = percentage(readyCount.value, modelCount)
+    const total = enrichedProcurementRows.value.length || 1
+    const pendingListing = enrichedProcurementRows.value.filter(
+      (row) => row.decision_status === 'unlisted'
+    ).length
+    const missingChannel = enrichedProcurementRows.value.filter(
+      (row) => row.decision_status === 'no_supply'
+    ).length
+    const lowYield = enrichedProcurementRows.value.filter(
+      (row) => row.decision_status === 'low_yield'
+    ).length
+    const dataAnomaly = enrichedProcurementRows.value.filter(
+      (row) => row.is_data_anomaly
+    ).length
     return [
       {
-        label: t('llmOps.kpi.ready.label'),
-        value: `${readyCount.value}/${modelCount}`,
-        badge: `${readyRate}%`,
-        hint: t('llmOps.kpi.ready.hint', { count: readyCount.value }),
-        progress: readyRate,
-        tone: readyRate >= 80 ? 'good' : 'warn',
-        barClass: 'bg-emerald-500'
-      },
-      {
-        label: t('llmOps.kpi.procurement.label'),
-        value: `${procuredCount.value}/${modelCount}`,
-        badge: `${procurementRate}%`,
-        hint: t('llmOps.kpi.procurement.hint', {
-          missing: missingChannelCount.value,
-          currency: currencyMismatchCount.value
-        }),
-        progress: procurementRate,
-        tone: procurementRate >= 80 ? 'good' : 'warn',
+        key: 'pending_listing',
+        group: 'supply',
+        label: t('llmOps.overview.kpi.pendingListing.label'),
+        value: pendingListing,
+        badge: `${percentage(pendingListing, total)}%`,
+        hint: t('llmOps.overview.kpi.pendingListing.hint'),
+        progress: percentage(pendingListing, total),
+        tone: pendingListing ? 'warn' : 'good',
         barClass: 'bg-agione-500'
       },
       {
-        label: t('llmOps.kpi.listing.label'),
-        value: `${listedCount.value}/${modelCount}`,
-        badge: `${listingRate}%`,
-        hint: t('llmOps.kpi.listing.hint', {
-          unlisted: unlistedCount.value,
-          nonLowest: nonLowestCount.value
-        }),
-        progress: listingRate,
-        tone: listingRate >= 80 ? 'good' : 'warn',
-        barClass: 'bg-cyan-500'
+        key: 'missing_channel',
+        group: 'supply',
+        label: t('llmOps.overview.kpi.missingChannel.label'),
+        value: missingChannel,
+        badge: `${percentage(missingChannel, total)}%`,
+        hint: t('llmOps.overview.kpi.missingChannel.hint'),
+        progress: percentage(missingChannel, total),
+        tone: missingChannel ? 'danger' : 'good',
+        barClass: 'bg-rose-500'
       },
       {
-        label: t('llmOps.kpi.channels.label'),
-        value: channelCount,
-        badge: t('llmOps.kpi.channels.badge', {
-          count: enabledPriceSourceCount.value
-        }),
-        hint: t('llmOps.kpi.channels.hint'),
-        progress: channelCount ? 100 : 0,
-        tone: channelCount ? 'good' : 'danger',
-        barClass: 'bg-violet-500'
+        key: 'low_yield',
+        group: 'yield',
+        label: t('llmOps.overview.kpi.lowYield.label'),
+        value: lowYield,
+        badge: `${percentage(lowYield, total)}%`,
+        hint: t('llmOps.overview.kpi.lowYield.hint'),
+        progress: percentage(lowYield, total),
+        tone: lowYield ? 'danger' : 'good',
+        barClass: 'bg-amber-500'
       },
       {
-        label: t('llmOps.kpi.reconciliation.label'),
-        value: reconciliationAnomalyCount.value,
-        badge: reconciliationAnomalyCount.value
+        key: 'data_anomaly',
+        group: 'data',
+        label: t('llmOps.overview.kpi.dataAnomaly.label'),
+        value: dataAnomaly,
+        badge: dataAnomaly
           ? t('llmOps.status.needsHandling')
           : t('llmOps.status.normal'),
-        hint: t('llmOps.kpi.reconciliation.hint'),
-        progress: reconciliationAnomalyCount.value ? 100 : 0,
-        tone: reconciliationAnomalyCount.value ? 'danger' : 'good',
-        barClass: reconciliationAnomalyCount.value
-          ? 'bg-rose-500'
-          : 'bg-emerald-500'
+        hint: t('llmOps.overview.kpi.dataAnomaly.hint'),
+        progress: dataAnomaly ? 100 : 0,
+        tone: dataAnomaly ? 'danger' : 'good',
+        barClass: dataAnomaly ? 'bg-rose-500' : 'bg-emerald-500'
       }
     ]
   })
 
-  const actionItems = computed(() => [
-    {
-      label: t('llmOps.queue.fillChannelPrice.label'),
-      hint: t('llmOps.queue.fillChannelPrice.hint'),
-      value: missingChannelCount.value,
-      tone: missingChannelCount.value ? 'danger' : 'good',
-      section: 'channels'
-    },
-    {
-      label: t('llmOps.queue.configureExchange.label'),
-      hint: t('llmOps.queue.configureExchange.hint'),
-      value: currencyMismatchCount.value,
-      tone: currencyMismatchCount.value ? 'warn' : 'good',
-      section: 'channels'
-    },
-    {
-      label: t('llmOps.queue.publishToPlatform.label'),
-      hint: t('llmOps.queue.publishToPlatform.hint'),
-      value: unlistedCount.value,
-      tone: unlistedCount.value ? 'warn' : 'good',
-      section: 'reseller'
-    },
-    {
-      label: t('llmOps.queue.switchLowestChannel.label'),
-      hint: t('llmOps.queue.switchLowestChannel.hint'),
-      value: nonLowestCount.value,
-      tone: nonLowestCount.value ? 'warn' : 'good',
-      section: 'reseller'
-    },
-    {
-      label: t('llmOps.queue.addChannelCoverage.label'),
-      hint: t('llmOps.queue.addChannelCoverage.hint'),
-      value: lowCoverageCount.value,
-      tone: lowCoverageCount.value ? 'warn' : 'good',
-      section: 'channels'
-    },
-    {
-      label: t('llmOps.queue.checkPriceSource.label'),
-      hint: latestCollectionRun.value
-        ? t('llmOps.queue.checkPriceSource.latestRun', {
-            status: latestCollectionRun.value.status || '-',
-            time: formatDateTime(
-              latestCollectionRun.value.finished_at ||
-                latestCollectionRun.value.started_at
-            )
-          })
-        : t('llmOps.queue.checkPriceSource.empty'),
-      value: collectionAttentionCount.value,
-      tone: collectionAttentionCount.value ? 'danger' : 'good',
-      section: 'taskLogs'
-    },
-    {
-      label: t('llmOps.queue.handleReconciliation.label'),
-      hint: t('llmOps.queue.handleReconciliation.hint'),
-      value: reconciliationAnomalyCount.value,
-      tone: reconciliationAnomalyCount.value ? 'danger' : 'good',
-      section: 'reconciler'
-    }
-  ])
-
-  const latestCollectionRun = computed(
-    () =>
-      asArray(collectionRuns.value)
-        .slice()
-        .sort(
-          (left, right) =>
-            new Date(
-              right.finished_at || right.started_at || right.created_at || 0
-            ).getTime() -
-            new Date(
-              left.finished_at || left.started_at || left.created_at || 0
-            ).getTime()
-        )[0] || null
-  )
-
-  const collectionAttentionCount = computed(
-    () =>
-      asArray(collectionRuns.value).filter((run) =>
-        ['failed', 'running', 'pending', 'processing'].includes(run.status)
-      ).length
-  )
-
-  const channelCoverageRows = computed(() =>
-    asArray(channels.value)
-      .map((channel) => {
-        const covered = asArray(procurementRows.value).filter((row) =>
-          asArray(row.options).some(
-            (option) => String(option.channel_id) === String(channel.id)
-          )
-        ).length
-        const bestCount = asArray(procurementRows.value).filter(
-          (row) => String(row.best_channel?.channel_id) === String(channel.id)
-        ).length
-        return {
-          ...channel,
-          covered,
-          best_count: bestCount,
-          coverage_rate: percentage(covered, operationalModelCount.value)
-        }
-      })
-      .sort((left, right) => right.covered - left.covered)
-  )
-
-  const providerCoverageRows = computed(() => {
-    const rowsByProvider = new Map()
-    enrichedProcurementRows.value.forEach((row) => {
-      const providerName = row.provider_name || '-'
-      const rows = rowsByProvider.get(providerName) || []
-      rows.push(row)
-      rowsByProvider.set(providerName, rows)
-    })
-    return Array.from(rowsByProvider.entries())
-      .map(([providerName, providerRows]) => {
-        const procured = providerRows.filter((row) => row.best_channel).length
-        const listed = providerRows.filter((row) => row.is_agione_listed).length
-        const ready = providerRows.filter(
-          (row) => row.status_priority === 5
-        ).length
-        return {
-          name: providerName,
-          model_count: providerRows.length,
-          procured_count: procured,
-          listed_count: listed,
-          todo_count: Math.max(providerRows.length - ready, 0),
-          ready_rate: percentage(ready, providerRows.length)
-        }
-      })
-      .sort((left, right) => right.model_count - left.model_count)
-  })
-
   const filteredProcurementRows = computed(() => {
-    const rows = enrichedProcurementRows.value
-    if (!simulationChannel.value) {
-      return rows.map((row) => ({ ...row, display_channel: row.best_channel }))
-    }
-    return rows
-      .map((row) => {
-        const option = row.options?.find(
-          (item) => String(item.channel_id) === String(simulationChannel.value)
-        )
-        return { ...row, display_channel: option || null }
-      })
-      .filter((row) => row.display_channel)
+    return enrichedProcurementRows.value.map((row) => ({
+      ...row,
+      display_channel: row.best_channel
+    }))
   })
 
   const monitorTableRows = computed(() => {
     const rows = filteredProcurementRows.value.filter((row) => {
       if (simulationStatus.value === 'all') return true
-      if (simulationStatus.value === 'currency_mismatch') {
-        return row.requires_currency_conversion
-      }
-      if (simulationStatus.value === 'missing_channel') return !row.best_channel
-      if (simulationStatus.value === 'unlisted') return !row.is_agione_listed
-      if (simulationStatus.value === 'ready') {
-        return (
-          row.best_channel && row.is_agione_listed && row.has_lowest_listing
-        )
-      }
       return (
-        !row.best_channel ||
-        !row.is_agione_listed ||
-        !row.has_lowest_listing ||
-        row.coverage_count <= 1
+        row.decision_status === simulationStatus.value ||
+        (simulationStatus.value === 'priority' &&
+          (row.decision_priority < 8 || row.is_data_anomaly))
       )
     })
+    const inputYieldMagnitude = (row) => {
+      const value = Number(row.input_yield)
+      if (Number.isFinite(value)) return Math.abs(value)
+      return 0
+    }
     return rows.slice().sort((left, right) => {
-      if (left.status_priority !== right.status_priority) {
-        return left.status_priority - right.status_priority
+      if (left.decision_priority !== right.decision_priority) {
+        return left.decision_priority - right.decision_priority
       }
-      return String(left.provider_name).localeCompare(
-        String(right.provider_name)
+      const yl = inputYieldMagnitude(right) - inputYieldMagnitude(left)
+      if (yl !== 0) return yl
+      const lt = left.last_data_event_at || ''
+      const rt = right.last_data_event_at || ''
+      if (lt !== rt) return lt.localeCompare(rt)
+      return String(left.provider_name || '').localeCompare(
+        String(right.provider_name || '')
       )
     })
   })
 
-  function isLowestListing(listing, bestChannel, options) {
-    if (!bestChannel) return false
-    if (!listing.channel) return true
-    const option = options.find(
-      (item) => String(item.channel_id) === String(listing.channel)
-    )
-    return String(option?.channel_id) === String(bestChannel.channel_id)
+  const DECISION_TONE = {
+    no_supply: 'danger',
+    currency_unresolved: 'info',
+    platform_fee_unresolved: 'info',
+    low_yield: 'danger',
+    not_lowest_channel: 'warn',
+    unlisted: 'warn',
+    single_channel: 'info',
+    ready: 'success'
   }
 
-  function resolveMonitorStatus({
-    bestChannel,
-    coverageCount,
-    isAgioneListed,
-    hasLowestListing,
-    requiresCurrencyConversion
-  }) {
-    if (requiresCurrencyConversion) {
-      return {
-        status_label: t('llmOps.status.currencyMismatch'),
-        status_tone: 'info',
-        status_priority: 1
-      }
-    }
-    if (!bestChannel) {
-      return {
-        status_label: t('llmOps.status.missingChannel'),
-        status_tone: 'danger',
-        status_priority: 1
-      }
-    }
-    if (!isAgioneListed) {
-      return {
-        status_label: t('llmOps.status.readyToList'),
-        status_tone: 'warn',
-        status_priority: 2
-      }
-    }
-    if (!hasLowestListing) {
-      return {
-        status_label: t('llmOps.status.notLowest'),
-        status_tone: 'warn',
-        status_priority: 3
-      }
-    }
-    if (coverageCount <= 1) {
-      return {
-        status_label: t('llmOps.status.lowCoverage'),
-        status_tone: 'info',
-        status_priority: 4
-      }
-    }
-    return {
-      status_label: t('llmOps.status.ready'),
-      status_tone: 'success',
-      status_priority: 5
-    }
-  }
-
-  function monitorStatusTone(status) {
-    const tones = {
-      currency_mismatch: 'info',
-      not_lowest: 'warn',
-      missing_channel: 'danger',
-      unlisted: 'warn',
-      low_coverage: 'info',
-      ready: 'success'
-    }
-    return tones[status] || 'success'
-  }
-
-  function localizedMonitorStatusLabel(status) {
-    const labelKey = monitorStatusLabelKeys[status]
-    return labelKey ? t(labelKey) : t('llmOps.status.readyShort')
+  function decisionTone(status) {
+    return DECISION_TONE[status] || 'info'
   }
 
   return {
-    actionItems,
-    channelCoverageRows,
-    currentPlatformListingLabel,
     kpiCards,
     monitorModelSubtitle,
     monitorTableRows,
-    money,
     operationalChannelCount,
-    providerCoverageRows,
-    simulationChannel,
-    simulationChannelOptions,
     simulationStatus,
     simulationStatusOptions
   }
@@ -583,14 +216,4 @@ function monitorModelSubtitle(row) {
   const code = String(row.model_code || '').trim()
   if (code && code !== name) return code
   return ''
-}
-
-function money(value, currency = 'USD') {
-  if (value === null || value === undefined || value === '') return '-'
-  return `${currency || 'USD'} ${Number(value).toFixed(4)}`
-}
-
-function formatDateTime(value) {
-  if (!value) return '-'
-  return new Date(value).toLocaleString()
 }

--- a/frontend/src/composables/useLLMOpsResalePublishing.js
+++ b/frontend/src/composables/useLLMOpsResalePublishing.js
@@ -81,7 +81,11 @@ export function useLLMOpsResalePublishing({
     }
     loadResaleWorkflowConfig(platformId)
     if (!loading.value) {
-      refreshLight()
+      if (activeSection.value === 'monitor') {
+        refreshSummary()
+      } else {
+        refreshLight()
+      }
     }
   })
 
@@ -243,18 +247,18 @@ export function useLLMOpsResalePublishing({
   async function handleResaleWorkspacePublished(payload) {
     if (!payload || !payload.listings || !payload.listings.length) {
       showInfo(t('llmOps.messages.noListingsToPublish'))
-      return
+      return false
     }
     if (!payload.hasChanges) {
       showInfo(t('llmOps.messages.noChangesToSave'))
-      return
+      return false
     }
     const changedListings = payload.listings.filter(
       (item) => item.hasChanges !== false
     )
     if (!changedListings.length) {
       showInfo(t('llmOps.messages.noChangesToSave'))
-      return
+      return false
     }
     const publishListings = changedListings.filter(
       (item) =>
@@ -265,7 +269,7 @@ export function useLLMOpsResalePublishing({
     const items = publishListings.map(mapWorkspaceListingToPayload)
     if (!items.length) {
       showError(t('llmOps.messages.invalidListingPrices'))
-      return
+      return false
     }
     try {
       const response = await llmOpsApi.bulkUpsertResaleListings(items)
@@ -285,6 +289,7 @@ export function useLLMOpsResalePublishing({
       )
       resalePublishingDrawerOpen.value = false
       refreshLight()
+      return true
     } catch (error) {
       const message =
         error?.response?.data?.detail ||
@@ -292,6 +297,7 @@ export function useLLMOpsResalePublishing({
         error?.message ||
         ''
       showError(message || t('llmOps.messages.submitFailed'))
+      return false
     }
   }
 
@@ -348,24 +354,25 @@ export function useLLMOpsResalePublishing({
   async function handleResaleWorkspaceDraft(payload) {
     if (!payload || !payload.listings || !payload.listings.length) {
       showInfo(t('llmOps.messages.noDraftsToSave'))
-      return
+      return false
     }
     if (!payload.hasChanges) {
       showInfo(t('llmOps.messages.noChangesToSave'))
-      return
+      return false
     }
     const items = payload.listings
       .filter((item) => item.hasChanges !== false)
       .map(mapWorkspaceListingToPayload)
     if (!items.length) {
       showInfo(t('llmOps.messages.noChangesToSave'))
-      return
+      return false
     }
     try {
       await llmOpsApi.bulkDraftResaleListings(items)
       showSuccess(t('llmOps.messages.draftsSaved', { count: items.length }))
       resalePublishingDrawerOpen.value = false
       refreshLight()
+      return true
     } catch (error) {
       const message =
         error?.response?.data?.detail ||
@@ -373,6 +380,7 @@ export function useLLMOpsResalePublishing({
         error?.message ||
         ''
       showError(message || t('llmOps.messages.saveFailed'))
+      return false
     }
   }
 

--- a/frontend/src/composables/useLLMOpsResalePublishing.js
+++ b/frontend/src/composables/useLLMOpsResalePublishing.js
@@ -34,6 +34,7 @@ export function useLLMOpsResalePublishing({
   models,
   normalizeDisplayCurrency,
   preloadResalePublishingData,
+  refreshChannelPricingData,
   refreshLight,
   refreshPlatformData,
   refreshProviderManagementData,
@@ -82,7 +83,7 @@ export function useLLMOpsResalePublishing({
     loadResaleWorkflowConfig(platformId)
     if (!loading.value) {
       if (activeSection.value === 'monitor') {
-        refreshSummary()
+        refreshSummary('monitor')
       } else {
         refreshLight()
       }
@@ -177,9 +178,9 @@ export function useLLMOpsResalePublishing({
     )
 
     try {
-      await refreshSummary()
+      await Promise.all([refreshChannelPricingData(), refreshSummary()])
     } catch (error) {
-      showError(errorMessage(error, '刷新汇总数据失败。'))
+      showError(errorMessage(error, t('llmOps.dataErrors.refreshSummary')))
     }
   }
 

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -2440,6 +2440,95 @@
           "updateDraft": "Update draft"
         }
       }
+    },
+    "overview": {
+      "kpi": {
+        "pendingListing": {
+          "label": "Pending listing",
+          "hint": "Models with supply but not yet listed on the current platform"
+        },
+        "missingChannel": {
+          "label": "Missing channel price",
+          "hint": "Models without usable procurement pricing"
+        },
+        "lowYield": {
+          "label": "Low yield",
+          "hint": "Listed models below the platform yield_warning threshold"
+        },
+        "dataAnomaly": {
+          "label": "Data anomaly",
+          "hint": "Collection failures, source disabled, reconciliation anomalies"
+        }
+      },
+      "decisionTable": {
+        "title": "Model Resale Decision Table",
+        "subtitle": "Sorted by decision priority: missing channel -> currency -> platform fee -> low yield -> not lowest -> unlisted."
+      },
+      "columns": {
+        "model": "Model",
+        "provider": "Provider",
+        "coverage": "Coverage",
+        "recommended": "Recommended channel",
+        "currentListing": "Current listing",
+        "purchasePrice": "Purchase price",
+        "listingPrice": "Listing price",
+        "inputYield": "Input yield",
+        "outputYield": "Output yield",
+        "action": "Recommended action",
+        "lastUpdate": "Last update"
+      },
+      "emptyDecisionRows": "No models match the current filters.",
+      "kpiGroup": {
+        "supply": "Supply",
+        "yield": "Yield",
+        "data": "Data"
+      },
+      "event": {
+        "updated": "Updated",
+        "collectionFailed": "Collection failed",
+        "sourceDisabled": "Source disabled",
+        "reconciliationAnomaly": "Reconciliation anomaly",
+        "stale": "Stale price"
+      },
+      "hover": {
+        "action": "Action",
+        "recommended": "Recommended",
+        "current": "Current",
+        "purchasePrice": "Purchase price",
+        "listingPrice": "Listing price",
+        "yield": "Yield"
+      },
+      "time": {
+        "justNow": "just now",
+        "secondsAgo": "{count}s ago",
+        "minutesAgo": "{count}m ago",
+        "hoursAgo": "{count}h ago",
+        "daysAgo": "{count}d ago"
+      },
+      "emptyDecisionAllReady": "No models need handling. All ready.",
+      "emptyDecisionFiltered": "No models match the current filters."
+    },
+    "decision": {
+      "status": {
+        "no_supply": "No channel price",
+        "currency_unresolved": "Currency unresolved",
+        "platform_fee_unresolved": "Platform fee unconfigured",
+        "low_yield": "Low yield",
+        "not_lowest_channel": "Not on lowest channel",
+        "unlisted": "Unlisted",
+        "single_channel": "Single channel",
+        "ready": "Ready"
+      },
+      "action": {
+        "configureChannel": "Configure channel",
+        "configureExchange": "Configure exchange rate",
+        "configurePlatformFee": "Configure platform fee rules",
+        "reviewMargin": "Review pricing or switch channel",
+        "switchLowestChannel": "Evaluate switching to lowest channel",
+        "publishToPlatform": "Open publishing workspace",
+        "addChannelCoverage": "Add backup channel",
+        "keep": "Keep"
+      }
     }
   },
   "sals": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -8,6 +8,8 @@
     "delete": "Delete",
     "edit": "Edit",
     "close": "Close",
+    "clear": "Clear",
+    "remove": "Remove",
     "confirm": "Confirm",
     "back": "Back",
     "required": "Required",
@@ -36,6 +38,7 @@
     "collapseSidebar": "Collapse sidebar",
     "share": "Share",
     "settings": "Settings",
+    "optional": "Optional",
     "about": "About",
     "logout": "Logout",
     "profile": "Profile",
@@ -861,6 +864,9 @@
       "actionQueueTitle": "Today's Priority Queue",
       "channelCoverageTitle": "Channel Coverage and Lowest-Price Hits",
       "channelCount": "{count} channels",
+      "sourceCount": "{count} price sources",
+      "procurementChannelCount": "{count} procurement channels",
+      "noProcurementChannels": "No procurement channels",
       "channelCoverageMeta": "{covered} models covered · {best} lowest-price hits",
       "emptyChannelCoverage": "No channel coverage data yet.",
       "providerMatrixTitle": "Provider Model Operations Coverage",
@@ -942,6 +948,18 @@
       "draftsSaved": "Saved {count} drafts",
       "saveFailed": "Save failed"
     },
+    "dataErrors": {
+      "loadCoreModels": "Failed to load base model data.",
+      "loadPublishing": "Failed to load publishing workspace data.",
+      "loadSecondary": "Failed to load extended LLM Ops data.",
+      "loadSection": "Failed to load the current page data.",
+      "refreshChannels": "Failed to refresh channel data.",
+      "refreshListings": "Failed to refresh resale listings.",
+      "refreshMetaModels": "Failed to refresh meta-model data.",
+      "refreshPlatforms": "Failed to refresh resale platform data.",
+      "refreshProviders": "Failed to refresh price source data.",
+      "refreshSummary": "Failed to refresh summary data."
+    },
     "publishingDrawer": {
       "back": "Back",
       "title": "Immersive Model Publishing Workspace",
@@ -952,6 +970,22 @@
       "submitFailed": "Submit failed"
     },
     "publishingWorkspace": {
+      "actions": {
+        "appendListing": "Append listing",
+        "appendListingHint": "Appending adds listing prices for the current channel without affecting existing listed channels.",
+        "selectChannelFirst": "Select a procurement channel before generating listing prices.",
+        "switchAvailableHint": "Appending keeps existing channels; switching delists other channels on the same platform and keeps only the current channel.",
+        "updateListedHint": "This channel is already listed. This action updates its listing price.",
+        "updateLowestListedHint": "This channel is already listed and is the lowest procurement channel. You can update the price derived from the margin.",
+        "updatePrice": "Update price"
+      },
+      "decision": {
+        "currentlyListed": "Currently listed",
+        "listedLowest": "Listed at lowest price",
+        "lowestProcurement": "Lowest procurement price",
+        "noChannelSelected": "No channel selected",
+        "notLowestProcurement": "Not lowest procurement price"
+      },
       "filters": {
         "platform": "Publishing platform",
         "vendor": "Meta vendor",
@@ -967,6 +1001,30 @@
         "exchangeRate": "Exchange rate",
         "pointConversion": "{point} conversion"
       },
+      "metrics": {
+        "audioInput": "Audio input",
+        "audioOutput": "Audio output",
+        "cacheInput": "Cache input price",
+        "imageOutput": "Image output",
+        "input": "Input price",
+        "output": "Output price",
+        "videoInput": "Video input",
+        "videoOutput": "Video output"
+      },
+      "modelSelect": {
+        "actionableGroup": "Available models ({count} with configured channels)",
+        "description": "{actionable} decision-ready models · {unavailable} channels pending configuration",
+        "label": "Select model",
+        "needsChannel": "Needs channel",
+        "unavailableGroup": "Unavailable models ({count} without channels)"
+      },
+      "plan": {
+        "listed": "Listed",
+        "listedLowestSource": "Listed lowest source",
+        "lowestProcurementChannel": "Lowest procurement channel",
+        "notLowestSource": "Not lowest source",
+        "notSelected": "Not selected"
+      },
       "supply": {
         "title": "Supply Chain Selection",
         "selectedCount": "{count} selected links",
@@ -979,6 +1037,7 @@
         "sourcePrefix": "Supply source: {name}",
         "lowest": "Lowest",
         "lowestProcurement": "Lowest procurement link",
+        "higherCost": "{amount} higher · {percent}%",
         "selectRequired": "Select at least one supply link in the selection panel to continue pricing.",
         "chainFallback": "Supply link"
       },
@@ -1060,6 +1119,609 @@
         "staging": "Staging",
         "test": "Test"
       }
+    },
+    "resalePlatformModal": {
+      "apiKeyHint": "Used to call the resale platform API for listing, price updates, and delisting.",
+      "createPlatform": "Create platform",
+      "createTitle": "New resale platform",
+      "decimalPlaces": "{count} decimals",
+      "defaultPointName": "Points",
+      "description": "Configure the Agione platform instance, region, API access, commission, auto-approval margin, and point conversion rules.",
+      "disabled": "Platform disabled",
+      "editTitle": "Edit resale platform",
+      "enabled": "Platform enabled",
+      "errors": {
+        "invalidMetadataJson": "Extended metadata is not valid JSON.",
+        "metadataObject": "Extended metadata must be a JSON object."
+      },
+      "fields": {
+        "apiEndpoint": "API endpoint",
+        "apiKey": "Platform API key",
+        "autoApproveMaxMargin": "Auto-approval max margin (%)",
+        "code": "Platform code",
+        "currency": "Platform currency",
+        "decimalPlaces": "Decimal places",
+        "environment": "Environment",
+        "feeRate": "Platform commission rate (%)",
+        "name": "Platform name",
+        "platformType": "Platform type",
+        "pointName": "Point name",
+        "pointsPerCurrencyUnit": "Points per 1 platform currency unit",
+        "region": "Region",
+        "regionName": "Region name",
+        "roundingMode": "Point rounding mode",
+        "serviceFeeRate": "Service fee rate (%)",
+        "settlementRate": "Settlement rate (%)",
+        "taxRate": "Tax rate (%)",
+        "website": "Website",
+        "yieldTarget": "Target yield (%)",
+        "yieldWarning": "Yield warning line (%)"
+      },
+      "metadataHint": "Record tenant, channel, account, settlement basis, and other platform-specific information.",
+      "metadataTitle": "Extended metadata",
+      "notesHint": "Record platform differences, contract terms, or API limitations.",
+      "notesTitle": "Notes",
+      "placeholders": {
+        "apiKey": "Used for listing API authentication",
+        "autoApproveMaxMargin": "Example: 20",
+        "code": "Example: agione-main",
+        "feeRate": "Example: 3",
+        "metadata": "Example: {\"tenant_id\":\"tenant-001\",\"channel\":\"direct\"}",
+        "name": "Example: Agione main platform",
+        "notes": "Example: point multiplier source, settlement cycle, API integration status",
+        "optionalRate": "Leave blank if not configured",
+        "pointName": "Points",
+        "pointsPerCurrencyUnit": "Example: 100.00",
+        "regionName": "Example: Singapore",
+        "serviceFeeRate": "Example: 10",
+        "settlementRate": "Example: 95",
+        "yieldTarget": "Example: 25",
+        "yieldWarning": "Example: 15"
+      },
+      "platformInfo": "Platform information",
+      "platformInfoHint": "Identifies the Agione listing platform instance and downstream API integration.",
+      "regions": {
+        "apNortheast1": "Japan",
+        "apSoutheast1": "Singapore",
+        "cn": "Mainland China",
+        "cnEast": "China East",
+        "cnHongkong": "Hong Kong",
+        "cnNorth": "China North",
+        "cnSouth": "China South",
+        "euWest1": "EU West",
+        "global": "Global / default",
+        "usEast1": "US East"
+      },
+      "rounding": {
+        "down": "Round down",
+        "halfUp": "Round half up",
+        "up": "Round up"
+      },
+      "saveChanges": "Save changes",
+      "settlementHint": "Used on the listing page to convert platform listing prices into points.",
+      "settlementTitle": "Settlement and points"
+    },
+    "channelModelDrawer": {
+      "addDescription": "Select meta models first, then choose the upstream supplier source used by this channel. Added models are enabled by default and can be assigned cost rules or fixed costs below.",
+      "addTitle": "Add channel models",
+      "addableMetaModels": "{count} addable meta models",
+      "availableCount": "{count} available",
+      "batchAddModels": "Add {count} models",
+      "capability": "Capability",
+      "changeAdded": "{count} added",
+      "changeDisabled": "{count} disabled",
+      "changeEnabled": "{count} enabled",
+      "changeModified": "{count} cost changes",
+      "changeRemoved": "{count} removed",
+      "channelCost": "Channel cost",
+      "channelDefaultDiscount": "Channel default discount",
+      "clearSelection": "Clear selection",
+      "closeConfirm": "There are unsaved channel model changes. Close the drawer?",
+      "comparisonDelta": "Compared with upstream price: {currency} {delta} / {percent}%",
+      "comparisonUnknown": "Displayed after conversion to the global display currency. Without an upstream baseline for the same dimension, the direction cannot be determined.",
+      "configDetails": "Configuration details",
+      "configValue": "Config value",
+      "configuredCount": "{count} configured",
+      "configuredMetaModelsTitle": "Configured meta models ({count})",
+      "configuredSearchPlaceholder": "Search configured meta models, code, or upstream source",
+      "cost": "Cost",
+      "costCurrencyChannelDefault": "Cost prices follow the channel settlement currency {currency}; page prices are converted to the global display currency.",
+      "costCurrencyFixed": "Cost prices are saved as {currency}; page prices are converted to the global display currency.",
+      "costRule": "Cost rule",
+      "costSummary": "Cost {value}",
+      "currency": {
+        "fixedCny": "Always save as CNY",
+        "fixedUsd": "Always save as USD",
+        "savedAs": "Saved as {currency}",
+        "useChannelDefault": "Use channel default currency"
+      },
+      "defaultCurrency": "Default currency",
+      "emptyConfigured": "No models are configured yet. Add one from above.",
+      "enabledCount": "{count} enabled",
+      "fixedOverrideUnsupported": "This model does not support manual fixed-cost overrides.",
+      "followCostRule": "Follow cost rule",
+      "forwardingCapability": "Model forwarding capability",
+      "generatedAfterSave": "Generated after save",
+      "hiddenModels": "{count} more models. Click to show all.",
+      "metaVendor": "Meta-model vendor",
+      "missingPrice": "Missing price",
+      "modality": {
+        "audio": "Audio",
+        "multimodal": "Multimodal",
+        "text": "Text",
+        "video": "Video"
+      },
+      "modelSearchPlaceholder": "Name / code / modality",
+      "noAvailableUpstream": "No available upstream",
+      "noChanges": "No changes",
+      "noMatchedModels": "No addable models match",
+      "noUpstreamSelected": "No channel upstream selected",
+      "notApplicable": "N/A",
+      "pendingCostGeneration": "Cost pending generation",
+      "pendingUpstream": "Select a channel upstream",
+      "performance": {
+        "latency": "Latency (ms)",
+        "latencyPlaceholder": "Milliseconds",
+        "latencyShort": "Latency",
+        "latencyTitle": "Average channel latency in milliseconds",
+        "rpm": "RPM",
+        "rpmPlaceholder": "Requests per minute",
+        "rpmShort": "RPM",
+        "rpmTitle": "Requests per minute limit",
+        "tpm": "TPM",
+        "tpmPlaceholder": "Tokens per minute",
+        "tpmShort": "TPM",
+        "tpmTitle": "Tokens per minute limit"
+      },
+      "price": "Price",
+      "priceAfterSelection": "Prices appear after selection",
+      "priceField": {
+        "audioInput": "Audio input / second",
+        "audioInputShort": "Audio in",
+        "audioOutput": "Audio output / second",
+        "audioOutputShort": "Audio out",
+        "textInput": "Text input / million tokens",
+        "textInputShort": "Text in",
+        "textOutput": "Text output / million tokens",
+        "textOutputShort": "Text out",
+        "videoInput": "Video input / second",
+        "videoInputShort": "Video in",
+        "videoOutput": "Video output / second",
+        "videoOutputShort": "Video out"
+      },
+      "priceMode": {
+        "channelDefault": "Default discount",
+        "discount": "Discount ratio",
+        "fixed": "Fixed cost"
+      },
+      "priceRule": {
+        "defaultDiscount": "Default discount {value}",
+        "discount": "Discount {value}",
+        "fixed": "Fixed cost"
+      },
+      "resolvedUpstreamCount": "{count} upstreams selected",
+      "rule": "Rule",
+      "saveChanges": "Save changes",
+      "saving": "Saving",
+      "searchAndSelectModel": "Search and select meta models",
+      "searchUpstream": "Search upstream / currency / type",
+      "searchVendor": "Search vendors",
+      "selectAllVisible": "Select visible results",
+      "selectChannelUpstream": "Select channel upstream",
+      "selectMetaModel": "Select meta model",
+      "selectMetaVendor": "Select a meta-model vendor first",
+      "selectModelForFixed": "Select a meta model before configuring fixed costs.",
+      "selectedMetaModels": "{count} meta models selected",
+      "selectedModels": "Selected models",
+      "selectedModelsHint": "Choose the actual channel upstream used by each meta model.",
+      "selectedShort": "{count} selected",
+      "showAll": "Show all {count}",
+      "sourceCategory": {
+        "manual": "Manual",
+        "officialProvider": "Official",
+        "supplier": "Supplier",
+        "unknown": "Unlabeled type"
+      },
+      "sourceNotIngested": "Source not ingested",
+      "unassignedVendor": "Unassigned vendor",
+      "unboundUpstream": "Unbound upstream",
+      "unsaved": "Unsaved changes",
+      "unsupportedFixedPriceNote": "This model's image or other special pricing dimensions cannot be manually overridden in channel configuration yet. It will use the upstream price or discounted channel cost.",
+      "upstream": "Upstream",
+      "upstreamPrice": "Upstream price",
+      "upstreamSourceCount": "{count} upstream price sources",
+      "upstreamSummary": "Upstream {value}",
+      "vendorAddableCount": "{count} addable meta models"
+    },
+    "providerPricingDrawer": {
+      "allSources": "All sources",
+      "billingUnit": {
+        "perGeneration": "{base}/generation",
+        "perImage": "{base}/image",
+        "perSecond": "{base}/second"
+      },
+      "compactDimension": {
+        "audioInput": "Audio in",
+        "audioOutput": "Audio out",
+        "cache": "Cache",
+        "imageInput": "Image in",
+        "imageOutput": "Image out",
+        "input": "Input",
+        "output": "Output",
+        "videoInput": "Video in",
+        "videoOutput": "Video out"
+      },
+      "dimension": {
+        "audioInput": "Audio input",
+        "audioOutput": "Audio output",
+        "cacheInput": "Cache input",
+        "imageInput": "Image input",
+        "imageOutput": "Image output",
+        "textInput": "Text input",
+        "textOutput": "Text output",
+        "videoInput": "Video input",
+        "videoOutput": "Video output"
+      },
+      "empty": "This provider has no model pricing records yet.",
+      "legacyPrice": {
+        "audioInputSecond": "Audio input / second",
+        "audioOutputSecond": "Audio output / second",
+        "cacheInput1m": "Cache input / 1M",
+        "imageOutputImage": "Image output / image",
+        "input1m": "Input / 1M",
+        "output1m": "Output / 1M",
+        "resolutionInput": "{resolution} input",
+        "resolutionOutput": "{resolution} output",
+        "videoInputSecond": "Video input / second",
+        "videoOutputSecond": "Video output / second"
+      },
+      "modality": {
+        "audio": "Audio",
+        "multimodal": "Multimodal",
+        "text": "Text",
+        "video": "Video"
+      },
+      "modelCount": "Models",
+      "modelPriceSources": "Model price sources",
+      "noPrice": "No price",
+      "officialPriceName": "{provider} official pricing",
+      "priceSource": "Price source",
+      "priceStructure": "Price structure",
+      "priceStructureSummary": "Official {official} · Cloud hosted {cloud} · External {external}",
+      "priceSummary": "Price summary",
+      "pricedModelCount": "Priced models",
+      "providerFallback": "Provider",
+      "searchPlaceholder": "Search model, source, or code",
+      "sourceCategory": {
+        "cloudHosted": "Cloud hosted",
+        "manual": "Manual",
+        "officialProvider": "Official",
+        "supplier": "Supplier",
+        "unknown": "Other"
+      },
+      "sourceSummary": "{slug} · {count} sources",
+      "sourceType": "Source type",
+      "subtitle": "Summarizes core input, output, and cache prices by model to reduce per-dimension noise.",
+      "title": "Provider model prices",
+      "unboundPriceSource": "Unbound price source",
+      "updatedAt": "Updated at"
+    },
+    "modelWorkbenchPanel": {
+      "channelPrices": "Channel procurement prices",
+      "columns": {
+        "channel": "Channel",
+        "date": "Date",
+        "dimension": "Dimension",
+        "platform": "Platform",
+        "price": "Price",
+        "source": "Source",
+        "status": "Status",
+        "variance": "Variance"
+      },
+      "dimension": {
+        "audioInput": "Audio input",
+        "audioOutput": "Audio output",
+        "cacheInput": "Cache input",
+        "imageOutput": "Image output",
+        "textInput": "Text input",
+        "textOutput": "Text output",
+        "videoInput": "Video input",
+        "videoOutput": "Video output"
+      },
+      "emptyChannelPrices": "No channel price items yet.",
+      "emptyListingRecords": "No listing records yet.",
+      "emptyReconciliationRecords": "No reconciliation records yet.",
+      "emptyStandardPrices": "No standard price items yet.",
+      "kpi": {
+        "channelCoverage": "Channel coverage",
+        "channelCoverageHint": "Available procurement channel count",
+        "listingLinks": "Listing links",
+        "listingLinksHint": "Records on the current and other platforms",
+        "metaModel": "Meta model",
+        "reconciliationAnomalies": "Reconciliation anomalies",
+        "reconciliationAnomaliesHint": "Reconciliation records that are not perfect"
+      },
+      "listingRecords": "Listing records",
+      "platformFallback": "Platform {id}",
+      "publishStatus": {
+        "deleted": "Deleted",
+        "none": "Unpublished",
+        "offline": "Delisted",
+        "online": "Published"
+      },
+      "reconciliationRecords": "Reconciliation records",
+      "standardPrices": "Standard price items",
+      "subtitle": "Inspect official prices, channel procurement, listing status, and reconciliation for a single model.",
+      "title": "Model Detail Workbench",
+      "workflowStatus": {
+        "deleted": "Deleted",
+        "draft": "Draft",
+        "offline": "Delisted",
+        "offlineException": "Delist exception",
+        "online": "Online",
+        "pendingOffline": "Pending delist",
+        "pendingPublish": "Pending publish",
+        "pendingUpdate": "Pending update",
+        "updateDraft": "Update draft"
+      }
+    },
+    "metaModelModal": {
+      "aliasHint": "Aliases are used to match the same meta-model identity from collected results.",
+      "aliasTitle": "Aliases",
+      "capabilityHint": "Used for operations filtering, channel planning, and model availability display.",
+      "capabilityTitle": "Category and capabilities",
+      "createMetaModel": "Create meta model",
+      "createNote": "After creation, it can be linked to model SKUs.",
+      "createTitle": "New meta model",
+      "description": "Meta models normalize the same model identity across price sources into vendor, capability, and version.",
+      "editNote": "Saving changes affects the display identity of linked models.",
+      "editTitle": "Edit meta model",
+      "errors": {
+        "invalidMetadataJson": "Metadata must be a valid JSON object.",
+        "metadataObject": "Metadata must be a JSON object.",
+        "saveFailed": "Failed to save the meta model. Please try again later."
+      },
+      "featureHelp": "Separate with English commas.",
+      "fields": {
+        "aliases": "Aliases",
+        "code": "Model code",
+        "contextWindow": "Context window",
+        "family": "Model family",
+        "features": "Capability tags",
+        "maxOutputTokens": "Max output tokens",
+        "modality": "Modality",
+        "name": "Display name",
+        "owner": "Model owner",
+        "status": "Status"
+      },
+      "identityHint": "Used to merge models across official, supplier, and manual price sources.",
+      "identityTitle": "Model identity",
+      "metadataHint": "Record collection sources, official page identifiers, or operations notes. Must be a JSON object.",
+      "metadataTitle": "Metadata",
+      "ownerUnbound": "Unbound",
+      "placeholders": {
+        "aliases": "One alias per line, e.g. GPT-4o mini",
+        "code": "Example: gpt-4o-mini",
+        "family": "Example: GPT-4o",
+        "name": "Example: GPT-4o mini"
+      },
+      "saveChanges": "Save changes"
+    },
+    "priceChangePanel": {
+      "columns": {
+        "currency": "Currency",
+        "object": "Object",
+        "time": "Time",
+        "type": "Type"
+      },
+      "dimension": {
+        "audioInput": "Audio input",
+        "audioOutput": "Audio output",
+        "cacheInput": "Cache input",
+        "imageOutput": "Image output",
+        "textInput": "Text input",
+        "textOutput": "Text output",
+        "videoInput": "Video input",
+        "videoOutput": "Video output"
+      },
+      "empty": "No price change records yet.",
+      "fallback": {
+        "channel": "Channel {id}",
+        "model": "Model {id}",
+        "platform": "Platform {id}"
+      },
+      "filters": {
+        "all": "All prices"
+      },
+      "metrics": {
+        "channelHistory": {
+          "hint": "Procurement channel price version records",
+          "label": "Channel price history"
+        },
+        "listingHistory": {
+          "hint": "Platform listing price version records",
+          "label": "Listing price history"
+        },
+        "officialItems": {
+          "hint": "Current standard price dimension count",
+          "label": "Standard price items"
+        }
+      },
+      "subtitle": "Summarizes recent changes in channel procurement prices, listing prices, and standard price items.",
+      "title": "Price Change Dashboard",
+      "types": {
+        "channel": "Channel procurement price",
+        "listing": "Platform listing price",
+        "official": "Standard price item"
+      }
+    },
+    "collectionHealthPanel": {
+      "badges": {
+        "needsHandling": "Needs handling",
+        "normal": "Normal",
+        "sevenDayThreshold": "7-day threshold"
+      },
+      "collectionMethod": {
+        "apiSync": "API sync",
+        "autoCollect": "Auto collect",
+        "manualEntry": "Manual entry",
+        "manualImport": "Manual import",
+        "unknown": "Pending config"
+      },
+      "columns": {
+        "consecutiveFailures": "Consecutive failures",
+        "health": "Health",
+        "lastCollected": "Last collected",
+        "latestStatus": "Latest status",
+        "source": "Price source",
+        "successRate": "Success rate",
+        "type": "Type"
+      },
+      "empty": "No price sources yet.",
+      "health": {
+        "disabled": "Disabled",
+        "failed": "Collection failed",
+        "healthy": "Healthy",
+        "stale": "Stale data"
+      },
+      "metrics": {
+        "failed": {
+          "hint": "Latest task failed or consecutive failures exist",
+          "label": "Collection failed"
+        },
+        "healthy": {
+          "hint": "Latest collection succeeded and is within the freshness window",
+          "label": "Healthy sources"
+        },
+        "stale": {
+          "hint": "Latest collection is older than 7 days",
+          "label": "Stale data"
+        },
+        "total": {
+          "hint": "Enabled official, supplier, and manual price sources",
+          "label": "Total price sources"
+        }
+      },
+      "runStatus": {
+        "failed": "Failed",
+        "none": "None",
+        "running": "Running",
+        "succeeded": "Succeeded"
+      },
+      "subtitle": "Review latest collection status, consecutive failures, and freshness by price source.",
+      "title": "Collection Health Dashboard"
+    },
+    "channelModal": {
+      "basicHint": "Used to identify the channel and record the entry point for future API integration.",
+      "basicTitle": "Basic information",
+      "createChannel": "Create channel",
+      "createTitle": "New forwarding channel",
+      "description": "Channels configure the supply entry point and default settlement rules for purchasable and forwardable models.",
+      "disabled": "Channel disabled",
+      "editTitle": "Edit forwarding channel",
+      "enabled": "Channel enabled",
+      "fields": {
+        "apiEndpoint": "Forwarding API Base URL",
+        "code": "Channel code",
+        "currency": "Default settlement currency",
+        "name": "Channel display name",
+        "notes": "Operations notes",
+        "settlementRatio": "Default procurement discount ratio"
+      },
+      "help": {
+        "apiEndpoint": "Forwarding API endpoint provided by the channel. Leave blank if no API is available yet.",
+        "code": "System-unique identifier. Use lowercase letters, numbers, and hyphens.",
+        "currency": "Default procurement currency for the channel. Individual models can override it in model management.",
+        "name": "Name shown in channel lists, model forwarding relations, and price comparisons.",
+        "notes": "Record billing period, rate limits, contract discounts, model coverage, and related notes.",
+        "settlementRatio": "Procurement price = price source price × discount ratio. 85% means procurement at 0.85x."
+      },
+      "notesHint": "Record contracts, billing periods, or model coverage limits.",
+      "notesTitle": "Additional information",
+      "placeholders": {
+        "apiEndpoint": "Example: https://llm.example.com/v1",
+        "code": "Example: prod-forwarding-channel",
+        "name": "Example: production forwarding channel",
+        "notes": "Example: contract discount, settlement cycle, special limits",
+        "settlementRatio": "Example: 85"
+      },
+      "saveChanges": "Save changes",
+      "settlementHint": "Default procurement pricing rule for models in this channel. Individual models can still override it.",
+      "settlementTitle": "Settlement rules"
+    },
+    "providerModal": {
+      "basicHint": "Used to identify providers in model pricing, channel publishing, and Agione listing.",
+      "basicTitle": "Basic information",
+      "createProvider": "Create provider",
+      "createTitle": "New model provider",
+      "description": "Model providers are system-adapted. This page only maintains display name, price collection URL, and operations notes.",
+      "disabled": "Provider disabled",
+      "editTitle": "Edit model provider",
+      "enabled": "Provider enabled",
+      "errors": {
+        "saveFailed": "Failed to save the model provider. Please try again later.",
+        "sourceSaveFailed": "The provider was saved, but the price source URL failed to save. Please retry."
+      },
+      "fields": {
+        "code": "Provider code",
+        "name": "Provider display name",
+        "notes": "Notes",
+        "priceSourceEndpoint": "Price source URL"
+      },
+      "help": {
+        "code": "System adapter identifier. Existing provider codes should not be changed.",
+        "name": "Name shown in provider lists, model details, and operations overview.",
+        "priceSourceEndpoint": "Enter the provider's official pricing page or use https://models.dev/api.json as an aggregated pricing source. Enabled state is maintained in the model price source list."
+      },
+      "notesHint": "Record pricing basis, collection limits, or provider adapter notes.",
+      "notesTitle": "Operations notes",
+      "placeholders": {
+        "code": "Example: openai",
+        "name": "Example: OpenAI",
+        "notes": "Example: price page update frequency, special model basis, pending collection adapter",
+        "priceSourceEndpoint": "Example: https://models.dev/api.json"
+      },
+      "priceSourceHint": "Only affects the model price source bound to this provider. It does not change the provider website or API endpoint.",
+      "priceSourceTitle": "Price collection URL",
+      "saveChanges": "Save changes",
+      "websitePrefix": "Provider website / endpoint: {website}"
+    },
+    "channelPriceMatrixPanel": {
+      "columns": {
+        "coverage": "Coverage",
+        "lowestChannel": "Lowest channel"
+      },
+      "empty": "No models match the current filters.",
+      "filters": {
+        "all": "All statuses",
+        "missing": "Missing channel price",
+        "ready": "Multi-channel coverage",
+        "single": "Single-channel coverage"
+      },
+      "metrics": {
+        "covered": {
+          "hint": "Coverage {percent}%",
+          "label": "Has channel price"
+        },
+        "missing": {
+          "hint": "Procurement cost cannot be calculated",
+          "label": "Missing channel price"
+        },
+        "single": {
+          "hint": "Only one procurement channel is available",
+          "label": "Single-channel risk"
+        },
+        "total": {
+          "hint": "Active models participating in channel comparison",
+          "label": "Total models"
+        }
+      },
+      "searchPlaceholder": "Search model or provider",
+      "status": {
+        "missing": "Missing channel price"
+      },
+      "subtitle": "Compare procurement prices, lowest-price hits, and coverage gaps across channels by model.",
+      "title": "Channel Price Matrix"
     },
     "globalConfigPanel": {
       "actions": {
@@ -1252,6 +1914,8 @@
         "vendorsTitle": "No meta model providers yet"
       },
       "errors": {
+        "loadDetails": "Failed to load meta-model details.",
+        "loadOwnerSummary": "Failed to load meta-model provider summary.",
         "sync": "Failed to sync meta models"
       },
       "features": {
@@ -1394,12 +2058,16 @@
         "added": "Added",
         "bulkImport": "Bulk import",
         "cancel": "Cancel",
+        "configureModelPrice": "Configure model prices",
         "createSource": "New price source",
         "delete": "Delete",
+        "deleteSource": "Delete price source",
         "deleting": "Deleting",
         "edit": "Edit",
+        "editSource": "Edit price source",
         "manualPricing": "Manual pricing",
         "notSupported": "Not supported",
+        "resetOfficialPrice": "Reset official prices",
         "submitting": "Submitting",
         "syncAllPrices": "Sync price collection",
         "syncPrice": "Sync prices",
@@ -1530,9 +2198,33 @@
       "confirm": {
         "deleteSource": "Delete model price source \"{name}\"?\n\nThis removes the price source and its collection records. Linked models or channels will lose this price source."
       },
+      "officialReset": {
+        "allSources": "All official sources",
+        "confirm": "Clean the selected official price data and resync? This deletes official price items, collection snapshots, and legacy model-level sources.",
+        "description": "Clean legacy official price data written by seed or sync jobs, then resync official prices.",
+        "emptyPreview": "Preview the cleanup scope before executing. Manual prices, supplier prices, and channel configuration are retained.",
+        "execute": "Confirm reset and sync",
+        "executing": "Resetting...",
+        "legacySources": "Legacy model-level sources to delete",
+        "preview": "Preview impact",
+        "previewing": "Previewing...",
+        "scope": "Cleanup scope",
+        "stats": {
+          "history": "History deleted",
+          "legacySources": "Legacy sources deleted",
+          "modelsReset": "Models reset",
+          "priceItems": "Price items deleted",
+          "runs": "Run records deleted",
+          "snapshots": "Snapshots deleted",
+          "sourcesKept": "Real sources kept",
+          "sourcesMatched": "Sources matched"
+        },
+        "title": "Reset Official Price Data"
+      },
       "messages": {
         "deleted": "Model price source deleted",
         "officialSourceAdded": "Official price source \"{name}\" added",
+        "officialResetSuccess": "Official prices reset and synced: {priceItems} price items deleted, {models} models reset",
         "syncAllSubmitted": "Price collection task submitted{taskId}",
         "syncSubmitted": "{name} sync task submitted{taskId}",
         "taskId": " ({taskId})"
@@ -1540,7 +2232,11 @@
       "errors": {
         "addOfficialSourceFailed": "Failed to add official price source",
         "deleteFailed": "Failed to delete model price source",
+        "loadManualEntryCatalog": "Failed to load the manual price entry model catalog.",
+        "loadSourceDetail": "Failed to load price source details.",
         "loadOfficialSourcesFailed": "Failed to load official price sources",
+        "officialReset": "Failed to reset official prices.",
+        "previewOfficialReset": "Failed to preview official price reset scope.",
         "saveFailed": "Failed to save model price source",
         "syncAllFailed": "Failed to submit model price source sync task",
         "syncFailed": "Failed to submit price sync task"
@@ -2529,6 +3225,71 @@
         "addChannelCoverage": "Add backup channel",
         "keep": "Keep"
       }
+    },
+    "channel": {
+      "autoBest": "Auto best",
+      "fallback": "Channel",
+      "unnamed": "Unnamed channel",
+      "unspecified": "Unspecified channel"
+    },
+    "diagnostic": {
+      "status": {
+        "currency_mismatch": "Currency required",
+        "missing_channel": "Missing channel price",
+        "unlisted": "Unlisted",
+        "not_lowest": "Not lowest",
+        "low_coverage": "Low coverage",
+        "ready": "Ready"
+      }
+    },
+    "listingRisk": {
+      "title": "Listing Profit Risk",
+      "subtitle": "Aggregates low margin, non-lowest procurement, unlisted, and currency conversion risks.",
+      "columns": {
+        "model": "Model",
+        "risk": "Risk type",
+        "inputMargin": "Input margin",
+        "outputMargin": "Output margin",
+        "channel": "Current channel",
+        "action": "Recommended action"
+      },
+      "filters": {
+        "all": "All risks"
+      },
+      "risk": {
+        "currency_mismatch": "Currency required",
+        "missing_channel": "Missing channel price",
+        "unlisted": "Unlisted",
+        "not_lowest": "Not lowest",
+        "margin": "Low margin"
+      },
+      "actions": {
+        "currency_mismatch": "Add exchange rate and compare procurement pricing again",
+        "missing_channel": "Configure at least one procurement channel price first",
+        "unlisted": "Open the publishing workspace to create a listing",
+        "not_lowest": "Evaluate switching to the lowest procurement channel",
+        "margin": "Review listing price, service fee, or procurement channel",
+        "fallback": "Review status"
+      },
+      "metrics": {
+        "total": {
+          "label": "Total risks",
+          "hint": "Visible listing and procurement risks on the current platform"
+        },
+        "margin": {
+          "label": "Low margin",
+          "hint": "Input or output margin below 10%"
+        },
+        "notLowest": {
+          "label": "Not lowest",
+          "hint": "Listed but not using the lowest procurement channel"
+        },
+        "unlisted": {
+          "label": "Unlisted",
+          "hint": "Supply exists but has not entered the current platform"
+        }
+      },
+      "empty": "No risk items match the current filters."
     }
   },
   "sals": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1393,7 +1393,7 @@
         "channelRequired": "请选择账单归属的转发渠道。",
         "modelRequired": "请选择本次用量对应的调用模型。"
       }
-      },
+    },
     "providerManagement": {
       "title": "服务商价格源",
       "modelsCount": "{count} 个元模型",
@@ -2449,6 +2449,137 @@
           "pendingUpdate": "待更新",
           "updateDraft": "更新草稿"
         }
+      }
+    },
+    "overview": {
+      "kpi": {
+        "pendingListing": {
+          "label": "待上架",
+          "hint": "有供应但尚未挂售到当前平台的模型数"
+        },
+        "missingChannel": {
+          "label": "缺渠道价",
+          "hint": "无法计算采购成本，必须先补渠道价"
+        },
+        "lowYield": {
+          "label": "低收益率",
+          "hint": "已挂售但低于平台 yield_warning 阈值的模型"
+        },
+        "dataAnomaly": {
+          "label": "数据异常",
+          "hint": "采集失败 / 源失效 / 对账异常 的模型"
+        }
+      },
+      "decisionTable": {
+        "title": "模型挂售决策表",
+        "subtitle": "按决策优先级排序：先处理缺渠道价、汇率、平台费用，再处理低收益率、非最低渠道、未挂售。"
+      },
+      "columns": {
+        "model": "模型",
+        "provider": "服务商",
+        "coverage": "渠道覆盖",
+        "recommended": "推荐采购渠道",
+        "currentListing": "当前挂售",
+        "purchasePrice": "采购价",
+        "listingPrice": "挂售价",
+        "inputYield": "Input 收益率",
+        "outputYield": "Output 收益率",
+        "action": "推荐动作",
+        "lastUpdate": "数据时间"
+      },
+      "emptyDecisionRows": "当前筛选条件下没有需要处理的模型。",
+      "statusOptions": [
+        {
+          "value": "priority",
+          "label": "优先处理"
+        },
+        {
+          "value": "all",
+          "label": "全部"
+        },
+        {
+          "value": "no_supply",
+          "label": "缺渠道价"
+        },
+        {
+          "value": "currency_unresolved",
+          "label": "需要汇率"
+        },
+        {
+          "value": "platform_fee_unresolved",
+          "label": "平台费用未配置"
+        },
+        {
+          "value": "low_yield",
+          "label": "低收益率"
+        },
+        {
+          "value": "not_lowest_channel",
+          "label": "非最低渠道"
+        },
+        {
+          "value": "unlisted",
+          "label": "未挂售"
+        },
+        {
+          "value": "single_channel",
+          "label": "单渠道覆盖"
+        },
+        {
+          "value": "ready",
+          "label": "已就绪"
+        }
+      ],
+      "kpiGroup": {
+        "supply": "供给",
+        "yield": "收益",
+        "data": "数据"
+      },
+      "event": {
+        "updated": "已更新",
+        "collectionFailed": "采集失败",
+        "sourceDisabled": "源已停用",
+        "reconciliationAnomaly": "对账异常",
+        "stale": "价格过期"
+      },
+      "hover": {
+        "action": "动作",
+        "recommended": "推荐",
+        "current": "当前",
+        "purchasePrice": "采购价",
+        "listingPrice": "挂售价",
+        "yield": "收益"
+      },
+      "time": {
+        "justNow": "刚刚",
+        "secondsAgo": "{count} 秒前",
+        "minutesAgo": "{count} 分钟前",
+        "hoursAgo": "{count} 小时前",
+        "daysAgo": "{count} 天前"
+      },
+      "emptyDecisionAllReady": "当前没有需要处理的模型，全部就绪。",
+      "emptyDecisionFiltered": "当前筛选条件下没有匹配的模型。"
+    },
+    "decision": {
+      "status": {
+        "no_supply": "缺渠道价",
+        "currency_unresolved": "需要汇率",
+        "platform_fee_unresolved": "平台费用未配置",
+        "low_yield": "低收益率",
+        "not_lowest_channel": "非最低渠道",
+        "unlisted": "未挂售",
+        "single_channel": "单渠道覆盖",
+        "ready": "已就绪"
+      },
+      "action": {
+        "configureChannel": "去渠道配置",
+        "configureExchange": "补汇率",
+        "configurePlatformFee": "配置平台费用规则",
+        "reviewMargin": "复核售价或切换渠道",
+        "switchLowestChannel": "评估切换到最低渠道",
+        "publishToPlatform": "去挂售",
+        "addChannelCoverage": "增加备选渠道",
+        "keep": "保持"
       }
     }
   },

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -8,6 +8,8 @@
     "delete": "删除",
     "edit": "编辑",
     "close": "关闭",
+    "clear": "清空",
+    "remove": "移除",
     "confirm": "确认",
     "back": "返回",
     "required": "必填",
@@ -36,6 +38,7 @@
     "collapseSidebar": "收起侧边栏",
     "share": "分享",
     "settings": "设置",
+    "optional": "可选",
     "about": "关于",
     "logout": "退出登录",
     "profile": "个人资料",
@@ -871,6 +874,9 @@
       "actionQueueTitle": "今日优先处理",
       "channelCoverageTitle": "渠道覆盖与最低价命中",
       "channelCount": "{count} 个渠道",
+      "sourceCount": "{count} 个价格源",
+      "procurementChannelCount": "{count} 个采购渠道",
+      "noProcurementChannels": "暂无采购渠道",
       "channelCoverageMeta": "覆盖 {covered} 个模型 · 最低价命中 {best} 个",
       "emptyChannelCoverage": "暂无渠道覆盖数据。",
       "providerMatrixTitle": "厂商模型运营覆盖",
@@ -952,6 +958,18 @@
       "draftsSaved": "已保存 {count} 条草稿",
       "saveFailed": "保存失败"
     },
+    "dataErrors": {
+      "loadCoreModels": "加载基础模型数据失败。",
+      "loadPublishing": "加载发布工作台数据失败。",
+      "loadSecondary": "加载 LLM Ops 扩展数据失败。",
+      "loadSection": "加载当前页面数据失败。",
+      "refreshChannels": "刷新渠道数据失败。",
+      "refreshListings": "刷新转售列表失败。",
+      "refreshMetaModels": "刷新元模型数据失败。",
+      "refreshPlatforms": "刷新转售平台数据失败。",
+      "refreshProviders": "刷新价格源数据失败。",
+      "refreshSummary": "刷新汇总数据失败。"
+    },
     "publishingDrawer": {
       "back": "返回",
       "title": "模型沉浸式上架工作台",
@@ -962,6 +980,22 @@
       "submitFailed": "提交失败"
     },
     "publishingWorkspace": {
+      "actions": {
+        "appendListing": "追加上架",
+        "appendListingHint": "追加会新增当前渠道的挂售价格，不会影响已有上架渠道。",
+        "selectChannelFirst": "先选择采购渠道后再生成上架价格。",
+        "switchAvailableHint": "追加会保留现有渠道；切换会下架同平台其他渠道，仅保留当前渠道。",
+        "updateListedHint": "当前渠道已经上架，本次操作会更新该渠道的挂售价格。",
+        "updateLowestListedHint": "当前渠道已经上架且是最低采购渠道，可直接更新收益率后的售价。",
+        "updatePrice": "更新价格"
+      },
+      "decision": {
+        "currentlyListed": "当前已上架",
+        "listedLowest": "已上架最低价",
+        "lowestProcurement": "最低采购价",
+        "noChannelSelected": "未选择渠道",
+        "notLowestProcurement": "非最低采购价"
+      },
       "filters": {
         "platform": "发布平台",
         "vendor": "元厂商",
@@ -977,6 +1011,30 @@
         "exchangeRate": "汇率",
         "pointConversion": "{point}换算"
       },
+      "metrics": {
+        "audioInput": "音频输入",
+        "audioOutput": "音频输出",
+        "cacheInput": "缓存输入价",
+        "imageOutput": "图片输出",
+        "input": "输入价",
+        "output": "输出价",
+        "videoInput": "视频输入",
+        "videoOutput": "视频输出"
+      },
+      "modelSelect": {
+        "actionableGroup": "可选模型（已配置渠道 {count}）",
+        "description": "{actionable} 个可决策模型 · {unavailable} 个待配置渠道",
+        "label": "选择模型",
+        "needsChannel": "需配置渠道",
+        "unavailableGroup": "不可选模型（暂无渠道 {count}）"
+      },
+      "plan": {
+        "listed": "已上架",
+        "listedLowestSource": "已上架最低源",
+        "lowestProcurementChannel": "最低采购渠道",
+        "notLowestSource": "非最低源",
+        "notSelected": "未选择"
+      },
       "supply": {
         "title": "供应链路甄选",
         "selectedCount": "已选 {count} 条链路",
@@ -989,6 +1047,7 @@
         "sourcePrefix": "供应源：{name}",
         "lowest": "最低",
         "lowestProcurement": "最低采购链路",
+        "higherCost": "高 {amount} · {percent}%",
         "selectRequired": "请在链路甄选面板中勾选至少一条供应链路，继续定价。",
         "chainFallback": "供货链路"
       },
@@ -1070,6 +1129,609 @@
         "staging": "预发",
         "test": "测试"
       }
+    },
+    "resalePlatformModal": {
+      "apiKeyHint": "用于调用挂售平台接口执行上架、改价和下架操作。",
+      "createPlatform": "创建平台",
+      "createTitle": "新建挂售平台",
+      "decimalPlaces": "{count} 位",
+      "defaultPointName": "积分",
+      "description": "配置 Agione 平台实例、区域、接口、抽佣、免审收益率和积分规则。",
+      "disabled": "平台已停用",
+      "editTitle": "编辑挂售平台",
+      "enabled": "平台已启用",
+      "errors": {
+        "invalidMetadataJson": "扩展元数据不是有效的 JSON。",
+        "metadataObject": "扩展元数据必须是 JSON 对象。"
+      },
+      "fields": {
+        "apiEndpoint": "API 接入地址",
+        "apiKey": "平台 API Key",
+        "autoApproveMaxMargin": "免审最高收益率（%）",
+        "code": "平台标识",
+        "currency": "平台货币",
+        "decimalPlaces": "保留小数位",
+        "environment": "环境",
+        "feeRate": "平台抽佣比例（%）",
+        "name": "平台名称",
+        "platformType": "平台类型",
+        "pointName": "积分名称",
+        "pointsPerCurrencyUnit": "积分兑换比例（每 1 平台货币）",
+        "region": "区域",
+        "regionName": "区域名称",
+        "roundingMode": "积分舍入方式",
+        "serviceFeeRate": "服务费率（%）",
+        "settlementRate": "结算比例（%）",
+        "taxRate": "税费率（%）",
+        "website": "官网地址",
+        "yieldTarget": "目标收益率（%）",
+        "yieldWarning": "收益率预警线（%）"
+      },
+      "metadataHint": "记录租户、渠道、账号、结算口径等平台特有信息。",
+      "metadataTitle": "扩展元数据",
+      "notesHint": "记录平台差异、合同口径或接口限制。",
+      "notesTitle": "备注",
+      "placeholders": {
+        "apiKey": "用于挂售接口鉴权",
+        "autoApproveMaxMargin": "例如：20",
+        "code": "例如：agione-main",
+        "feeRate": "例如：3",
+        "metadata": "例如：{\"tenant_id\":\"tenant-001\",\"channel\":\"direct\"}",
+        "name": "例如：Agione 主平台",
+        "notes": "例如：积分倍率来源、结算周期、接口适配状态",
+        "optionalRate": "留空表示未配置",
+        "pointName": "积分",
+        "pointsPerCurrencyUnit": "例如：100.00",
+        "regionName": "例如：新加坡",
+        "serviceFeeRate": "例如：10",
+        "settlementRate": "例如：95",
+        "yieldTarget": "例如：25",
+        "yieldWarning": "例如：15"
+      },
+      "platformInfo": "平台信息",
+      "platformInfoHint": "用于区分 Agione 上架平台实例和后续接口适配。",
+      "regions": {
+        "apNortheast1": "日本",
+        "apSoutheast1": "新加坡",
+        "cn": "中国大陆",
+        "cnEast": "华东",
+        "cnHongkong": "香港",
+        "cnNorth": "华北",
+        "cnSouth": "华南",
+        "euWest1": "欧洲西部",
+        "global": "全球 / 默认",
+        "usEast1": "美国东部"
+      },
+      "rounding": {
+        "down": "向下舍入",
+        "halfUp": "四舍五入",
+        "up": "向上舍入"
+      },
+      "saveChanges": "保存修改",
+      "settlementHint": "用于挂售页将平台上架价换算为积分。",
+      "settlementTitle": "结算与积分"
+    },
+    "channelModelDrawer": {
+      "addDescription": "先选择元模型，再指定该渠道实际使用的上游供货源。添加后默认启用，可在下方设置成本规则和固定成本价。",
+      "addTitle": "添加渠道模型",
+      "addableMetaModels": "{count} 个可添加元模型",
+      "availableCount": "可添加 {count}",
+      "batchAddModels": "批量添加 {count} 个模型",
+      "capability": "能力",
+      "changeAdded": "新增 {count}",
+      "changeDisabled": "停用 {count}",
+      "changeEnabled": "启用 {count}",
+      "changeModified": "改成本 {count}",
+      "changeRemoved": "移除 {count}",
+      "channelCost": "渠道成本价",
+      "channelDefaultDiscount": "渠道默认折扣",
+      "clearSelection": "清空选择",
+      "closeConfirm": "当前有未保存的模型配置变更，确定关闭抽屉吗？",
+      "comparisonDelta": "较上游价格 {currency} {delta} / {percent}%",
+      "comparisonUnknown": "已按全局显示货币换算展示；缺少同维度上游基准价时，暂无法判断高低。",
+      "configDetails": "配置详情",
+      "configValue": "配置值",
+      "configuredCount": "已配置 {count}",
+      "configuredMetaModelsTitle": "已配置元模型（{count}）",
+      "configuredSearchPlaceholder": "搜索已配置元模型、code 或上游来源",
+      "cost": "成本",
+      "costCurrencyChannelDefault": "成本价跟随渠道结算币种 {currency} 保存；页面价格按全局显示货币换算。",
+      "costCurrencyFixed": "成本价保存为 {currency}；页面价格按全局显示货币换算。",
+      "costRule": "成本规则",
+      "costSummary": "成本 {value}",
+      "currency": {
+        "fixedCny": "固定保存为人民币",
+        "fixedUsd": "固定保存为美元",
+        "savedAs": "保存为 {currency}",
+        "useChannelDefault": "使用渠道默认币种"
+      },
+      "defaultCurrency": "默认币种",
+      "emptyConfigured": "还没有配置模型，请先从上方添加。",
+      "enabledCount": "已启用 {count}",
+      "fixedOverrideUnsupported": "当前模型暂不支持手动覆盖固定成本价。",
+      "followCostRule": "跟随成本规则",
+      "forwardingCapability": "模型转发能力",
+      "generatedAfterSave": "保存后自动生成",
+      "hiddenModels": "还有 {count} 个模型，点击显示全部",
+      "metaVendor": "元模型厂商",
+      "missingPrice": "缺价格",
+      "modality": {
+        "audio": "音频",
+        "multimodal": "多模态",
+        "text": "文本",
+        "video": "视频"
+      },
+      "modelSearchPlaceholder": "名称 / code / 模态",
+      "noAvailableUpstream": "无可用上游",
+      "noChanges": "暂无变更",
+      "noMatchedModels": "没有匹配的可添加模型",
+      "noUpstreamSelected": "未选择渠道上游",
+      "notApplicable": "不适用",
+      "pendingCostGeneration": "成本待生成",
+      "pendingUpstream": "待选择渠道上游",
+      "performance": {
+        "latency": "延迟(ms)",
+        "latencyPlaceholder": "毫秒",
+        "latencyShort": "延迟",
+        "latencyTitle": "渠道平均延迟，单位毫秒",
+        "rpm": "RPM",
+        "rpmPlaceholder": "每分钟请求",
+        "rpmShort": "RPM",
+        "rpmTitle": "每分钟请求上限",
+        "tpm": "TPM",
+        "tpmPlaceholder": "每分钟 Token",
+        "tpmShort": "TPM",
+        "tpmTitle": "每分钟 Token 上限"
+      },
+      "price": "价格",
+      "priceAfterSelection": "选择后显示价格",
+      "priceField": {
+        "audioInput": "音频输入 / 秒",
+        "audioInputShort": "音入",
+        "audioOutput": "音频输出 / 秒",
+        "audioOutputShort": "音出",
+        "textInput": "文本输入 / 百万 tokens",
+        "textInputShort": "文入",
+        "textOutput": "文本输出 / 百万 tokens",
+        "textOutputShort": "文出",
+        "videoInput": "视频输入 / 秒",
+        "videoInputShort": "视入",
+        "videoOutput": "视频输出 / 秒",
+        "videoOutputShort": "视出"
+      },
+      "priceMode": {
+        "channelDefault": "默认折扣",
+        "discount": "折扣比例",
+        "fixed": "固定成本价"
+      },
+      "priceRule": {
+        "defaultDiscount": "默认折扣 {value}",
+        "discount": "折扣 {value}",
+        "fixed": "固定成本价"
+      },
+      "resolvedUpstreamCount": "{count} 个已指定上游",
+      "rule": "规则",
+      "saveChanges": "保存变更",
+      "saving": "保存中",
+      "searchAndSelectModel": "搜索并选择元模型",
+      "searchUpstream": "搜索上游 / 币种 / 类型",
+      "searchVendor": "搜索厂商",
+      "selectAllVisible": "全选当前结果",
+      "selectChannelUpstream": "选择渠道上游",
+      "selectMetaModel": "选择元模型",
+      "selectMetaVendor": "先选择元模型厂商",
+      "selectModelForFixed": "先选择元模型，再配置固定成本价。",
+      "selectedMetaModels": "已选 {count} 个元模型",
+      "selectedModels": "已选模型",
+      "selectedModelsHint": "为每个元模型指定实际使用的渠道上游。",
+      "selectedShort": "已选 {count}",
+      "showAll": "显示全部 {count}",
+      "sourceCategory": {
+        "manual": "人工",
+        "officialProvider": "原厂",
+        "supplier": "供货商",
+        "unknown": "未标记类型"
+      },
+      "sourceNotIngested": "源未入库",
+      "unassignedVendor": "未归属厂商",
+      "unboundUpstream": "未绑定上游",
+      "unsaved": "未保存变更",
+      "unsupportedFixedPriceNote": "当前模型的图片等特殊计价维度暂不支持在渠道配置中手动覆盖，会使用上游价格或折扣后的渠道成本价。",
+      "upstream": "上游",
+      "upstreamPrice": "上游价格",
+      "upstreamSourceCount": "{count} 个上游价格源",
+      "upstreamSummary": "上游 {value}",
+      "vendorAddableCount": "{count} 个可添加元模型"
+    },
+    "providerPricingDrawer": {
+      "allSources": "全部来源",
+      "billingUnit": {
+        "perGeneration": "{base}/次",
+        "perImage": "{base}/张",
+        "perSecond": "{base}/秒"
+      },
+      "compactDimension": {
+        "audioInput": "音入",
+        "audioOutput": "音出",
+        "cache": "缓存",
+        "imageInput": "图入",
+        "imageOutput": "图出",
+        "input": "输入",
+        "output": "输出",
+        "videoInput": "视入",
+        "videoOutput": "视出"
+      },
+      "dimension": {
+        "audioInput": "音频输入",
+        "audioOutput": "音频输出",
+        "cacheInput": "缓存输入",
+        "imageInput": "图片输入",
+        "imageOutput": "图片输出",
+        "textInput": "文本输入",
+        "textOutput": "文本输出",
+        "videoInput": "视频输入",
+        "videoOutput": "视频输出"
+      },
+      "empty": "当前服务商还没有模型定价记录。",
+      "legacyPrice": {
+        "audioInputSecond": "音频输入 / 秒",
+        "audioOutputSecond": "音频输出 / 秒",
+        "cacheInput1m": "缓存输入 / 1M",
+        "imageOutputImage": "图片输出 / 张",
+        "input1m": "输入 / 1M",
+        "output1m": "输出 / 1M",
+        "resolutionInput": "{resolution} 输入",
+        "resolutionOutput": "{resolution} 输出",
+        "videoInputSecond": "视频输入 / 秒",
+        "videoOutputSecond": "视频输出 / 秒"
+      },
+      "modality": {
+        "audio": "音频",
+        "multimodal": "多模态",
+        "text": "文本",
+        "video": "视频"
+      },
+      "modelCount": "模型数量",
+      "modelPriceSources": "模型价格源",
+      "noPrice": "暂无价格",
+      "officialPriceName": "{provider} 官方价格",
+      "priceSource": "价格来源",
+      "priceStructure": "价格结构",
+      "priceStructureSummary": "原厂 {official} · 云托管 {cloud} · 外部 {external}",
+      "priceSummary": "价格摘要",
+      "pricedModelCount": "已定价模型",
+      "providerFallback": "服务商",
+      "searchPlaceholder": "搜索模型、来源或 code",
+      "sourceCategory": {
+        "cloudHosted": "云托管",
+        "manual": "人工",
+        "officialProvider": "原厂",
+        "supplier": "供货商",
+        "unknown": "其他"
+      },
+      "sourceSummary": "{slug} · {count} 个来源",
+      "sourceType": "来源类型",
+      "subtitle": "按模型汇总输入、输出、缓存等核心价格，减少逐维度展开带来的噪音。",
+      "title": "服务商模型价格",
+      "unboundPriceSource": "未绑定价格源",
+      "updatedAt": "更新时间"
+    },
+    "modelWorkbenchPanel": {
+      "channelPrices": "渠道采购价",
+      "columns": {
+        "channel": "渠道",
+        "date": "日期",
+        "dimension": "维度",
+        "platform": "平台",
+        "price": "价格",
+        "source": "来源",
+        "status": "状态",
+        "variance": "差异"
+      },
+      "dimension": {
+        "audioInput": "音频输入",
+        "audioOutput": "音频输出",
+        "cacheInput": "缓存输入",
+        "imageOutput": "图片输出",
+        "textInput": "文本输入",
+        "textOutput": "文本输出",
+        "videoInput": "视频输入",
+        "videoOutput": "视频输出"
+      },
+      "emptyChannelPrices": "暂无渠道价格项。",
+      "emptyListingRecords": "暂无挂售记录。",
+      "emptyReconciliationRecords": "暂无对账记录。",
+      "emptyStandardPrices": "暂无标准价格项。",
+      "kpi": {
+        "channelCoverage": "渠道覆盖",
+        "channelCoverageHint": "可用采购渠道数量",
+        "listingLinks": "挂售链路",
+        "listingLinksHint": "当前平台及其他平台记录",
+        "metaModel": "元模型",
+        "reconciliationAnomalies": "对账异常",
+        "reconciliationAnomaliesHint": "非 perfect 的对账记录"
+      },
+      "listingRecords": "挂售记录",
+      "platformFallback": "平台 {id}",
+      "publishStatus": {
+        "deleted": "已删除",
+        "none": "未发布",
+        "offline": "已下架",
+        "online": "已发布"
+      },
+      "reconciliationRecords": "对账记录",
+      "standardPrices": "标准价格项",
+      "subtitle": "集中查看单个模型的官方价格、渠道采购、挂售状态和对账记录。",
+      "title": "模型详情工作台",
+      "workflowStatus": {
+        "deleted": "已删除",
+        "draft": "草稿",
+        "offline": "已下架",
+        "offlineException": "下架异常",
+        "online": "在线",
+        "pendingOffline": "待下架",
+        "pendingPublish": "待发布",
+        "pendingUpdate": "待更新",
+        "updateDraft": "更新草稿"
+      }
+    },
+    "metaModelModal": {
+      "aliasHint": "别名用于从采集结果中匹配同一元模型身份。",
+      "aliasTitle": "别名",
+      "capabilityHint": "用于运营筛选、渠道规划和模型可用性展示。",
+      "capabilityTitle": "分类与能力",
+      "createMetaModel": "创建元模型",
+      "createNote": "创建后可绑定到模型 SKU。",
+      "createTitle": "新建元模型",
+      "description": "元模型用于把不同价格源中的同一模型身份归一到厂商、能力和版本。",
+      "editNote": "保存后会影响关联模型的展示身份。",
+      "editTitle": "编辑元模型",
+      "errors": {
+        "invalidMetadataJson": "元数据必须是合法 JSON 对象。",
+        "metadataObject": "元数据必须是 JSON 对象。",
+        "saveFailed": "元模型保存失败，请稍后重试。"
+      },
+      "featureHelp": "英文逗号分隔。",
+      "fields": {
+        "aliases": "别名",
+        "code": "模型标识 Code",
+        "contextWindow": "上下文窗口",
+        "family": "模型家族",
+        "features": "能力标签",
+        "maxOutputTokens": "最大输出 Token",
+        "modality": "模态",
+        "name": "显示名称",
+        "owner": "模型归属方",
+        "status": "状态"
+      },
+      "identityHint": "用于跨官方、供应商和人工价格源归并模型。",
+      "identityTitle": "模型身份",
+      "metadataHint": "可记录采集来源、官方页面标识或运营备注，必须是 JSON 对象。",
+      "metadataTitle": "元数据",
+      "ownerUnbound": "未绑定",
+      "placeholders": {
+        "aliases": "每行一个别名，例如 GPT-4o mini",
+        "code": "例如：gpt-4o-mini",
+        "family": "例如：GPT-4o",
+        "name": "例如：GPT-4o mini"
+      },
+      "saveChanges": "保存修改"
+    },
+    "priceChangePanel": {
+      "columns": {
+        "currency": "币种",
+        "object": "对象",
+        "time": "时间",
+        "type": "类型"
+      },
+      "dimension": {
+        "audioInput": "音频输入",
+        "audioOutput": "音频输出",
+        "cacheInput": "缓存输入",
+        "imageOutput": "图片输出",
+        "textInput": "文本输入",
+        "textOutput": "文本输出",
+        "videoInput": "视频输入",
+        "videoOutput": "视频输出"
+      },
+      "empty": "暂无价格变化记录。",
+      "fallback": {
+        "channel": "渠道 {id}",
+        "model": "模型 {id}",
+        "platform": "平台 {id}"
+      },
+      "filters": {
+        "all": "全部价格"
+      },
+      "metrics": {
+        "channelHistory": {
+          "hint": "采购渠道价格版本记录",
+          "label": "渠道价历史"
+        },
+        "listingHistory": {
+          "hint": "平台挂售价格版本记录",
+          "label": "挂售价历史"
+        },
+        "officialItems": {
+          "hint": "当前标准价格维度数量",
+          "label": "标准价格项"
+        }
+      },
+      "subtitle": "汇总渠道采购价、挂售价和标准价格项的最近变化。",
+      "title": "价格变化看板",
+      "types": {
+        "channel": "渠道采购价",
+        "listing": "平台挂售价",
+        "official": "标准价格项"
+      }
+    },
+    "collectionHealthPanel": {
+      "badges": {
+        "needsHandling": "需处理",
+        "normal": "正常",
+        "sevenDayThreshold": "7天阈值"
+      },
+      "collectionMethod": {
+        "apiSync": "接口同步",
+        "autoCollect": "自动采集",
+        "manualEntry": "手动录入",
+        "manualImport": "手动导入",
+        "unknown": "待配置"
+      },
+      "columns": {
+        "consecutiveFailures": "连续失败",
+        "health": "健康状态",
+        "lastCollected": "最近采集",
+        "latestStatus": "最近状态",
+        "source": "价格源",
+        "successRate": "成功率",
+        "type": "类型"
+      },
+      "empty": "暂无价格源。",
+      "health": {
+        "disabled": "已停用",
+        "failed": "采集失败",
+        "healthy": "健康",
+        "stale": "数据过期"
+      },
+      "metrics": {
+        "failed": {
+          "hint": "最近任务失败或存在连续失败",
+          "label": "采集失败"
+        },
+        "healthy": {
+          "hint": "最近一次采集成功且未超过新鲜度窗口",
+          "label": "健康价格源"
+        },
+        "stale": {
+          "hint": "最近采集时间超过 7 天",
+          "label": "数据过期"
+        },
+        "total": {
+          "hint": "启用的官方、供应商和手工价格源",
+          "label": "价格源总数"
+        }
+      },
+      "runStatus": {
+        "failed": "失败",
+        "none": "暂无",
+        "running": "运行中",
+        "succeeded": "成功"
+      },
+      "subtitle": "按价格源查看最近采集、连续失败和数据新鲜度。",
+      "title": "采集健康度看板"
+    },
+    "channelModal": {
+      "basicHint": "用于识别渠道，以及记录后续对接接口的入口。",
+      "basicTitle": "基础信息",
+      "createChannel": "创建渠道",
+      "createTitle": "新建转发渠道",
+      "description": "渠道用于配置可采购/转发模型的供应入口和默认结算规则。",
+      "disabled": "渠道已停用",
+      "editTitle": "编辑转发渠道",
+      "enabled": "渠道已启用",
+      "fields": {
+        "apiEndpoint": "转发 API Base URL",
+        "code": "渠道标识",
+        "currency": "默认结算币种",
+        "name": "渠道显示名称",
+        "notes": "运营备注",
+        "settlementRatio": "默认采购折扣比例"
+      },
+      "help": {
+        "apiEndpoint": "渠道提供的模型转发接口地址；暂无接口时可先留空。",
+        "code": "系统唯一标识，建议使用小写英文、数字和短横线。",
+        "currency": "渠道默认采购币种；单个模型可在模型管理中覆盖。",
+        "name": "展示在渠道列表、模型转发关系和价格对比中的名称。",
+        "notes": "可记录账期、限流、合同折扣、模型覆盖范围等信息。",
+        "settlementRatio": "采购价 = 价格源价格 × 折扣比例；85% 表示按 0.85 倍采购。"
+      },
+      "notesHint": "记录合同、账期或模型覆盖限制。",
+      "notesTitle": "补充信息",
+      "placeholders": {
+        "apiEndpoint": "例如：https://llm.example.com/v1",
+        "code": "例如：prod-forwarding-channel",
+        "name": "例如：生产转发渠道",
+        "notes": "例如：合同折扣、结算周期、特殊限制",
+        "settlementRatio": "例如：85"
+      },
+      "saveChanges": "保存修改",
+      "settlementHint": "作为该渠道模型的默认采购价规则，单个模型仍可覆盖。",
+      "settlementTitle": "结算规则"
+    },
+    "providerModal": {
+      "basicHint": "用于在模型定价、渠道发布和 Agione 挂售中识别厂商。",
+      "basicTitle": "基础信息",
+      "createProvider": "创建厂商",
+      "createTitle": "新建模型厂商",
+      "description": "模型厂商由系统适配，页面只维护展示名称、价格采集地址和运营备注。",
+      "disabled": "厂商已停用",
+      "editTitle": "编辑模型厂商",
+      "enabled": "厂商已启用",
+      "errors": {
+        "saveFailed": "模型厂商保存失败，请稍后重试。",
+        "sourceSaveFailed": "厂商已保存，但价格源地址保存失败，请重试。"
+      },
+      "fields": {
+        "code": "厂商标识 Code",
+        "name": "厂商显示名称",
+        "notes": "备注",
+        "priceSourceEndpoint": "价格源地址"
+      },
+      "help": {
+        "code": "系统适配标识，已创建厂商不建议修改。",
+        "name": "展示在厂商列表、模型详情和运营总览中的名称。",
+        "priceSourceEndpoint": "可填写厂商官方价格页，或使用 https://models.dev/api.json 作为聚合价格数据源；停用状态请在模型价格源列表中维护。"
+      },
+      "notesHint": "记录价格口径、采集限制或厂商适配说明。",
+      "notesTitle": "运营备注",
+      "placeholders": {
+        "code": "例如：openai",
+        "name": "例如：OpenAI",
+        "notes": "例如：价格页更新频率、特殊模型口径、待补充采集适配",
+        "priceSourceEndpoint": "例如：https://models.dev/api.json"
+      },
+      "priceSourceHint": "只影响该厂商绑定的模型价格源，不修改厂商官网或 API 接入地址。",
+      "priceSourceTitle": "价格采集地址",
+      "saveChanges": "保存修改",
+      "websitePrefix": "厂商官网 / 接入地址：{website}"
+    },
+    "channelPriceMatrixPanel": {
+      "columns": {
+        "coverage": "覆盖",
+        "lowestChannel": "最低价渠道"
+      },
+      "empty": "当前筛选条件下没有模型。",
+      "filters": {
+        "all": "全部状态",
+        "missing": "缺渠道价",
+        "ready": "多渠道覆盖",
+        "single": "单渠道覆盖"
+      },
+      "metrics": {
+        "covered": {
+          "hint": "覆盖率 {percent}%",
+          "label": "有渠道价"
+        },
+        "missing": {
+          "hint": "无法计算采购成本",
+          "label": "缺渠道价"
+        },
+        "single": {
+          "hint": "只有一个采购渠道，缺少备选",
+          "label": "单渠道风险"
+        },
+        "total": {
+          "hint": "参与渠道比价的活跃模型",
+          "label": "模型总数"
+        }
+      },
+      "searchPlaceholder": "搜索模型或厂商",
+      "status": {
+        "missing": "缺渠道价"
+      },
+      "subtitle": "按模型比较各渠道采购价格、最低价命中和覆盖缺口。",
+      "title": "渠道横向比价矩阵"
     },
     "globalConfigPanel": {
       "actions": {
@@ -1262,6 +1924,8 @@
         "vendorsTitle": "暂无元模型厂商"
       },
       "errors": {
+        "loadDetails": "加载元模型明细失败。",
+        "loadOwnerSummary": "加载元模型厂商汇总失败。",
         "sync": "同步元模型失败"
       },
       "features": {
@@ -1404,12 +2068,16 @@
         "added": "已添加",
         "bulkImport": "批量导入",
         "cancel": "取消",
+        "configureModelPrice": "配置模型价格",
         "createSource": "新建价格源",
         "delete": "删除",
+        "deleteSource": "删除价格源",
         "deleting": "删除中",
         "edit": "编辑",
+        "editSource": "编辑价格源",
         "manualPricing": "手工录价",
         "notSupported": "暂不支持",
+        "resetOfficialPrice": "重置官方价格",
         "submitting": "提交中",
         "syncAllPrices": "同步全部价格采集",
         "syncPrice": "同步价格",
@@ -1540,9 +2208,33 @@
       "confirm": {
         "deleteSource": "确认删除模型价格源「{name}」吗？\n\n删除后会移除该价格源及其采集记录，关联模型或渠道会失去这个价格来源。"
       },
+      "officialReset": {
+        "allSources": "全部官方来源",
+        "confirm": "确认清理所选官方价格数据并重新同步？该操作会删除官方价格项、采集快照和历史模型级来源。",
+        "description": "清理历史 seed / 同步写入的官方价格脏数据，并重新同步官方价格。",
+        "emptyPreview": "先预览清理范围，再执行重置。平台会保留手工价格、供货商价格和渠道配置。",
+        "execute": "确认重置并同步",
+        "executing": "重置中...",
+        "legacySources": "将删除的历史模型级来源",
+        "preview": "预览影响",
+        "previewing": "预览中...",
+        "scope": "清理范围",
+        "stats": {
+          "history": "删除历史",
+          "legacySources": "删除历史来源",
+          "modelsReset": "重置模型",
+          "priceItems": "删除价格项",
+          "runs": "删除运行记录",
+          "snapshots": "删除快照",
+          "sourcesKept": "保留真实来源",
+          "sourcesMatched": "匹配来源"
+        },
+        "title": "重置官方价格数据"
+      },
       "messages": {
         "deleted": "模型价格源已删除",
         "officialSourceAdded": "原厂价格源「{name}」已添加",
+        "officialResetSuccess": "官方价格已重置并同步：删除价格项 {priceItems}，重置模型 {models}",
         "syncAllSubmitted": "价格采集任务已提交{taskId}",
         "syncSubmitted": "{name} 同步任务已提交{taskId}",
         "taskId": "（{taskId}）"
@@ -1550,7 +2242,11 @@
       "errors": {
         "addOfficialSourceFailed": "添加原厂价格源失败",
         "deleteFailed": "删除模型价格源失败",
+        "loadManualEntryCatalog": "加载手工录价模型目录失败。",
+        "loadSourceDetail": "加载价格源明细失败。",
         "loadOfficialSourcesFailed": "加载原厂价格源失败",
+        "officialReset": "重置官方价格失败。",
+        "previewOfficialReset": "预览官方价格重置范围失败。",
         "saveFailed": "保存模型价格源失败",
         "syncAllFailed": "提交全部价格源同步任务失败",
         "syncFailed": "提交价格同步任务失败"
@@ -2581,6 +3277,71 @@
         "addChannelCoverage": "增加备选渠道",
         "keep": "保持"
       }
+    },
+    "channel": {
+      "autoBest": "自动最优",
+      "fallback": "渠道",
+      "unnamed": "未命名渠道",
+      "unspecified": "未指定渠道"
+    },
+    "diagnostic": {
+      "status": {
+        "currency_mismatch": "需要汇率",
+        "missing_channel": "缺渠道价",
+        "unlisted": "未挂售",
+        "not_lowest": "非最低价",
+        "low_coverage": "覆盖偏少",
+        "ready": "就绪"
+      }
+    },
+    "listingRisk": {
+      "title": "挂售利润风险榜",
+      "subtitle": "聚合低毛利、非最低采购、未挂售和币种换算风险。",
+      "columns": {
+        "model": "模型",
+        "risk": "风险类型",
+        "inputMargin": "Input 毛利",
+        "outputMargin": "Output 毛利",
+        "channel": "当前渠道",
+        "action": "建议动作"
+      },
+      "filters": {
+        "all": "全部风险"
+      },
+      "risk": {
+        "currency_mismatch": "需要汇率",
+        "missing_channel": "缺渠道价",
+        "unlisted": "未挂售",
+        "not_lowest": "非最低价",
+        "margin": "低毛利"
+      },
+      "actions": {
+        "currency_mismatch": "补充汇率后重新比较采购价",
+        "missing_channel": "先为模型配置至少一个渠道采购价",
+        "unlisted": "进入挂售工作台创建平台上架记录",
+        "not_lowest": "评估切换到最低采购渠道",
+        "margin": "复核售价、服务费率或采购渠道",
+        "fallback": "复核状态"
+      },
+      "metrics": {
+        "total": {
+          "label": "风险总数",
+          "hint": "当前平台可见的挂售和采购风险"
+        },
+        "margin": {
+          "label": "低毛利",
+          "hint": "Input 或 Output 毛利低于 10%"
+        },
+        "notLowest": {
+          "label": "非最低价",
+          "hint": "已挂售但未使用最低采购渠道"
+        },
+        "unlisted": {
+          "label": "未挂售",
+          "hint": "已有供应但未进入当前平台"
+        }
+      },
+      "empty": "当前筛选条件下没有风险项。"
     }
   },
   "sals": {

--- a/frontend/src/pages/LLMOps.vue
+++ b/frontend/src/pages/LLMOps.vue
@@ -45,39 +45,106 @@
           >
             <LLMOpsMonitorDashboard
               v-if="activeSection === 'monitor'"
-              v-model:simulation-channel="simulationChannel"
               v-model:simulation-status="simulationStatus"
-              :action-items="actionItems"
-              :channel-coverage-rows="channelCoverageRows"
-              :current-platform-listing-label="currentPlatformListingLabel"
               :kpi-cards="kpiCards"
               :monitor-model-subtitle="monitorModelSubtitle"
               :monitor-table-rows="monitorTableRows"
-              :money="money"
               :operational-channel-count="operationalChannelCount"
-              :provider-coverage-rows="providerCoverageRows"
-              :simulation-channel-options="simulationChannelOptions"
               :simulation-status-options="simulationStatusOptions"
-              @navigate="setActiveSection"
+              @navigate-to-workspace="onNavigateToWorkspace"
             />
 
-            <AgioneListingStatusBoard
-              v-else-if="activeSection === 'reseller'"
-              :agione-platform="agionePlatform"
-              :providers="providers"
-              :models="models"
-              :price-items="modelPriceItems"
-              :listings="listings"
-              :summary="summary"
-              :platform-count="activeResalePlatforms.length"
-              :point-conversion="pointConversion"
-              :display-currency="summaryDisplayCurrency"
-              :exchange-rate="exchangeRate"
-              @refresh="refreshLight"
-              @listings-updated="mergeResaleListings"
-              @action="openListingActionDrawer"
-              @open-workspace="openResalePublishingWorkspace"
-            />
+            <template v-else-if="activeSection === 'reseller'">
+              <section
+                v-if="resaleWorkspaceFocusModelId"
+                class="panel overflow-hidden p-0"
+              >
+                <header
+                  class="flex flex-wrap items-center justify-between gap-3 border-b border-slate-200 bg-white px-5 py-4"
+                >
+                  <div class="min-w-0">
+                    <p
+                      class="text-[11px] font-bold uppercase tracking-[0.18em] text-agione-600"
+                    >
+                      Model Publishing Workspace
+                    </p>
+                    <h2 class="mt-0.5 text-base font-bold text-slate-900">
+                      {{ t('llmOps.publishingDrawer.title') }}
+                    </h2>
+                  </div>
+                  <div class="flex items-center gap-2">
+                    <button
+                      type="button"
+                      class="btn-secondary"
+                      @click="closeInlineWorkspace"
+                    >
+                      {{ t('llmOps.publishingDrawer.back') }}
+                    </button>
+                    <button
+                      type="button"
+                      class="btn-secondary btn-action-save"
+                      :disabled="!inlineCanDraft || inlineSaving"
+                      @click="handleInlineSaveDraft"
+                    >
+                      {{ t('llmOps.publishingDrawer.saveDraft') }}
+                    </button>
+                    <button
+                      type="button"
+                      class="btn-primary btn-action-submit"
+                      :disabled="!inlineCanPublish || inlineSaving"
+                      @click="handleInlinePublish"
+                    >
+                      {{
+                        inlineSaving
+                          ? t('llmOps.publishingDrawer.submitting')
+                          : t('llmOps.publishingDrawer.submit')
+                      }}
+                    </button>
+                  </div>
+                </header>
+                <div class="px-5 py-5">
+                  <ResalePublishingWorkspace
+                    :key="inlineWorkspaceKey"
+                    ref="inlineWorkspaceRef"
+                    :initial-model-id="resaleWorkspaceFocusModelId"
+                    :initial-auto-listing="resaleWorkspaceFocusAutoListing"
+                    :agione-platform="agionePlatform"
+                    :platforms="activeResalePlatforms"
+                    :providers="providers"
+                    :meta-models="metaModels"
+                    :models="models"
+                    :channels="channels"
+                    :procurement-rows="procurementRows"
+                    :price-items="modelPriceItems"
+                    :channel-price-items="channelPriceItems"
+                    :listings="listings"
+                    :point-conversion="pointConversion"
+                    :display-currency="summaryDisplayCurrency"
+                    :exchange-rate="exchangeRate"
+                    :workflow-config="workflowConfigForWorkspace"
+                    @change="onInlineWorkspaceChange"
+                  />
+                </div>
+              </section>
+
+              <AgioneListingStatusBoard
+                :agione-platform="agionePlatform"
+                :providers="providers"
+                :models="models"
+                :price-items="modelPriceItems"
+                :listings="listings"
+                :summary="summary"
+                :platform-count="activeResalePlatforms.length"
+                :point-conversion="pointConversion"
+                :display-currency="summaryDisplayCurrency"
+                :exchange-rate="exchangeRate"
+                :focus-model-id="resaleWorkspaceFocusModelId"
+                @refresh="refreshLight"
+                @listings-updated="mergeResaleListings"
+                @action="openListingActionDrawer"
+                @open-workspace="openResalePublishingWorkspace"
+              />
+            </template>
 
             <CollectionHealthPanel
               v-else-if="activeSection === 'collectionHealth'"
@@ -223,7 +290,8 @@ import '@/components/llm-ops/llmOpsSelects.css'
 import '@/components/llm-ops/llmOpsTables.css'
 import '@/components/llm-ops/llmOpsShell.css'
 
-import { onBeforeUnmount, onMounted, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import AppLayout from '@/components/layout/AppLayout.vue'
 import BaseLoading from '@/components/ui/BaseLoading.vue'
@@ -245,6 +313,7 @@ import ProviderManagement from '@/components/llm-ops/ProviderManagement.vue'
 import ReconciliationPanel from '@/components/llm-ops/ReconciliationPanel.vue'
 import ResalePlatformModal from '@/components/llm-ops/ResalePlatformModal.vue'
 import ResalePublishingDrawer from '@/components/llm-ops/ResalePublishingDrawer.vue'
+import ResalePublishingWorkspace from '@/components/llm-ops/ResalePublishingWorkspace.vue'
 import ResaleWorkflowConfigPanel from '@/components/llm-ops/ResaleWorkflowConfigPanel.vue'
 import { useToast } from '@/composables/useToast'
 import { useLLMOpsData } from '@/composables/useLLMOpsData'
@@ -259,6 +328,7 @@ import { useLLMOpsResalePublishing } from '@/composables/useLLMOpsResalePublishi
 import { errorMessage } from '@/utils/llmOpsPagination'
 
 const { showError } = useToast()
+const { t } = useI18n()
 
 const {
   activeNav,
@@ -266,7 +336,6 @@ const {
   expandedNavGroupKeys,
   navGroups,
   selectNavItem,
-  setActiveSection,
   sidebarCollapsed,
   sidebarToggleLabel,
   toggleNavGroup,
@@ -357,29 +426,93 @@ const {
 })
 
 const {
-  actionItems,
-  channelCoverageRows,
-  currentPlatformListingLabel,
   kpiCards,
   monitorModelSubtitle,
   monitorTableRows,
-  money,
   operationalChannelCount,
-  providerCoverageRows,
-  simulationChannel,
-  simulationChannelOptions,
   simulationStatus,
   simulationStatusOptions
 } = useLLMOpsMonitor({
-  agionePlatform,
   channels,
-  collectionRuns,
-  listings,
-  models,
   procurementRows,
-  providerCollectionSources,
   summary
 })
+
+const resaleWorkspaceFocusModelId = ref(null)
+const resaleWorkspaceFocusAutoListing = ref(false)
+const inlineWorkspacePayload = ref(null)
+const inlineWorkspaceRef = ref(null)
+const inlineSaving = ref(false)
+const inlineWorkspaceKey = computed(
+  () => `inline-${resaleWorkspaceFocusModelId.value || 'new'}`
+)
+
+const inlineCanPublish = computed(() => {
+  if (!inlineWorkspacePayload.value) return false
+  const { hasChanges, listings, platformId, modelId } =
+    inlineWorkspacePayload.value
+  if (!platformId || !modelId || !hasChanges || !listings.length) return false
+  const changedListings = listings.filter((item) => item.hasChanges !== false)
+  if (!changedListings.length) return false
+  return changedListings.every(
+    (listing) =>
+      !listing.priceBelowReference &&
+      Number.isFinite(Number(listing.priceIn)) &&
+      Number.isFinite(Number(listing.priceOut)) &&
+      Number(listing.priceIn) > 0 &&
+      Number(listing.priceOut) > 0
+  )
+})
+
+const inlineCanDraft = computed(() => {
+  return Boolean(
+    inlineWorkspacePayload.value?.platformId &&
+      inlineWorkspacePayload.value?.listings?.length &&
+      inlineWorkspacePayload.value?.hasChanges
+  )
+})
+
+function onNavigateToWorkspace(payload) {
+  const modelId =
+    payload && typeof payload === 'object' ? payload.modelId : payload
+  resaleWorkspaceFocusModelId.value = modelId || null
+  resaleWorkspaceFocusAutoListing.value = Boolean(payload?.autoListing)
+  activeSection.value = 'reseller'
+}
+
+function onInlineWorkspaceChange(payload) {
+  inlineWorkspacePayload.value = payload
+}
+
+function closeInlineWorkspace() {
+  resaleWorkspaceFocusModelId.value = null
+  resaleWorkspaceFocusAutoListing.value = false
+  inlineWorkspacePayload.value = null
+}
+
+async function handleInlineSaveDraft() {
+  if (!inlineCanDraft.value || inlineSaving.value) return
+  inlineSaving.value = true
+  try {
+    const saved = await handleResaleWorkspaceDraft(inlineWorkspacePayload.value)
+    if (saved) closeInlineWorkspace()
+  } finally {
+    inlineSaving.value = false
+  }
+}
+
+async function handleInlinePublish() {
+  if (!inlineCanPublish.value || inlineSaving.value) return
+  inlineSaving.value = true
+  try {
+    const saved = await handleResaleWorkspacePublished(
+      inlineWorkspacePayload.value
+    )
+    if (saved) closeInlineWorkspace()
+  } finally {
+    inlineSaving.value = false
+  }
+}
 
 function handleRefreshAll() {
   refreshAll(activeSection.value)
@@ -393,7 +526,11 @@ watch(displayCurrency, (currency) => {
   }
   localStorage.setItem('llm_ops_display_currency', normalized)
   if (!loading.value) {
-    refreshLight()
+    if (activeSection.value === 'monitor') {
+      refreshSummary()
+    } else {
+      refreshLight()
+    }
   }
 })
 

--- a/frontend/src/pages/LLMOps.vue
+++ b/frontend/src/pages/LLMOps.vue
@@ -366,6 +366,7 @@ const {
   providers,
   records,
   refreshAll,
+  refreshChannelPricingData,
   refreshChannelManagementData,
   refreshCollectionRuns,
   refreshCoreData,
@@ -415,6 +416,7 @@ const {
   models,
   normalizeDisplayCurrency,
   preloadResalePublishingData,
+  refreshChannelPricingData,
   refreshLight,
   refreshPlatformData,
   refreshProviderManagementData,
@@ -527,7 +529,7 @@ watch(displayCurrency, (currency) => {
   localStorage.setItem('llm_ops_display_currency', normalized)
   if (!loading.value) {
     if (activeSection.value === 'monitor') {
-      refreshSummary()
+      refreshSummary('monitor')
     } else {
       refreshLight()
     }
@@ -542,7 +544,7 @@ watch(activeSection, (section) => {
     !loading.value
   ) {
     refreshSectionData(section).catch((error) => {
-      showError(errorMessage(error, '加载当前页面数据失败。'))
+      showError(errorMessage(error, t('llmOps.dataErrors.loadSection')))
     })
   }
   if (
@@ -551,7 +553,7 @@ watch(activeSection, (section) => {
     !loading.value
   ) {
     refreshCoreData(section).catch((error) => {
-      showError(errorMessage(error, '加载基础模型数据失败。'))
+      showError(errorMessage(error, t('llmOps.dataErrors.loadCoreModels')))
     })
   }
 })

--- a/frontend/src/utils/llmOpsPriceSources.js
+++ b/frontend/src/utils/llmOpsPriceSources.js
@@ -1,9 +1,9 @@
 const DEFAULT_CATEGORY_LABELS = {
-  official_provider: '原厂',
-  cloud_hosted: '云托管',
-  supplier: '供货商',
-  manual: '内部维护',
-  unknown: '其他'
+  official_provider: 'Official',
+  cloud_hosted: 'Cloud hosted',
+  supplier: 'Supplier',
+  manual: 'Internal',
+  unknown: 'Other'
 }
 
 const CATEGORY_TONES = {
@@ -23,19 +23,19 @@ const CATEGORY_RANKS = {
 }
 
 const OWNER_TYPE_LABELS = {
-  model_provider_official: '模型厂商官方',
-  cloud_provider_official: '云厂商官方',
-  supplier: '供应商',
-  internal: '内部维护',
-  unknown: '未知'
+  model_provider_official: 'Model provider official',
+  cloud_provider_official: 'Cloud provider official',
+  supplier: 'Supplier',
+  internal: 'Internal',
+  unknown: 'Unknown'
 }
 
 const COLLECTION_METHOD_LABELS = {
-  auto_collect: '自动采集',
-  api_sync: '接口同步',
-  manual_entry: '手动录入',
-  manual_import: '手动导入',
-  unknown: '待配置'
+  auto_collect: 'Auto collect',
+  api_sync: 'API sync',
+  manual_entry: 'Manual entry',
+  manual_import: 'Manual import',
+  unknown: 'Pending config'
 }
 
 const COLLECTION_GROUP_RANKS = {


### PR DESCRIPTION
## Summary

- Add nullable per-platform tax, settlement, warning-yield, and target-yield configuration with validation and migration support.
- Centralize recommended channel, listing, yield, decision, and anomaly fields in the LLM Ops summary API.
- Keep derived channel prices synchronized after upstream official, manual-import, and API price changes.
- Reduce operational-page query and payload cost with scoped summaries, filtered/paged lists, annotated source counts, and supporting database indexes.
- Simplify the overview into four operational KPIs and a model resale decision table that opens the scoped publishing workspace.
- Complete bilingual operator copy and state handling across channel, provider, model, collection, pricing, risk, and resale workflows.

Closes #137

## Test plan

- [x] `.venv/bin/pytest backend/llm_ops/tests/test_services.py backend/llm_ops/tests/test_views.py -q` (129 passed)
- [x] ESLint on all changed Vue and JavaScript files
- [x] `npm run build`
- [x] `.venv/bin/python backend/manage.py makemigrations --check --dry-run llm_ops`
- [x] `git diff --check`
- [ ] `.venv/bin/pytest backend/llm_ops/tests -q` (340 passed, 3 failed: unbound meta-model expectation, explicit non-auto source filtering, and Yunce base-model reuse)

Made with [Orca](https://github.com/stablyai/orca) 🐋
