### PR TITLE
Fix LiteLLM function-tool FastAPI import failure

### DIFF
--- a/backend/tests/test_dependency_constraints.py
+++ b/backend/tests/test_dependency_constraints.py
@@ -1,0 +1,22 @@
+from importlib import import_module
+from importlib.metadata import requires
+
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+
+def test_litellm_excludes_fastapi_import_regression():
+    """Require the LiteLLM release that avoids importing FastAPI for tools."""
+    project_requirements = {
+        requirement.name: requirement
+        for value in requires("backend") or []
+        if (requirement := Requirement(value)).marker is None
+    }
+
+    litellm = project_requirements.get("litellm")
+
+    assert litellm is not None
+    assert Version("1.91.3") in litellm.specifier
+    assert Version("1.89.4") not in litellm.specifier
+
+    import_module("litellm.responses.mcp.chat_completions_handler")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "cryptography>=44.0.0",
     "pydantic>=2.7.0",
     "langchain-openai>=1.0.0,<2.0.0",
+    "litellm==1.91.3",
     "deepagents==0.4.9",
     "langfuse>=4.0.0,<5.0.0",
     "jira>=3.10.0",


### PR DESCRIPTION
### **User description**
## Summary
- pin LiteLLM to 1.91.3, whose function-tool path no longer imports the optional FastAPI proxy stack
- guard the package constraint and the previously failing MCP/tool import boundary with a regression test
- address Sentry TOWER-48 without adding FastAPI or changing Data Ops business logic

Sentry: https://sentry.oneprocloud.com/organizations/sentry/issues/1088/

## Test plan
- [x] `uv pip compile pyproject.toml --python-version 3.12 --no-cache --quiet` resolves `litellm==1.91.3`
- [x] TOWER-48 regression test: 1 passed
- [x] Data Ops non-database AI context tests: 11 passed
- [x] agentcore-metering tracker tests: 19 passed
- [x] `ruff check backend/tests/test_dependency_constraints.py`
- [x] `mypy backend/tests/test_dependency_constraints.py`

## Known repository baseline
- Full pytest collection currently fails because separately packaged agentcore submodules expose duplicate top-level `tests.conftest` modules; SQLite database tests also hit the pre-existing HyperBDR 0002 migration ordering error.
- Full `ruff check backend` reports 153 pre-existing findings outside this two-file change.
- Full `mypy backend` stops on the same duplicate agentcore `tests` module names.

No deployment, Sentry resolution, or Jira transition is included. Those remain gated on production verification.

Made with [Orca](https://github.com/stablyai/orca) 🐋


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- 将 LiteLLM 锁定至 1.91.3，避免可选 FastAPI 代理栈的导入失败

- 添加回归测试，验证依赖版本约束及关键导入路径

- 无需改动业务逻辑


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>固定 LiteLLM 版本依赖</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

<ul><li>在 <code>dependencies</code> 段新增 <code>"litellm==1.91.3"</code> 显式约束<br> <li> 确保 Data Ops 使用的 LiteLLM 版本不导入 FastAPI 代理代码</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/devmind/pull/161/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_dependency_constraints.py</strong><dd><code>添加 LiteLLM 回归测试</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/tests/test_dependency_constraints.py

<ul><li>新建回归测试 <code>test_litellm_excludes_fastapi_import_regression</code><br> <li> 从 <code>requires("backend")</code> 解析项目依赖并断言 LiteLLM 版本符合 1.91.3<br> <li> 动态导入 <code>litellm.responses.mcp.chat_completions_handler</code> 确保路径可用</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/devmind/pull/161/files#diff-1e1976e0f33b5b18ff6a2b163f229f4df80c413b84ca401312d8dafffaeb9b7a">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

