### PR TITLE
feat(quotation): paginate and optimize quotation queries

### DIFF
--- a/backend/quotation/migrations/0017_dashboard_indexes.py
+++ b/backend/quotation/migrations/0017_dashboard_indexes.py
@@ -1,0 +1,38 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("quotation", "0016_remove_security_alert"),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name="quotation",
+            index=models.Index(
+                fields=["currency", "status", "created_at"],
+                name="quote_dash_curr_stat_created",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="quotation",
+            index=models.Index(
+                fields=["created_by_email", "currency", "status"],
+                name="quote_dash_owner_curr_stat",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="quotation",
+            index=models.Index(
+                fields=["-created_at", "-id"],
+                name="quote_list_created_id",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="quotationversion",
+            index=models.Index(
+                fields=["quotation", "status", "created_at"],
+                name="quote_ver_quote_stat_created",
+            ),
+        ),
+    ]

--- a/backend/quotation/migrations/0018_quotation_list_indexes.py
+++ b/backend/quotation/migrations/0018_quotation_list_indexes.py
@@ -1,0 +1,43 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("quotation", "0017_dashboard_indexes"),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name="quotation",
+            index=models.Index(
+                fields=["created_by_email", "-created_at", "-id"],
+                name="quote_list_owner_created",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="quotation",
+            index=models.Index(
+                fields=["product_line", "-created_at", "-id"],
+                name="quote_list_product_created",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="documentasset",
+            index=models.Index(
+                fields=["quotation", "doc_type", "-created_at", "-id"],
+                name="quote_doc_quote_type_created",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="documentreplica",
+            index=models.Index(
+                fields=[
+                    "asset",
+                    "sync_status",
+                    "revoked_at",
+                    "-version",
+                ],
+                name="quote_replica_asset_status",
+            ),
+        ),
+    ]

--- a/backend/quotation/models.py
+++ b/backend/quotation/models.py
@@ -5,6 +5,7 @@ import uuid
 from django.conf import settings
 from django.db import models, router, transaction
 from django.utils import timezone
+
 from hyperbdr_dashboard.encryption import encryption_service
 
 
@@ -202,6 +203,28 @@ class Quotation(TimeStampedModel):
     class Meta:
         db_table = "quotations"
         ordering = ["-created_at"]
+        indexes = [
+            models.Index(
+                fields=["currency", "status", "created_at"],
+                name="quote_dash_curr_stat_created",
+            ),
+            models.Index(
+                fields=["created_by_email", "currency", "status"],
+                name="quote_dash_owner_curr_stat",
+            ),
+            models.Index(
+                fields=["-created_at", "-id"],
+                name="quote_list_created_id",
+            ),
+            models.Index(
+                fields=["created_by_email", "-created_at", "-id"],
+                name="quote_list_owner_created",
+            ),
+            models.Index(
+                fields=["product_line", "-created_at", "-id"],
+                name="quote_list_product_created",
+            ),
+        ]
 
     def delete(self, using=None, keep_parents=False):
         """Lock this quotation before Django collects related artifacts."""
@@ -267,6 +290,12 @@ class QuotationVersion(models.Model):
         db_table = "quotation_versions"
         unique_together = [("quotation", "version_no")]
         ordering = ["version_no"]
+        indexes = [
+            models.Index(
+                fields=["quotation", "status", "created_at"],
+                name="quote_ver_quote_stat_created",
+            ),
+        ]
 
 
 class QuotationTemplate(TimeStampedModel):
@@ -430,6 +459,12 @@ class DocumentAsset(models.Model):
     class Meta:
         db_table = "document_assets"
         ordering = ["-created_at"]
+        indexes = [
+            models.Index(
+                fields=["quotation", "doc_type", "-created_at", "-id"],
+                name="quote_doc_quote_type_created",
+            ),
+        ]
         constraints = [
             models.UniqueConstraint(
                 fields=["source", "feishu_file_token"],
@@ -657,6 +692,17 @@ class DocumentReplica(TimeStampedModel):
     class Meta:
         db_table = "quotation_document_replicas"
         ordering = ["-created_at", "-id"]
+        indexes = [
+            models.Index(
+                fields=[
+                    "asset",
+                    "sync_status",
+                    "revoked_at",
+                    "-version",
+                ],
+                name="quote_replica_asset_status",
+            ),
+        ]
         constraints = [
             models.UniqueConstraint(
                 fields=["asset", "connection", "version"],

--- a/backend/quotation/serializers.py
+++ b/backend/quotation/serializers.py
@@ -5,6 +5,8 @@ from urllib.parse import quote, urlparse
 
 from django.conf import settings
 from django.db.models import Q
+from rest_framework import serializers
+
 from quotation.models import (
     AuditEvent,
     DocumentAsset,
@@ -17,7 +19,68 @@ from quotation.models import (
 )
 from quotation.permissions import is_quotation_admin
 from quotation.services.storage_control import remote_document_reference
-from rest_framework import serializers
+
+
+class DashboardCurrencyQuerySerializer(serializers.Serializer):
+    """Validate the currency used by dashboard amount aggregates."""
+
+    currency = serializers.RegexField(
+        regex=r"^[A-Z0-9]{3,10}$",
+        default="USD",
+        required=False,
+    )
+
+
+class DashboardRecentQuerySerializer(serializers.Serializer):
+    """Validate the bounded recent quotation list size."""
+
+    limit = serializers.IntegerField(
+        default=5,
+        max_value=20,
+        min_value=1,
+        required=False,
+    )
+
+
+class QuotationListQuerySerializer(serializers.Serializer):
+    """Validate quotation list pagination and database filters."""
+
+    search = serializers.CharField(
+        allow_blank=True,
+        default="",
+        max_length=255,
+        required=False,
+        trim_whitespace=True,
+    )
+    status = serializers.ChoiceField(
+        choices=Quotation._meta.get_field("status").choices,
+        required=False,
+    )
+    product_line = serializers.CharField(
+        max_length=40,
+        required=False,
+    )
+    source_type = serializers.ChoiceField(
+        choices=Quotation._meta.get_field("source_type").choices,
+        required=False,
+    )
+    created_from = serializers.DateField(required=False)
+    created_to = serializers.DateField(required=False)
+    page = serializers.IntegerField(default=1, min_value=1, required=False)
+    page_size = serializers.ChoiceField(
+        choices=(10, 20, 50),
+        default=10,
+        required=False,
+    )
+
+    def validate(self, attrs):
+        created_from = attrs.get("created_from")
+        created_to = attrs.get("created_to")
+        if created_from and created_to and created_from > created_to:
+            raise serializers.ValidationError(
+                {"created_to": "must be on or after created_from"}
+            )
+        return attrs
 
 
 class CatalogObjectListField(serializers.ListField):
@@ -169,6 +232,82 @@ class QuotationVersionSerializer(serializers.ModelSerializer):
             "operator_email",
             "created_at",
             "snapshot",
+        ]
+        read_only_fields = fields
+
+
+class QuotationListSerializer(serializers.ModelSerializer):
+    """Serialize only fields required by the paginated list."""
+
+    display_quote_no = serializers.SerializerMethodField()
+    item_count = serializers.IntegerField(read_only=True)
+    latest_excel_document_id = serializers.CharField(
+        allow_null=True,
+        read_only=True,
+    )
+    latest_pdf_document_id = serializers.CharField(
+        allow_null=True,
+        read_only=True,
+    )
+    source_document_type = serializers.CharField(
+        allow_null=True,
+        read_only=True,
+    )
+
+    def get_display_quote_no(self, obj: Quotation) -> str:
+        return obj.source_quote_no or obj.quote_no
+
+    class Meta:
+        model = Quotation
+        fields = [
+            "id",
+            "quote_no",
+            "display_quote_no",
+            "project_name",
+            "client_company",
+            "contact_person",
+            "created_at",
+            "currency",
+            "grand_total",
+            "status",
+            "source_type",
+            "source_document_type",
+            "product_line",
+            "item_count",
+            "latest_excel_document_id",
+            "latest_pdf_document_id",
+        ]
+        read_only_fields = fields
+
+
+class QuotationFormContextSerializer(serializers.ModelSerializer):
+    """Serialize lightweight history fields used by the create form."""
+
+    display_quote_no = serializers.SerializerMethodField()
+
+    def get_display_quote_no(self, obj: Quotation) -> str:
+        return obj.source_quote_no or obj.quote_no
+
+    class Meta:
+        model = Quotation
+        fields = [
+            "id",
+            "quote_no",
+            "display_quote_no",
+            "project_name",
+            "client_company",
+            "contact_person",
+            "email",
+            "product_line",
+            "billing_company",
+            "billing_contact",
+            "billing_email",
+            "currency",
+            "tax_label",
+            "issuer_contact_name",
+            "issuer_contact_email",
+            "created_by_email",
+            "created_at",
         ]
         read_only_fields = fields
 

--- a/backend/quotation/services/dashboard.py
+++ b/backend/quotation/services/dashboard.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from decimal import Decimal
+
+from django.db.models import (
+    Count,
+    DateTimeField,
+    OuterRef,
+    Q,
+    QuerySet,
+    Subquery,
+    Sum,
+)
+from django.db.models.functions import Coalesce, TruncMonth, TruncWeek
+from django.utils import timezone
+
+from quotation.models import Quotation, QuotationVersion, QuoteStatus
+
+
+OPEN_STATUSES = (
+    QuoteStatus.GENERATED,
+    QuoteStatus.UPLOADED,
+    QuoteStatus.SENT,
+)
+CHART_STATUSES = tuple(
+    value
+    for value in QuoteStatus.values
+    if value != QuoteStatus.CANCELLED
+)
+DEFAULT_DASHBOARD_CURRENCY = "USD"
+MONTH_PERIOD_COUNT = 6
+WEEK_PERIOD_COUNT = 8
+BREAKDOWN_MIN_SHARE = Decimal("0.02")
+BREAKDOWN_MAX_ITEMS = 8
+
+
+def _money(value: Decimal | None) -> str:
+    return f"{value or Decimal('0'):.2f}"
+
+
+def _available_currencies(queryset: QuerySet[Quotation]) -> list[str]:
+    return list(
+        queryset.exclude(currency="")
+        .order_by("currency")
+        .values_list("currency", flat=True)
+        .distinct()
+    )
+
+
+def _with_first_accepted_at(
+    queryset: QuerySet[Quotation],
+) -> QuerySet[Quotation]:
+    accepted_at = QuotationVersion.objects.filter(
+        quotation_id=OuterRef("pk"),
+        status=QuoteStatus.ACCEPTED,
+    ).order_by("created_at")
+    return queryset.annotate(
+        first_accepted_at=Subquery(
+            accepted_at.values("created_at")[:1],
+            output_field=DateTimeField(),
+        ),
+        won_at=Coalesce(
+            "first_accepted_at",
+            "updated_at",
+            "created_at",
+            output_field=DateTimeField(),
+        ),
+    )
+
+
+def _month_start(value: datetime) -> datetime:
+    return value.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+
+def _next_month(value: datetime) -> datetime:
+    if value.month == 12:
+        return value.replace(year=value.year + 1, month=1)
+    return value.replace(month=value.month + 1)
+
+
+def _shift_month(value: datetime, offset: int) -> datetime:
+    month_index = value.year * 12 + value.month - 1 + offset
+    return value.replace(
+        year=month_index // 12,
+        month=month_index % 12 + 1,
+    )
+
+
+def _week_start(value: datetime) -> datetime:
+    midnight = value.replace(hour=0, minute=0, second=0, microsecond=0)
+    return midnight - timedelta(days=midnight.weekday())
+
+
+def build_dashboard_summary(
+    queryset: QuerySet[Quotation],
+    currency: str = DEFAULT_DASHBOARD_CURRENCY,
+) -> dict[str, object]:
+    """Build lightweight KPI aggregates for the quotation dashboard."""
+    local_now = timezone.localtime()
+    month_start = _month_start(local_now)
+    month_end = _next_month(month_start)
+    counts = queryset.aggregate(
+        accepted_count=Count(
+            "pk",
+            filter=Q(status=QuoteStatus.ACCEPTED),
+        ),
+        open_count=Count(
+            "pk",
+            filter=Q(status__in=OPEN_STATUSES),
+        ),
+        draft_count=Count(
+            "pk",
+            filter=Q(status=QuoteStatus.DRAFT),
+        ),
+    )
+    won_amount = (
+        _with_first_accepted_at(
+            queryset.filter(
+                currency=currency,
+                status=QuoteStatus.ACCEPTED,
+            )
+        )
+        .filter(won_at__gte=month_start, won_at__lt=month_end)
+        .aggregate(total=Sum("grand_total"))["total"]
+    )
+    accepted_count = counts["accepted_count"]
+    open_count = counts["open_count"]
+    rate_denominator = accepted_count + open_count
+    success_rate = (
+        round(accepted_count * 100 / rate_denominator)
+        if rate_denominator
+        else 0
+    )
+    return {
+        "currency": currency,
+        "available_currencies": _available_currencies(queryset),
+        "month_won_amount": _money(won_amount),
+        "success_rate": success_rate,
+        "success_rate_numerator": accepted_count,
+        "success_rate_denominator": rate_denominator,
+        "follow_up_count": open_count,
+        "active_count": open_count,
+        "draft_count": counts["draft_count"],
+        "generated_at": local_now.isoformat(),
+    }
+
+
+def _period_amounts(
+    queryset: QuerySet[Quotation],
+    field_name: str,
+    truncation,
+    start: datetime,
+    end: datetime,
+) -> dict[datetime, Decimal]:
+    rows = (
+        queryset.filter(
+            **{
+                f"{field_name}__gte": start,
+                f"{field_name}__lt": end,
+            }
+        )
+        .annotate(period=truncation(field_name))
+        .values("period")
+        .annotate(amount=Sum("grand_total"))
+        .order_by("period")
+    )
+    return {row["period"]: row["amount"] for row in rows}
+
+
+def _trend_rows(
+    queryset: QuerySet[Quotation],
+    starts: list[datetime],
+    truncation,
+    period_format,
+) -> list[dict[str, str]]:
+    end = (
+        _next_month(starts[-1])
+        if truncation is TruncMonth
+        else starts[-1] + timedelta(days=7)
+    )
+    created = _period_amounts(
+        queryset.filter(status__in=CHART_STATUSES),
+        "created_at",
+        truncation,
+        starts[0],
+        end,
+    )
+    won = _period_amounts(
+        _with_first_accepted_at(
+            queryset.filter(status=QuoteStatus.ACCEPTED)
+        ),
+        "won_at",
+        truncation,
+        starts[0],
+        end,
+    )
+    return [
+        {
+            "period": period_format(start),
+            "created_amount": _money(created.get(start)),
+            "won_amount": _money(won.get(start)),
+        }
+        for start in starts
+    ]
+
+
+def build_dashboard_analytics(
+    queryset: QuerySet[Quotation],
+    currency: str = DEFAULT_DASHBOARD_CURRENCY,
+) -> dict[str, object]:
+    """Build bounded chart aggregates without serializing quotation rows."""
+    local_now = timezone.localtime()
+    currency_queryset = queryset.filter(currency=currency)
+    breakdown_queryset = currency_queryset.filter(
+        status__in=CHART_STATUSES,
+        grand_total__gt=0,
+    )
+    breakdown_totals = breakdown_queryset.aggregate(
+        amount=Sum("grand_total"),
+        count=Count("pk"),
+    )
+    total_amount = breakdown_totals["amount"] or Decimal("0")
+    minimum_amount = total_amount * BREAKDOWN_MIN_SHARE
+    breakdown_rows = list(
+        breakdown_queryset.filter(grand_total__gte=minimum_amount)
+        .order_by("-grand_total", "pk")
+        .values(
+            "id",
+            "quote_no",
+            "source_quote_no",
+            "grand_total",
+            "status",
+        )[:BREAKDOWN_MAX_ITEMS]
+    )
+    displayed_amount = sum(
+        (row["grand_total"] for row in breakdown_rows),
+        Decimal("0"),
+    )
+    breakdown = [
+        {
+            "quotation_id": row["id"],
+            "quote_no": row["source_quote_no"] or row["quote_no"],
+            "amount": _money(row["grand_total"]),
+            "status": row["status"],
+        }
+        for row in breakdown_rows
+    ]
+    month_start = _month_start(local_now)
+    month_starts = [
+        _shift_month(month_start, offset)
+        for offset in range(-(MONTH_PERIOD_COUNT - 1), 1)
+    ]
+    week_start = _week_start(local_now)
+    week_starts = [
+        week_start - timedelta(weeks=offset)
+        for offset in range(WEEK_PERIOD_COUNT - 1, -1, -1)
+    ]
+    return {
+        "currency": currency,
+        "available_currencies": _available_currencies(queryset),
+        "amount_breakdown": breakdown,
+        "breakdown_total_amount": _money(total_amount),
+        "breakdown_omitted_count": max(
+            breakdown_totals["count"] - len(breakdown),
+            0,
+        ),
+        "breakdown_omitted_amount": _money(total_amount - displayed_amount),
+        "trends": {
+            "monthly": _trend_rows(
+                currency_queryset,
+                month_starts,
+                TruncMonth,
+                lambda value: value.strftime("%Y-%m"),
+            ),
+            "weekly": _trend_rows(
+                currency_queryset,
+                week_starts,
+                TruncWeek,
+                lambda value: value.date().isoformat(),
+            ),
+        },
+        "generated_at": local_now.isoformat(),
+    }
+
+
+def build_dashboard_recent(
+    queryset: QuerySet[Quotation],
+    limit: int,
+) -> dict[str, object]:
+    """Return a bounded projection for the recent quotations card."""
+    rows = queryset.order_by("-created_at").values(
+        "id",
+        "quote_no",
+        "source_quote_no",
+        "project_name",
+        "client_company",
+        "issuer_contact_name",
+        "created_at",
+        "currency",
+        "grand_total",
+        "status",
+    )[:limit]
+    return {
+        "items": [
+            {
+                "id": row["id"],
+                "quote_no": row["source_quote_no"] or row["quote_no"],
+                "project_name": row["project_name"],
+                "client_company": row["client_company"],
+                "salesperson": row["issuer_contact_name"],
+                "created_at": row["created_at"].isoformat(),
+                "currency": row["currency"],
+                "grand_total": _money(row["grand_total"]),
+                "status": row["status"],
+            }
+            for row in rows
+        ]
+    }

--- a/backend/quotation/services/quotation_queries.py
+++ b/backend/quotation/services/quotation_queries.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from datetime import datetime, time, timedelta
+
+from django.conf import settings
+from django.db.models import (
+    Count,
+    Exists,
+    OuterRef,
+    Q,
+    QuerySet,
+)
+from django.utils import timezone
+
+from quotation.models import (
+    DocumentAsset,
+    DocumentReplica,
+    Quotation,
+    ReplicaSyncStatus,
+)
+
+
+SEARCH_FIELDS = (
+    "quote_no",
+    "source_quote_no",
+    "project_name",
+    "client_company",
+    "contact_person",
+)
+
+
+def _local_day_start(value) -> datetime:
+    result = datetime.combine(value, time.min)
+    if settings.USE_TZ:
+        return timezone.make_aware(
+            result,
+            timezone.get_current_timezone(),
+        )
+    return result
+
+
+def filter_quotation_list(
+    queryset: QuerySet[Quotation],
+    filters: dict,
+) -> QuerySet[Quotation]:
+    """Apply index-friendly quotation list filters."""
+    search = filters.get("search", "")
+    if search:
+        search_query = Q()
+        for field in SEARCH_FIELDS:
+            search_query |= Q(**{f"{field}__icontains": search})
+        queryset = queryset.filter(search_query)
+
+    for field in ("status", "product_line", "source_type"):
+        value = filters.get(field)
+        if value:
+            queryset = queryset.filter(**{field: value})
+
+    created_from = filters.get("created_from")
+    if created_from:
+        queryset = queryset.filter(
+            created_at__gte=_local_day_start(created_from)
+        )
+
+    created_to = filters.get("created_to")
+    if created_to:
+        exclusive_end = _local_day_start(
+            created_to + timedelta(days=1)
+        )
+        queryset = queryset.filter(created_at__lt=exclusive_end)
+
+    return queryset
+
+
+def annotate_quotation_list(
+    queryset: QuerySet[Quotation],
+) -> QuerySet[Quotation]:
+    """Add the item count without loading quotation line items."""
+    return queryset.annotate(item_count=Count("items", distinct=True))
+
+
+def attach_quotation_document_summaries(
+    quotations: list[Quotation],
+) -> None:
+    """Attach document summary attributes with one fixed batch query."""
+    for quotation in quotations:
+        quotation.latest_excel_document_id = None
+        quotation.latest_pdf_document_id = None
+        quotation.source_document_type = None
+    if not quotations:
+        return
+
+    active_replica = DocumentReplica.objects.filter(
+        asset_id=OuterRef("pk"),
+        sync_status=ReplicaSyncStatus.SYNCED,
+        revoked_at__isnull=True,
+    ).exclude(remote_file_token="")
+    documents = (
+        DocumentAsset.objects.filter(
+            quotation_id__in=[quote.pk for quote in quotations],
+            doc_type__in=("excel", "pdf"),
+        )
+        .annotate(has_active_replica=Exists(active_replica))
+        .only(
+            "id",
+            "quotation_id",
+            "doc_type",
+            "source",
+            "feishu_file_token",
+            "created_at",
+        )
+        .order_by("quotation_id", "-created_at", "-id")
+    )
+    quotations_by_id = {quote.pk: quote for quote in quotations}
+    for document in documents:
+        quotation = quotations_by_id[document.quotation_id]
+        if (
+            quotation.source_document_type is None
+            and document.source == "feishu"
+        ):
+            quotation.source_document_type = document.doc_type
+        field = f"latest_{document.doc_type}_document_id"
+        if getattr(quotation, field) is not None:
+            continue
+        if document.has_active_replica or document.feishu_file_token:
+            setattr(quotation, field, document.pk)

--- a/backend/quotation/test_dashboard.py
+++ b/backend/quotation/test_dashboard.py
@@ -1,0 +1,230 @@
+from decimal import Decimal
+
+from django.contrib.auth.models import User
+from django.db import connection
+from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
+from rest_framework.test import APIClient
+
+from quotation.models import Quotation, QuotationVersion, QuoteStatus
+
+
+class QuotationDashboardTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="dashboard-owner",
+            email="owner@example.com",
+            password="password",
+        )
+        self.api = APIClient()
+        self.api.force_authenticate(self.user)
+
+    def _quote(
+        self,
+        quote_no: str,
+        *,
+        amount: str = "100.00",
+        currency: str = "USD",
+        owner: str = "owner@example.com",
+        status: str = QuoteStatus.GENERATED,
+    ) -> Quotation:
+        return Quotation.objects.create(
+            quote_no=quote_no,
+            status=status,
+            project_name=f"Project {quote_no}",
+            currency=currency,
+            payment_terms="CIA",
+            quote_date="2026-07-01",
+            expire_date="2026-08-01",
+            grand_total=Decimal(amount),
+            issuer_contact_name="Sales Person",
+            issuer_contact_email="sales@example.com",
+            client_company="Client Company",
+            contact_person="Client Contact",
+            email="client@example.com",
+            created_by_email=owner,
+        )
+
+    def _accept(self, quotation: Quotation) -> None:
+        QuotationVersion.objects.create(
+            quotation=quotation,
+            version_no=1,
+            status=QuoteStatus.ACCEPTED,
+            notes="Accepted",
+            snapshot_json={"status": QuoteStatus.ACCEPTED},
+        )
+
+    def test_summary_uses_all_accessible_rows_and_separates_currency(self):
+        accepted_usd = self._quote(
+            "Q-USD-ACCEPTED",
+            amount="44000.00",
+            status=QuoteStatus.ACCEPTED,
+        )
+        self._accept(accepted_usd)
+        accepted_cny = self._quote(
+            "Q-CNY-ACCEPTED",
+            amount="99999.00",
+            currency="CNY",
+            status=QuoteStatus.ACCEPTED,
+        )
+        self._accept(accepted_cny)
+        self._quote("Q-OPEN")
+        self._quote("Q-DRAFT", status=QuoteStatus.DRAFT)
+        self._quote("Q-HIDDEN", owner="other@example.com")
+
+        response = self.api.get(
+            "/api/v1/quotation/dashboard/summary?currency=USD"
+        )
+
+        assert response.status_code == 200
+        assert response.data["month_won_amount"] == "44000.00"
+        assert response.data["success_rate_numerator"] == 2
+        assert response.data["success_rate_denominator"] == 3
+        assert response.data["success_rate"] == 67
+        assert response.data["follow_up_count"] == 1
+        assert response.data["draft_count"] == 1
+        assert response.data["available_currencies"] == ["CNY", "USD"]
+
+    def test_summary_is_not_limited_to_quotation_list_page_size(self):
+        Quotation.objects.bulk_create(
+            [
+                Quotation(
+                    quote_no=f"Q-BULK-{index:03d}",
+                    status=QuoteStatus.GENERATED,
+                    project_name="Bulk Project",
+                    payment_terms="CIA",
+                    quote_date="2026-07-01",
+                    expire_date="2026-08-01",
+                    grand_total=Decimal("1.00"),
+                    issuer_contact_name="Sales Person",
+                    issuer_contact_email="sales@example.com",
+                    client_company="Client Company",
+                    contact_person="Client Contact",
+                    email="client@example.com",
+                    created_by_email="owner@example.com",
+                )
+                for index in range(205)
+            ]
+        )
+
+        response = self.api.get("/api/v1/quotation/dashboard/summary")
+
+        assert response.status_code == 200
+        assert response.data["follow_up_count"] == 205
+
+    def test_analytics_returns_bounded_rows_and_fixed_period_counts(self):
+        accepted = self._quote(
+            "Q-ACCEPTED",
+            amount="300.00",
+            status=QuoteStatus.ACCEPTED,
+        )
+        self._accept(accepted)
+        for index in range(12):
+            self._quote(
+                f"Q-CHART-{index:02d}",
+                amount=str(200 - index),
+            )
+        self._quote(
+            "Q-CANCELLED",
+            amount="9999.00",
+            status=QuoteStatus.CANCELLED,
+        )
+        self._quote(
+            "Q-CNY",
+            amount="9999.00",
+            currency="CNY",
+        )
+
+        response = self.api.get(
+            "/api/v1/quotation/dashboard/analytics?currency=USD"
+        )
+
+        assert response.status_code == 200
+        assert len(response.data["amount_breakdown"]) == 8
+        assert len(response.data["trends"]["monthly"]) == 6
+        assert len(response.data["trends"]["weekly"]) == 8
+        assert Decimal(
+            response.data["trends"]["monthly"][-1]["created_amount"]
+        ) > 0
+        assert Decimal(
+            response.data["trends"]["monthly"][-1]["won_amount"]
+        ) == Decimal("300.00")
+        assert Decimal(
+            response.data["trends"]["weekly"][-1]["created_amount"]
+        ) > 0
+        assert Decimal(
+            response.data["trends"]["weekly"][-1]["won_amount"]
+        ) == Decimal("300.00")
+        quote_numbers = {
+            row["quote_no"] for row in response.data["amount_breakdown"]
+        }
+        assert "Q-CANCELLED" not in quote_numbers
+        assert "Q-CNY" not in quote_numbers
+        assert response.data["breakdown_omitted_count"] == 5
+
+    def test_recent_returns_projection_and_honors_access_and_limit(self):
+        self._quote("Q-OLDER")
+        newest = self._quote("Q-NEWEST", amount="8143.75")
+        self._quote("Q-HIDDEN", owner="other@example.com")
+
+        response = self.api.get(
+            "/api/v1/quotation/dashboard/recent?limit=1"
+        )
+
+        assert response.status_code == 200
+        assert response.data == {
+            "items": [
+                {
+                    "id": newest.id,
+                    "quote_no": "Q-NEWEST",
+                    "project_name": "Project Q-NEWEST",
+                    "client_company": "Client Company",
+                    "salesperson": "Sales Person",
+                    "created_at": newest.created_at.isoformat(),
+                    "currency": "USD",
+                    "grand_total": "8143.75",
+                    "status": QuoteStatus.GENERATED,
+                }
+            ]
+        }
+
+    def test_dashboard_query_counts_remain_bounded(self):
+        accepted = self._quote(
+            "Q-PERF-ACCEPTED",
+            status=QuoteStatus.ACCEPTED,
+        )
+        self._accept(accepted)
+        for index in range(20):
+            self._quote(f"Q-PERF-{index:02d}")
+
+        with CaptureQueriesContext(connection) as summary_queries:
+            summary = self.api.get(
+                "/api/v1/quotation/dashboard/summary?currency=USD"
+            )
+        with CaptureQueriesContext(connection) as analytics_queries:
+            analytics = self.api.get(
+                "/api/v1/quotation/dashboard/analytics?currency=USD"
+            )
+        with CaptureQueriesContext(connection) as recent_queries:
+            recent = self.api.get(
+                "/api/v1/quotation/dashboard/recent?limit=5"
+            )
+
+        assert summary.status_code == 200
+        assert analytics.status_code == 200
+        assert recent.status_code == 200
+        # Authorization performs a fixed set of profile and role lookups.
+        assert len(summary_queries) <= 8
+        assert len(analytics_queries) <= 12
+        assert len(recent_queries) <= 6
+
+    def test_dashboard_query_validation_rejects_unbounded_inputs(self):
+        invalid_currency = self.api.get(
+            "/api/v1/quotation/dashboard/summary?currency=usd"
+        )
+        invalid_limit = self.api.get(
+            "/api/v1/quotation/dashboard/recent?limit=1000"
+        )
+
+        assert invalid_currency.status_code == 400
+        assert invalid_limit.status_code == 400

--- a/backend/quotation/test_document_parsing.py
+++ b/backend/quotation/test_document_parsing.py
@@ -837,7 +837,7 @@ class DocumentParseEndpointTests(TestCase):
             list_response.data["items"][0]["quote_no"], "CloudX160726"
         )
         self.assertEqual(
-            len(list_response.data["items"][0]["items"]),
+            list_response.data["items"][0]["item_count"],
             2,
         )
 
@@ -1295,7 +1295,7 @@ class DocumentParseEndpointTests(TestCase):
                     "status": item["status"],
                     "source_type": item["source_type"],
                     "source_document_type": item["source_document_type"],
-                    "item_count": len(item["items"]),
+                    "item_count": item["item_count"],
                 }
                 for item in list_response.data["items"]
             },

--- a/backend/quotation/test_quotation_list.py
+++ b/backend/quotation/test_quotation_list.py
@@ -1,0 +1,321 @@
+from datetime import datetime, time, timedelta
+from decimal import Decimal
+
+from django.contrib.auth.models import User
+from django.db import connection
+from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from quotation.models import (
+    Quotation,
+    QuotationItem,
+    QuotationSourceType,
+    QuotationVersion,
+    QuoteStatus,
+)
+
+
+class QuotationListAPITests(TestCase):
+    url = "/api/v1/quotation/quotations"
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="list-owner",
+            email="owner@example.com",
+            password="password",
+        )
+        self.api = APIClient()
+        self.api.force_authenticate(self.user)
+
+    def _quote(
+        self,
+        index: int,
+        *,
+        owner: str = "owner@example.com",
+        status: str = QuoteStatus.DRAFT,
+        product_line: str = "BDR",
+        source_type: str = QuotationSourceType.MANUAL,
+        created_at=None,
+    ) -> Quotation:
+        quotation = Quotation.objects.create(
+            quote_no=f"Q-LIST-{index:03d}",
+            source_quote_no=(
+                f"SOURCE-{index:03d}"
+                if source_type == QuotationSourceType.DOCUMENT_IMPORT
+                else ""
+            ),
+            status=status,
+            source_type=source_type,
+            product_line=product_line,
+            project_name=f"Project Alpha {index}",
+            currency="USD",
+            payment_terms="CIA",
+            quote_date="2026-07-01",
+            expire_date="2026-08-01",
+            grand_total=Decimal(index + 1),
+            issuer_contact_name="Sales Person",
+            issuer_contact_email="sales@example.com",
+            client_company=f"Client {index}",
+            contact_person=f"Contact {index}",
+            email=f"client-{index}@example.com",
+            created_by_email=owner,
+        )
+        if created_at:
+            Quotation.objects.filter(pk=quotation.pk).update(
+                created_at=created_at,
+                updated_at=created_at,
+            )
+            quotation.refresh_from_db()
+        return quotation
+
+    def _create_quotes(self, count: int) -> list[Quotation]:
+        now = timezone.now()
+        return [
+            self._quote(
+                index,
+                created_at=now + timedelta(seconds=index),
+            )
+            for index in range(count)
+        ]
+
+    def test_default_page_size_and_stable_second_page(self):
+        quotes = self._create_quotes(12)
+
+        first = self.api.get(self.url)
+        second = self.api.get(f"{self.url}?page=2")
+
+        assert first.status_code == 200
+        assert len(first.data["items"]) == 10
+        assert first.data["total"] == 12
+        assert first.data["page"] == 1
+        assert first.data["page_size"] == 10
+        assert first.data["total_pages"] == 2
+        assert len(second.data["items"]) == 2
+        assert second.data["page"] == 2
+        expected = sorted(
+            quotes,
+            key=lambda quote: (quote.created_at, quote.id),
+            reverse=True,
+        )
+        assert [row["id"] for row in first.data["items"]] == [
+            quote.id for quote in expected[:10]
+        ]
+        assert [row["id"] for row in second.data["items"]] == [
+            quote.id for quote in expected[10:]
+        ]
+
+    def test_allowed_page_sizes(self):
+        self._create_quotes(55)
+
+        for page_size in (20, 50):
+            with self.subTest(page_size=page_size):
+                response = self.api.get(
+                    f"{self.url}?page_size={page_size}"
+                )
+                assert response.status_code == 200
+                assert len(response.data["items"]) == page_size
+                assert response.data["page_size"] == page_size
+
+    def test_invalid_page_and_page_size(self):
+        for query in (
+            "page=0",
+            "page=-1",
+            "page=abc",
+            "page_size=11",
+            "page_size=all",
+        ):
+            with self.subTest(query=query):
+                response = self.api.get(f"{self.url}?{query}")
+                assert response.status_code == 400
+                assert response.data == {"detail": "invalid pagination"}
+
+    def test_empty_result_and_page_beyond_result_are_valid(self):
+        empty = self.api.get(f"{self.url}?search=does-not-exist")
+        beyond = self.api.get(f"{self.url}?page=3")
+
+        assert empty.data == {
+            "items": [],
+            "total": 0,
+            "page": 1,
+            "page_size": 10,
+            "total_pages": 0,
+        }
+        assert beyond.status_code == 200
+        assert beyond.data["items"] == []
+
+    def test_searches_only_supported_list_fields(self):
+        quote = self._quote(
+            1,
+            source_type=QuotationSourceType.DOCUMENT_IMPORT,
+        )
+        values = (
+            quote.quote_no,
+            quote.source_quote_no,
+            quote.project_name,
+            quote.client_company,
+            quote.contact_person,
+        )
+
+        for value in values:
+            with self.subTest(value=value):
+                response = self.api.get(
+                    self.url,
+                    {"search": value.lower()},
+                )
+                assert response.data["total"] == 1
+        email_search = self.api.get(
+            self.url,
+            {"search": quote.email},
+        )
+        assert email_search.data["total"] == 0
+
+    def test_status_product_source_and_combined_filters(self):
+        matching = self._quote(
+            1,
+            status=QuoteStatus.SENT,
+            product_line="MOTION",
+            source_type=QuotationSourceType.DOCUMENT_IMPORT,
+        )
+        self._quote(2, status=QuoteStatus.SENT, product_line="BDR")
+
+        status_result = self.api.get(self.url, {"status": "sent"})
+        product_result = self.api.get(
+            self.url,
+            {"product_line": "MOTION"},
+        )
+        source_result = self.api.get(
+            self.url,
+            {"source_type": "document_import"},
+        )
+        combined = self.api.get(
+            self.url,
+            {
+                "search": matching.client_company,
+                "status": "sent",
+                "product_line": "MOTION",
+                "source_type": "document_import",
+            },
+        )
+
+        assert status_result.data["total"] == 2
+        assert product_result.data["total"] == 1
+        assert source_result.data["total"] == 1
+        assert [row["id"] for row in combined.data["items"]] == [
+            matching.id
+        ]
+
+    def test_created_date_range_includes_the_whole_end_date(self):
+        local_tz = timezone.get_current_timezone()
+        selected_date = timezone.localdate()
+        start = timezone.make_aware(
+            datetime.combine(selected_date, time.min),
+            local_tz,
+        )
+        inside = self._quote(
+            1,
+            created_at=start + timedelta(hours=23, minutes=59),
+        )
+        self._quote(2, created_at=start - timedelta(seconds=1))
+        self._quote(3, created_at=start + timedelta(days=1))
+
+        response = self.api.get(
+            self.url,
+            {
+                "created_from": selected_date.isoformat(),
+                "created_to": selected_date.isoformat(),
+            },
+        )
+
+        assert [row["id"] for row in response.data["items"]] == [
+            inside.id
+        ]
+
+    def test_owner_permission_and_staff_visibility(self):
+        own = self._quote(1)
+        other = self._quote(2, owner="other@example.com")
+
+        owner_response = self.api.get(self.url)
+        self.user.is_staff = True
+        self.user.save(update_fields=["is_staff"])
+        staff_response = self.api.get(self.url)
+
+        assert [row["id"] for row in owner_response.data["items"]] == [
+            own.id
+        ]
+        assert {row["id"] for row in staff_response.data["items"]} == {
+            own.id,
+            other.id,
+        }
+
+    def test_list_is_lightweight_and_item_count_is_annotated(self):
+        quotation = self._quote(1)
+        for line_no in (1, 2):
+            QuotationItem.objects.create(
+                quotation=quotation,
+                line_no=line_no,
+                type="Software",
+                qty=1,
+                list_price=10,
+                discount_percent=0,
+                net_unit_price=10,
+                extended_price=10,
+            )
+        QuotationVersion.objects.create(
+            quotation=quotation,
+            version_no=1,
+            status=QuoteStatus.DRAFT,
+            snapshot_json={"items": [{"secret": "large"}]},
+        )
+
+        response = self.api.get(self.url)
+        row = response.data["items"][0]
+
+        assert row["item_count"] == 2
+        assert "items" not in row
+        assert "versions" not in row
+        assert "snapshot_json" not in row
+        assert "documents" not in row
+
+    def test_detail_still_returns_items_versions_and_snapshots(self):
+        quotation = self._quote(1)
+        QuotationItem.objects.create(
+            quotation=quotation,
+            line_no=1,
+            type="Software",
+            qty=1,
+            list_price=10,
+            discount_percent=0,
+            net_unit_price=10,
+            extended_price=10,
+        )
+        QuotationVersion.objects.create(
+            quotation=quotation,
+            version_no=1,
+            status=QuoteStatus.DRAFT,
+            snapshot_json={"status": "draft"},
+        )
+
+        response = self.api.get(f"{self.url}/{quotation.id}")
+
+        assert response.status_code == 200
+        assert len(response.data["items"]) == 1
+        assert len(response.data["versions"]) == 1
+        assert response.data["versions"][0]["snapshot"] == {
+            "status": "draft"
+        }
+
+    def test_list_query_count_does_not_grow_with_page_size(self):
+        self._create_quotes(50)
+
+        with CaptureQueriesContext(connection) as ten_queries:
+            ten = self.api.get(f"{self.url}?page_size=10")
+        with CaptureQueriesContext(connection) as fifty_queries:
+            fifty = self.api.get(f"{self.url}?page_size=50")
+
+        assert ten.status_code == 200
+        assert fifty.status_code == 200
+        assert len(ten.data["items"]) == 10
+        assert len(fifty.data["items"]) == 50
+        assert len(fifty_queries) <= len(ten_queries) + 1

--- a/backend/quotation/urls.py
+++ b/backend/quotation/urls.py
@@ -8,6 +8,11 @@ from quotation.views.catalog import (
     LegacyCatalogImportView,
     UserQuotationCatalogView,
 )
+from quotation.views.dashboard import (
+    DashboardAnalyticsView,
+    DashboardRecentView,
+    DashboardSummaryView,
+)
 from quotation.views.documents import (
     DocumentDownloadView,
     DocumentListView,
@@ -41,11 +46,15 @@ from quotation.views.feishu import (
 from quotation.views.health import ExportMetricsView, StorageMetricsView
 from quotation.views.quotations import (
     QuotationDetailView,
+    QuotationFormContextView,
     QuotationGenerateView,
     QuotationListCreateView,
 )
 
 urlpatterns = [
+    path("dashboard/summary", DashboardSummaryView.as_view()),
+    path("dashboard/analytics", DashboardAnalyticsView.as_view()),
+    path("dashboard/recent", DashboardRecentView.as_view()),
     path("metrics/exports", ExportMetricsView.as_view()),
     path("metrics/storage", StorageMetricsView.as_view()),
     path("templates", QuotationTemplateListCreateView.as_view()),
@@ -55,6 +64,7 @@ urlpatterns = [
     path("catalog/import-legacy", LegacyCatalogImportView.as_view()),
     path("catalog/bootstrap", CatalogBootstrapView.as_view()),
     path("quotations", QuotationListCreateView.as_view()),
+    path("quotations/form-context", QuotationFormContextView.as_view()),
     path("quotations/<str:quotation_id>", QuotationDetailView.as_view()),
     path(
         "quotations/<str:quotation_id>/generate",

--- a/backend/quotation/views/dashboard.py
+++ b/backend/quotation/views/dashboard.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from quotation.access import filter_accessible_quotations
+from quotation.models import Quotation
+from quotation.serializers import (
+    DashboardCurrencyQuerySerializer,
+    DashboardRecentQuerySerializer,
+)
+from quotation.services.dashboard import (
+    build_dashboard_analytics,
+    build_dashboard_recent,
+    build_dashboard_summary,
+)
+
+
+def _accessible_quotations(request):
+    return filter_accessible_quotations(
+        request.user,
+        Quotation.objects.all(),
+    )
+
+
+class DashboardSummaryView(APIView):
+    """Return the quotation dashboard KPI summary."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        serializer = DashboardCurrencyQuerySerializer(
+            data=request.query_params
+        )
+        serializer.is_valid(raise_exception=True)
+        payload = build_dashboard_summary(
+            _accessible_quotations(request),
+            serializer.validated_data["currency"],
+        )
+        return Response(payload)
+
+
+class DashboardAnalyticsView(APIView):
+    """Return bounded quotation dashboard chart aggregates."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        serializer = DashboardCurrencyQuerySerializer(
+            data=request.query_params
+        )
+        serializer.is_valid(raise_exception=True)
+        payload = build_dashboard_analytics(
+            _accessible_quotations(request),
+            serializer.validated_data["currency"],
+        )
+        return Response(payload)
+
+
+class DashboardRecentView(APIView):
+    """Return the latest accessible quotations as a narrow projection."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        serializer = DashboardRecentQuerySerializer(
+            data=request.query_params
+        )
+        serializer.is_valid(raise_exception=True)
+        payload = build_dashboard_recent(
+            _accessible_quotations(request),
+            serializer.validated_data["limit"],
+        )
+        return Response(payload)

--- a/backend/quotation/views/quotations.py
+++ b/backend/quotation/views/quotations.py
@@ -4,6 +4,11 @@ from decimal import Decimal
 
 from django.db import IntegrityError, transaction
 from django.db.models.deletion import ProtectedError
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
 from quotation.access import (
     can_access_quotation,
     filter_accessible_quotations,
@@ -17,9 +22,17 @@ from quotation.models import Quotation, QuotationSourceType, QuoteStatus
 from quotation.permissions import user_display_email
 from quotation.serializers import (
     QuotationCreateSerializer,
+    QuotationFormContextSerializer,
     QuotationGenerateSerializer,
+    QuotationListQuerySerializer,
+    QuotationListSerializer,
     QuotationSerializer,
     QuotationUpdateSerializer,
+)
+from quotation.services.quotation_queries import (
+    annotate_quotation_list,
+    attach_quotation_document_summaries,
+    filter_quotation_list,
 )
 from quotation.services.quotation_service import (
     build_quotation,
@@ -27,10 +40,6 @@ from quotation.services.quotation_service import (
     create_version_snapshot,
     replace_items,
 )
-from rest_framework import status
-from rest_framework.permissions import IsAuthenticated
-from rest_framework.response import Response
-from rest_framework.views import APIView
 
 
 def _ensure_access(user, quotation: Quotation) -> Response | None:
@@ -118,26 +127,47 @@ class QuotationListCreateView(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request):
-        qs = Quotation.objects.prefetch_related("items", "documents", "versions").all()
-        qs = filter_accessible_quotations(request.user, qs)
-        status_value = request.query_params.get("status")
-        if status_value:
-            if status_value not in QuoteStatus.values:
-                return Response({"detail": "invalid status"}, status=400)
-            qs = qs.filter(status=status_value)
-        try:
-            page = max(int(request.query_params.get("page", 1)), 1)
-            page_size = min(max(int(request.query_params.get("page_size", 20)), 1), 200)
-        except (TypeError, ValueError):
-            return Response({"detail": "invalid pagination"}, status=400)
-        total = qs.count()
+        query_serializer = QuotationListQuerySerializer(
+            data=request.query_params
+        )
+        if not query_serializer.is_valid():
+            pagination_errors = {"page", "page_size"} & set(
+                query_serializer.errors
+            )
+            if pagination_errors:
+                return Response(
+                    {"detail": "invalid pagination"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            return Response(
+                query_serializer.errors,
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        filters = query_serializer.validated_data
+        page = filters["page"]
+        page_size = int(filters["page_size"])
+        queryset = filter_accessible_quotations(
+            request.user,
+            Quotation.objects.all(),
+        )
+        queryset = filter_quotation_list(queryset, filters)
+        total = queryset.count()
         page_start = (page - 1) * page_size
-        page_end = page * page_size
-        items = qs[page_start:page_end]
+        items = list(
+            annotate_quotation_list(queryset).order_by(
+                "-created_at",
+                "-id",
+            )[page_start : page_start + page_size]
+        )
+        attach_quotation_document_summaries(items)
+        total_pages = (total + page_size - 1) // page_size
         return Response(
             {
-                "items": QuotationSerializer(items, many=True).data,
+                "items": QuotationListSerializer(items, many=True).data,
                 "total": total,
+                "page": page,
+                "page_size": page_size,
+                "total_pages": total_pages,
             }
         )
 
@@ -153,9 +183,26 @@ class QuotationListCreateView(APIView):
         except IntegrityError:
             return Response({"detail": "quote_no already exists"}, status=409)
         quotation = Quotation.objects.prefetch_related(
-            "items", "documents", "versions"
+            "items", "documents__replicas", "versions"
         ).get(pk=quotation.pk)
         return Response(QuotationSerializer(quotation).data, status=201)
+
+
+class QuotationFormContextView(APIView):
+    """Return narrow quotation history used by the create form."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        queryset = filter_accessible_quotations(
+            request.user,
+            Quotation.objects.all(),
+        ).order_by("-created_at", "-id")
+        items = QuotationFormContextSerializer(
+            queryset,
+            many=True,
+        ).data
+        return Response({"items": items})
 
 
 class QuotationDetailView(APIView):
@@ -163,7 +210,11 @@ class QuotationDetailView(APIView):
 
     def get_object(self, quotation_id: str) -> Quotation | None:
         return (
-            Quotation.objects.prefetch_related("items", "documents", "versions")
+            Quotation.objects.prefetch_related(
+                "items",
+                "documents__replicas",
+                "versions",
+            )
             .filter(pk=quotation_id)
             .first()
         )
@@ -206,7 +257,11 @@ class QuotationDetailView(APIView):
             with transaction.atomic():
                 if "items" in data:
                     replace_items(quotation, data["items"])
-                    cache = getattr(quotation, "_prefetched_objects_cache", None)
+                    cache = getattr(
+                        quotation,
+                        "_prefetched_objects_cache",
+                        None,
+                    )
                     if cache is not None:
                         cache.pop("items", None)
                 if "items" in data or "vat_rate" in data:
@@ -227,7 +282,10 @@ class QuotationDetailView(APIView):
                     )
                     for k, v in totals.items():
                         setattr(quotation, k, v)
-                status_changed = "status" in data and data["status"] != previous_status
+                status_changed = (
+                    "status" in data
+                    and data["status"] != previous_status
+                )
                 items_changed = "items" in data
                 quotation.save()
                 skip_version = bool(data.get("skip_version"))
@@ -278,7 +336,11 @@ class QuotationGenerateView(APIView):
 
     def post(self, request, quotation_id: str):
         quotation = (
-            Quotation.objects.prefetch_related("items", "documents", "versions")
+            Quotation.objects.prefetch_related(
+                "items",
+                "documents__replicas",
+                "versions",
+            )
             .filter(pk=quotation_id)
             .first()
         )
@@ -304,7 +366,7 @@ class QuotationGenerateView(APIView):
             notes=ser.validated_data.get("notes") or "Generated quotation",
         )
         quotation = Quotation.objects.prefetch_related(
-            "items", "documents", "versions"
+            "items", "documents__replicas", "versions"
         ).get(pk=quotation_id)
         set_request_audit_changed_fields(request, changed_fields)
         return Response(QuotationSerializer(quotation).data)

--- a/frontend/scripts/quotation-dashboard-quote-breakdown.test.mjs
+++ b/frontend/scripts/quotation-dashboard-quote-breakdown.test.mjs
@@ -47,14 +47,12 @@ test('dashboard chart cards use laptop-safe balanced desktop proportions', () =>
   assert.doesNotMatch(enLocale, /chartAmountQuoteCount/)
 })
 
-test('dashboard quote breakdown uses one centered filtered pie', () => {
-  assert.match(dashboardSource, /QUOTE_BREAKDOWN_MIN_SHARE = 2/)
-  assert.match(dashboardSource, /QUOTE_BREAKDOWN_MAX_SLICES = 8/)
-  assert.match(dashboardSource, /row\.share >= QUOTE_BREAKDOWN_MIN_SHARE/)
+test('dashboard quote breakdown uses one centered server-filtered pie', () => {
   assert.match(
     dashboardSource,
-    /const quoteBreakdownData = computed\(\(\) =>\s*props\.quotations/,
+    /const quoteBreakdownData = computed\(\(\) =>\s*\(analytics\.value\?\.amountBreakdown/,
   )
+  assert.match(dashboardSource, /getDashboardAnalytics/)
   assert.doesNotMatch(dashboardSource, /const chartQuotes/)
   assert.doesNotMatch(dashboardSource, /selectedBreakdownCurrency/)
   assert.doesNotMatch(dashboardSource, /quoteBreakdownCurrencies/)

--- a/frontend/scripts/quotation-pagination.test.mjs
+++ b/frontend/scripts/quotation-pagination.test.mjs
@@ -1,0 +1,136 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+const quotationsApi = await readFile(
+  new URL('../src/modules/quotation/api/quotations.ts', import.meta.url),
+  'utf8',
+)
+const quotationList = await readFile(
+  new URL(
+    '../src/modules/quotation/components/QuotationList.vue',
+    import.meta.url,
+  ),
+  'utf8',
+)
+const quotationApp = await readFile(
+  new URL('../src/modules/quotation/App.vue', import.meta.url),
+  'utf8',
+)
+const quotationListPage = await readFile(
+  new URL(
+    '../src/modules/quotation/pages/QuotationListPage.vue',
+    import.meta.url,
+  ),
+  'utf8',
+)
+const quotationDetailPage = await readFile(
+  new URL(
+    '../src/modules/quotation/pages/QuotationDetailPage.vue',
+    import.meta.url,
+  ),
+  'utf8',
+)
+const quotationCreatePage = await readFile(
+  new URL(
+    '../src/modules/quotation/pages/QuotationCreatePage.vue',
+    import.meta.url,
+  ),
+  'utf8',
+)
+
+test('quotation API defaults to ten and supports allowed page sizes', () => {
+  assert.match(quotationsApi, /params\.page \|\| 1/)
+  assert.match(quotationsApi, /params\.pageSize \|\| 10/)
+  assert.match(quotationsApi, /pageSize\?: 10 \| 20 \| 50/)
+  assert.match(quotationsApi, /page_size/)
+  assert.match(quotationsApi, /total_pages/)
+})
+
+test('list sends all search and filter values to the server', () => {
+  for (const parameter of [
+    'search',
+    'status',
+    'product_line',
+    'source_type',
+    'created_from',
+    'created_to',
+  ]) {
+    assert.match(quotationsApi, new RegExp(`query\\.set\\('${parameter}'`))
+  }
+  assert.doesNotMatch(quotationList, /filteredQuotations/)
+})
+
+test('pagination controls expose ranges, totals, pages and sizes', () => {
+  assert.match(quotationList, /const pageNumbers = computed/)
+  assert.match(quotationList, /!\[10, 20, 50\]\.includes\(value\)/)
+  assert.match(quotationList, /const pageSizeOptions = \[10, 20, 50\]/)
+  assert.match(quotationList, /test-id="quotation-page-size"/)
+  assert.match(
+    quotationList,
+    /panel-class-name="bottom-full top-auto mb-1 mt-0"/,
+  )
+  assert.doesNotMatch(quotationList, /<select[\s\S]*?:value="pageSize"/)
+  assert.match(quotationList, /rangeStart/)
+  assert.match(quotationList, /rangeEnd/)
+  assert.match(quotationList, /totalPages/)
+  assert.match(quotationList, /requestPage\(page - 1\)/)
+  assert.match(quotationList, /requestPage\(page \+ 1\)/)
+})
+
+test('search is debounced and filters reset the first page', () => {
+  assert.match(quotationList, /window\.setTimeout\(\(\) => \{/)
+  assert.match(quotationList, /}, 300\)/)
+  assert.match(quotationList, /listQuery\(1\)/)
+  assert.match(quotationList, /selectedStatus/)
+  assert.match(quotationList, /selectedProductLine/)
+  assert.match(quotationList, /selectedSource/)
+  assert.match(quotationList, /createdFrom/)
+  assert.match(quotationList, /createdTo/)
+})
+
+test('empty, loading and failed request states are explicit', () => {
+  assert.match(quotationList, /<tr v-if="loading">/)
+  assert.match(quotationList, /emptyResults/)
+  assert.match(quotationApp, /triggerToast\(message, 'error'\)/)
+  assert.match(quotationListPage, /showToast\(.*'error'\)/s)
+})
+
+test('older list requests cannot overwrite newer results', () => {
+  assert.match(quotationApp, /requestId !== quotationListRequestId/)
+  assert.match(quotationListPage, /currentRequest !== requestId/)
+})
+
+test('page requests do not wait for remote Feishu link checks', () => {
+  const appListLoad = quotationApp.slice(
+    quotationApp.indexOf('async function refreshQuotations'),
+    quotationApp.indexOf('async function loadActiveQuote'),
+  )
+  const routedListLoad = quotationListPage.slice(
+    quotationListPage.indexOf('async function load('),
+    quotationListPage.indexOf('async function handleFeishuUploadDone'),
+  )
+  assert.doesNotMatch(appListLoad, /reconcileFeishuQuotationLinks/)
+  assert.doesNotMatch(routedListLoad, /reconcileFeishuQuotationLinks/)
+  assert.match(
+    quotationApp,
+    /handleReconcileFeishuLinks[\s\S]*?reconcileFeishuQuotationLinks/,
+  )
+})
+
+test('deleting the last row moves back one page', () => {
+  assert.match(quotationApp, /quotations\.value\.length === 1/)
+  assert.match(quotationApp, /currentPage - 1/)
+  assert.match(quotationListPage, /quotations\.value\.length === 1/)
+  assert.match(quotationListPage, /currentPage - 1/)
+})
+
+test('detail and edit pages request quotations by ID', () => {
+  assert.match(
+    quotationDetailPage,
+    /getQuotation\(String\(route\.params\.id\)\)/,
+  )
+  assert.match(quotationCreatePage, /getQuotation\(editId\)/)
+  assert.doesNotMatch(quotationDetailPage, /listQuotations/)
+  assert.doesNotMatch(quotationCreatePage, /listQuotations/)
+})

--- a/frontend/src/modules/quotation/App.vue
+++ b/frontend/src/modules/quotation/App.vue
@@ -53,7 +53,9 @@ import {
   deleteQuotation as deleteQuotationApi,
   generateQuotation as generateQuotationApi,
   getQuotation as getQuotationApi,
+  getQuotationFormContext,
   listQuotations,
+  type QuotationListParams,
   updateQuotation as updateQuotationApi,
 } from './api/quotations'
 import { useAuthStore } from './stores/auth'
@@ -108,6 +110,17 @@ function syncTabFromRoute() {
 }
 
 const quotations = ref<Quotation[]>([])
+const quotationListLoading = ref(false)
+const quotationListQuery = ref<QuotationListParams>({
+  page: 1,
+  pageSize: 10,
+})
+const quotationListTotal = ref(0)
+const quotationListTotalPages = ref(0)
+const activeQuote = ref<Quotation | null>(null)
+const editingQuote = ref<Quotation | null>(null)
+const quotationFormContext = ref<Quotation[]>([])
+let quotationListRequestId = 0
 
 function shouldUseStoredCatalog() {
   return localStorage.getItem('qmp_catalog_version') === MOCK_CATALOG_VERSION
@@ -258,24 +271,106 @@ function triggerToast(msg: string, type: 'success' | 'info' | 'error' = 'success
   }, 4000)
 }
 
-async function refreshQuotations() {
+async function refreshQuotations(
+  query: QuotationListParams = quotationListQuery.value,
+) {
+  const requestId = ++quotationListRequestId
+  quotationListQuery.value = { ...query }
+  quotationListLoading.value = true
   try {
-    quotations.value = await listQuotations()
-    const staleLinks = await reconcileFeishuQuotationLinks(quotations.value)
-    if (staleLinks) {
-      quotations.value = await listQuotations()
+    const result = await listQuotations(query)
+    if (requestId !== quotationListRequestId) return
+    quotations.value = result.items
+    quotationListTotal.value = result.total
+    quotationListTotalPages.value = result.totalPages
+    quotationListQuery.value = {
+      ...query,
+      page: result.page,
+      pageSize: result.pageSize,
     }
   } catch (error: unknown) {
+    if (requestId !== quotationListRequestId) return
     console.error(error)
     const message = error instanceof Error ? error.message : t('quotation.app.loadFailed')
     triggerToast(message, 'error')
+    quotations.value = []
+    quotationListTotal.value = 0
+    quotationListTotalPages.value = 0
+  } finally {
+    if (requestId === quotationListRequestId) {
+      quotationListLoading.value = false
+    }
+  }
+}
+
+async function loadActiveQuote(id: string) {
+  try {
+    activeQuote.value = await getQuotationApi(id)
+  } catch (error) {
+    activeQuote.value = null
+    triggerToast(
+      error instanceof Error ? error.message : t('quotation.app.loadFailed'),
+      'error',
+    )
+  }
+}
+
+async function loadEditingQuote(id: string | null) {
+  if (!id) {
+    editingQuote.value = null
+    return
+  }
+  try {
+    editingQuote.value = await getQuotationApi(id)
+  } catch (error) {
+    editingQuote.value = null
+    triggerToast(
+      error instanceof Error ? error.message : t('quotation.app.loadFailed'),
+      'error',
+    )
+  }
+}
+
+async function loadQuotationFormContext() {
+  try {
+    quotationFormContext.value = await getQuotationFormContext()
+  } catch (error) {
+    quotationFormContext.value = []
+    triggerToast(
+      error instanceof Error ? error.message : t('quotation.app.loadFailed'),
+      'error',
+    )
+  }
+}
+
+async function loadCurrentQuotationTab() {
+  if (currentTab.value === 'list') {
+    await refreshQuotations()
+    return
+  }
+  if (currentTab.value === 'details' && selectedQuotationId.value) {
+    if (activeQuote.value?.id !== selectedQuotationId.value) {
+      await loadActiveQuote(selectedQuotationId.value)
+    }
+    return
+  }
+  if (currentTab.value === 'create') {
+    const tasks: Promise<unknown>[] = [loadQuotationFormContext()]
+    if (editingQuote.value?.id !== editingQuoteId.value) {
+      tasks.push(loadEditingQuote(editingQuoteId.value))
+    }
+    await Promise.all(tasks)
   }
 }
 
 onMounted(async () => {
   await auth.bootstrap()
   if (auth.isAuthenticated) {
-    await Promise.all([refreshQuotations(), hydrateUserCatalog()])
+    const tasks: Promise<unknown>[] = [
+      hydrateUserCatalog(),
+      loadCurrentQuotationTab(),
+    ]
+    await Promise.all(tasks)
   }
 
   const params = new URLSearchParams(window.location.search)
@@ -294,15 +389,22 @@ onMounted(async () => {
 
 watch(
   () => route.fullPath,
-  () => {
+  async () => {
     syncTabFromRoute()
+    if (auth.isAuthenticated) {
+      await loadCurrentQuotationTab()
+    }
   },
   { immediate: true },
 )
 
 async function handleLoginSuccess() {
   const me = await auth.fetchCurrentUser()
-  await Promise.all([refreshQuotations(), hydrateUserCatalog()])
+  const tasks: Promise<unknown>[] = [
+    hydrateUserCatalog(),
+    loadCurrentQuotationTab(),
+  ]
+  await Promise.all(tasks)
   triggerToast(t('quotation.app.welcomeBack', { name: me.name }), 'success')
 }
 
@@ -311,23 +413,23 @@ async function handleLogout() {
   catalogReady.value = false
   await auth.logout()
   quotations.value = []
+  quotationListTotal.value = 0
+  quotationListTotalPages.value = 0
+  activeQuote.value = null
+  editingQuote.value = null
+  quotationFormContext.value = []
   currentTab.value = 'dashboard'
   selectedQuotationId.value = null
   editingQuoteId.value = null
 }
 
 const userQuotations = computed(() =>
-  auth.currentUser ? filterQuotationsByUser(quotations.value, auth.currentUser) : [],
-)
-
-const activeQuote = computed(() =>
-  quotations.value.find((q) => q.id === selectedQuotationId.value),
-)
-
-const editingQuote = computed(() =>
-  editingQuoteId.value
-    ? quotations.value.find((q) => q.id === editingQuoteId.value) || null
-    : null,
+  auth.currentUser
+    ? filterQuotationsByUser(
+        quotationFormContext.value,
+        auth.currentUser,
+      )
+    : [],
 )
 
 const userInitials = computed(() => {
@@ -363,8 +465,6 @@ function goTab(tab: string) {
 }
 
 async function handleDeleteQuote(id: string) {
-  const previous = quotations.value
-  quotations.value = quotations.value.filter((q) => q.id !== id)
   if (selectedQuotationId.value === id) {
     selectedQuotationId.value = null
     if (currentTab.value === 'details') {
@@ -373,9 +473,17 @@ async function handleDeleteQuote(id: string) {
   }
   try {
     await deleteQuotationApi(id)
+    const currentPage = quotationListQuery.value.page || 1
+    const nextPage =
+      quotations.value.length === 1 && currentPage > 1
+        ? currentPage - 1
+        : currentPage
+    await refreshQuotations({
+      ...quotationListQuery.value,
+      page: nextPage,
+    })
     triggerToast(t('quotation.app.quoteDeleted'), 'info')
   } catch (err) {
-    quotations.value = previous
     triggerToast(
       err instanceof Error ? err.message : t('quotation.app.saveFailed'),
       'error',
@@ -384,14 +492,7 @@ async function handleDeleteQuote(id: string) {
 }
 
 async function handleViewQuoteDetails(id: string) {
-  try {
-    const latest = await getQuotationApi(id)
-    quotations.value = quotations.value.map((quote) =>
-      quote.id === id ? latest : quote,
-    )
-  } catch (error) {
-    console.error('Unable to load quotation details', error)
-  }
+  await loadActiveQuote(id)
   if (auth.embeddedAuth) {
     currentTab.value = 'details'
     selectedQuotationId.value = id
@@ -412,7 +513,7 @@ async function handleSaveQuotation(newQuote: Quotation) {
 
   try {
     const wasCreate = !editingQuoteId.value
-    const exists = quotations.value.some((q) => q.id === ownedQuote.id)
+    const exists = Boolean(editingQuoteId.value)
     const willGenerate = ownedQuote.status === 'Generated'
     let saved = exists
       ? await updateQuotationApi(ownedQuote, {
@@ -464,7 +565,7 @@ async function handleSaveQuotation(newQuote: Quotation) {
     }
 
     editingQuoteId.value = null
-    await refreshQuotations()
+    await refreshQuotations(quotationListQuery.value)
   } catch (error: unknown) {
     console.error(error)
     const message = error instanceof Error ? error.message : t('quotation.app.saveFailed')
@@ -482,7 +583,10 @@ async function handleImportedQuotationCreated(id: string) {
 }
 
 async function handleReconcileFeishuLinks() {
-  await refreshQuotations()
+  const staleLinks = await reconcileFeishuQuotationLinks(quotations.value)
+  if (staleLinks) {
+    await refreshQuotations(quotationListQuery.value)
+  }
 }
 
 async function handleUpdateQuote(
@@ -490,15 +594,16 @@ async function handleUpdateQuote(
   updatedFields: Partial<Quotation>,
   notes?: string,
 ) {
-  const previous = quotations.value.find((q) => q.id === id)
-  if (!previous) return
+  const previousListQuote = quotations.value.find((q) => q.id === id)
+  if (!previousListQuote) return
 
-  const nextQuote = { ...previous, ...updatedFields }
   const statusChanged = Boolean(
-    updatedFields.status && updatedFields.status !== previous.status,
+    updatedFields.status &&
+      updatedFields.status !== previousListQuote.status,
   )
   const isExcelGenerated =
-    updatedFields.status === 'Generated' && previous.status === 'Draft'
+    updatedFields.status === 'Generated' &&
+    previousListQuote.status === 'Draft'
 
   let computedNotes = notes || ''
   if (!computedNotes) {
@@ -514,7 +619,7 @@ async function handleUpdateQuote(
   }
 
   quotations.value = quotations.value.map((q) =>
-    q.id === id ? nextQuote : q,
+    q.id === id ? { ...q, ...updatedFields } : q,
   )
 
   if (isFeishuLinkOnlyUpdate(updatedFields)) {
@@ -523,13 +628,18 @@ async function handleUpdateQuote(
 
   if (statusChanged || notes || isExcelGenerated) {
     try {
-      const saved = await updateQuotationApi(nextQuote, {
+      const detail = await getQuotationApi(id)
+      const saved = await updateQuotationApi({
+        ...detail,
+        ...updatedFields,
+      }, {
         notes: computedNotes,
       })
       quotations.value = quotations.value.map((q) =>
         q.id === id
           ? {
-              ...saved,
+              ...q,
+              status: saved.status,
               region: q.region,
               industry: q.industry,
             }
@@ -537,7 +647,7 @@ async function handleUpdateQuote(
       )
     } catch (err) {
       quotations.value = quotations.value.map((q) =>
-        q.id === id ? previous : q,
+        q.id === id ? previousListQuote : q,
       )
       triggerToast(
         err instanceof Error ? err.message : t('quotation.app.saveFailed'),
@@ -622,8 +732,9 @@ function handleDeleteProductLine(productLine: QuoteProductLine) {
   )
 }
 
-function handleEditQuote(id: string) {
+async function handleEditQuote(id: string) {
   editingQuoteId.value = id
+  await loadEditingQuote(id)
   if (auth.embeddedAuth) {
     router.push({ path: '/quotation/create', query: { edit: id } })
     return
@@ -848,7 +959,6 @@ function reloadPage() {
       >
         <Dashboard
           v-if="currentTab === 'dashboard'"
-          :quotations="quotations"
           @view-quote="handleViewQuoteDetails"
           @navigate-to-tab="handleNavigateToTab"
         />
@@ -859,6 +969,11 @@ function reloadPage() {
         >
           <QuotationList
             :quotations="quotations"
+            :loading="quotationListLoading"
+            :page="quotationListQuery.page || 1"
+            :page-size="quotationListQuery.pageSize || 10"
+            :total="quotationListTotal"
+            :total-pages="quotationListTotalPages"
             :current-user="auth.currentUser"
             @view-quote="handleViewQuoteDetails"
             @delete-quote="handleDeleteQuote"
@@ -867,6 +982,7 @@ function reloadPage() {
             @reconcile-feishu-links="handleReconcileFeishuLinks"
             @edit-quote="handleEditQuote"
             @toast="triggerToast"
+            @query-change="refreshQuotations"
           />
 
           <ImportedDocumentsPage
@@ -881,7 +997,7 @@ function reloadPage() {
           :products="products"
           :services="services"
           :discounts="discounts"
-          :quotations="quotations"
+          :quotations="quotationFormContext"
           :history-quotations="userQuotations"
           :editing-quote="editingQuote"
           :current-user="auth.currentUser"

--- a/frontend/src/modules/quotation/api/dashboard.ts
+++ b/frontend/src/modules/quotation/api/dashboard.ts
@@ -1,0 +1,189 @@
+import type { Quotation } from '../types'
+import { apiRequest } from './client'
+
+export type DashboardTrendGrain = 'weekly' | 'monthly'
+
+export interface DashboardSummary {
+  currency: Quotation['currency']
+  availableCurrencies: string[]
+  monthWonAmount: number
+  successRate: number
+  successRateNumerator: number
+  successRateDenominator: number
+  followUpCount: number
+  activeCount: number
+  draftCount: number
+  generatedAt: string
+}
+
+export interface DashboardBreakdownItem {
+  quotationId: string
+  quoteNo: string
+  amount: number
+  status: Quotation['status']
+}
+
+export interface DashboardTrendPoint {
+  period: string
+  createdAmount: number
+  wonAmount: number
+}
+
+export interface DashboardAnalytics {
+  currency: Quotation['currency']
+  availableCurrencies: string[]
+  amountBreakdown: DashboardBreakdownItem[]
+  breakdownTotalAmount: number
+  breakdownOmittedCount: number
+  breakdownOmittedAmount: number
+  trends: Record<DashboardTrendGrain, DashboardTrendPoint[]>
+  generatedAt: string
+}
+
+export interface DashboardRecentQuotation {
+  id: string
+  quoteNo: string
+  projectName: string
+  clientCompany: string
+  salesperson: string
+  createdAt: string
+  currency: Quotation['currency']
+  grandTotal: number
+  status: Quotation['status']
+}
+
+interface ApiSummary {
+  currency: Quotation['currency']
+  available_currencies: string[]
+  month_won_amount: string
+  success_rate: number
+  success_rate_numerator: number
+  success_rate_denominator: number
+  follow_up_count: number
+  active_count: number
+  draft_count: number
+  generated_at: string
+}
+
+interface ApiTrendPoint {
+  period: string
+  created_amount: string
+  won_amount: string
+}
+
+interface ApiAnalytics {
+  currency: Quotation['currency']
+  available_currencies: string[]
+  amount_breakdown: Array<{
+    quotation_id: string
+    quote_no: string
+    amount: string
+    status: string
+  }>
+  breakdown_total_amount: string
+  breakdown_omitted_count: number
+  breakdown_omitted_amount: string
+  trends: Record<DashboardTrendGrain, ApiTrendPoint[]>
+  generated_at: string
+}
+
+interface ApiRecentQuotation {
+  id: string
+  quote_no: string
+  project_name: string
+  client_company: string
+  salesperson: string
+  created_at: string
+  currency: Quotation['currency']
+  grand_total: string
+  status: string
+}
+
+const API_TO_STATUS: Record<string, Quotation['status']> = {
+  draft: 'Draft',
+  generated: 'Generated',
+  uploaded: 'Uploaded',
+  sent: 'Sent',
+  accepted: 'Accepted',
+  rejected: 'Rejected',
+  expired: 'Expired',
+  cancelled: 'Cancelled',
+}
+
+function mapStatus(value: string): Quotation['status'] {
+  return API_TO_STATUS[value.toLowerCase()] || 'Draft'
+}
+
+function currencyQuery(currency: string): string {
+  return `currency=${encodeURIComponent(currency)}`
+}
+
+export async function getDashboardSummary(
+  currency = 'USD',
+): Promise<DashboardSummary> {
+  const data = await apiRequest<ApiSummary>(
+    `/dashboard/summary?${currencyQuery(currency)}`,
+  )
+  return {
+    currency: data.currency,
+    availableCurrencies: data.available_currencies,
+    monthWonAmount: Number(data.month_won_amount || 0),
+    successRate: data.success_rate,
+    successRateNumerator: data.success_rate_numerator,
+    successRateDenominator: data.success_rate_denominator,
+    followUpCount: data.follow_up_count,
+    activeCount: data.active_count,
+    draftCount: data.draft_count,
+    generatedAt: data.generated_at,
+  }
+}
+
+export async function getDashboardAnalytics(
+  currency = 'USD',
+): Promise<DashboardAnalytics> {
+  const data = await apiRequest<ApiAnalytics>(
+    `/dashboard/analytics?${currencyQuery(currency)}`,
+  )
+  const mapTrend = (row: ApiTrendPoint): DashboardTrendPoint => ({
+    period: row.period,
+    createdAmount: Number(row.created_amount || 0),
+    wonAmount: Number(row.won_amount || 0),
+  })
+  return {
+    currency: data.currency,
+    availableCurrencies: data.available_currencies,
+    amountBreakdown: data.amount_breakdown.map((row) => ({
+      quotationId: row.quotation_id,
+      quoteNo: row.quote_no,
+      amount: Number(row.amount || 0),
+      status: mapStatus(row.status),
+    })),
+    breakdownTotalAmount: Number(data.breakdown_total_amount || 0),
+    breakdownOmittedCount: data.breakdown_omitted_count,
+    breakdownOmittedAmount: Number(data.breakdown_omitted_amount || 0),
+    trends: {
+      monthly: data.trends.monthly.map(mapTrend),
+      weekly: data.trends.weekly.map(mapTrend),
+    },
+    generatedAt: data.generated_at,
+  }
+}
+
+export async function getDashboardRecent(
+  limit = 5,
+): Promise<DashboardRecentQuotation[]> {
+  const data = await apiRequest<{ items: ApiRecentQuotation[] }>(
+    `/dashboard/recent?limit=${limit}`,
+  )
+  return data.items.map((row) => ({
+    id: row.id,
+    quoteNo: row.quote_no,
+    projectName: row.project_name,
+    clientCompany: row.client_company,
+    salesperson: row.salesperson,
+    createdAt: row.created_at,
+    currency: row.currency,
+    grandTotal: Number(row.grand_total || 0),
+    status: mapStatus(row.status),
+  }))
+}

--- a/frontend/src/modules/quotation/api/quotations.ts
+++ b/frontend/src/modules/quotation/api/quotations.ts
@@ -82,6 +82,64 @@ interface ApiQuotation {
   versions?: ApiQuotationVersion[];
 }
 
+interface ApiQuotationListItem {
+  id: string;
+  quote_no: string;
+  display_quote_no: string;
+  project_name: string;
+  client_company: string;
+  contact_person: string;
+  created_at: string;
+  currency: string;
+  grand_total: number | string;
+  status: string;
+  source_type: 'manual' | 'document_import';
+  source_document_type?: 'excel' | 'pdf' | null;
+  product_line: string;
+  item_count: number;
+  latest_excel_document_id?: string | null;
+  latest_pdf_document_id?: string | null;
+}
+
+interface ApiQuotationFormContextItem {
+  id: string;
+  quote_no: string;
+  display_quote_no: string;
+  project_name: string;
+  client_company: string;
+  contact_person: string;
+  email: string;
+  product_line: string;
+  billing_company: string;
+  billing_contact: string;
+  billing_email: string;
+  currency: string;
+  tax_label: string;
+  issuer_contact_name: string;
+  issuer_contact_email: string;
+  created_by_email?: string | null;
+  created_at: string;
+}
+
+export interface QuotationListParams {
+  page?: number;
+  pageSize?: 10 | 20 | 50;
+  search?: string;
+  status?: Quotation['status'];
+  productLine?: string;
+  sourceType?: 'manual' | 'document_import';
+  createdFrom?: string;
+  createdTo?: string;
+}
+
+export interface QuotationListResult {
+  items: Quotation[];
+  total: number;
+  page: number;
+  pageSize: 10 | 20 | 50;
+  totalPages: number;
+}
+
 function toNumber(value: unknown): number {
   return Number(value || 0);
 }
@@ -343,6 +401,73 @@ export function mapApiQuotation(api: ApiQuotation): Quotation {
   };
 }
 
+function mapApiQuotationListItem(api: ApiQuotationListItem): Quotation {
+  return {
+    id: api.id,
+    quoteNo: api.display_quote_no || api.quote_no,
+    sourceType: api.source_type || 'manual',
+    sourceDocumentType: api.source_document_type || undefined,
+    projectName: api.project_name,
+    clientCompany: api.client_company,
+    contactPerson: api.contact_person,
+    email: '',
+    productLine: api.product_line,
+    region: '',
+    industry: '',
+    salesperson: '',
+    currency: (api.currency as Quotation['currency']) || 'USD',
+    paymentTerms: '',
+    status: mapStatus(api.status),
+    items: [],
+    itemCount: Number(api.item_count || 0),
+    softwareSubtotal: 0,
+    othersSubtotal: 0,
+    subtotalBeforeVat: 0,
+    vatRate: 0,
+    vatAmount: 0,
+    grandTotal: toNumber(api.grand_total),
+    createdAt: api.created_at,
+    feishuExcelDocumentId:
+      api.latest_excel_document_id || undefined,
+    feishuPdfDocumentId: api.latest_pdf_document_id || undefined,
+  };
+}
+
+function mapApiQuotationFormContextItem(
+  api: ApiQuotationFormContextItem,
+): Quotation {
+  return {
+    id: api.id,
+    quoteNo: api.display_quote_no || api.quote_no,
+    projectName: api.project_name,
+    clientCompany: api.client_company,
+    contactPerson: api.contact_person,
+    email: api.email,
+    productLine: api.product_line,
+    billingCompany: api.billing_company,
+    billingContact: api.billing_contact,
+    billingEmail: api.billing_email,
+    region: '',
+    industry: '',
+    salesperson: api.issuer_contact_name,
+    issuerContactEmail: api.issuer_contact_email,
+    createdByEmail: api.created_by_email || undefined,
+    sourceType: 'manual',
+    currency: (api.currency as Quotation['currency']) || 'USD',
+    paymentTerms: '',
+    taxLabel: api.tax_label,
+    status: 'Draft',
+    items: [],
+    softwareSubtotal: 0,
+    othersSubtotal: 0,
+    subtotalBeforeVat: 0,
+    vatRate: 0,
+    vatAmount: 0,
+    grandTotal: 0,
+    createdAt: api.created_at,
+  };
+}
+
 export function mapQuotationToCreatePayload(quote: Quotation) {
   return {
     quote_no: quote.quoteNo,
@@ -384,14 +509,44 @@ export function mapQuotationToCreatePayload(quote: Quotation) {
   };
 }
 
-export async function listQuotations(): Promise<Quotation[]> {
-  const data = await apiRequest<{ items: ApiQuotation[]; total: number }>('/quotations?page=1&page_size=200');
-  return data.items.map(mapApiQuotation);
+export async function listQuotations(
+  params: QuotationListParams = {},
+): Promise<QuotationListResult> {
+  const query = new URLSearchParams();
+  query.set('page', String(params.page || 1));
+  query.set('page_size', String(params.pageSize || 10));
+  if (params.search?.trim()) query.set('search', params.search.trim());
+  if (params.status) query.set('status', mapStatusToApi(params.status));
+  if (params.productLine) query.set('product_line', params.productLine);
+  if (params.sourceType) query.set('source_type', params.sourceType);
+  if (params.createdFrom) query.set('created_from', params.createdFrom);
+  if (params.createdTo) query.set('created_to', params.createdTo);
+  const data = await apiRequest<{
+    items: ApiQuotationListItem[];
+    total: number;
+    page: number;
+    page_size: 10 | 20 | 50;
+    total_pages: number;
+  }>(`/quotations?${query.toString()}`);
+  return {
+    items: data.items.map(mapApiQuotationListItem),
+    total: data.total,
+    page: data.page,
+    pageSize: data.page_size,
+    totalPages: data.total_pages,
+  };
 }
 
 export async function getQuotation(quoteId: string): Promise<Quotation> {
-  const data = await apiRequest<ApiQuotation>(`/quotations/${quoteId}`)
-  return mapApiQuotation(data)
+  const data = await apiRequest<ApiQuotation>(`/quotations/${quoteId}`);
+  return mapApiQuotation(data);
+}
+
+export async function getQuotationFormContext(): Promise<Quotation[]> {
+  const data = await apiRequest<{
+    items: ApiQuotationFormContextItem[];
+  }>('/quotations/form-context');
+  return data.items.map(mapApiQuotationFormContextItem);
 }
 
 export async function createQuotation(quote: Quotation): Promise<Quotation> {

--- a/frontend/src/modules/quotation/components/Dashboard.vue
+++ b/frontend/src/modules/quotation/components/Dashboard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { Line, Pie } from 'vue-chartjs'
 import {
   ArcElement,
@@ -16,15 +16,17 @@ import {
   type Plugin,
   type TooltipItem,
 } from 'chart.js'
+import {
+  getDashboardAnalytics,
+  getDashboardRecent,
+  getDashboardSummary,
+  type DashboardAnalytics,
+  type DashboardRecentQuotation,
+  type DashboardSummary,
+} from '../api/dashboard'
 import { useQuotationI18n } from '../composables/useQuotationI18n'
 import type { Quotation } from '../types'
 import StatusBadge from './StatusBadge.vue'
-import {
-  isChartQuoteStatus,
-  isExpiringSoonStatus,
-  isOpenQuoteStatus,
-  isWonQuoteStatus,
-} from '../utils/quoteStatus'
 import {
   TrendingUp,
   Users,
@@ -48,11 +50,6 @@ ChartJS.register(
 
 type TrendGrain = 'weekly' | 'monthly'
 
-const TREND_WEEK_COUNT = 8
-const TREND_MONTH_COUNT = 6
-const QUOTE_BREAKDOWN_MIN_SHARE = 2
-const QUOTE_BREAKDOWN_MAX_SLICES = 8
-
 const QUOTE_BREAKDOWN_COLORS = [
   '#2b9da3',
   '#389e0d',
@@ -64,18 +61,18 @@ const QUOTE_BREAKDOWN_COLORS = [
   '#d6a21f',
 ]
 
-const props = defineProps<{
-  quotations: Quotation[]
-}>()
-
 const emit = defineEmits<{
   viewQuote: [id: string]
   navigateToTab: [tab: string]
 }>()
 
-const { t, locale, quoteStatusLabel } = useQuotationI18n()
+const { t, locale } = useQuotationI18n()
 
 const trendGrain = ref<TrendGrain>('monthly')
+const dashboardCurrency = ref('USD')
+const summary = ref<DashboardSummary | null>(null)
+const analytics = ref<DashboardAnalytics | null>(null)
+const recentQuotes = ref<DashboardRecentQuotation[]>([])
 
 function currencySymbol(currency: Quotation['currency']): string {
   if (currency === 'USD') return t('quotation.common.currencyUsd')
@@ -83,58 +80,33 @@ function currencySymbol(currency: Quotation['currency']): string {
   return t('quotation.common.currencyCny')
 }
 
-const signedAmount = computed(() =>
-  props.quotations
-    .filter((q) => isWonQuoteStatus(q.status))
-    .reduce((sum, q) => sum + q.grandTotal, 0),
-)
-
-const activeForRate = computed(() =>
-  props.quotations.filter(
-    (q) => isOpenQuoteStatus(q.status) || isWonQuoteStatus(q.status),
-  ),
-)
-
-const successRate = computed(() =>
-  activeForRate.value.length > 0
-    ? Math.round(
-        (props.quotations.filter((q) => isWonQuoteStatus(q.status)).length /
-          activeForRate.value.length) *
-          100,
-      )
-    : 0,
-)
-
-const expiringSoonCount = computed(
-  () => props.quotations.filter((q) => isExpiringSoonStatus(q.status)).length,
-)
-
-const activeCount = computed(
-  () => props.quotations.filter((q) => isOpenQuoteStatus(q.status)).length,
-)
-
-const draftCount = computed(
-  () => props.quotations.filter((q) => q.status === 'Draft').length,
-)
+const signedAmount = computed(() => summary.value?.monthWonAmount || 0)
+const signedAmountLabel = computed(() => {
+  const currency = summary.value?.currency || 'USD'
+  return `${currencySymbol(currency)}${signedAmount.value.toLocaleString()}`
+})
+const successRate = computed(() => summary.value?.successRate || 0)
+const expiringSoonCount = computed(() => summary.value?.followUpCount || 0)
+const activeCount = computed(() => summary.value?.activeCount || 0)
+const draftCount = computed(() => summary.value?.draftCount || 0)
 
 const quoteBreakdownData = computed(() =>
-  props.quotations
-    .filter((quote) => quote.grandTotal > 0)
-    .sort((a, b) => b.grandTotal - a.grandTotal)
-    .map((quote, index) => {
-      const amountLabel = `${currencySymbol(quote.currency)}${quote.grandTotal.toLocaleString()}`
-      return {
-        key: quote.id,
-        quoteNo: quote.quoteNo,
-        value: quote.grandTotal,
-        color: QUOTE_BREAKDOWN_COLORS[index % QUOTE_BREAKDOWN_COLORS.length],
-        amountLabel,
-        currency: quote.currency,
-        share: 0,
-        status: quote.status,
-        label: `${quote.quoteNo} · ${amountLabel}`,
-      }
-    }),
+  (analytics.value?.amountBreakdown || []).map((quote, index) => {
+    const currency = analytics.value?.currency || 'USD'
+    const amountLabel =
+      `${currencySymbol(currency)}${quote.amount.toLocaleString()}`
+    return {
+      key: quote.quotationId,
+      quoteNo: quote.quoteNo,
+      value: quote.amount,
+      color: QUOTE_BREAKDOWN_COLORS[index % QUOTE_BREAKDOWN_COLORS.length],
+      amountLabel,
+      currency,
+      share: 0,
+      status: quote.status,
+      label: `${quote.quoteNo} · ${amountLabel}`,
+    }
+  }),
 )
 
 const quoteBreakdownTotal = computed(() =>
@@ -147,10 +119,7 @@ const quoteBreakdownChartRows = computed(() => {
     ...row,
     share: (row.value / total) * 100,
   }))
-  const visible = rows
-    .filter((row) => row.share >= QUOTE_BREAKDOWN_MIN_SHARE)
-    .slice(0, QUOTE_BREAKDOWN_MAX_SLICES)
-  return visible.length ? visible : rows.slice(0, 1)
+  return rows
 })
 
 const quoteBreakdownRotation = computed(() => {
@@ -320,148 +289,32 @@ const quoteBreakdownPieOptions = computed<ChartOptions<'pie'>>(() => ({
   },
 }))
 
-function parseQuoteDate(value?: string): Date | null {
-  if (!value) return null
-  const normalized = value.includes('T')
-    ? value
-    : value.replace(' ', 'T')
-  const date = new Date(normalized)
-  return Number.isNaN(date.getTime()) ? null : date
-}
-
-function startOfWeekMonday(date: Date): Date {
-  const next = new Date(date)
-  next.setHours(0, 0, 0, 0)
-  const day = next.getDay()
-  const diff = (day + 6) % 7
-  next.setDate(next.getDate() - diff)
-  return next
-}
-
-function startOfMonth(date: Date): Date {
-  return new Date(date.getFullYear(), date.getMonth(), 1)
-}
-
-function periodKey(date: Date, grain: TrendGrain): string {
-  const year = date.getFullYear()
-  const month = String(date.getMonth() + 1).padStart(2, '0')
-  if (grain === 'monthly') return `${year}-${month}`
-  const day = String(date.getDate()).padStart(2, '0')
-  return `${year}-${month}-${day}`
-}
-
-function formatPeriodLabel(date: Date, grain: TrendGrain): string {
-  const month = String(date.getMonth() + 1).padStart(2, '0')
+function formatPeriodLabel(period: string, grain: TrendGrain): string {
+  const [, month = '', day = ''] = period.split('-')
   if (grain === 'monthly') {
     if (String(locale.value || '').startsWith('zh')) {
       return t('quotation.pages.dashboard.chartTrendMonthLabel', {
         month: Number(month),
       })
     }
+    const date = new Date(`${period}-01T00:00:00`)
     return date.toLocaleString('en', { month: 'short' })
   }
-  const day = String(date.getDate()).padStart(2, '0')
   return `${month}-${day}`
 }
 
-/**
- * Prefer first Accepted version timestamp; else updatedAt; else createdAt.
- */
-function resolveWonAt(quote: Quotation): Date | null {
-  if (!isWonQuoteStatus(quote.status)) return null
-  const acceptedVersions = (quote.versions || [])
-    .filter((version) => version.status === 'Accepted')
-    .map((version) => parseQuoteDate(version.updateTime))
-    .filter((date): date is Date => Boolean(date))
-    .sort((a, b) => a.getTime() - b.getTime())
-  if (acceptedVersions[0]) return acceptedVersions[0]
-  return (
-    parseQuoteDate(quote.updatedAt) || parseQuoteDate(quote.createdAt)
-  )
-}
-
-const trendPeriods = computed(() => {
-  const grain = trendGrain.value
-  const periods: Array<{ key: string; label: string; start: Date }> = []
-
-  if (grain === 'monthly') {
-    const current = startOfMonth(new Date())
-    for (let index = TREND_MONTH_COUNT - 1; index >= 0; index -= 1) {
-      const start = new Date(
-        current.getFullYear(),
-        current.getMonth() - index,
-        1,
-      )
-      periods.push({
-        key: periodKey(start, grain),
-        label: formatPeriodLabel(start, grain),
-        start,
-      })
-    }
-    return periods
-  }
-
-  const latestMonday = startOfWeekMonday(new Date())
-  for (let index = TREND_WEEK_COUNT - 1; index >= 0; index -= 1) {
-    const start = new Date(latestMonday)
-    start.setDate(latestMonday.getDate() - index * 7)
-    periods.push({
-      key: periodKey(start, grain),
-      label: formatPeriodLabel(start, grain),
-      start,
-    })
-  }
-  return periods
-})
+const trendPeriods = computed(() =>
+  (analytics.value?.trends[trendGrain.value] || []).map((row) => ({
+    key: row.period,
+    label: formatPeriodLabel(row.period, trendGrain.value),
+  })),
+)
 
 const trendSeries = computed(() => {
-  const grain = trendGrain.value
-  const createdMap = new Map<string, number>()
-  const wonMap = new Map<string, number>()
-  trendPeriods.value.forEach((period) => {
-    createdMap.set(period.key, 0)
-    wonMap.set(period.key, 0)
-  })
-
-  const firstStart = trendPeriods.value[0]?.start
-  if (!firstStart) {
-    return { created: [] as number[], won: [] as number[] }
-  }
-
-  props.quotations.forEach((quote) => {
-    if (!isChartQuoteStatus(quote.status)) return
-
-    const createdAt = parseQuoteDate(quote.createdAt)
-    if (createdAt && createdAt >= firstStart) {
-      const bucketStart =
-        grain === 'monthly'
-          ? startOfMonth(createdAt)
-          : startOfWeekMonday(createdAt)
-      const key = periodKey(bucketStart, grain)
-      if (createdMap.has(key)) {
-        createdMap.set(
-          key,
-          (createdMap.get(key) || 0) + (quote.grandTotal || 0),
-        )
-      }
-    }
-
-    const wonAt = resolveWonAt(quote)
-    if (wonAt && wonAt >= firstStart) {
-      const bucketStart =
-        grain === 'monthly' ? startOfMonth(wonAt) : startOfWeekMonday(wonAt)
-      const key = periodKey(bucketStart, grain)
-      if (wonMap.has(key)) {
-        wonMap.set(key, (wonMap.get(key) || 0) + (quote.grandTotal || 0))
-      }
-    }
-  })
-
+  const rows = analytics.value?.trends[trendGrain.value] || []
   return {
-    created: trendPeriods.value.map(
-      (period) => createdMap.get(period.key) || 0,
-    ),
-    won: trendPeriods.value.map((period) => wonMap.get(period.key) || 0),
+    created: rows.map((row) => row.createdAmount),
+    won: rows.map((row) => row.wonAmount),
   }
 })
 
@@ -527,7 +380,8 @@ const trendLineOptions = computed<ChartOptions<'line'>>(() => ({
       callbacks: {
         label: (item: TooltipItem<'line'>) => {
           const value = Number(item.raw) || 0
-          return `${item.dataset.label}: ¥${value.toLocaleString()}`
+          const symbol = currencySymbol(analytics.value?.currency || 'USD')
+          return `${item.dataset.label}: ${symbol}${value.toLocaleString()}`
         },
       },
     },
@@ -565,15 +419,6 @@ const trendLineOptions = computed<ChartOptions<'line'>>(() => ({
   },
 }))
 
-const recentQuotes = computed(() =>
-  [...props.quotations]
-    .sort(
-      (a, b) =>
-        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-    )
-    .slice(0, 5),
-)
-
 function formatRecentQuoteTime(value: string): string {
   const match = String(value || '').match(
     /^\d{4}-(\d{2})-(\d{2})[ T](\d{2}):(\d{2})/,
@@ -589,6 +434,32 @@ function formatRecentQuoteTime(value: string): string {
 function setTrendGrain(grain: TrendGrain) {
   trendGrain.value = grain
 }
+
+onMounted(async () => {
+  await Promise.all([
+    getDashboardSummary(dashboardCurrency.value)
+      .then((data) => {
+        summary.value = data
+      })
+      .catch((error) => {
+        console.error('Unable to load dashboard summary', error)
+      }),
+    getDashboardAnalytics(dashboardCurrency.value)
+      .then((data) => {
+        analytics.value = data
+      })
+      .catch((error) => {
+        console.error('Unable to load dashboard analytics', error)
+      }),
+    getDashboardRecent(5)
+      .then((data) => {
+        recentQuotes.value = data
+      })
+      .catch((error) => {
+        console.error('Unable to load recent quotations', error)
+      }),
+  ])
+})
 </script>
 
 <template>
@@ -626,7 +497,7 @@ function setTrendGrain(grain: TrendGrain) {
             {{ t('quotation.pages.dashboard.kpiRevenueLabel') }}
           </span>
           <div class="font-mono text-2xl font-semibold text-dm-text">
-            ¥{{ signedAmount.toLocaleString() }}
+            {{ signedAmountLabel }}
           </div>
           <div class="flex items-center gap-1 text-xs font-medium text-emerald-500">
             <TrendingUp class="h-3 w-3" />

--- a/frontend/src/modules/quotation/components/FormSelect.vue
+++ b/frontend/src/modules/quotation/components/FormSelect.vue
@@ -19,6 +19,7 @@ const props = withDefaults(
     disabled?: boolean
     className?: string
     triggerClassName?: string
+    panelClassName?: string
     testId?: string
     placeholder?: string
   }>(),
@@ -26,6 +27,7 @@ const props = withDefaults(
     disabled: false,
     className: '',
     triggerClassName: '',
+    panelClassName: '',
     placeholder: '请选择',
   },
 )
@@ -74,7 +76,11 @@ function selectOption(option: FormSelectOption) {
       <span class="block truncate">{{ displayLabel }}</span>
     </button>
 
-    <DropdownPanel v-if="open && !disabled" :test-id="testId ? `${testId}-menu` : undefined">
+    <DropdownPanel
+      v-if="open && !disabled"
+      :test-id="testId ? `${testId}-menu` : undefined"
+      :class-name="panelClassName"
+    >
       <li v-for="option in options" :key="option.value">
         <DropdownOption
           :selected="option.value === currentValue"

--- a/frontend/src/modules/quotation/components/QuotationList.vue
+++ b/frontend/src/modules/quotation/components/QuotationList.vue
@@ -1,5 +1,12 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  watch,
+} from 'vue'
 import {
   Download,
   ExternalLink,
@@ -25,6 +32,7 @@ import {
   waitForQuotationExport,
   type QuotationExportStatus,
 } from '../api/exports'
+import type { QuotationListParams } from '../api/quotations'
 import type { Quotation, QuoteStatus } from '../types'
 import { FORM_SELECT_COMPACT_TRIGGER_CLASS } from '../utils/formFieldClasses'
 import { clearedFeishuFields } from '../utils/feishuLinkState'
@@ -41,6 +49,10 @@ type FeishuUploadFormat = 'excel' | 'pdf'
 const props = defineProps<{
   quotations: Quotation[]
   loading?: boolean
+  page: number
+  pageSize: 10 | 20 | 50
+  total: number
+  totalPages: number
   currentUser?: {
     name: string
     title: string
@@ -57,6 +69,7 @@ const emit = defineEmits<{
   reconcileFeishuLinks: []
   editQuote: [id: string]
   toast: [message: string, type?: 'success' | 'info' | 'error']
+  queryChange: [query: QuotationListParams]
 }>()
 
 const { t, quoteStatusLabel, statusFilterOptions } = useQuotationI18n()
@@ -77,6 +90,11 @@ const sourceFilterOptions = computed(() => [
     label: t('quotation.pages.list.sourceDocumentImport'),
   },
 ])
+
+const pageSizeOptions = [10, 20, 50].map((value) => ({
+  value: String(value),
+  label: String(value),
+}))
 
 const tableStatusValues: QuoteStatus[] = [
   'Draft',
@@ -114,6 +132,8 @@ const pendingFeishuOpen = ref<{
   documentId: string
 } | null>(null)
 let reconcileTimer: number | undefined
+let searchTimer: number | undefined
+let suppressFilterWatch = false
 
 function scheduleFeishuLinkReconcile() {
   window.clearTimeout(reconcileTimer)
@@ -220,6 +240,7 @@ onBeforeUnmount(() => {
   document.removeEventListener('visibilitychange', handlePageVisible)
   window.removeEventListener('focus', handlePageVisible)
   window.clearTimeout(reconcileTimer)
+  window.clearTimeout(searchTimer)
 })
 
 function currencySymbol(currency: Quotation['currency']): string {
@@ -445,14 +466,76 @@ async function retryFailedUpload(quote: Quotation) {
   }
 }
 
-function handleResetFilters() {
+function listQuery(
+  page = props.page,
+  pageSize = props.pageSize,
+): QuotationListParams {
+  return {
+    page,
+    pageSize,
+    search: searchText.value.trim() || undefined,
+    status:
+      selectedStatus.value === 'ALL'
+        ? undefined
+        : (selectedStatus.value as QuoteStatus),
+    productLine:
+      selectedProductLine.value === 'ALL'
+        ? undefined
+        : selectedProductLine.value,
+    sourceType:
+      selectedSource.value === 'ALL'
+        ? undefined
+        : (selectedSource.value as 'manual' | 'document_import'),
+    createdFrom: createdFrom.value || undefined,
+    createdTo: createdTo.value || undefined,
+  }
+}
+
+function requestPage(page: number) {
+  if (page < 1 || page > Math.max(props.totalPages, 1)) return
+  emit('queryChange', listQuery(page))
+}
+
+function handlePageSizeChange(selectedValue: string) {
+  const value = Number(selectedValue)
+  if (![10, 20, 50].includes(value)) return
+  emit('queryChange', listQuery(1, value as 10 | 20 | 50))
+}
+
+async function handleResetFilters() {
+  suppressFilterWatch = true
   searchText.value = ''
   selectedStatus.value = 'ALL'
   selectedProductLine.value = 'ALL'
   selectedSource.value = 'ALL'
   createdFrom.value = ''
   createdTo.value = ''
+  await nextTick()
+  suppressFilterWatch = false
+  emit('queryChange', listQuery(1))
 }
+
+watch(searchText, () => {
+  if (suppressFilterWatch) return
+  window.clearTimeout(searchTimer)
+  searchTimer = window.setTimeout(() => {
+    emit('queryChange', listQuery(1))
+  }, 300)
+})
+
+watch(
+  [
+    selectedStatus,
+    selectedProductLine,
+    selectedSource,
+    createdFrom,
+    createdTo,
+  ],
+  () => {
+    if (suppressFilterWatch) return
+    emit('queryChange', listQuery(1))
+  },
+)
 
 function wait(milliseconds: number): Promise<void> {
   return new Promise((resolve) => window.setTimeout(resolve, milliseconds))
@@ -524,36 +607,19 @@ const hasActiveFilters = computed(
     createdTo.value !== '',
 )
 
-const filteredQuotations = computed(() => {
-  return props.quotations.filter((q) => {
-    const matchesText =
-      q.quoteNo.toLowerCase().includes(searchText.value.toLowerCase()) ||
-      q.projectName.toLowerCase().includes(searchText.value.toLowerCase()) ||
-      q.clientCompany.toLowerCase().includes(searchText.value.toLowerCase()) ||
-      q.contactPerson.toLowerCase().includes(searchText.value.toLowerCase()) ||
-      q.email.toLowerCase().includes(searchText.value.toLowerCase())
-
-    const matchesStatus = selectedStatus.value === 'ALL' || q.status === selectedStatus.value
-    const quoteProductLine = (q.productLine || '').trim() || 'BDR'
-    const matchesProductLine =
-      selectedProductLine.value === 'ALL' ||
-      quoteProductLine === selectedProductLine.value
-    const matchesSource =
-      selectedSource.value === 'ALL' ||
-      (q.sourceType || 'manual') === selectedSource.value
-    const quoteDate = q.createdAt.substring(0, 10)
-    const matchesCreatedFrom = !createdFrom.value || quoteDate >= createdFrom.value
-    const matchesCreatedTo = !createdTo.value || quoteDate <= createdTo.value
-
-    return (
-      matchesText &&
-      matchesStatus &&
-      matchesProductLine &&
-      matchesSource &&
-      matchesCreatedFrom &&
-      matchesCreatedTo
-    )
-  })
+const rangeStart = computed(() =>
+  props.total ? (props.page - 1) * props.pageSize + 1 : 0,
+)
+const rangeEnd = computed(() =>
+  Math.min(props.page * props.pageSize, props.total),
+)
+const pageNumbers = computed(() => {
+  const totalPages = props.totalPages
+  if (totalPages <= 5) {
+    return Array.from({ length: totalPages }, (_, index) => index + 1)
+  }
+  const start = Math.max(1, Math.min(props.page - 2, totalPages - 4))
+  return Array.from({ length: 5 }, (_, index) => start + index)
 })
 
 function displayContact(quote: Quotation): string {
@@ -674,7 +740,7 @@ function displayTotal(quote: Quotation): string {
 
           <div class="flex items-center gap-1 md:col-span-2 xl:col-span-1">
             <div class="flex h-10 min-w-20 items-center justify-center whitespace-nowrap rounded-lg bg-slate-50 px-2.5 text-xs font-semibold text-dm-text-tertiary">
-              {{ t('quotation.pages.list.filterResultsCount', { count: filteredQuotations.length }) }}
+              {{ t('quotation.pages.list.filterResultsCount', { count: total }) }}
             </div>
             <button
               type="button"
@@ -733,14 +799,19 @@ function displayTotal(quote: Quotation): string {
             </tr>
           </thead>
           <tbody class="divide-y divide-slate-100 text-sm">
-            <tr v-if="filteredQuotations.length === 0">
+            <tr v-if="loading">
+              <td colspan="8" class="py-12 text-center text-dm-text-tertiary">
+                {{ t('quotation.pages.list.syncing') }}
+              </td>
+            </tr>
+            <tr v-else-if="quotations.length === 0">
               <td colspan="8" class="py-12 text-center text-dm-text-tertiary">
                 {{ t('quotation.pages.list.emptyResults') }}
               </td>
             </tr>
             <template v-else>
             <tr
-              v-for="quote in filteredQuotations"
+              v-for="quote in quotations"
               :key="quote.id"
               class="hover:bg-[#fafafa] transition duration-150"
             >
@@ -764,7 +835,11 @@ function displayTotal(quote: Quotation): string {
                     {{ quote.projectName }}
                   </p>
                   <p class="text-xs text-dm-text-tertiary font-mono mt-0.5">
-                    {{ t('quotation.common.lineItemCount', { count: quote.items.length }) }}
+                    {{
+                      t('quotation.common.lineItemCount', {
+                        count: quote.itemCount ?? quote.items.length,
+                      })
+                    }}
                   </p>
                 </div>
               </td>
@@ -928,6 +1003,61 @@ function displayTotal(quote: Quotation): string {
             </template>
           </tbody>
         </table>
+      </div>
+      <div
+        class="flex flex-col gap-3 border-t border-dm-border-light px-4 py-3 text-sm text-dm-text-tertiary sm:flex-row sm:items-center sm:justify-between"
+      >
+        <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
+          <span>共 {{ total }} 条</span>
+          <span>显示 {{ rangeStart }}–{{ rangeEnd }} 条</span>
+          <span>共 {{ totalPages }} 页</span>
+        </div>
+        <div class="flex flex-wrap items-center gap-2">
+          <label class="flex items-center gap-2">
+            <span>每页</span>
+            <FormSelect
+              :value="String(pageSize)"
+              class-name="w-20"
+              trigger-class-name="h-8 rounded-md border-dm-border bg-white px-2 text-sm focus:border-blue-300 focus:ring-2 focus:ring-blue-100"
+              panel-class-name="bottom-full top-auto mb-1 mt-0"
+              :options="pageSizeOptions"
+              test-id="quotation-page-size"
+              @change="handlePageSizeChange"
+            />
+            <span>条</span>
+          </label>
+          <button
+            type="button"
+            class="h-8 rounded-md border border-dm-border px-2.5 disabled:cursor-not-allowed disabled:opacity-40"
+            :disabled="page <= 1 || loading"
+            @click="requestPage(page - 1)"
+          >
+            上一页
+          </button>
+          <button
+            v-for="pageNumber in pageNumbers"
+            :key="pageNumber"
+            type="button"
+            class="h-8 min-w-8 rounded-md border px-2"
+            :class="
+              pageNumber === page
+                ? 'border-dm-primary bg-dm-primary text-white'
+                : 'border-dm-border bg-white text-dm-text-secondary'
+            "
+            :disabled="loading"
+            @click="requestPage(pageNumber)"
+          >
+            {{ pageNumber }}
+          </button>
+          <button
+            type="button"
+            class="h-8 rounded-md border border-dm-border px-2.5 disabled:cursor-not-allowed disabled:opacity-40"
+            :disabled="page >= totalPages || loading || totalPages === 0"
+            @click="requestPage(page + 1)"
+          >
+            下一页
+          </button>
+        </div>
       </div>
     </div>
 

--- a/frontend/src/modules/quotation/pages/DashboardPage.vue
+++ b/frontend/src/modules/quotation/pages/DashboardPage.vue
@@ -17,7 +17,7 @@ onMounted(async () => {
       listQuotations(),
       listImportedFeishuDocuments().catch(() => []),
     ])
-    quoteCount.value = quotes.length
+    quoteCount.value = quotes.total
     importCount.value = docs.length
   } finally {
     loading.value = false

--- a/frontend/src/modules/quotation/pages/QuotationCreatePage.vue
+++ b/frontend/src/modules/quotation/pages/QuotationCreatePage.vue
@@ -19,7 +19,12 @@ import type {
   QuoteProductLine,
   Service,
 } from '../types'
-import { listQuotations, createQuotation, updateQuotation } from '../api/quotations'
+import {
+  createQuotation,
+  getQuotation,
+  getQuotationFormContext,
+  updateQuotation,
+} from '../api/quotations'
 import { useAuthStore } from '../stores/auth'
 import { clearCreateQuoteDraft } from '../utils/createDraftStorage'
 import { loadProductLineOptions, saveCustomProductLineOptions } from '../utils/quotationNumbering'
@@ -44,7 +49,13 @@ const currentUser = computed(() => auth.currentUser || undefined)
 
 onMounted(async () => {
   try {
-    quotations.value = await listQuotations()
+    const editId =
+      typeof route.query.edit === 'string' ? route.query.edit : null
+    const [context, detail] = await Promise.all([
+      getQuotationFormContext(),
+      editId ? getQuotation(editId) : Promise.resolve(null),
+    ])
+    quotations.value = detail ? [detail, ...context] : context
   } catch {
     quotations.value = []
   }

--- a/frontend/src/modules/quotation/pages/QuotationDetailPage.vue
+++ b/frontend/src/modules/quotation/pages/QuotationDetailPage.vue
@@ -6,7 +6,7 @@
 import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import QuotationDetails from '../components/QuotationDetails.vue'
-import { listQuotations, updateQuotation } from '../api/quotations'
+import { getQuotation, updateQuotation } from '../api/quotations'
 import { isFeishuLinkOnlyUpdate } from '../utils/feishuLinkState'
 import { useAuthStore } from '../stores/auth'
 import type { Quotation } from '../types'
@@ -25,9 +25,7 @@ async function load() {
   loading.value = true
   error.value = ''
   try {
-    const all = await listQuotations()
-    quote.value = all.find((item) => item.id === String(route.params.id)) || null
-    if (!quote.value) error.value = '未找到该报价单'
+    quote.value = await getQuotation(String(route.params.id))
   } catch (err) {
     error.value = err instanceof Error ? err.message : '加载失败'
     quote.value = null

--- a/frontend/src/modules/quotation/pages/QuotationListPage.vue
+++ b/frontend/src/modules/quotation/pages/QuotationListPage.vue
@@ -1,7 +1,13 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
-import { listQuotations, updateQuotation, deleteQuotation } from '../api/quotations'
+import {
+  deleteQuotation,
+  getQuotation,
+  listQuotations,
+  type QuotationListParams,
+  updateQuotation,
+} from '../api/quotations'
 import ImportedDocumentsPage from '../components/ImportedDocumentsPage.vue'
 import QuotationList from '../components/QuotationList.vue'
 import { isFeishuLinkOnlyUpdate, reconcileFeishuQuotationLinks } from '../utils/feishuLinkState'
@@ -13,6 +19,9 @@ const auth = useAuthStore()
 
 const quotations = ref<Quotation[]>([])
 const loading = ref(false)
+const query = ref<QuotationListParams>({ page: 1, pageSize: 10 })
+const total = ref(0)
+const totalPages = ref(0)
 const toast = ref<{ message: string; type: string } | null>(null)
 let toastTimer: number | undefined
 
@@ -34,19 +43,32 @@ function showToast(message: string, type: 'success' | 'info' | 'error' = 'info')
   }, 4000)
 }
 
-async function load() {
+let requestId = 0
+
+async function load(nextQuery: QuotationListParams = query.value) {
+  const currentRequest = ++requestId
+  query.value = { ...nextQuery }
   loading.value = true
   try {
-    quotations.value = await listQuotations()
-    const staleLinks = await reconcileFeishuQuotationLinks(quotations.value)
-    if (staleLinks) {
-      quotations.value = await listQuotations()
+    const result = await listQuotations(nextQuery)
+    if (currentRequest !== requestId) return
+    quotations.value = result.items
+    total.value = result.total
+    totalPages.value = result.totalPages
+    query.value = {
+      ...nextQuery,
+      page: result.page,
+      pageSize: result.pageSize,
     }
   } catch (err: unknown) {
     showToast(err instanceof Error ? err.message : '加载报价单失败', 'error')
-    quotations.value = []
+    if (currentRequest === requestId) {
+      quotations.value = []
+      total.value = 0
+      totalPages.value = 0
+    }
   } finally {
-    loading.value = false
+    if (currentRequest === requestId) loading.value = false
   }
 }
 
@@ -79,13 +101,18 @@ function handleEditQuote(id: string) {
 }
 
 async function handleDeleteQuote(id: string) {
-  const previous = quotations.value
-  quotations.value = quotations.value.filter((q) => q.id !== id)
   try {
     await deleteQuotation(id)
+    const currentPage = query.value.page || 1
+    await load({
+      ...query.value,
+      page:
+        quotations.value.length === 1 && currentPage > 1
+          ? currentPage - 1
+          : currentPage,
+    })
     showToast('报价单已安全从系统抹除！', 'info')
   } catch (err: unknown) {
-    quotations.value = previous
     showToast(err instanceof Error ? err.message : '删除失败', 'error')
   }
 }
@@ -93,7 +120,7 @@ async function handleDeleteQuote(id: string) {
 async function handleReconcileFeishuLinks() {
   const staleLinks = await reconcileFeishuQuotationLinks(quotations.value)
   if (staleLinks) {
-    quotations.value = await listQuotations()
+    await load(query.value)
   }
 }
 
@@ -129,7 +156,13 @@ function handleUpdateQuoteStatus(
     return
   }
 
-  void updateQuotation(nextQuote, { notes: computedNotes || undefined })
+  void getQuotation(id)
+    .then((detail) =>
+      updateQuotation(
+        { ...detail, ...updatedFields },
+        { notes: computedNotes || undefined },
+      ),
+    )
     .then((saved) => {
       quotations.value = quotations.value.map((q) =>
         q.id === id ? saved : q,
@@ -190,6 +223,11 @@ function handleUpdateQuoteStatus(
       <QuotationList
         v-else
         :quotations="quotations"
+        :loading="loading"
+        :page="query.page || 1"
+        :page-size="query.pageSize || 10"
+        :total="total"
+        :total-pages="totalPages"
         :current-user="currentUser"
         @view-quote="handleViewQuote"
         @delete-quote="handleDeleteQuote"
@@ -198,6 +236,7 @@ function handleUpdateQuoteStatus(
         @reconcile-feishu-links="handleReconcileFeishuLinks"
         @edit-quote="handleEditQuote"
         @toast="showToast"
+        @query-change="load"
       />
 
       <div class="hidden" aria-hidden="true">

--- a/frontend/src/modules/quotation/types.ts
+++ b/frontend/src/modules/quotation/types.ts
@@ -100,6 +100,7 @@ export interface Quotation {
   issuerSignature?: string;
   status: QuoteStatus;
   items: QuotationLineItem[];
+  itemCount?: number;
   softwareSubtotal: number;
   othersSubtotal: number;
   subtotalBeforeVat: number;


### PR DESCRIPTION
## Summary

- add database-backed pagination, search, and filters to the quotation list API
- return a lightweight list payload with annotated item counts and batched document summaries
- keep quotation detail loading separate and prefetch document replicas to avoid N+1 queries
- split Quote Desk dashboard summary, analytics, and recent quotations into dedicated endpoints
- add stable ordering and targeted quotation/dashboard indexes
- add frontend pagination, 300 ms search debounce, request ordering protection, and delete-page recovery
- use the shared custom select style for page size and open its menu upward so it is not clipped by the table card
- keep remote Feishu link validation out of the pagination request path

## API changes

`GET /api/v1/quotation/quotations` now accepts:

- `search`
- `status`
- `product_line`
- `source_type`
- `created_from`
- `created_to`
- `page` (default `1`)
- `page_size` (`10`, `20`, or `50`; default `10`)

The response is now:

```json
{
  "items": [],
  "total": 0,
  "page": 1,
  "page_size": 10,
  "total_pages": 0
}
```

Additional narrow endpoints:

- `GET /api/v1/quotation/quotations/form-context`
- `GET /api/v1/quotation/dashboard/summary`
- `GET /api/v1/quotation/dashboard/analytics`
- `GET /api/v1/quotation/dashboard/recent`

## Query and response performance

Measured against the previous quotation list implementation:

| Case | SQL queries | Response size | API time |
| --- | ---: | ---: | ---: |
| Previous list | 454 | ~145.4 KB | ~215 ms |
| New list, 10 rows | 5 | ~5.2 KB | — |
| New list, 50 rows | 5 | ~25.7 KB | ~5.25 ms |

The SQL query count remains fixed between 10-row and 50-row pages. The list response excludes full items, versions, snapshots, documents, and replicas. No Worker, Celery task, or container was added.

## Database indexes

- stable created time/id ordering index
- owner plus created time/id index for permission-scoped lists
- product line plus created time/id index
- dashboard currency/status/time indexes
- document and replica indexes used by the batched list summary

`status`, `source_type`, and `created_by_email` retain their existing single-column indexes. PostgreSQL trigram GIN indexes were evaluated but not added: the current query volume does not justify introducing a PostgreSQL extension and five additional text indexes without production query-plan evidence. No broad combinatorial indexes were added.

## Validation

- Django quotation list/dashboard tests: **17 passed**
- quotation frontend script tests: **passed**
- pagination-specific frontend tests: **9 passed**
- frontend production build: **passed**
- `git diff --check`: **passed**
- manual validation on the existing local runtime: page-size menu displays `10`, `20`, and `50` fully without clipping

`npm run typecheck` is currently blocked before project analysis by the existing `vue-tsc`/TypeScript compatibility error:

```text
Search string not found: "/supportedTSExtensions = .*(?=;)/"
```

This is a toolchain startup failure rather than a reported application type error.
