### PR TITLE
Suppress Celery Beat PostgreSQL refusal noise

### DIFF
--- a/backend/core/sentry.py
+++ b/backend/core/sentry.py
@@ -7,6 +7,10 @@ POSTGRES_DNS_ERROR = (
     'could not translate host name "postgresql" to address: '
     "Temporary failure in name resolution"
 )
+POSTGRES_CONNECTION_REFUSED_PARTS = (
+    'connection to server at "postgresql"',
+    "port 5432 failed: Connection refused",
+)
 CELERY_BEAT_LOGGER = "django_celery_beat.schedulers"
 CELERY_CONSUMER_LOGGER = "celery.worker.consumer.consumer"
 REDIS_BROKER_RECONNECT_PREFIX = "consumer: Cannot connect to redis://"
@@ -17,14 +21,14 @@ def before_send(event, hint):
     """
     Drop expected transient infrastructure logs before sending to Sentry.
     """
-    if _is_celery_beat_postgres_dns_error(event):
+    if _is_celery_beat_postgres_connection_error(event):
         return None
     if _is_celery_redis_broker_reconnect_log(event):
         return None
     return event
 
 
-def _is_celery_beat_postgres_dns_error(event):
+def _is_celery_beat_postgres_connection_error(event):
     if event.get("logger") != CELERY_BEAT_LOGGER:
         return False
 
@@ -47,13 +51,20 @@ def _exception_matches(event):
     for value in values:
         if value.get("type") != "OperationalError":
             continue
-        if POSTGRES_DNS_ERROR in str(value.get("value", "")):
+        if _postgres_connection_error_matches(value.get("value", "")):
             return True
     return False
 
 
 def _logentry_matches(event):
-    return POSTGRES_DNS_ERROR in _logentry_message(event)
+    return _postgres_connection_error_matches(_logentry_message(event))
+
+
+def _postgres_connection_error_matches(message):
+    message = str(message)
+    return POSTGRES_DNS_ERROR in message or all(
+        part in message for part in POSTGRES_CONNECTION_REFUSED_PARTS
+    )
 
 
 def _logentry_message(event):

--- a/backend/tests/test_sentry.py
+++ b/backend/tests/test_sentry.py
@@ -35,6 +35,26 @@ def test_before_send_drops_celery_beat_postgres_dns_errors():
     assert core_sentry.before_send(event, {}) is None
 
 
+def test_before_send_drops_celery_beat_postgres_connection_refused():
+    event = {
+        "logger": "django_celery_beat.schedulers",
+        "exception": {
+            "values": [
+                {
+                    "type": "OperationalError",
+                    "value": (
+                        'connection to server at "postgresql" '
+                        "(172.18.0.4), port 5432 failed: "
+                        "Connection refused\n"
+                    ),
+                }
+            ]
+        },
+    }
+
+    assert core_sentry.before_send(event, {}) is None
+
+
 def test_before_send_drops_celery_redis_broker_reconnect_logs():
     event = {
         "logger": "celery.worker.consumer.consumer",


### PR DESCRIPTION
### **User description**
## Summary
- suppress handled Celery Beat PostgreSQL `Connection refused` events for Sentry TOWER-K
- require the Celery Beat logger, `OperationalError`, PostgreSQL service name, port 5432, and refusal signature
- preserve other loggers and other database failures such as timeouts
- add a regression test reproduced RED before the fix and GREEN afterward

## Root cause
`django_celery_beat.schedulers` catches database connectivity failures and continues, but its exception log is collected by Sentry. The existing filter covered PostgreSQL DNS failures for TOWER-K but not the connection-refused signature seen in release 1.11.0.

## Test plan
- [x] `.venv/bin/pytest backend/tests/test_sentry.py -q` (6 passed)
- [x] `.venv/bin/ruff check backend/core/sentry.py backend/tests/test_sentry.py`
- [x] `MYPYPATH=backend .venv/bin/mypy --explicit-package-bases --follow-imports=skip --ignore-missing-imports backend/core/sentry.py backend/tests/test_sentry.py`
- [x] `git diff --check`

## Repository baseline
- Full pytest collection is blocked by three pre-existing HyperBDR/SALS import and model-registration errors.
- Full ruff reports 139 pre-existing errors outside these files.
- Full mypy is blocked by duplicate top-level `tools` modules in existing skill scripts.

## Operations gate
- No deployment is included or authorized by this PR.
- After production validation confirms the event no longer recurs, resolve Sentry TOWER-K and close the associated Jira task if one is identified.

Made with [Orca](https://github.com/stablyai/orca) 🐋


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- 扩展 Sentry before_send 过滤器，抑制 Celery Beat PostgreSQL 连接被拒绝错误

- 重构异常匹配逻辑，统一处理 DNS 错误与连接被拒绝

- 添加回归测试，验证新的匹配规则


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Event["Sentry 事件"] --> Check["before_send 过滤器"]
  Check -->|"logger 为 django_celery_beat.schedulers"| Match["匹配连接错误?"]
  Match -->|"DNS 错误或连接被拒绝"| Drop["丢弃事件 (return None)"]
  Match -->|"其他"| Pass["放行"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sentry.py</strong><dd><code>扩展 Sentry 过滤器，纳入连接被拒绝错误</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/core/sentry.py

<ul><li>新增 <code>POSTGRES_CONNECTION_REFUSED_PARTS</code> 常量，定义连接被拒绝的片段<br> <li> 将 <code>_is_celery_beat_postgres_dns_error</code> 重命名为 <br><code>_is_celery_beat_postgres_connection_error</code><br> <li> 新增 <code>_postgres_connection_error_matches</code> 函数，同时检测 DNS 错误与连接被拒绝<br> <li> 修改 <code>_exception_matches</code> 和 <code>_logentry_matches</code>，使用新函数<br> <li> 更新 <code>before_send</code> 调用为新函数名</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/devmind/pull/165/files#diff-b2a0a239caa82f2cef65998664fd2aebe04182acd06c8a60a7e8e2a9efd015b9">+15/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_sentry.py</strong><dd><code>添加 PostgreSQL 连接被拒绝回归测试</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/tests/test_sentry.py

<ul><li>新增测试用例 <code>test_before_send_drops_celery_beat_postgres_connection_refused</code><br> <li> 构造包含 <code>connection refused</code> 异常的事件，验证被 <code>before_send</code> 丢弃</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/devmind/pull/165/files#diff-6638fffcea0fe14f977adefd36f51ac9eb6d3087e134ea52b0b682aaabf2a97e">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

