### PR TITLE
Fix duplicate billing from shadow default accounts

### DIFF
--- a/backend/cloud_billing/dashboard.py
+++ b/backend/cloud_billing/dashboard.py
@@ -18,7 +18,11 @@ from django.db.models import Prefetch
 from django.utils import timezone
 from django.utils.translation import gettext as _
 
-from .models import BillingData, CloudProvider
+from .models import (
+    BillingData,
+    CloudProvider,
+    exclude_shadow_default_accounts,
+)
 from .serializers import get_balance_support_info
 
 LLM_PROVIDER_TYPES = {'deepseek', 'yunce', 'zhipu'}
@@ -211,9 +215,11 @@ def _recent_collected_days_from_snapshots(account_rows, now, local_tz) -> int:
 def _daily_rows_for_current_month(local_tz):
     now = timezone.now().astimezone(local_tz)
     month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
-    rows = BillingData.objects.select_related('provider').filter(
-        provider__is_active=True,
-        collected_at__gte=month_start.astimezone(dt_timezone.utc),
+    rows = exclude_shadow_default_accounts(
+        BillingData.objects.select_related('provider').filter(
+            provider__is_active=True,
+            collected_at__gte=month_start.astimezone(dt_timezone.utc),
+        )
     ).order_by('provider_id', 'account_id', 'day', 'hour', 'collected_at')
     return now, month_start, list(rows)
 
@@ -228,9 +234,11 @@ def _billing_rows_for_current_year(local_tz):
         second=0,
         microsecond=0,
     )
-    rows = BillingData.objects.select_related('provider').filter(
-        provider__is_active=True,
-        collected_at__gte=year_start.astimezone(dt_timezone.utc),
+    rows = exclude_shadow_default_accounts(
+        BillingData.objects.select_related('provider').filter(
+            provider__is_active=True,
+            collected_at__gte=year_start.astimezone(dt_timezone.utc),
+        )
     ).order_by('provider_id', 'account_id', 'day', 'hour', 'collected_at')
     return now, year_start, list(rows)
 
@@ -243,9 +251,11 @@ def _billing_rows_for_recent_days(local_tz, days: int = 30):
         second=0,
         microsecond=0,
     )
-    rows = BillingData.objects.select_related('provider').filter(
-        provider__is_active=True,
-        collected_at__gte=window_start.astimezone(dt_timezone.utc),
+    rows = exclude_shadow_default_accounts(
+        BillingData.objects.select_related('provider').filter(
+            provider__is_active=True,
+            collected_at__gte=window_start.astimezone(dt_timezone.utc),
+        )
     ).order_by('provider_id', 'account_id', 'day', 'hour', 'collected_at')
     return now, window_start, list(rows)
 
@@ -255,7 +265,9 @@ def _latest_billings():
         'display_name',
         'id',
     )
-    billings = BillingData.objects.select_related('provider').order_by(
+    billings = exclude_shadow_default_accounts(
+        BillingData.objects.select_related('provider')
+    ).order_by(
         'provider_id',
         'account_id',
         '-day',

--- a/backend/cloud_billing/models.py
+++ b/backend/cloud_billing/models.py
@@ -247,6 +247,21 @@ class BillingData(models.Model):
         )
 
 
+def exclude_shadow_default_accounts(
+    queryset: models.QuerySet,
+) -> models.QuerySet:
+    """Exclude blank account rows once a provider has a real account ID."""
+    identified_accounts = BillingData.objects.filter(
+        provider_id=models.OuterRef("provider_id")
+    ).exclude(account_id="")
+    return queryset.annotate(
+        has_identified_account=models.Exists(identified_accounts)
+    ).exclude(
+        account_id="",
+        has_identified_account=True,
+    )
+
+
 class AlertRule(models.Model):
     """
     Alert rule model for billing cost monitoring.

--- a/backend/cloud_billing/tests/test_dashboard.py
+++ b/backend/cloud_billing/tests/test_dashboard.py
@@ -1,11 +1,10 @@
-from unittest.mock import Mock, patch
-
-from django.test import SimpleTestCase
-
-from decimal import Decimal
 from datetime import datetime, timezone as dt_timezone
+from decimal import Decimal
 from types import SimpleNamespace
+from unittest.mock import Mock, patch
 from zoneinfo import ZoneInfo
+
+from django.test import SimpleTestCase, TestCase
 
 from cloud_billing.dashboard import (
     LLM_PROVIDER_TYPES,
@@ -14,10 +13,57 @@ from cloud_billing.dashboard import (
     _build_currency_breakdown,
     _build_exchange_rate_info,
     _build_financial_health,
+    _latest_billings,
     _recent_spend_from_snapshots,
     _payment_type_for_provider,
     _build_trend_ranges,
 )
+from cloud_billing.models import BillingData, CloudProvider
+
+
+class LatestBillingsTests(TestCase):
+    def setUp(self):
+        self.provider = CloudProvider.objects.create(
+            name='baidu-test',
+            provider_type='baidu',
+            display_name='Baidu Test',
+            config={},
+        )
+
+    def test_excludes_blank_account_when_provider_has_identified_account(self):
+        BillingData.objects.create(
+            provider=self.provider,
+            period='2026-07',
+            day=datetime(2026, 7, 20).date(),
+            hour=9,
+            total_cost=Decimal('200.00'),
+            currency='CNY',
+            account_id='',
+        )
+        identified = BillingData.objects.create(
+            provider=self.provider,
+            period='2026-07',
+            day=datetime(2026, 7, 20).date(),
+            hour=8,
+            total_cost=Decimal('100.00'),
+            currency='CNY',
+            account_id='967',
+        )
+
+        self.assertEqual(_latest_billings(), [identified])
+
+    def test_keeps_blank_account_when_provider_has_no_identified_account(self):
+        default_account = BillingData.objects.create(
+            provider=self.provider,
+            period='2026-07',
+            day=datetime(2026, 7, 20).date(),
+            hour=9,
+            total_cost=Decimal('200.00'),
+            currency='CNY',
+            account_id='',
+        )
+
+        self.assertEqual(_latest_billings(), [default_account])
 
 
 class ExchangeRateInfoTests(SimpleTestCase):

--- a/backend/cloud_billing/tests/test_views.py
+++ b/backend/cloud_billing/tests/test_views.py
@@ -555,6 +555,39 @@ class TestBillingDataViewSet:
         assert response.data["average_cost"] == 102.5
         assert response.data["cost_by_period"] == {"2026-04": 205.0}
 
+    def test_stats_excludes_shadow_default_account(
+        self, api_client, cloud_provider
+    ):
+        BillingData.objects.create(
+            provider=cloud_provider,
+            period="2026-07",
+            day=datetime(2026, 7, 20).date(),
+            hour=9,
+            total_cost=Decimal("200.00"),
+            currency="CNY",
+            account_id="",
+        )
+        BillingData.objects.create(
+            provider=cloud_provider,
+            period="2026-07",
+            day=datetime(2026, 7, 20).date(),
+            hour=8,
+            total_cost=Decimal("100.00"),
+            currency="CNY",
+            account_id="967",
+        )
+
+        response = api_client.get(
+            "/api/v1/cloud-billing/billing-data/stats/"
+            "?start_period=2026-07&end_period=2026-07"
+        )
+
+        assert response.status_code == 200
+        assert response.data["total_cost"] == 100.0
+        assert list(response.data["by_provider"]) == [
+            f"{cloud_provider.id}_967"
+        ]
+
     def test_list_filters_by_search(self, api_client, cloud_provider):
         """
         Billing list should support backend search by provider name and account.
@@ -656,6 +689,38 @@ class TestBillingDataViewSet:
             },
         ]
 
+    def test_daily_series_excludes_shadow_default_account(
+        self, api_client, cloud_provider
+    ):
+        BillingData.objects.create(
+            provider=cloud_provider,
+            period="2026-07",
+            day=datetime(2026, 7, 20).date(),
+            hour=9,
+            total_cost=Decimal("200.00"),
+            currency="CNY",
+            account_id="",
+        )
+        BillingData.objects.create(
+            provider=cloud_provider,
+            period="2026-07",
+            day=datetime(2026, 7, 20).date(),
+            hour=8,
+            total_cost=Decimal("100.00"),
+            currency="CNY",
+            account_id="967",
+        )
+
+        response = api_client.get(
+            "/api/v1/cloud-billing/billing-data/daily-series/"
+            "?start_date=2026-07-20&end_date=2026-07-20"
+        )
+
+        assert response.status_code == 200
+        assert [
+            item["account_id"] for item in response.data["results"]
+        ] == ["967"]
+
     def test_list_serializer_includes_change_from_last_hour_from_db(
         self, cloud_provider
     ):
@@ -736,6 +801,37 @@ class TestBillingDataViewSet:
             item["account_id"] == "acct-1" and item["hour"] == 18
             for item in response.data
         )
+
+    def test_latest_by_provider_account_excludes_shadow_default_account(
+        self, api_client, cloud_provider
+    ):
+        BillingData.objects.create(
+            provider=cloud_provider,
+            period="2026-07",
+            day=datetime(2026, 7, 20).date(),
+            hour=9,
+            total_cost=Decimal("200.00"),
+            currency="CNY",
+            account_id="",
+        )
+        BillingData.objects.create(
+            provider=cloud_provider,
+            period="2026-07",
+            day=datetime(2026, 7, 20).date(),
+            hour=8,
+            total_cost=Decimal("100.00"),
+            currency="CNY",
+            account_id="967",
+        )
+
+        response = api_client.get(
+            "/api/v1/cloud-billing/billing-data/"
+            "latest-by-provider-account/?provider_id="
+            f"{cloud_provider.id}"
+        )
+
+        assert response.status_code == 200
+        assert [item["account_id"] for item in response.data] == ["967"]
 
     def test_list_excludes_inactive_provider_data(
         self, api_client, cloud_provider_inactive

--- a/backend/cloud_billing/views/billing.py
+++ b/backend/cloud_billing/views/billing.py
@@ -12,7 +12,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from ..dashboard import CNY_RATE, _build_exchange_rate_info, build_dashboard_overview
-from ..models import BillingData
+from ..models import BillingData, exclude_shadow_default_accounts
 from ..serializers import (
     BillingDataListSerializer,
     BillingDataSerializer,
@@ -143,6 +143,7 @@ class BillingDataViewSet(viewsets.ReadOnlyModelViewSet):
         if end_period:
             queryset = queryset.filter(period__lte=end_period)
 
+        queryset = exclude_shadow_default_accounts(queryset)
         latest_billings_queryset = self._latest_per_period_queryset(queryset)
         latest_billings = list(
             latest_billings_queryset.select_related('provider').order_by(
@@ -326,9 +327,9 @@ class BillingDataViewSet(viewsets.ReadOnlyModelViewSet):
         """
         Return the latest billing record for each provider/account/day.
         """
-        queryset = self._latest_per_day_queryset(self.get_queryset()).order_by(
-            'day', 'provider__display_name', 'account_id'
-        )
+        queryset = self._latest_per_day_queryset(
+            exclude_shadow_default_accounts(self.get_queryset())
+        ).order_by('day', 'provider__display_name', 'account_id')
         results = [
             {
                 'provider_id': billing.provider_id,
@@ -382,6 +383,8 @@ class BillingDataViewSet(viewsets.ReadOnlyModelViewSet):
             end_day = parse_date(end_date)
             if end_day:
                 queryset = queryset.filter(day__lte=end_day)
+
+        queryset = exclude_shadow_default_accounts(queryset)
 
         # Get the latest billing record for each provider + account_id
         # combination using subquery


### PR DESCRIPTION
### **User description**
## Summary

- Exclude blank-account snapshots from grouped billing results once the provider has reported a real account ID.
- Apply the shared filter to dashboard overview, statistics, daily series, and latest-by-provider/account queries.
- Preserve raw billing history and keep the default account when no real account ID has ever been observed.
- Add regression coverage for mixed real/default accounts and default-only providers.

Closes #166

## Test plan

- [x] `.venv/bin/pytest --nomigrations` for the 5 new regression tests: 5 passed.
- [x] `git diff --check origin/main...HEAD`.
- [x] Python `compileall` for all 5 changed files.
- [ ] Full affected test files with migrations: blocked during test database setup by the pre-existing `NewHost.data_source` migration constraint mismatch; 21 non-database tests passed before the shared setup errors.

Made with [Orca](https://github.com/stablyai/orca) 🐋


___

### **PR Type**
Bug fix


___

### **Description**
- 排除影子默认账号（空 account_id）导致的重复统计

- 在概览、统计、日序列和最新账单接口中应用统一过滤器

- 新增模型层函数 `exclude_shadow_default_accounts`，基于子查询判断

- 补充 5 个回归测试覆盖混合账号与仅默认账号场景


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Q["BillingData queryset"] --> F["exclude_shadow_default_accounts()"]
  F --> SUB["Subquery: 同一 provider 是否存在非空 account_id"]
  SUB -- "存在真实账号" --> EXCLUDE["排除 account_id='' 的记录"]
  SUB -- "不存在真实账号" --> KEEP["保留空账号记录"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dashboard.py</strong><dd><code>在所有概览查询入口添加影子账号过滤</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/cloud_billing/dashboard.py

<ul><li>在 <br><code>_daily_rows_for_current_month</code>、<code>_billing_rows_for_current_year</code>、<code>_billing_rows_for_recent_days</code>、<code>_latest_billings</code> <br>四个聚合入口中应用 <code>exclude_shadow_default_accounts</code> 过滤<br> <li> 确保月度/年度/近期趋势/最新账单不再包含影子默认账号</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/devmind/pull/167/files#diff-15a792fb3307f3eab743bcb53fbf1429605cfb7db132335c038dad2b52ee8f1c">+23/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>models.py</strong><dd><code>新增模型层过滤函数排除影子默认账号</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/cloud_billing/models.py

<ul><li>新增 <code>exclude_shadow_default_accounts</code> 函数，通过 <code>OuterRef</code> 子查询判断 provider <br>是否已有非空账号<br> <li> 若存在真实账号则排除 <code>account_id=''</code> 的记录，否则保留</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/devmind/pull/167/files#diff-4aef97ced61dcf6e87a843855b42bc076f46ec04e4876e0051e01b9be8fbd0ff">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>billing.py</strong><dd><code>在统计、日序列、最新账单接口中应用过滤</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/cloud_billing/views/billing.py

<ul><li>导入 <code>exclude_shadow_default_accounts</code> 并应用到 <br><code>stats</code>、<code>daily_series</code>、<code>latest_by_provider_account</code> 三个 action 的 queryset 上<br> <li> 保持其他接口（如列表、创建）不变</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/devmind/pull/167/files#diff-3a5786a8994ca9b2b08f3e17a8d9c21d5983fb233e9ae174a7b3ffd19a5a5708">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_dashboard.py</strong><dd><code>为最新账单视图添加影子账号回归测试</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/cloud_billing/tests/test_dashboard.py

- 新增 `LatestBillingsTests` 类，包含两个测试用例
- 验证混合账号时排除空账号、仅默认账号时保留空账号


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/devmind/pull/167/files#diff-824673ae174c8217b9292a1661db7ee4bbcb526f8961711e92fbbf41387b81f9">+51/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_views.py</strong><dd><code>为三个 ViewSet action 增加排除影子账号测试</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/cloud_billing/tests/test_views.py

<ul><li>在 stats、daily_series、latest_by_provider_account 三个测试中新增影子默认账号排除验证<br> <li> 每个测试均创建空账号和真实账号记录，断言结果仅包含真实账号</ul>


</details>


  </td>
  <td><a href="https://github.com/HyperBDR/devmind/pull/167/files#diff-db42193b15b842c7957e3935afdede4fd0d4bb3eaac3c02a5391608e2e0295a7">+96/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

