### PR TITLE
Classify Zhipu security verification as account action

### DIFF
--- a/backend/cloud_billing/clouds/zhipu_provider.py
+++ b/backend/cloud_billing/clouds/zhipu_provider.py
@@ -504,8 +504,24 @@ class ZhipuCloud(BaseCloudProvider):
             logger.error("Zhipu billing HTTP error: %s", body)
             return {"status": "error", "data": None, "error": body}
         except Exception as exc:
-            logger.error("Zhipu billing error: %s", exc)
-            return {"status": "error", "data": None, "error": str(exc)}
+            error_message = str(exc)
+            requires_security_verification = (
+                "安全验证" in error_message
+                or "security verification" in error_message.lower()
+            )
+            if requires_security_verification:
+                logger.warning(
+                    "Zhipu billing requires account action: %s",
+                    error_message,
+                )
+                return {
+                    "status": "error",
+                    "data": None,
+                    "error": error_message,
+                    "is_config_error": True,
+                }
+            logger.error("Zhipu billing error: %s", error_message)
+            return {"status": "error", "data": None, "error": error_message}
 
     def get_account_id(self) -> str:
         if self._last_account_id:

--- a/backend/cloud_billing/tests/test_zhipu_provider.py
+++ b/backend/cloud_billing/tests/test_zhipu_provider.py
@@ -1,5 +1,6 @@
 """Tests for the Zhipu AI billing provider."""
 
+import logging
 from unittest.mock import Mock, patch
 
 import pytest
@@ -102,3 +103,34 @@ class TestZhipuCloud:
 
         assert provider.validate_credentials() is True
         assert mock_request.call_count == 1
+
+    @patch("cloud_billing.clouds.zhipu_provider.requests.Session.request")
+    def test_security_verification_is_configuration_error(
+        self, mock_request, caplog
+    ):
+        provider = self._make_provider()
+        login_response = Mock()
+        login_response.raise_for_status.return_value = None
+        login_response.json.return_value = {
+            "code": 500,
+            "msg": "请完成安全验证",
+        }
+        mock_request.return_value = login_response
+
+        with caplog.at_level(
+            logging.WARNING,
+            logger="cloud_billing.clouds.zhipu_provider",
+        ):
+            result = provider.get_billing_info("2026-08")
+
+        assert result == {
+            "status": "error",
+            "data": None,
+            "error": "请完成安全验证",
+            "is_config_error": True,
+        }
+        assert not [
+            record
+            for record in caplog.records
+            if record.levelno >= logging.ERROR
+        ]


### PR DESCRIPTION
## Summary

- classify the Zhipu “complete security verification” login response as an account/configuration action
- preserve the failed billing result while logging a warning instead of an application error
- add regression coverage for the result contract and log severity

Closes #211

Sentry: https://sentry.oneprocloud.com/organizations/sentry/issues/1248/

## Test plan

- [x] `DJANGO_SETTINGS_MODULE=cloud_billing.tests.settings PYTHONPATH=backend .venv/bin/pytest --no-migrations backend/cloud_billing/tests -q` (451 passed, 1 skipped)
- [x] `.venv/bin/ruff check --isolated --select E4,E7,E9,F backend/cloud_billing/clouds/zhipu_provider.py backend/cloud_billing/tests/test_zhipu_provider.py`
- [x] `MYPYPATH=backend .venv/bin/mypy --ignore-missing-imports --follow-imports=skip backend/cloud_billing/clouds/zhipu_provider.py backend/cloud_billing/tests/test_zhipu_provider.py`

## Deployment

- not deployed or merged by this workflow
- resolve Sentry and close any linked Jira issue only after production verification