### PR TITLE
feat(llm-ops): add tier-aware channel costing

### DIFF
--- a/backend/llm_ops/assistant_tools.py
+++ b/backend/llm_ops/assistant_tools.py
@@ -29,10 +29,11 @@ from llm_ops.services import (
     compute_model_decision,
     convert_currency_amount,
     resolve_channel_model_currency,
-    resolve_channel_model_price,
+    resolve_channel_price_schedule,
     resolve_resale_listing_currency,
     selected_price_item_group,
 )
+from llm_ops.tier_pricing import UsageContext, resolve_usage_unit_prices
 
 DEFAULT_LIMIT = 30
 MAX_LIMIT = 100
@@ -522,13 +523,18 @@ def _channel_options(
     price_items_by_override,
 ):
     options = []
+    usage_context = UsageContext(
+        input_tokens=DEFAULT_INPUT_TOKENS,
+        output_tokens=DEFAULT_OUTPUT_TOKENS,
+    )
     for override in overrides:
-        unit_prices = resolve_channel_model_price(
+        schedule = resolve_channel_price_schedule(
             override.channel,
             model,
             override=override,
             source_items=price_items_by_override.get(override.id, []),
         )
+        unit_prices = resolve_usage_unit_prices(schedule, usage_context)
         input_price = Decimal(str(unit_prices.input_per_million or "0"))
         output_price = Decimal(str(unit_prices.output_per_million or "0"))
         if input_price <= 0 or output_price <= 0:

--- a/backend/llm_ops/collection_services.py
+++ b/backend/llm_ops/collection_services.py
@@ -46,6 +46,10 @@ from .price_collectors import (
     registered_vendor_price_collector_codes,
     vendor_price_collector_exists,
 )
+from .price_table_validation import (
+    validate_price_table_groups,
+    with_usage_range_spec,
+)
 from .services import (
     find_aggregated_model,
     match_meta_model_by_alias_or_name,
@@ -3181,6 +3185,8 @@ def sync_model_price_items(
     if not payloads:
         return []
 
+    validate_price_table_groups(payloads)
+
     now = timezone.now()
     current_filter = {
         "offering": offering,
@@ -3582,6 +3588,7 @@ def price_item_payload(
     tier_type = ModelPriceItem.TIER_FLAT
     if tier_start is not None or tier_end is not None:
         tier_type = ModelPriceItem.TIER_USAGE_RANGE
+        spec = with_usage_range_spec(spec)
     return {
         **common,
         "dimension": dimension,

--- a/backend/llm_ops/migrations/0009_usagereconciliationrecord_cache_input_tokens.py
+++ b/backend/llm_ops/migrations/0009_usagereconciliationrecord_cache_input_tokens.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("llm_ops", "0008_performance_indexes"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="usagereconciliationrecord",
+            name="cache_input_tokens",
+            field=models.PositiveBigIntegerField(default=0),
+        ),
+    ]

--- a/backend/llm_ops/models.py
+++ b/backend/llm_ops/models.py
@@ -2096,6 +2096,7 @@ class UsageReconciliationRecord(models.Model):
     )
     input_tokens = models.PositiveBigIntegerField(default=0)
     output_tokens = models.PositiveBigIntegerField(default=0)
+    cache_input_tokens = models.PositiveBigIntegerField(default=0)
     audio_input_seconds = models.DecimalField(
         max_digits=14,
         decimal_places=3,

--- a/backend/llm_ops/price_table_validation.py
+++ b/backend/llm_ops/price_table_validation.py
@@ -1,4 +1,12 @@
-"""Shared executable contract for normalized tiered price tables."""
+"""Shared executable contract for normalized tiered price tables.
+
+A table represents one model, source/platform variant, billing dimension,
+currency, and billing unit. Usage-range tiers use ``[tier_start, tier_end)``;
+``tier_end=None`` means that the final tier is unbounded. The first-phase
+metric is the input token count of one request, and the matched tier prices
+the whole request. Volume tiers remain disabled until cumulative periods and
+graduated-versus-matched charging are defined.
+"""
 
 from __future__ import annotations
 
@@ -136,7 +144,7 @@ def validate_price_table_groups(rows: Sequence[Any]) -> None:
     for row in rows:
         key = (
             str(_value(row, "dimension") or ""),
-            _variant_spec_key(_value(row, "spec")),
+            price_table_variant_key(row),
         )
         tables.setdefault(key, []).append(row)
     for table in tables.values():
@@ -160,6 +168,11 @@ def match_usage_range_tier(rows: Sequence[Any], metric_value: Any) -> Any:
             if end is None or value < end:
                 return row
     return None
+
+
+def price_table_variant_key(row: Any) -> str:
+    """Return display metadata that identifies an independent table."""
+    return _variant_spec_key(_value(row, "spec"))
 
 
 def _validate_flat_table(rows: Sequence[Any]) -> None:

--- a/backend/llm_ops/price_table_validation.py
+++ b/backend/llm_ops/price_table_validation.py
@@ -1,0 +1,318 @@
+"""Shared executable contract for normalized tiered price tables."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from decimal import Decimal, InvalidOperation
+import json
+from typing import Any
+
+
+TIER_FLAT = "flat"
+TIER_USAGE_RANGE = "usage_range"
+TIER_VOLUME = "volume"
+
+TIER_METRIC_REQUEST_INPUT_TOKENS = "request_input_tokens"
+TIER_CHARGE_MODE_MATCHED_TIER = "matched_tier"
+AGGREGATION_PERIOD_REQUEST = "request"
+
+TIER_CONTRACT_SPEC_KEYS = frozenset(
+    {
+        "tier_metric",
+        "tier_charge_mode",
+        "aggregation_period",
+    }
+)
+SUPPORTED_TIER_DIMENSIONS = frozenset(
+    {
+        "text_input",
+        "text_output",
+        "cache_input",
+    }
+)
+
+ERROR_MIXED_FLAT_AND_TIERED = "price_table_mixed_flat_and_tiered"
+ERROR_INCONSISTENT_DIMENSION = "price_table_inconsistent_dimension"
+ERROR_INCONSISTENT_CURRENCY = "price_table_inconsistent_currency"
+ERROR_INCONSISTENT_UNIT = "price_table_inconsistent_billing_unit"
+ERROR_INCONSISTENT_TIER_TYPE = "price_table_inconsistent_tier_type"
+ERROR_INCONSISTENT_METRIC = "price_table_inconsistent_tier_metric"
+ERROR_INCONSISTENT_CHARGE_MODE = (
+    "price_table_inconsistent_tier_charge_mode"
+)
+ERROR_INCONSISTENT_AGGREGATION_PERIOD = (
+    "price_table_inconsistent_aggregation_period"
+)
+ERROR_UNSUPPORTED_DIMENSION = "price_table_unsupported_tier_dimension"
+ERROR_INVALID_USAGE_RANGE_SPEC = "price_table_invalid_usage_range_spec"
+ERROR_TIER_MUST_START_AT_ZERO = "price_table_first_tier_must_start_at_zero"
+ERROR_INVALID_BOUNDARY = "price_table_invalid_boundary"
+ERROR_DUPLICATE_RANGE = "price_table_duplicate_range"
+ERROR_GAP = "price_table_gap"
+ERROR_UNBOUNDED_TIER_NOT_LAST = "price_table_unbounded_tier_not_last"
+ERROR_VOLUME_UNSUPPORTED = "price_table_volume_unsupported"
+
+
+class PriceTableValidationError(ValueError):
+    """Machine-readable price table contract violation."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+def usage_range_spec() -> dict[str, str]:
+    """Return the first-phase executable usage-range contract."""
+    return {
+        "tier_metric": TIER_METRIC_REQUEST_INPUT_TOKENS,
+        "tier_charge_mode": TIER_CHARGE_MODE_MATCHED_TIER,
+        "aggregation_period": AGGREGATION_PERIOD_REQUEST,
+    }
+
+
+def with_usage_range_spec(spec: Mapping[str, Any] | None) -> dict:
+    """Add the canonical usage-range contract to display metadata."""
+    return {**dict(spec or {}), **usage_range_spec()}
+
+
+def validate_price_table(rows: Sequence[Any]) -> None:
+    """Validate one flat or tiered table using the shared contract."""
+    if not rows:
+        return
+
+    tier_types = {_value(row, "tier_type") or TIER_FLAT for row in rows}
+    if TIER_FLAT in tier_types and len(tier_types) > 1:
+        _raise(
+            ERROR_MIXED_FLAT_AND_TIERED,
+            "A price table cannot mix flat and tiered rows.",
+        )
+
+    _require_consistent(
+        rows,
+        "dimension",
+        ERROR_INCONSISTENT_DIMENSION,
+        "All rows must use the same dimension.",
+    )
+    _require_consistent(
+        rows,
+        "currency",
+        ERROR_INCONSISTENT_CURRENCY,
+        "All rows must use the same currency.",
+    )
+    _require_consistent(
+        rows,
+        "billing_unit",
+        ERROR_INCONSISTENT_UNIT,
+        "All rows must use the same billing unit.",
+    )
+    if len(tier_types) > 1:
+        _raise(
+            ERROR_INCONSISTENT_TIER_TYPE,
+            "All rows must use the same tier type.",
+        )
+
+    tier_type = next(iter(tier_types))
+    if tier_type == TIER_FLAT:
+        _validate_flat_table(rows)
+        return
+    if tier_type == TIER_VOLUME:
+        _raise(
+            ERROR_VOLUME_UNSUPPORTED,
+            "Volume tiers are disabled until their billing contract is set.",
+        )
+    if tier_type != TIER_USAGE_RANGE:
+        _raise(
+            ERROR_INVALID_BOUNDARY,
+            f"Unsupported tier type: {tier_type}.",
+        )
+
+    _validate_usage_range_table(rows)
+
+
+def validate_price_table_groups(rows: Sequence[Any]) -> None:
+    """Validate independent dimension and variant tables in one catalog."""
+    tables: dict[tuple[str, str], list[Any]] = {}
+    for row in rows:
+        key = (
+            str(_value(row, "dimension") or ""),
+            _variant_spec_key(_value(row, "spec")),
+        )
+        tables.setdefault(key, []).append(row)
+    for table in tables.values():
+        validate_price_table(table)
+
+
+def match_usage_range_tier(rows: Sequence[Any], metric_value: Any) -> Any:
+    """Return the row containing a request metric under ``[start, end)``."""
+    validate_price_table(rows)
+    value = _decimal(metric_value)
+    if value is None or value < Decimal("0"):
+        _raise(
+            ERROR_INVALID_BOUNDARY,
+            "The tier metric value must be a non-negative number.",
+        )
+
+    for row in _sorted_tiers(rows):
+        start = _decimal(_value(row, "tier_start"))
+        end = _decimal(_value(row, "tier_end"))
+        if start is not None and start <= value:
+            if end is None or value < end:
+                return row
+    return None
+
+
+def _validate_flat_table(rows: Sequence[Any]) -> None:
+    for row in rows:
+        if (
+            _value(row, "tier_start") is not None
+            or _value(row, "tier_end") is not None
+        ):
+            _raise(
+                ERROR_INVALID_BOUNDARY,
+                "Flat price rows cannot define tier boundaries.",
+            )
+
+
+def _validate_usage_range_table(rows: Sequence[Any]) -> None:
+    dimension = str(_value(rows[0], "dimension") or "")
+    if dimension not in SUPPORTED_TIER_DIMENSIONS:
+        _raise(
+            ERROR_UNSUPPORTED_DIMENSION,
+            "Usage-range tiers only support text and cached input prices.",
+        )
+
+    specs = [dict(_value(row, "spec") or {}) for row in rows]
+    _require_spec_consistent(
+        specs,
+        "tier_metric",
+        ERROR_INCONSISTENT_METRIC,
+        "All rows must use the same tier metric.",
+    )
+    _require_spec_consistent(
+        specs,
+        "tier_charge_mode",
+        ERROR_INCONSISTENT_CHARGE_MODE,
+        "All rows must use the same tier charge mode.",
+    )
+    _require_spec_consistent(
+        specs,
+        "aggregation_period",
+        ERROR_INCONSISTENT_AGGREGATION_PERIOD,
+        "All rows must use the same aggregation period.",
+    )
+    expected = usage_range_spec()
+    if any(
+        any(spec.get(key) != value for key, value in expected.items())
+        for spec in specs
+    ):
+        _raise(
+            ERROR_INVALID_USAGE_RANGE_SPEC,
+            "Usage-range rows must use the request input token contract.",
+        )
+
+    tiers = _sorted_tiers(rows)
+    first_start = _decimal(_value(tiers[0], "tier_start"))
+    if first_start != Decimal("0"):
+        _raise(
+            ERROR_TIER_MUST_START_AT_ZERO,
+            "The first tier must start at zero.",
+        )
+
+    seen_ranges = set()
+    previous_end = None
+    for index, row in enumerate(tiers):
+        start = _decimal(_value(row, "tier_start"))
+        end = _decimal(_value(row, "tier_end"))
+        range_key = (start, end)
+        if range_key in seen_ranges:
+            _raise(ERROR_DUPLICATE_RANGE, "Tier ranges must be unique.")
+        seen_ranges.add(range_key)
+
+        if start is None or start < Decimal("0"):
+            _raise(
+                ERROR_INVALID_BOUNDARY,
+                "Tier boundaries must be non-negative numbers.",
+            )
+        if end is not None and end <= start:
+            _raise(
+                ERROR_INVALID_BOUNDARY,
+                "A tier end must be greater than its start.",
+            )
+        if end is None and index != len(tiers) - 1:
+            _raise(
+                ERROR_UNBOUNDED_TIER_NOT_LAST,
+                "Only the final tier may have no upper bound.",
+            )
+        if index:
+            if previous_end is None:
+                _raise(
+                    ERROR_UNBOUNDED_TIER_NOT_LAST,
+                    "Only the final tier may have no upper bound.",
+                )
+            if start < previous_end:
+                _raise(ERROR_INVALID_BOUNDARY, "Tier ranges overlap.")
+            if start > previous_end:
+                _raise(ERROR_GAP, "Tier ranges must not contain gaps.")
+        previous_end = end
+
+
+def _require_consistent(
+    rows: Sequence[Any],
+    field: str,
+    code: str,
+    message: str,
+) -> None:
+    values = {_value(row, field) for row in rows}
+    if len(values) > 1:
+        _raise(code, message)
+
+
+def _require_spec_consistent(
+    specs: Sequence[Mapping[str, Any]],
+    field: str,
+    code: str,
+    message: str,
+) -> None:
+    values = {spec.get(field) for spec in specs}
+    if len(values) > 1:
+        _raise(code, message)
+
+
+def _sorted_tiers(rows: Sequence[Any]) -> list[Any]:
+    try:
+        return sorted(
+            rows,
+            key=lambda row: (
+                _decimal(_value(row, "tier_start")) is None,
+                _decimal(_value(row, "tier_start")) or Decimal("0"),
+            ),
+        )
+    except (InvalidOperation, TypeError, ValueError):
+        _raise(ERROR_INVALID_BOUNDARY, "Tier boundaries must be numbers.")
+
+
+def _variant_spec_key(spec: Any) -> str:
+    values = dict(spec or {})
+    for key in TIER_CONTRACT_SPEC_KEYS:
+        values.pop(key, None)
+    return json.dumps(values, default=str, sort_keys=True)
+
+
+def _decimal(value: Any) -> Decimal | None:
+    if value is None or value == "":
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        _raise(ERROR_INVALID_BOUNDARY, "Tier boundaries must be numbers.")
+
+
+def _value(row: Any, field: str) -> Any:
+    if isinstance(row, Mapping):
+        return row.get(field)
+    return getattr(row, field, None)
+
+
+def _raise(code: str, message: str) -> None:
+    raise PriceTableValidationError(code, message)

--- a/backend/llm_ops/price_table_validation.py
+++ b/backend/llm_ops/price_table_validation.py
@@ -81,6 +81,11 @@ def usage_range_spec() -> dict[str, str]:
 
 def with_usage_range_spec(spec: Mapping[str, Any] | None) -> dict:
     """Add the canonical usage-range contract to display metadata."""
+    if spec is not None and not isinstance(spec, Mapping):
+        _raise(
+            ERROR_INVALID_USAGE_RANGE_SPEC,
+            "Tier spec must be a JSON object.",
+        )
     return {**dict(spec or {}), **usage_range_spec()}
 
 
@@ -332,9 +337,12 @@ def _decimal(value: Any) -> Decimal | None:
     if value is None or value == "":
         return None
     try:
-        return Decimal(str(value))
+        result = Decimal(str(value))
     except (InvalidOperation, TypeError, ValueError):
         _raise(ERROR_INVALID_BOUNDARY, "Tier boundaries must be numbers.")
+    if not result.is_finite():
+        _raise(ERROR_INVALID_BOUNDARY, "Tier boundaries must be finite.")
+    return result
 
 
 def _value(row: Any, field: str) -> Any:

--- a/backend/llm_ops/price_table_validation.py
+++ b/backend/llm_ops/price_table_validation.py
@@ -195,7 +195,7 @@ def _validate_usage_range_table(rows: Sequence[Any]) -> None:
             "Usage-range tiers only support text and cached input prices.",
         )
 
-    specs = [dict(_value(row, "spec") or {}) for row in rows]
+    specs = [_price_spec(row) for row in rows]
     _require_spec_consistent(
         specs,
         "tier_metric",
@@ -306,10 +306,26 @@ def _sorted_tiers(rows: Sequence[Any]) -> list[Any]:
 
 
 def _variant_spec_key(spec: Any) -> str:
+    if spec is not None and not isinstance(spec, Mapping):
+        return json.dumps(
+            {"invalid_spec": spec},
+            default=str,
+            sort_keys=True,
+        )
     values = dict(spec or {})
     for key in TIER_CONTRACT_SPEC_KEYS:
         values.pop(key, None)
     return json.dumps(values, default=str, sort_keys=True)
+
+
+def _price_spec(row: Any) -> dict:
+    value = _value(row, "spec")
+    if value is not None and not isinstance(value, Mapping):
+        _raise(
+            ERROR_INVALID_USAGE_RANGE_SPEC,
+            "Tier spec must be a JSON object.",
+        )
+    return dict(value or {})
 
 
 def _decimal(value: Any) -> Decimal | None:

--- a/backend/llm_ops/serializers.py
+++ b/backend/llm_ops/serializers.py
@@ -1298,7 +1298,10 @@ def validate_serializer_price_table(rows) -> None:
     try:
         validate_price_table(rows)
     except PriceTableValidationError as exc:
-        error = serializers.ErrorDetail(exc.message, code=exc.code)
+        error = {
+            "code": serializers.ErrorDetail(exc.code, code=exc.code),
+            "message": serializers.ErrorDetail(exc.message, code=exc.code),
+        }
         raise serializers.ValidationError({"price_table": error}) from exc
 
 

--- a/backend/llm_ops/serializers.py
+++ b/backend/llm_ops/serializers.py
@@ -38,6 +38,11 @@ from .models import (
     ResaleWorkflowConfig,
     UsageReconciliationRecord,
 )
+from .price_table_validation import (
+    PriceTableValidationError,
+    price_table_variant_key,
+    validate_price_table,
+)
 from .services import (
     SUPPORTED_DISPLAY_CURRENCIES,
     calculate_channel_model_cost,
@@ -874,6 +879,11 @@ class ModelPriceItemSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError("unit_price must be >= 0.")
         return value
 
+    def validate(self, attrs):
+        rows = model_price_table_rows(attrs, instance=self.instance)
+        validate_serializer_price_table(rows)
+        return attrs
+
     def create(self, validated_data):
         meta_model = price_item_meta_model(validated_data)
         source = price_item_source(validated_data)
@@ -1264,6 +1274,94 @@ def related_id(data: dict, field: str, instance) -> int | None:
     return value.id if value is not None else None
 
 
+PRICE_TABLE_FIELDS = (
+    "dimension",
+    "billing_unit",
+    "currency",
+    "tier_type",
+    "tier_start",
+    "tier_end",
+    "spec",
+)
+
+
+def price_table_candidate(data: dict, instance=None) -> dict:
+    """Merge serializer input with persisted values for table validation."""
+    return {
+        field: data.get(field, getattr(instance, field, None))
+        for field in PRICE_TABLE_FIELDS
+    }
+
+
+def validate_serializer_price_table(rows) -> None:
+    """Translate the shared contract error to a stable DRF error code."""
+    try:
+        validate_price_table(rows)
+    except PriceTableValidationError as exc:
+        error = serializers.ErrorDetail(exc.message, code=exc.code)
+        raise serializers.ValidationError({"price_table": error}) from exc
+
+
+def model_price_table_rows(data: dict, *, instance=None) -> list:
+    """Return the current official table plus a serializer candidate."""
+    candidate = price_table_candidate(data, instance)
+    queryset = ModelPriceItem.objects.none()
+    offering = data.get("offering", getattr(instance, "offering", None))
+    model = data.get("model", getattr(instance, "model", None))
+    sku = data.get("sku", getattr(instance, "sku", None))
+    source = data.get("source", getattr(instance, "source", None))
+    dimension = candidate["dimension"]
+    if offering is not None:
+        queryset = ModelPriceItem.objects.filter(
+            offering=offering,
+            dimension=dimension,
+            is_current=True,
+        )
+    elif model is not None:
+        queryset = ModelPriceItem.objects.filter(
+            model=model,
+            source=source,
+            dimension=dimension,
+            is_current=True,
+        )
+    elif sku is not None:
+        queryset = ModelPriceItem.objects.filter(
+            sku=sku,
+            source=source,
+            dimension=dimension,
+            is_current=True,
+        )
+    if instance is not None and instance.pk:
+        queryset = queryset.exclude(pk=instance.pk)
+    variant_key = price_table_variant_key(candidate)
+    rows = [
+        row for row in queryset if price_table_variant_key(row) == variant_key
+    ]
+    return [*rows, candidate]
+
+
+def channel_price_table_rows(data: dict, *, instance=None) -> list:
+    """Return the current channel table plus a serializer candidate."""
+    candidate = price_table_candidate(data, instance)
+    channel = data.get("channel", getattr(instance, "channel", None))
+    model = data.get("model", getattr(instance, "model", None))
+    queryset = ChannelPriceItem.objects.none()
+    if channel is not None and model is not None:
+        queryset = ChannelPriceItem.objects.filter(
+            channel=channel,
+            model=model,
+            dimension=candidate["dimension"],
+            is_current=True,
+        )
+    if instance is not None and instance.pk:
+        queryset = queryset.exclude(pk=instance.pk)
+    variant_key = price_table_variant_key(candidate)
+    rows = [
+        row for row in queryset if price_table_variant_key(row) == variant_key
+    ]
+    return [*rows, candidate]
+
+
 class ProcurementChannelSerializer(serializers.ModelSerializer):
     """Serializer for upstream procurement channels."""
 
@@ -1465,6 +1563,11 @@ class ChannelPriceItemSerializer(serializers.ModelSerializer):
         if value < Decimal("0"):
             raise serializers.ValidationError("unit_price must be >= 0.")
         return value
+
+    def validate(self, attrs):
+        rows = channel_price_table_rows(attrs, instance=self.instance)
+        validate_serializer_price_table(rows)
+        return attrs
 
     def create(self, validated_data):
         validated_data["meta_model"] = validated_data["model"].meta_model

--- a/backend/llm_ops/serializers.py
+++ b/backend/llm_ops/serializers.py
@@ -1883,6 +1883,7 @@ class UsageReconciliationRecordSerializer(serializers.ModelSerializer):
             model,
             input_tokens=attrs.get("input_tokens") or 0,
             output_tokens=attrs.get("output_tokens") or 0,
+            cache_input_tokens=attrs.get("cache_input_tokens") or 0,
             audio_input_seconds=attrs.get("audio_input_seconds") or 0,
             audio_output_seconds=attrs.get("audio_output_seconds") or 0,
             video_input_seconds=attrs.get("video_input_seconds") or 0,

--- a/backend/llm_ops/services.py
+++ b/backend/llm_ops/services.py
@@ -33,6 +33,15 @@ from .price_table_validation import (
     validate_price_table_groups,
     with_usage_range_spec,
 )
+from .tier_pricing import (
+    PriceSchedule,
+    PriceTier,
+    TieredPriceNotSupportedError,
+    UnitPrices,
+    UsageContext,
+    calculate_price_schedule_usage_cost,
+    resolve_usage_unit_prices,
+)
 
 
 ZERO = Decimal("0")
@@ -87,20 +96,6 @@ def invalidate_meta_model_lookup_cache() -> None:
 def normalize_meta_model_lookup_name(value: str | None) -> str:
     """Normalize a model display name for loose matching."""
     return _normalize_lookup_name(value)
-
-
-@dataclass(frozen=True)
-class UnitPrices:
-    """Resolved procurement unit prices for a channel/model pair."""
-
-    input_per_million: Decimal
-    output_per_million: Decimal
-    cache_input_per_million: Decimal
-    image_output_per_image: Decimal
-    audio_input_per_second: Decimal
-    audio_output_per_second: Decimal
-    video_input_per_second: Decimal
-    video_output_per_second: Decimal
 
 
 @dataclass(frozen=True)
@@ -1039,6 +1034,282 @@ def decimal_or_zero(value) -> Decimal:
     return Decimal(str(value))
 
 
+def resolve_channel_price_schedule(
+    channel: ProcurementChannel,
+    model: LLMModel,
+    *,
+    override: ChannelModelPrice | None = None,
+    source_items: list[ModelPriceItem] | None = None,
+    video_resolution: str = "",
+) -> PriceSchedule:
+    """Resolve every channel price interval without flattening tiers."""
+    if override is None:
+        override = ChannelModelPrice.objects.filter(
+            channel=channel,
+            model=model,
+        ).first()
+
+    if source_items is None and override is not None:
+        source_items = current_model_price_items_for_channel_price(override)
+    source_items = list(source_items or [])
+    if source_items:
+        return _schedule_from_source_items(
+            channel,
+            model,
+            override=override,
+            source_items=source_items,
+            video_resolution=video_resolution,
+        )
+    if override is not None and override.price_source_id:
+        return _schedule_from_source_items(
+            channel,
+            model,
+            override=override,
+            source_items=[],
+            video_resolution=video_resolution,
+        )
+
+    unit_prices = resolve_channel_model_price(
+        channel,
+        model,
+        override=override,
+        source_items=[],
+        video_resolution=video_resolution,
+    )
+    currency = resolve_channel_model_currency(
+        channel,
+        model,
+        override=override,
+    )
+    return _flat_schedule_from_unit_prices(unit_prices, currency=currency)
+
+
+def _schedule_from_source_items(
+    channel: ProcurementChannel,
+    model: LLMModel,
+    *,
+    override: ChannelModelPrice | None,
+    source_items: list[ModelPriceItem],
+    video_resolution: str,
+) -> PriceSchedule:
+    """Convert normalized source items into channel settlement prices."""
+    currency = resolve_channel_model_currency(
+        channel,
+        model,
+        override=override,
+    )
+    ratio = decimal_or_zero(channel.settlement_ratio) or ONE
+    if override is not None and override.settlement_ratio is not None:
+        ratio = decimal_or_zero(override.settlement_ratio)
+
+    tiers = []
+    for item in source_items:
+        spec = item.spec or {}
+        if item.tier_type == ModelPriceItem.TIER_USAGE_RANGE:
+            spec = with_usage_range_spec(spec)
+        item_currency = currency
+        unit_price = convert_currency_between(
+            item.unit_price,
+            item.currency,
+            currency,
+        )
+        if unit_price is None:
+            unit_price = decimal_or_zero(item.unit_price)
+            item_currency = normalize_currency(item.currency) or currency
+        unit_price *= ratio
+        custom_price = None
+        if override is not None:
+            custom_price = custom_price_for_dimension(
+                override,
+                item.dimension,
+            )
+        if custom_price is not None and item.tier_type == item.TIER_FLAT:
+            unit_price = custom_price
+        resolution_price = _video_resolution_price(
+            model,
+            override=override,
+            dimension=item.dimension,
+            video_resolution=video_resolution,
+            ratio=ratio,
+        )
+        if resolution_price is not None and item.tier_type == item.TIER_FLAT:
+            unit_price = resolution_price
+        tiers.append(
+            PriceTier(
+                dimension=item.dimension,
+                billing_unit=item.billing_unit,
+                currency=item_currency,
+                unit_price=unit_price,
+                tier_type=item.tier_type,
+                tier_start=item.tier_start,
+                tier_end=item.tier_end,
+                spec=dict(spec),
+            )
+        )
+    existing_dimensions = {tier.dimension for tier in tiers}
+    custom_dimensions = (
+        (
+            ModelPriceItem.DIMENSION_TEXT_INPUT,
+            ModelPriceItem.UNIT_PER_1M_TOKENS,
+        ),
+        (
+            ModelPriceItem.DIMENSION_TEXT_OUTPUT,
+            ModelPriceItem.UNIT_PER_1M_TOKENS,
+        ),
+        (
+            ModelPriceItem.DIMENSION_AUDIO_INPUT,
+            ModelPriceItem.UNIT_PER_SECOND,
+        ),
+        (
+            ModelPriceItem.DIMENSION_AUDIO_OUTPUT,
+            ModelPriceItem.UNIT_PER_SECOND,
+        ),
+        (
+            ModelPriceItem.DIMENSION_VIDEO_INPUT,
+            ModelPriceItem.UNIT_PER_SECOND,
+        ),
+        (
+            ModelPriceItem.DIMENSION_VIDEO_OUTPUT,
+            ModelPriceItem.UNIT_PER_SECOND,
+        ),
+    )
+    for dimension, billing_unit in custom_dimensions:
+        if override is None or dimension in existing_dimensions:
+            continue
+        custom_price = custom_price_for_dimension(override, dimension)
+        resolution_price = _video_resolution_price(
+            model,
+            override=override,
+            dimension=dimension,
+            video_resolution=video_resolution,
+            ratio=ratio,
+        )
+        if custom_price is None and resolution_price is None:
+            continue
+        tiers.append(
+            PriceTier(
+                dimension=dimension,
+                billing_unit=billing_unit,
+                currency=currency,
+                unit_price=(
+                    resolution_price
+                    if resolution_price is not None
+                    else custom_price
+                ),
+                tier_type=ModelPriceItem.TIER_FLAT,
+                tier_start=None,
+                tier_end=None,
+                spec={},
+            )
+        )
+    schedule = PriceSchedule(tiers=tuple(tiers))
+    validate_price_table_groups(schedule.tiers)
+    return schedule
+
+
+def _video_resolution_price(
+    model: LLMModel,
+    *,
+    override: ChannelModelPrice | None,
+    dimension: str,
+    video_resolution: str,
+    ratio: Decimal,
+) -> Decimal | None:
+    """Resolve the legacy video-resolution override precedence."""
+    dimension_key = {
+        ModelPriceItem.DIMENSION_VIDEO_INPUT: "input",
+        ModelPriceItem.DIMENSION_VIDEO_OUTPUT: "output",
+    }.get(dimension)
+    if not video_resolution or dimension_key is None:
+        return None
+
+    unit_price = None
+    resolution_prices = model.video_resolution_prices or {}
+    model_price = resolution_prices.get(video_resolution) or {}
+    if model_price.get(dimension_key) is not None:
+        unit_price = decimal_or_zero(model_price[dimension_key]) * ratio
+
+    if override is None:
+        return unit_price
+    custom_price = custom_price_for_dimension(override, dimension)
+    if custom_price is not None:
+        unit_price = custom_price
+    custom_resolution_prices = override.custom_video_resolution_prices or {}
+    custom_resolution_price = (
+        custom_resolution_prices.get(video_resolution) or {}
+    )
+    if custom_resolution_price.get(dimension_key) is not None:
+        unit_price = decimal_or_zero(
+            custom_resolution_price[dimension_key]
+        )
+    return unit_price
+
+
+def _flat_schedule_from_unit_prices(
+    unit_prices: UnitPrices,
+    *,
+    currency: str,
+) -> PriceSchedule:
+    """Expose legacy scalar prices through the normalized schedule API."""
+    values = (
+        (
+            ModelPriceItem.DIMENSION_TEXT_INPUT,
+            ModelPriceItem.UNIT_PER_1M_TOKENS,
+            unit_prices.input_per_million,
+        ),
+        (
+            ModelPriceItem.DIMENSION_TEXT_OUTPUT,
+            ModelPriceItem.UNIT_PER_1M_TOKENS,
+            unit_prices.output_per_million,
+        ),
+        (
+            ModelPriceItem.DIMENSION_CACHE_INPUT,
+            ModelPriceItem.UNIT_PER_1M_TOKENS,
+            unit_prices.cache_input_per_million,
+        ),
+        (
+            ModelPriceItem.DIMENSION_IMAGE_OUTPUT,
+            ModelPriceItem.UNIT_PER_IMAGE,
+            unit_prices.image_output_per_image,
+        ),
+        (
+            ModelPriceItem.DIMENSION_AUDIO_INPUT,
+            ModelPriceItem.UNIT_PER_SECOND,
+            unit_prices.audio_input_per_second,
+        ),
+        (
+            ModelPriceItem.DIMENSION_AUDIO_OUTPUT,
+            ModelPriceItem.UNIT_PER_SECOND,
+            unit_prices.audio_output_per_second,
+        ),
+        (
+            ModelPriceItem.DIMENSION_VIDEO_INPUT,
+            ModelPriceItem.UNIT_PER_SECOND,
+            unit_prices.video_input_per_second,
+        ),
+        (
+            ModelPriceItem.DIMENSION_VIDEO_OUTPUT,
+            ModelPriceItem.UNIT_PER_SECOND,
+            unit_prices.video_output_per_second,
+        ),
+    )
+    return PriceSchedule(
+        tiers=tuple(
+            PriceTier(
+                dimension=dimension,
+                billing_unit=billing_unit,
+                currency=currency,
+                unit_price=unit_price,
+                tier_type=ModelPriceItem.TIER_FLAT,
+                tier_start=None,
+                tier_end=None,
+                spec={},
+            )
+            for dimension, billing_unit, unit_price in values
+        )
+    )
+
+
 def resolve_channel_model_price(
     channel: ProcurementChannel,
     model: LLMModel,
@@ -1244,15 +1515,9 @@ def source_unit_prices_for_channel_model(
 def selected_price_item_for_channel_model(
     items: list[ModelPriceItem],
 ) -> ModelPriceItem | None:
-    """Select a flat item or the highest tiered unit price."""
+    """Select one flat item for the legacy scalar price interface."""
     if not items:
         return None
-
-    flat_items = [
-        item for item in items if item.tier_type == ModelPriceItem.TIER_FLAT
-    ]
-    if flat_items:
-        return sorted(flat_items, key=lambda item: item.id)[0]
 
     tiered_items = [
         item
@@ -1260,18 +1525,17 @@ def selected_price_item_for_channel_model(
         if item.tier_type
         in (ModelPriceItem.TIER_USAGE_RANGE, ModelPriceItem.TIER_VOLUME)
     ]
-    if not tiered_items:
-        return None
+    if tiered_items:
+        raise TieredPriceNotSupportedError(
+            "Tiered prices require resolve_channel_price_schedule()."
+        )
 
-    return sorted(
-        tiered_items,
-        key=lambda item: (
-            decimal_or_zero(item.unit_price),
-            decimal_or_zero(item.tier_start),
-            item.id,
-        ),
-        reverse=True,
-    )[0]
+    flat_items = [
+        item for item in items if item.tier_type == ModelPriceItem.TIER_FLAT
+    ]
+    if flat_items:
+        return sorted(flat_items, key=lambda item: item.id)[0]
+    return None
 
 
 def calculate_usage_cost(
@@ -1279,6 +1543,7 @@ def calculate_usage_cost(
     *,
     input_tokens: int = 0,
     output_tokens: int = 0,
+    cache_input_tokens: int = 0,
     audio_input_seconds: Decimal | int | str = 0,
     audio_output_seconds: Decimal | int | str = 0,
     video_input_seconds: Decimal | int | str = 0,
@@ -1289,6 +1554,8 @@ def calculate_usage_cost(
     input_cost *= unit_prices.input_per_million
     output_cost = Decimal(output_tokens or 0) / Decimal(1000000)
     output_cost *= unit_prices.output_per_million
+    cache_input_cost = Decimal(cache_input_tokens or 0) / Decimal(1000000)
+    cache_input_cost *= unit_prices.cache_input_per_million
 
     audio_input_cost = decimal_or_zero(audio_input_seconds)
     audio_input_cost *= unit_prices.audio_input_per_second
@@ -1302,6 +1569,7 @@ def calculate_usage_cost(
     return (
         input_cost
         + output_cost
+        + cache_input_cost
         + audio_input_cost
         + audio_output_cost
         + video_input_cost
@@ -1315,6 +1583,7 @@ def calculate_channel_model_cost(
     *,
     input_tokens: int = 0,
     output_tokens: int = 0,
+    cache_input_tokens: int = 0,
     audio_input_seconds: Decimal | int | str = 0,
     audio_output_seconds: Decimal | int | str = 0,
     video_input_seconds: Decimal | int | str = 0,
@@ -1322,19 +1591,22 @@ def calculate_channel_model_cost(
     video_resolution: str = "",
 ) -> Decimal:
     """Resolve channel prices and calculate expected usage cost."""
-    unit_prices = resolve_channel_model_price(
+    schedule = resolve_channel_price_schedule(
         channel,
         model,
         video_resolution=video_resolution,
     )
-    return calculate_usage_cost(
-        unit_prices,
-        input_tokens=input_tokens,
-        output_tokens=output_tokens,
-        audio_input_seconds=audio_input_seconds,
-        audio_output_seconds=audio_output_seconds,
-        video_input_seconds=video_input_seconds,
-        video_output_seconds=video_output_seconds,
+    return calculate_price_schedule_usage_cost(
+        schedule,
+        UsageContext(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_input_tokens=cache_input_tokens,
+            audio_input_seconds=audio_input_seconds,
+            audio_output_seconds=audio_output_seconds,
+            video_input_seconds=video_input_seconds,
+            video_output_seconds=video_output_seconds,
+        ),
     )
 
 
@@ -1343,13 +1615,23 @@ def record_channel_model_price_history(
     *,
     video_resolution: str = "",
 ) -> ChannelModelPriceHistory | None:
-    """Record a channel/model price version when price fields change."""
-    unit_prices = resolve_channel_model_price(
+    """Record a flat channel price version when price fields change.
+
+    Tiered history remains in normalized channel price items because the
+    legacy snapshot cannot represent interval boundaries.
+    """
+    schedule = resolve_channel_price_schedule(
         price.channel,
         price.model,
         override=price,
         video_resolution=video_resolution,
     )
+    if any(
+        tier.tier_type != ModelPriceItem.TIER_FLAT
+        for tier in schedule.tiers
+    ):
+        return None
+    unit_prices = resolve_usage_unit_prices(schedule, UsageContext())
     currency = resolve_channel_model_currency(
         price.channel,
         price.model,
@@ -1423,6 +1705,7 @@ def record_channel_model_price_history(
     )
 
 
+@transaction.atomic
 def sync_channel_price_items(
     price: ChannelModelPrice,
 ) -> list[ChannelPriceItem]:

--- a/backend/llm_ops/services.py
+++ b/backend/llm_ops/services.py
@@ -29,6 +29,10 @@ from .models import (
     ResaleListing,
     ResaleListingPriceHistory,
 )
+from .price_table_validation import (
+    validate_price_table_groups,
+    with_usage_range_spec,
+)
 
 
 ZERO = Decimal("0")
@@ -1425,6 +1429,7 @@ def sync_channel_price_items(
     """Sync normalized channel price items from one channel/model config."""
     source = price.price_source
     payloads = channel_price_item_payloads(price, source=source)
+    validate_price_table_groups(payloads)
     now = timezone.now()
     ChannelPriceItem.objects.filter(
         channel=price.channel,
@@ -1767,6 +1772,9 @@ def channel_price_payload_from_base_item(
         currency,
         base_item,
     )
+    spec = base_item.spec or {}
+    if base_item.tier_type == ModelPriceItem.TIER_USAGE_RANGE:
+        spec = with_usage_range_spec(spec)
     return {
         "channel": price.channel,
         "model": price.model,
@@ -1780,7 +1788,7 @@ def channel_price_payload_from_base_item(
         "tier_type": base_item.tier_type,
         "tier_start": base_item.tier_start,
         "tier_end": base_item.tier_end,
-        "spec": base_item.spec or {},
+        "spec": spec,
         "price_source_type": source_type,
         "settlement_ratio": price.settlement_ratio,
         "comparison_status": comparison["status"],

--- a/backend/llm_ops/tests/test_price_table_integrations.py
+++ b/backend/llm_ops/tests/test_price_table_integrations.py
@@ -14,6 +14,7 @@ from llm_ops.models import (
     SourceSkuOffering,
 )
 from llm_ops.price_table_validation import (
+    ERROR_INVALID_USAGE_RANGE_SPEC,
     ERROR_MIXED_FLAT_AND_TIERED,
     ERROR_VOLUME_UNSUPPORTED,
     usage_range_spec,
@@ -129,6 +130,16 @@ class PriceTableIntegrationTests(TestCase):
         )
 
         self.assert_price_table_error(serializer, ERROR_VOLUME_UNSUPPORTED)
+
+    def test_model_serializer_rejects_non_object_tier_spec(self):
+        serializer = ModelPriceItemSerializer(
+            data=self.model_payload(spec=["request_input_tokens"])
+        )
+
+        self.assert_price_table_error(
+            serializer,
+            ERROR_INVALID_USAGE_RANGE_SPEC,
+        )
 
     def test_channel_serializer_returns_same_volume_error_code(self):
         serializer = ChannelPriceItemSerializer(

--- a/backend/llm_ops/tests/test_price_table_integrations.py
+++ b/backend/llm_ops/tests/test_price_table_integrations.py
@@ -102,8 +102,10 @@ class PriceTableIntegrationTests(TestCase):
         """Assert the DRF boundary preserves the shared error code."""
         self.assertFalse(serializer.is_valid())
         self.assertIn("price_table", serializer.errors, serializer.errors)
-        error = serializer.errors["price_table"][0]
-        self.assertEqual(error.code, expected_code)
+        error = serializer.errors["price_table"]
+        self.assertEqual(str(error["code"]), expected_code)
+        self.assertEqual(error["code"].code, expected_code)
+        self.assertTrue(str(error["message"]))
 
     def test_collected_usage_range_payload_adds_contract_spec(self):
         payload = price_item_payload(

--- a/backend/llm_ops/tests/test_price_table_integrations.py
+++ b/backend/llm_ops/tests/test_price_table_integrations.py
@@ -1,0 +1,172 @@
+from decimal import Decimal
+
+from django.test import TestCase
+
+from llm_ops.collection_services import price_item_payload
+from llm_ops.models import (
+    ChannelPriceItem,
+    LLMModel,
+    LLMProvider,
+    ModelPriceItem,
+    ModelSku,
+    PriceCollectionSource,
+    ProcurementChannel,
+    SourceSkuOffering,
+)
+from llm_ops.price_table_validation import (
+    ERROR_MIXED_FLAT_AND_TIERED,
+    ERROR_VOLUME_UNSUPPORTED,
+    usage_range_spec,
+)
+from llm_ops.serializers import (
+    ChannelPriceItemSerializer,
+    ModelPriceItemSerializer,
+)
+
+
+class PriceTableIntegrationTests(TestCase):
+    def setUp(self):
+        self.provider = LLMProvider.objects.create(
+            name="OpenAI",
+            code="openai",
+        )
+        self.model = LLMModel.objects.create(
+            provider=self.provider,
+            name="GPT-5",
+            code="gpt-5",
+        )
+        self.source = PriceCollectionSource.objects.create(
+            provider=self.provider,
+            name="OpenAI Official",
+            slug="openai-official",
+        )
+        self.sku = ModelSku.objects.create(
+            meta_model=self.model.meta_model,
+            provider=self.provider,
+            canonical_sku_code=self.model.code,
+            upstream_model_name=self.model.code,
+            display_name=self.model.name,
+        )
+        self.offering = SourceSkuOffering.objects.create(
+            source=self.source,
+            sku=self.sku,
+            provider=self.provider,
+            exposed_model_name=self.model.code,
+        )
+        self.channel = ProcurementChannel.objects.create(
+            name="Supplier A",
+            code="supplier-a",
+        )
+
+    def model_payload(self, **overrides):
+        """Build one model price serializer payload."""
+        payload = {
+            "provider": self.provider.id,
+            "model": self.model.id,
+            "sku": self.sku.id,
+            "offering": self.offering.id,
+            "source": self.source.id,
+            "dimension": ModelPriceItem.DIMENSION_TEXT_INPUT,
+            "billing_unit": ModelPriceItem.UNIT_PER_1M_TOKENS,
+            "currency": "USD",
+            "unit_price": "1.000000",
+            "tier_type": ModelPriceItem.TIER_USAGE_RANGE,
+            "tier_start": "0",
+            "tier_end": None,
+            "spec": usage_range_spec(),
+            "price_fingerprint": "model-tier",
+        }
+        payload.update(overrides)
+        return payload
+
+    def channel_payload(self, **overrides):
+        """Build one channel price serializer payload."""
+        payload = {
+            "channel": self.channel.id,
+            "model": self.model.id,
+            "dimension": ModelPriceItem.DIMENSION_TEXT_INPUT,
+            "billing_unit": ModelPriceItem.UNIT_PER_1M_TOKENS,
+            "currency": "USD",
+            "unit_price": "0.800000",
+            "tier_type": ModelPriceItem.TIER_USAGE_RANGE,
+            "tier_start": "0",
+            "tier_end": None,
+            "spec": usage_range_spec(),
+            "price_fingerprint": "channel-tier",
+        }
+        payload.update(overrides)
+        return payload
+
+    def assert_price_table_error(self, serializer, expected_code):
+        """Assert the DRF boundary preserves the shared error code."""
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("price_table", serializer.errors, serializer.errors)
+        error = serializer.errors["price_table"][0]
+        self.assertEqual(error.code, expected_code)
+
+    def test_collected_usage_range_payload_adds_contract_spec(self):
+        payload = price_item_payload(
+            {},
+            dimension=ModelPriceItem.DIMENSION_TEXT_INPUT,
+            billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
+            unit_price=Decimal("1"),
+            spec={"region": "cn-beijing"},
+            tier_start=Decimal("0"),
+            tier_end=Decimal("1000000"),
+        )
+
+        self.assertEqual(payload["spec"]["region"], "cn-beijing")
+        self.assertEqual(
+            payload["spec"]["tier_metric"],
+            "request_input_tokens",
+        )
+        self.assertEqual(payload["spec"]["tier_charge_mode"], "matched_tier")
+        self.assertEqual(payload["spec"]["aggregation_period"], "request")
+
+    def test_model_serializer_returns_stable_volume_error_code(self):
+        serializer = ModelPriceItemSerializer(
+            data=self.model_payload(tier_type=ModelPriceItem.TIER_VOLUME)
+        )
+
+        self.assert_price_table_error(serializer, ERROR_VOLUME_UNSUPPORTED)
+
+    def test_channel_serializer_returns_same_volume_error_code(self):
+        serializer = ChannelPriceItemSerializer(
+            data=self.channel_payload(tier_type=ModelPriceItem.TIER_VOLUME)
+        )
+
+        self.assert_price_table_error(serializer, ERROR_VOLUME_UNSUPPORTED)
+
+    def test_model_serializer_rejects_mixed_current_table(self):
+        ModelPriceItem.objects.create(
+            provider=self.provider,
+            model=self.model,
+            meta_model=self.model.meta_model,
+            sku=self.sku,
+            offering=self.offering,
+            source=self.source,
+            dimension=ModelPriceItem.DIMENSION_TEXT_INPUT,
+            billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
+            currency="USD",
+            unit_price=Decimal("1"),
+            tier_type=ModelPriceItem.TIER_FLAT,
+            price_fingerprint="existing-flat",
+        )
+        serializer = ModelPriceItemSerializer(data=self.model_payload())
+
+        self.assert_price_table_error(
+            serializer,
+            ERROR_MIXED_FLAT_AND_TIERED,
+        )
+
+    def test_channel_serializer_accepts_valid_usage_range_contract(self):
+        serializer = ChannelPriceItemSerializer(data=self.channel_payload())
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        item = serializer.save()
+
+        self.assertEqual(item.meta_model_id, self.model.meta_model_id)
+        self.assertEqual(
+            item.spec["tier_metric"],
+            "request_input_tokens",
+        )

--- a/backend/llm_ops/tests/test_price_table_validation.py
+++ b/backend/llm_ops/tests/test_price_table_validation.py
@@ -1,0 +1,193 @@
+from decimal import Decimal
+from unittest import TestCase
+
+from llm_ops.price_table_validation import (
+    AGGREGATION_PERIOD_REQUEST,
+    ERROR_DUPLICATE_RANGE,
+    ERROR_GAP,
+    ERROR_INCONSISTENT_CURRENCY,
+    ERROR_INCONSISTENT_DIMENSION,
+    ERROR_INCONSISTENT_METRIC,
+    ERROR_INCONSISTENT_TIER_TYPE,
+    ERROR_INCONSISTENT_UNIT,
+    ERROR_INVALID_BOUNDARY,
+    ERROR_MIXED_FLAT_AND_TIERED,
+    ERROR_TIER_MUST_START_AT_ZERO,
+    ERROR_UNBOUNDED_TIER_NOT_LAST,
+    ERROR_VOLUME_UNSUPPORTED,
+    TIER_CHARGE_MODE_MATCHED_TIER,
+    TIER_METRIC_REQUEST_INPUT_TOKENS,
+    PriceTableValidationError,
+    match_usage_range_tier,
+    usage_range_spec,
+    validate_price_table,
+)
+
+
+def price_row(
+    start,
+    end,
+    *,
+    dimension="text_input",
+    currency="USD",
+    billing_unit="per_1m_tokens",
+    tier_type="usage_range",
+    spec=None,
+):
+    """Build one normalized price row for contract tests."""
+    return {
+        "dimension": dimension,
+        "currency": currency,
+        "billing_unit": billing_unit,
+        "tier_type": tier_type,
+        "tier_start": None if start is None else Decimal(str(start)),
+        "tier_end": None if end is None else Decimal(str(end)),
+        "spec": usage_range_spec() if spec is None else spec,
+    }
+
+
+class PriceTableValidationTests(TestCase):
+    def assert_error_code(self, expected_code, rows):
+        """Assert deterministic validation failure codes."""
+        with self.assertRaises(PriceTableValidationError) as raised:
+            validate_price_table(rows)
+        self.assertEqual(raised.exception.code, expected_code)
+
+    def test_usage_range_contract_is_explicit(self):
+        self.assertEqual(
+            usage_range_spec(),
+            {
+                "tier_metric": TIER_METRIC_REQUEST_INPUT_TOKENS,
+                "tier_charge_mode": TIER_CHARGE_MODE_MATCHED_TIER,
+                "aggregation_period": AGGREGATION_PERIOD_REQUEST,
+            },
+        )
+
+    def test_matches_zero_exact_boundary_and_unbounded_last_tier(self):
+        rows = [
+            price_row("0", "1000000"),
+            price_row("1000000", None),
+        ]
+
+        first = match_usage_range_tier(rows, Decimal("0"))
+        boundary = match_usage_range_tier(rows, Decimal("1000000"))
+        unbounded = match_usage_range_tier(rows, Decimal("9000000"))
+
+        self.assertEqual(first["tier_start"], Decimal("0"))
+        self.assertEqual(boundary["tier_start"], Decimal("1000000"))
+        self.assertEqual(unbounded["tier_start"], Decimal("1000000"))
+
+    def test_same_validator_accepts_all_price_surfaces(self):
+        tables = (
+            [
+                {
+                    **price_row("0", None),
+                    "provider": "openai",
+                    "source": "official",
+                }
+            ],
+            [
+                {
+                    **price_row("0", None),
+                    "channel": "supplier-a",
+                }
+            ],
+            [
+                {
+                    **price_row("0", None),
+                    "platform": "agione",
+                    "listing": "gpt-5",
+                }
+            ],
+        )
+
+        for table in tables:
+            with self.subTest(table=table):
+                validate_price_table(table)
+
+    def test_rejects_mixed_flat_and_tiered_rows(self):
+        rows = [
+            price_row(None, None, tier_type="flat", spec={}),
+            price_row("0", None),
+        ]
+
+        self.assert_error_code(ERROR_MIXED_FLAT_AND_TIERED, rows)
+
+    def test_rejects_first_tier_that_does_not_start_at_zero(self):
+        self.assert_error_code(
+            ERROR_TIER_MUST_START_AT_ZERO,
+            [price_row("1", None)],
+        )
+
+    def test_rejects_inverted_range(self):
+        self.assert_error_code(
+            ERROR_INVALID_BOUNDARY,
+            [price_row("0", "0")],
+        )
+
+    def test_rejects_duplicate_range(self):
+        rows = [price_row("0", "10"), price_row("0", "10")]
+
+        self.assert_error_code(ERROR_DUPLICATE_RANGE, rows)
+
+    def test_rejects_overlapping_range(self):
+        rows = [price_row("0", "10"), price_row("9", None)]
+
+        self.assert_error_code(ERROR_INVALID_BOUNDARY, rows)
+
+    def test_rejects_gap_between_ranges(self):
+        rows = [price_row("0", "10"), price_row("11", None)]
+
+        self.assert_error_code(ERROR_GAP, rows)
+
+    def test_rejects_unbounded_tier_before_last_tier(self):
+        rows = [price_row("0", None), price_row("10", None)]
+
+        self.assert_error_code(ERROR_UNBOUNDED_TIER_NOT_LAST, rows)
+
+    def test_rejects_inconsistent_dimension(self):
+        rows = [
+            price_row("0", "10"),
+            price_row("10", None, dimension="text_output"),
+        ]
+
+        self.assert_error_code(ERROR_INCONSISTENT_DIMENSION, rows)
+
+    def test_rejects_inconsistent_currency(self):
+        rows = [
+            price_row("0", "10"),
+            price_row("10", None, currency="CNY"),
+        ]
+
+        self.assert_error_code(ERROR_INCONSISTENT_CURRENCY, rows)
+
+    def test_rejects_inconsistent_billing_unit(self):
+        rows = [
+            price_row("0", "10"),
+            price_row("10", None, billing_unit="per_generation"),
+        ]
+
+        self.assert_error_code(ERROR_INCONSISTENT_UNIT, rows)
+
+    def test_rejects_inconsistent_tier_type(self):
+        rows = [
+            price_row("0", "10"),
+            price_row("10", None, tier_type="volume"),
+        ]
+
+        self.assert_error_code(ERROR_INCONSISTENT_TIER_TYPE, rows)
+
+    def test_rejects_inconsistent_metric(self):
+        other_spec = usage_range_spec()
+        other_spec["tier_metric"] = "monthly_tokens"
+        rows = [
+            price_row("0", "10"),
+            price_row("10", None, spec=other_spec),
+        ]
+
+        self.assert_error_code(ERROR_INCONSISTENT_METRIC, rows)
+
+    def test_rejects_volume_until_business_contract_is_defined(self):
+        rows = [price_row("0", None, tier_type="volume")]
+
+        self.assert_error_code(ERROR_VOLUME_UNSUPPORTED, rows)

--- a/backend/llm_ops/tests/test_price_table_validation.py
+++ b/backend/llm_ops/tests/test_price_table_validation.py
@@ -11,6 +11,7 @@ from llm_ops.price_table_validation import (
     ERROR_INCONSISTENT_TIER_TYPE,
     ERROR_INCONSISTENT_UNIT,
     ERROR_INVALID_BOUNDARY,
+    ERROR_INVALID_USAGE_RANGE_SPEC,
     ERROR_MIXED_FLAT_AND_TIERED,
     ERROR_TIER_MUST_START_AT_ZERO,
     ERROR_UNBOUNDED_TIER_NOT_LAST,
@@ -186,6 +187,11 @@ class PriceTableValidationTests(TestCase):
         ]
 
         self.assert_error_code(ERROR_INCONSISTENT_METRIC, rows)
+
+    def test_rejects_non_object_usage_range_spec(self):
+        rows = [price_row("0", None, spec=["request_input_tokens"])]
+
+        self.assert_error_code(ERROR_INVALID_USAGE_RANGE_SPEC, rows)
 
     def test_rejects_volume_until_business_contract_is_defined(self):
         rows = [price_row("0", None, tier_type="volume")]

--- a/backend/llm_ops/tests/test_price_table_validation.py
+++ b/backend/llm_ops/tests/test_price_table_validation.py
@@ -22,6 +22,7 @@ from llm_ops.price_table_validation import (
     match_usage_range_tier,
     usage_range_spec,
     validate_price_table,
+    with_usage_range_spec,
 )
 
 
@@ -126,6 +127,12 @@ class PriceTableValidationTests(TestCase):
             [price_row("0", "0")],
         )
 
+    def test_rejects_non_finite_boundary(self):
+        self.assert_error_code(
+            ERROR_INVALID_BOUNDARY,
+            [price_row("NaN", None)],
+        )
+
     def test_rejects_duplicate_range(self):
         rows = [price_row("0", "10"), price_row("0", "10")]
 
@@ -192,6 +199,15 @@ class PriceTableValidationTests(TestCase):
         rows = [price_row("0", None, spec=["request_input_tokens"])]
 
         self.assert_error_code(ERROR_INVALID_USAGE_RANGE_SPEC, rows)
+
+    def test_rejects_non_object_spec_when_adding_contract(self):
+        with self.assertRaises(PriceTableValidationError) as raised:
+            with_usage_range_spec(["request_input_tokens"])
+
+        self.assertEqual(
+            raised.exception.code,
+            ERROR_INVALID_USAGE_RANGE_SPEC,
+        )
 
     def test_rejects_volume_until_business_contract_is_defined(self):
         rows = [price_row("0", None, tier_type="volume")]

--- a/backend/llm_ops/tests/test_serializers.py
+++ b/backend/llm_ops/tests/test_serializers.py
@@ -325,6 +325,7 @@ class UsageReconciliationRecordSerializerTests(TestCase):
             code="gpt-4o",
             input_price_per_million=Decimal("2.5"),
             output_price_per_million=Decimal("10"),
+            cache_input_price_per_million=Decimal("1"),
         )
         channel = ProcurementChannel.objects.create(
             name="Direct",
@@ -338,6 +339,7 @@ class UsageReconciliationRecordSerializerTests(TestCase):
                 "model": model.id,
                 "input_tokens": 1_000_000,
                 "output_tokens": 1_000_000,
+                "cache_input_tokens": 2_000_000,
                 "charged_amount": "20",
             }
         )
@@ -345,8 +347,9 @@ class UsageReconciliationRecordSerializerTests(TestCase):
         self.assertTrue(serializer.is_valid(), serializer.errors)
         record = serializer.save()
 
-        self.assertEqual(record.expected_amount, Decimal("12.500000"))
-        self.assertEqual(record.discrepancy, Decimal("-7.500000"))
+        self.assertEqual(record.expected_amount, Decimal("14.500000"))
+        self.assertEqual(record.discrepancy, Decimal("-5.500000"))
+        self.assertEqual(record.cache_input_tokens, 2_000_000)
         self.assertEqual(record.status, "overcharged")
 
     def test_meta_model_serializer_exposes_owner_fields(self):

--- a/backend/llm_ops/tests/test_services.py
+++ b/backend/llm_ops/tests/test_services.py
@@ -21,6 +21,7 @@ from llm_ops.models import (
     ResalePlatform,
     SourceSkuOffering,
 )
+from llm_ops.price_table_validation import usage_range_spec
 from llm_ops.services import (
     calculate_channel_model_cost,
     import_manual_model_prices,
@@ -30,10 +31,12 @@ from llm_ops.services import (
     record_resale_listing_price_history,
     resolve_channel_model_currency,
     resolve_channel_model_price,
+    resolve_channel_price_schedule,
     resolve_resale_listing_currency,
     sync_channel_price_items,
     sync_dependent_channel_price_items_for_price_items,
 )
+from llm_ops.tier_pricing import TieredPriceNotSupportedError
 
 
 class LLMOpsPricingServiceTests(TestCase):
@@ -84,6 +87,19 @@ class LLMOpsPricingServiceTests(TestCase):
         )
 
         self.assertEqual(cost, Decimal("28.000000"))
+
+    def test_calculates_cached_token_cost(self):
+        self.model.cache_input_price_per_million = Decimal("1")
+        self.model.save(update_fields=["cache_input_price_per_million"])
+
+        cost = calculate_channel_model_cost(
+            self.channel,
+            self.model,
+            input_tokens=1_000_000,
+            cache_input_tokens=2_000_000,
+        )
+
+        self.assertEqual(cost, Decimal("3.600000"))
 
     def test_repeated_meta_model_alias_matches_share_full_table_load(self):
         from llm_ops import services
@@ -700,7 +716,7 @@ class LLMOpsPricingServiceTests(TestCase):
             {Decimal("1.000000"), Decimal("2.000000")},
         )
 
-    def test_channel_source_uses_highest_usage_range_price(self):
+    def test_channel_schedule_preserves_usage_range_prices(self):
         source = PriceCollectionSource.objects.create(
             name="Aliyun Tiered Official",
             slug="aliyun-tiered-official",
@@ -757,6 +773,7 @@ class LLMOpsPricingServiceTests(TestCase):
                 tier_type=ModelPriceItem.TIER_USAGE_RANGE,
                 tier_start=Decimal(start),
                 tier_end=Decimal(end),
+                spec=usage_range_spec(),
                 price_fingerprint=fingerprint,
                 is_current=True,
             )
@@ -766,14 +783,214 @@ class LLMOpsPricingServiceTests(TestCase):
             price_source=source,
         )
 
-        unit_prices = resolve_channel_model_price(
+        schedule = resolve_channel_price_schedule(
             self.channel,
             self.model,
             override=price,
         )
 
-        self.assertEqual(unit_prices.input_per_million, Decimal("0.960000"))
-        self.assertEqual(unit_prices.output_per_million, Decimal("9.600000"))
+        input_tiers = schedule.for_dimension(
+            ModelPriceItem.DIMENSION_TEXT_INPUT
+        )
+        output_tiers = schedule.for_dimension(
+            ModelPriceItem.DIMENSION_TEXT_OUTPUT
+        )
+        self.assertEqual(len(schedule.tiers), 4)
+        self.assertEqual(
+            [tier.unit_price for tier in input_tiers],
+            [Decimal("0.160000"), Decimal("0.960000")],
+        )
+        self.assertEqual(
+            [tier.tier_start for tier in output_tiers],
+            [Decimal("0"), Decimal("128000")],
+        )
+        self.assertEqual(output_tiers[-1].tier_end, Decimal("256000"))
+        self.assertEqual(output_tiers[-1].currency, "CNY")
+        self.assertEqual(
+            output_tiers[-1].spec,
+            usage_range_spec(),
+        )
+        self.assertEqual(
+            output_tiers[-1].billing_unit,
+            ModelPriceItem.UNIT_PER_1M_TOKENS,
+        )
+        self.assertIsNone(record_channel_model_price_history(price))
+
+    def test_legacy_unit_price_resolution_rejects_tiered_prices(self):
+        source = PriceCollectionSource.objects.create(
+            name="Tiered Supplier",
+            slug="tiered-supplier",
+            provider=self.provider,
+            source_category=PriceCollectionSource.SOURCE_CATEGORY_SUPPLIER,
+            currency="USD",
+        )
+        ModelPriceItem.objects.create(
+            provider=self.provider,
+            model=self.model,
+            source=source,
+            dimension=ModelPriceItem.DIMENSION_TEXT_INPUT,
+            billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
+            currency="USD",
+            unit_price=Decimal("1"),
+            tier_type=ModelPriceItem.TIER_USAGE_RANGE,
+            tier_start=Decimal("0"),
+            tier_end=None,
+            price_fingerprint="tiered-input",
+        )
+        price = ChannelModelPrice.objects.create(
+            channel=self.channel,
+            model=self.model,
+            price_source=source,
+        )
+
+        with self.assertRaises(TieredPriceNotSupportedError):
+            resolve_channel_model_price(
+                self.channel,
+                self.model,
+                override=price,
+            )
+
+    def test_channel_schedule_preserves_video_resolution_precedence(self):
+        source = PriceCollectionSource.objects.create(
+            name="Video Source",
+            slug="video-source",
+            provider=self.provider,
+            currency="USD",
+        )
+        ModelPriceItem.objects.create(
+            provider=self.provider,
+            model=self.model,
+            source=source,
+            dimension=ModelPriceItem.DIMENSION_VIDEO_OUTPUT,
+            billing_unit=ModelPriceItem.UNIT_PER_SECOND,
+            currency="USD",
+            unit_price=Decimal("1"),
+            price_fingerprint="video-output",
+        )
+        self.model.video_resolution_prices = {
+            "1080P": {"output": "4"},
+        }
+        self.model.save(update_fields=["video_resolution_prices"])
+        price = ChannelModelPrice.objects.create(
+            channel=self.channel,
+            model=self.model,
+            price_source=source,
+            settlement_ratio=Decimal("0.5"),
+        )
+
+        schedule = resolve_channel_price_schedule(
+            self.channel,
+            self.model,
+            override=price,
+            video_resolution="1080P",
+        )
+        output_tier = schedule.for_dimension(
+            ModelPriceItem.DIMENSION_VIDEO_OUTPUT
+        )[0]
+        self.assertEqual(output_tier.unit_price, Decimal("2"))
+
+        price.custom_video_output_price_per_second = Decimal("3")
+        price.custom_video_resolution_prices = {
+            "1080P": {"output": "6"},
+        }
+        price.save()
+        schedule = resolve_channel_price_schedule(
+            self.channel,
+            self.model,
+            override=price,
+            video_resolution="1080P",
+        )
+        output_tier = schedule.for_dimension(
+            ModelPriceItem.DIMENSION_VIDEO_OUTPUT
+        )[0]
+        self.assertEqual(output_tier.unit_price, Decimal("6"))
+
+    def test_channel_cost_hits_exact_boundary_and_includes_cached_tokens(self):
+        source = PriceCollectionSource.objects.create(
+            name="Tiered Supplier",
+            slug="tiered-cost-supplier",
+            provider=self.provider,
+            source_category=PriceCollectionSource.SOURCE_CATEGORY_SUPPLIER,
+            currency="USD",
+        )
+        tiers = (
+            (ModelPriceItem.DIMENSION_TEXT_INPUT, "1", "0", "1000"),
+            (ModelPriceItem.DIMENSION_TEXT_INPUT, "2", "1000", None),
+            (ModelPriceItem.DIMENSION_TEXT_OUTPUT, "4", "0", None),
+            (ModelPriceItem.DIMENSION_CACHE_INPUT, "0.5", "0", "500"),
+            (ModelPriceItem.DIMENSION_CACHE_INPUT, "1", "500", None),
+        )
+        for index, (dimension, unit_price, start, end) in enumerate(tiers):
+            ModelPriceItem.objects.create(
+                provider=self.provider,
+                model=self.model,
+                source=source,
+                dimension=dimension,
+                billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
+                currency="USD",
+                unit_price=Decimal(unit_price),
+                tier_type=ModelPriceItem.TIER_USAGE_RANGE,
+                tier_start=Decimal(start),
+                tier_end=Decimal(end) if end is not None else None,
+                price_fingerprint=f"tiered-cost-{index}",
+            )
+        ChannelModelPrice.objects.create(
+            channel=self.channel,
+            model=self.model,
+            price_source=source,
+            settlement_ratio=Decimal("1"),
+        )
+
+        cost = calculate_channel_model_cost(
+            self.channel,
+            self.model,
+            input_tokens=1000,
+            output_tokens=2000,
+            cache_input_tokens=500,
+        )
+
+        self.assertEqual(cost, Decimal("0.010500"))
+
+    def test_channel_price_sync_is_atomic(self):
+        for index, dimension in enumerate(
+            (
+                ModelPriceItem.DIMENSION_TEXT_INPUT,
+                ModelPriceItem.DIMENSION_TEXT_OUTPUT,
+            )
+        ):
+            ModelPriceItem.objects.create(
+                provider=self.provider,
+                model=self.model,
+                dimension=dimension,
+                billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
+                currency="USD",
+                unit_price=Decimal(index + 1),
+                price_fingerprint=f"atomic-{index}",
+            )
+        price = ChannelModelPrice.objects.create(
+            channel=self.channel,
+            model=self.model,
+        )
+        original = sync_channel_price_items(price)
+        original_ids = [item.id for item in original]
+
+        with mock.patch.object(
+            ChannelPriceItem.objects,
+            "update_or_create",
+            side_effect=RuntimeError("simulated write failure"),
+        ):
+            with self.assertRaises(RuntimeError):
+                sync_channel_price_items(price)
+
+        self.assertEqual(
+            list(
+                ChannelPriceItem.objects.filter(is_current=True)
+                .order_by("id")
+                .values_list("id", flat=True)
+            ),
+            original_ids,
+        )
+
 
     def test_marks_channel_item_comparison_unknown_for_currency_mismatch(self):
         ModelPriceItem.objects.create(

--- a/backend/llm_ops/tests/test_tier_pricing.py
+++ b/backend/llm_ops/tests/test_tier_pricing.py
@@ -1,0 +1,230 @@
+from decimal import Decimal
+
+from django.test import SimpleTestCase
+
+from llm_ops.models import ModelPriceItem
+from llm_ops.price_table_validation import (
+    PriceTableValidationError,
+    usage_range_spec,
+)
+from llm_ops.tier_pricing import (
+    PriceSchedule,
+    PriceTier,
+    RevenuePolicy,
+    UsageContext,
+    analyze_tier_profit,
+    calculate_price_schedule_usage_cost,
+    resolve_price_tier,
+    resolve_usage_unit_prices,
+)
+
+
+class TieredPricingKernelTests(SimpleTestCase):
+    def test_resolve_price_tier_uses_half_open_boundaries(self):
+        schedule = PriceSchedule(
+            tiers=(
+                self._tier("1", "0", "100"),
+                self._tier("2", "100", None),
+            )
+        )
+
+        self.assertEqual(
+            resolve_price_tier(
+                schedule,
+                dimension=ModelPriceItem.DIMENSION_TEXT_INPUT,
+                usage=Decimal("99.999999"),
+            ).unit_price,
+            Decimal("1"),
+        )
+        self.assertEqual(
+            resolve_price_tier(
+                schedule,
+                dimension=ModelPriceItem.DIMENSION_TEXT_INPUT,
+                usage=Decimal("100"),
+            ).unit_price,
+            Decimal("2"),
+        )
+
+    def test_usage_context_selects_all_tiers_by_request_input_tokens(self):
+        schedule = PriceSchedule(
+            tiers=(
+                self._tier(
+                    "1",
+                    "0",
+                    "100",
+                    dimension=ModelPriceItem.DIMENSION_TEXT_OUTPUT,
+                ),
+                self._tier(
+                    "2",
+                    "100",
+                    None,
+                    dimension=ModelPriceItem.DIMENSION_TEXT_OUTPUT,
+                ),
+            )
+        )
+
+        prices = resolve_usage_unit_prices(
+            schedule,
+            UsageContext(input_tokens=100, output_tokens=1),
+        )
+
+        self.assertEqual(prices.output_per_million, Decimal("2"))
+
+    def test_calculate_schedule_cost_supports_flat_and_cached_tiers(self):
+        schedule = PriceSchedule(
+            tiers=(
+                self._tier(
+                    "2",
+                    None,
+                    None,
+                    dimension=ModelPriceItem.DIMENSION_TEXT_INPUT,
+                    tier_type=ModelPriceItem.TIER_FLAT,
+                ),
+                self._tier(
+                    "0.5",
+                    "0",
+                    "1000",
+                    dimension=ModelPriceItem.DIMENSION_CACHE_INPUT,
+                ),
+                self._tier(
+                    "1",
+                    "1000",
+                    None,
+                    dimension=ModelPriceItem.DIMENSION_CACHE_INPUT,
+                ),
+            )
+        )
+
+        cost = calculate_price_schedule_usage_cost(
+            schedule,
+            UsageContext(
+                input_tokens=1_000_000,
+                cache_input_tokens=1000,
+            ),
+        )
+
+        self.assertEqual(cost, Decimal("2.001000"))
+
+    def test_profit_analysis_aligns_all_boundaries_and_flags_risk(self):
+        cost_schedule = PriceSchedule(
+            tiers=(
+                self._tier("2", "0", "100"),
+                self._tier("4", "100", None),
+            )
+        )
+        retail_schedule = PriceSchedule(
+            tiers=(
+                self._tier("10", "0", "50"),
+                self._tier("8", "50", "200"),
+                self._tier("5", "200", None),
+            )
+        )
+        policy = RevenuePolicy(
+            target_currency="CNY",
+            cost_exchange_rate=Decimal("2"),
+            retail_exchange_rate=Decimal("1"),
+            platform_fee_rate=Decimal("0.10"),
+            service_fee_rate=Decimal("0.05"),
+            tax_rate=Decimal("0.05"),
+            settlement_rate=Decimal("0.90"),
+            risk_net_yield_rate=Decimal("0"),
+        )
+
+        analysis = analyze_tier_profit(
+            cost_schedule,
+            retail_schedule,
+            dimension=ModelPriceItem.DIMENSION_TEXT_INPUT,
+            policy=policy,
+        )
+
+        self.assertEqual(
+            [(row.tier_start, row.tier_end) for row in analysis.intervals],
+            [
+                (Decimal("0"), Decimal("50")),
+                (Decimal("50"), Decimal("100")),
+                (Decimal("100"), Decimal("200")),
+                (Decimal("200"), None),
+            ],
+        )
+        first = analysis.intervals[0]
+        self.assertEqual(first.converted_cost_unit_price, Decimal("4.000000"))
+        self.assertEqual(first.cost, Decimal("3.600000"))
+        self.assertEqual(first.net_revenue, Decimal("8.000000"))
+        self.assertEqual(first.gross_profit, Decimal("4.400000"))
+        self.assertEqual(first.gross_margin_rate, Decimal("0.550000"))
+        self.assertEqual(
+            analysis.minimum_gross_margin_rate,
+            Decimal("-0.800000"),
+        )
+        self.assertEqual(
+            analysis.minimum_net_yield_rate,
+            Decimal("-0.640000"),
+        )
+        self.assertEqual(
+            [
+                (row.tier_start, row.tier_end)
+                for row in analysis.risk_intervals
+            ],
+            [
+                (Decimal("100"), Decimal("200")),
+                (Decimal("200"), None),
+            ],
+        )
+
+    def test_profit_analysis_does_not_hide_invalid_price_tables(self):
+        invalid_cost = PriceSchedule(
+            tiers=(
+                self._tier("1", "0", "10"),
+                self._tier("2", "20", None),
+            )
+        )
+        retail = PriceSchedule(tiers=(self._tier("3", "0", None),))
+
+        with self.assertRaises(PriceTableValidationError):
+            analyze_tier_profit(
+                invalid_cost,
+                retail,
+                dimension=ModelPriceItem.DIMENSION_TEXT_INPUT,
+                policy=RevenuePolicy(target_currency="USD"),
+            )
+
+    def test_profit_risk_uses_unrounded_net_yield(self):
+        analysis = analyze_tier_profit(
+            PriceSchedule(tiers=(self._tier("9.000004", "0", None),)),
+            PriceSchedule(tiers=(self._tier("10", "0", None),)),
+            dimension=ModelPriceItem.DIMENSION_TEXT_INPUT,
+            policy=RevenuePolicy(
+                target_currency="USD",
+                risk_net_yield_rate=Decimal("0.1"),
+            ),
+        )
+
+        interval = analysis.intervals[0]
+        self.assertEqual(interval.net_yield_rate, Decimal("0.100000"))
+        self.assertTrue(interval.is_risk)
+
+    @staticmethod
+    def _tier(
+        unit_price,
+        tier_start,
+        tier_end,
+        *,
+        dimension=ModelPriceItem.DIMENSION_TEXT_INPUT,
+        tier_type=ModelPriceItem.TIER_USAGE_RANGE,
+    ):
+        return PriceTier(
+            dimension=dimension,
+            billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
+            currency="USD",
+            unit_price=Decimal(unit_price),
+            tier_type=tier_type,
+            tier_start=(
+                Decimal(tier_start) if tier_start is not None else None
+            ),
+            tier_end=Decimal(tier_end) if tier_end is not None else None,
+            spec=(
+                usage_range_spec()
+                if tier_type == ModelPriceItem.TIER_USAGE_RANGE
+                else {}
+            ),
+        )

--- a/backend/llm_ops/tier_pricing.py
+++ b/backend/llm_ops/tier_pricing.py
@@ -1,0 +1,499 @@
+"""Tier-aware price resolution, usage costing, and profit analysis."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from .models import ModelPriceItem
+from .price_table_validation import (
+    match_usage_range_tier,
+    validate_price_table,
+)
+
+ZERO = Decimal("0")
+ONE = Decimal("1")
+SIX_PLACES = Decimal("0.000001")
+
+
+class TieredPriceNotSupportedError(ValueError):
+    """Raised when a flat-only compatibility API receives tiered prices."""
+
+
+class PriceTierNotFoundError(ValueError):
+    """Raised when a valid finite schedule does not cover a metric."""
+
+
+@dataclass(frozen=True)
+class UnitPrices:
+    """Resolved unit prices for every supported billing dimension."""
+
+    input_per_million: Decimal
+    output_per_million: Decimal
+    cache_input_per_million: Decimal
+    image_output_per_image: Decimal
+    audio_input_per_second: Decimal
+    audio_output_per_second: Decimal
+    video_input_per_second: Decimal
+    video_output_per_second: Decimal
+
+
+@dataclass(frozen=True)
+class PriceTier:
+    """One normalized price interval using ``[start, end)`` boundaries."""
+
+    dimension: str
+    billing_unit: str
+    currency: str
+    unit_price: Decimal
+    tier_type: str
+    tier_start: Decimal | None
+    tier_end: Decimal | None
+    spec: dict
+
+
+@dataclass(frozen=True)
+class PriceSchedule:
+    """Complete normalized price schedule for all billing dimensions."""
+
+    tiers: tuple[PriceTier, ...]
+
+    def for_dimension(self, dimension: str) -> tuple[PriceTier, ...]:
+        """Return one dimension ordered by its lower boundary."""
+        return tuple(
+            sorted(
+                (tier for tier in self.tiers if tier.dimension == dimension),
+                key=lambda tier: (
+                    tier.tier_start if tier.tier_start is not None else ZERO,
+                    tier.tier_end is None,
+                    tier.tier_end or ZERO,
+                ),
+            )
+        )
+
+
+@dataclass(frozen=True)
+class UsageContext:
+    """Actual request usage used for tier selection and billing."""
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_input_tokens: int = 0
+    image_output_count: int = 0
+    audio_input_seconds: Decimal | int | str = ZERO
+    audio_output_seconds: Decimal | int | str = ZERO
+    video_input_seconds: Decimal | int | str = ZERO
+    video_output_seconds: Decimal | int | str = ZERO
+
+
+@dataclass(frozen=True)
+class RevenuePolicy:
+    """Currency conversion, fee, settlement, and risk inputs.
+
+    Exchange rates express target-currency units per source-currency unit.
+    The settlement rate applies to converted cost. Platform, service, and
+    tax rates are deducted from converted retail revenue. Risk follows the
+    canonical #192 net-yield definition: profit divided by gross revenue.
+    """
+
+    target_currency: str
+    cost_exchange_rate: Decimal = ONE
+    retail_exchange_rate: Decimal = ONE
+    platform_fee_rate: Decimal = ZERO
+    service_fee_rate: Decimal = ZERO
+    tax_rate: Decimal = ZERO
+    settlement_rate: Decimal = ONE
+    risk_net_yield_rate: Decimal | None = None
+
+    def __post_init__(self) -> None:
+        """Reject fee and conversion inputs that cannot produce revenue."""
+        if not str(self.target_currency or "").strip():
+            raise ValueError("target_currency is required.")
+        if self.cost_exchange_rate <= ZERO:
+            raise ValueError("cost_exchange_rate must be > 0.")
+        if self.retail_exchange_rate <= ZERO:
+            raise ValueError("retail_exchange_rate must be > 0.")
+        if self.settlement_rate <= ZERO:
+            raise ValueError("settlement_rate must be > 0.")
+        fee_rates = (
+            self.platform_fee_rate,
+            self.service_fee_rate,
+            self.tax_rate,
+        )
+        if any(rate < ZERO for rate in fee_rates):
+            raise ValueError("fee rates must be >= 0.")
+        if sum(fee_rates, ZERO) >= ONE:
+            raise ValueError("combined fee rates must be < 1.")
+
+
+@dataclass(frozen=True)
+class TierProfitInterval:
+    """Cost and profit metrics for one aligned tier interval."""
+
+    dimension: str
+    billing_unit: str
+    currency: str
+    tier_start: Decimal
+    tier_end: Decimal | None
+    cost_currency: str
+    retail_currency: str
+    cost_unit_price: Decimal
+    retail_unit_price: Decimal
+    converted_cost_unit_price: Decimal
+    converted_retail_unit_price: Decimal
+    cost: Decimal
+    gross_revenue: Decimal
+    net_revenue: Decimal
+    gross_profit: Decimal
+    gross_margin_rate: Decimal
+    net_yield_rate: Decimal
+    is_risk: bool
+
+
+@dataclass(frozen=True)
+class TierProfitAnalysis:
+    """Aligned interval results and lowest-margin risk summary."""
+
+    dimension: str
+    currency: str
+    billing_unit: str
+    intervals: tuple[TierProfitInterval, ...]
+    minimum_gross_margin_rate: Decimal | None
+    minimum_net_yield_rate: Decimal | None
+    minimum_interval: TierProfitInterval | None
+    risk_intervals: tuple[TierProfitInterval, ...]
+
+
+def resolve_price_tier(
+    schedule: PriceSchedule,
+    *,
+    dimension: str,
+    usage: Decimal | int | str,
+) -> PriceTier:
+    """Resolve the tier containing a metric under ``[start, end)`` rules."""
+    metric_value = _decimal_or_zero(usage)
+    if metric_value < ZERO:
+        raise ValueError("usage must be >= 0.")
+
+    tiers = schedule.for_dimension(dimension)
+    if not tiers:
+        raise ValueError(f"No price tier exists for {dimension}.")
+    validate_price_table(tiers)
+    flat_tiers = tuple(
+        tier for tier in tiers if tier.tier_type == ModelPriceItem.TIER_FLAT
+    )
+    if flat_tiers:
+        if len(flat_tiers) != 1:
+            raise ValueError(f"Invalid flat price schedule for {dimension}.")
+        return flat_tiers[0]
+
+    tier = match_usage_range_tier(tiers, metric_value)
+    if tier is not None:
+        return tier
+    raise PriceTierNotFoundError(
+        f"No {dimension} price tier contains usage {metric_value}."
+    )
+
+
+def resolve_usage_price_tier(
+    schedule: PriceSchedule,
+    *,
+    dimension: str,
+    usage: UsageContext,
+) -> PriceTier:
+    """Resolve a dimension using the request-level tier metric."""
+    tiers = schedule.for_dimension(dimension)
+    if not tiers:
+        raise ValueError(f"No price tier exists for {dimension}.")
+    metric_value = ZERO
+    if any(tier.tier_type != ModelPriceItem.TIER_FLAT for tier in tiers):
+        metric_value = _decimal_or_zero(usage.input_tokens)
+    return resolve_price_tier(
+        schedule,
+        dimension=dimension,
+        usage=metric_value,
+    )
+
+
+def resolve_usage_unit_prices(
+    schedule: PriceSchedule,
+    usage: UsageContext,
+) -> UnitPrices:
+    """Resolve scalar unit prices for one explicit usage context."""
+
+    def unit_price(dimension: str) -> Decimal:
+        if not schedule.for_dimension(dimension):
+            return ZERO
+        tier = resolve_usage_price_tier(
+            schedule,
+            dimension=dimension,
+            usage=usage,
+        )
+        return tier.unit_price
+
+    return UnitPrices(
+        input_per_million=unit_price(ModelPriceItem.DIMENSION_TEXT_INPUT),
+        output_per_million=unit_price(ModelPriceItem.DIMENSION_TEXT_OUTPUT),
+        cache_input_per_million=unit_price(
+            ModelPriceItem.DIMENSION_CACHE_INPUT
+        ),
+        image_output_per_image=unit_price(
+            ModelPriceItem.DIMENSION_IMAGE_OUTPUT
+        ),
+        audio_input_per_second=unit_price(
+            ModelPriceItem.DIMENSION_AUDIO_INPUT
+        ),
+        audio_output_per_second=unit_price(
+            ModelPriceItem.DIMENSION_AUDIO_OUTPUT
+        ),
+        video_input_per_second=unit_price(
+            ModelPriceItem.DIMENSION_VIDEO_INPUT
+        ),
+        video_output_per_second=unit_price(
+            ModelPriceItem.DIMENSION_VIDEO_OUTPUT
+        ),
+    )
+
+
+def calculate_price_schedule_usage_cost(
+    schedule: PriceSchedule,
+    usage: UsageContext,
+) -> Decimal:
+    """Calculate actual usage cost from a complete price schedule."""
+    total = ZERO
+    for dimension, amount in _usage_amounts(usage).items():
+        if amount == ZERO or not schedule.for_dimension(dimension):
+            continue
+        tier = resolve_usage_price_tier(
+            schedule,
+            dimension=dimension,
+            usage=usage,
+        )
+        total += _billing_quantity(amount, tier.billing_unit) * tier.unit_price
+    return total.quantize(SIX_PLACES)
+
+
+def analyze_tier_profit(
+    cost_schedule: PriceSchedule,
+    retail_schedule: PriceSchedule,
+    *,
+    dimension: str,
+    policy: RevenuePolicy,
+) -> TierProfitAnalysis:
+    """Align cost and retail boundaries and calculate interval profits."""
+    cost_tiers = cost_schedule.for_dimension(dimension)
+    retail_tiers = retail_schedule.for_dimension(dimension)
+    if not cost_tiers or not retail_tiers:
+        raise ValueError(f"Both schedules require {dimension} prices.")
+
+    intervals = []
+    boundaries = _aligned_tier_boundaries(cost_tiers, retail_tiers)
+    for index, start in enumerate(boundaries):
+        end = boundaries[index + 1] if index + 1 < len(boundaries) else None
+        if not _both_schedules_cover_usage(
+            cost_schedule,
+            retail_schedule,
+            dimension=dimension,
+            usage=start,
+        ):
+            continue
+        cost_tier = resolve_price_tier(
+            cost_schedule,
+            dimension=dimension,
+            usage=start,
+        )
+        retail_tier = resolve_price_tier(
+            retail_schedule,
+            dimension=dimension,
+            usage=start,
+        )
+        if cost_tier.billing_unit != retail_tier.billing_unit:
+            raise ValueError("Cost and retail billing units must match.")
+        intervals.append(
+            _tier_profit_interval(
+                dimension=dimension,
+                start=start,
+                end=end,
+                cost_tier=cost_tier,
+                retail_tier=retail_tier,
+                policy=policy,
+            )
+        )
+
+    interval_rows = tuple(intervals)
+    minimum = min(
+        interval_rows,
+        key=lambda row: row.gross_margin_rate,
+        default=None,
+    )
+    minimum_yield = min(
+        (row.net_yield_rate for row in interval_rows),
+        default=None,
+    )
+    return TierProfitAnalysis(
+        dimension=dimension,
+        currency=_normalize_currency(policy.target_currency),
+        billing_unit=(interval_rows[0].billing_unit if interval_rows else ""),
+        intervals=interval_rows,
+        minimum_gross_margin_rate=(
+            minimum.gross_margin_rate if minimum is not None else None
+        ),
+        minimum_net_yield_rate=minimum_yield,
+        minimum_interval=minimum,
+        risk_intervals=tuple(row for row in interval_rows if row.is_risk),
+    )
+
+
+def _usage_amounts(usage: UsageContext) -> dict[str, Decimal]:
+    """Map and validate actual usage by pricing dimension."""
+    amounts = {
+        ModelPriceItem.DIMENSION_TEXT_INPUT: _decimal_or_zero(
+            usage.input_tokens
+        ),
+        ModelPriceItem.DIMENSION_TEXT_OUTPUT: _decimal_or_zero(
+            usage.output_tokens
+        ),
+        ModelPriceItem.DIMENSION_CACHE_INPUT: _decimal_or_zero(
+            usage.cache_input_tokens
+        ),
+        ModelPriceItem.DIMENSION_IMAGE_OUTPUT: _decimal_or_zero(
+            usage.image_output_count
+        ),
+        ModelPriceItem.DIMENSION_AUDIO_INPUT: _decimal_or_zero(
+            usage.audio_input_seconds
+        ),
+        ModelPriceItem.DIMENSION_AUDIO_OUTPUT: _decimal_or_zero(
+            usage.audio_output_seconds
+        ),
+        ModelPriceItem.DIMENSION_VIDEO_INPUT: _decimal_or_zero(
+            usage.video_input_seconds
+        ),
+        ModelPriceItem.DIMENSION_VIDEO_OUTPUT: _decimal_or_zero(
+            usage.video_output_seconds
+        ),
+    }
+    if any(amount < ZERO for amount in amounts.values()):
+        raise ValueError("usage values must be >= 0.")
+    return amounts
+
+
+def _billing_quantity(amount: Decimal, billing_unit: str) -> Decimal:
+    """Convert raw usage to the quantity represented by one unit price."""
+    if billing_unit == ModelPriceItem.UNIT_PER_1M_TOKENS:
+        return amount / Decimal("1000000")
+    if billing_unit in {
+        ModelPriceItem.UNIT_PER_IMAGE,
+        ModelPriceItem.UNIT_PER_SECOND,
+        ModelPriceItem.UNIT_PER_GENERATION,
+    }:
+        return amount
+    raise ValueError(f"Unsupported billing unit: {billing_unit}.")
+
+
+def _aligned_tier_boundaries(
+    cost_tiers: tuple[PriceTier, ...],
+    retail_tiers: tuple[PriceTier, ...],
+) -> tuple[Decimal, ...]:
+    """Return the sorted union of every finite schedule boundary."""
+    boundaries = {ZERO}
+    for tier in cost_tiers + retail_tiers:
+        if tier.tier_start is not None:
+            boundaries.add(tier.tier_start)
+        if tier.tier_end is not None:
+            boundaries.add(tier.tier_end)
+    return tuple(sorted(boundaries))
+
+
+def _both_schedules_cover_usage(
+    cost_schedule: PriceSchedule,
+    retail_schedule: PriceSchedule,
+    *,
+    dimension: str,
+    usage: Decimal,
+) -> bool:
+    """Return whether both schedules cover an aligned boundary."""
+    try:
+        resolve_price_tier(
+            cost_schedule,
+            dimension=dimension,
+            usage=usage,
+        )
+        resolve_price_tier(
+            retail_schedule,
+            dimension=dimension,
+            usage=usage,
+        )
+    except PriceTierNotFoundError:
+        return False
+    return True
+
+
+def _tier_profit_interval(
+    *,
+    dimension: str,
+    start: Decimal,
+    end: Decimal | None,
+    cost_tier: PriceTier,
+    retail_tier: PriceTier,
+    policy: RevenuePolicy,
+) -> TierProfitInterval:
+    """Calculate canonical resale metrics for one aligned interval."""
+    converted_cost = cost_tier.unit_price * policy.cost_exchange_rate
+    converted_retail = retail_tier.unit_price * policy.retail_exchange_rate
+    cost = converted_cost * policy.settlement_rate
+    net_factor = (
+        ONE
+        - policy.platform_fee_rate
+        - policy.service_fee_rate
+        - policy.tax_rate
+    )
+    net_revenue = converted_retail * net_factor
+    gross_profit = net_revenue - cost
+    gross_margin_rate = _safe_ratio(gross_profit, net_revenue)
+    net_yield_rate = _safe_ratio(gross_profit, converted_retail)
+    margin_rate = gross_margin_rate.quantize(SIX_PLACES)
+    yield_rate = net_yield_rate.quantize(SIX_PLACES)
+    risk_threshold = policy.risk_net_yield_rate
+    return TierProfitInterval(
+        dimension=dimension,
+        billing_unit=cost_tier.billing_unit,
+        currency=_normalize_currency(policy.target_currency),
+        tier_start=start,
+        tier_end=end,
+        cost_currency=_normalize_currency(cost_tier.currency),
+        retail_currency=_normalize_currency(retail_tier.currency),
+        cost_unit_price=cost_tier.unit_price,
+        retail_unit_price=retail_tier.unit_price,
+        converted_cost_unit_price=converted_cost.quantize(SIX_PLACES),
+        converted_retail_unit_price=converted_retail.quantize(SIX_PLACES),
+        cost=cost.quantize(SIX_PLACES),
+        gross_revenue=converted_retail.quantize(SIX_PLACES),
+        net_revenue=net_revenue.quantize(SIX_PLACES),
+        gross_profit=gross_profit.quantize(SIX_PLACES),
+        gross_margin_rate=margin_rate,
+        net_yield_rate=yield_rate,
+        is_risk=(
+            risk_threshold is not None and net_yield_rate < risk_threshold
+        ),
+    )
+
+
+def _safe_ratio(numerator: Decimal, denominator: Decimal) -> Decimal:
+    """Return a deterministic ratio for a zero denominator."""
+    if denominator:
+        return numerator / denominator
+    if numerator < ZERO:
+        return Decimal("-1")
+    return ZERO
+
+
+def _decimal_or_zero(value) -> Decimal:
+    """Return a Decimal value, falling back to zero."""
+    if value is None:
+        return ZERO
+    return Decimal(str(value))
+
+
+def _normalize_currency(value: str | None) -> str:
+    """Normalize currency codes in analysis output."""
+    return str(value or "").strip().upper()

--- a/backend/llm_ops/views.py
+++ b/backend/llm_ops/views.py
@@ -102,12 +102,13 @@ from .services import (
     record_channel_model_price_history,
     record_resale_listing_price_history,
     resolve_channel_model_currency,
-    resolve_channel_model_price,
+    resolve_channel_price_schedule,
     resolve_resale_listing_currency,
     selected_price_item_group,
     sync_channel_price_items,
     sync_dependent_channel_price_items_for_price_items,
 )
+from .tier_pricing import UsageContext, resolve_usage_unit_prices
 from .source_collectors import source_supports_code_collection
 from .tasks import collect_price_source_prices, run_model_price_sync_agent
 from .workflow_config import (
@@ -3111,6 +3112,7 @@ def _summary_listing_rows(
     overrides,
     price_item_indexes,
     rows_by_model,
+    usage_context,
     video_resolution,
 ):
     """Build full listing rows for dashboard sections that need them."""
@@ -3149,7 +3151,7 @@ def _summary_listing_rows(
                 or not override.is_listed
             ):
                 continue
-            unit_prices = resolve_channel_model_price(
+            schedule = resolve_channel_price_schedule(
                 channel,
                 listing.model,
                 override=override,
@@ -3158,6 +3160,10 @@ def _summary_listing_rows(
                     price_item_indexes,
                 ),
                 video_resolution=video_resolution,
+            )
+            unit_prices = resolve_usage_unit_prices(
+                schedule,
+                usage_context,
             )
             cost_input = unit_prices.input_per_million
             cost_output = unit_prices.output_per_million
@@ -3378,6 +3384,14 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
         output_tokens = int(
             request.query_params.get("output_tokens") or DEFAULT_OUTPUT_TOKENS
         )
+        cache_input_tokens = int(
+            request.query_params.get("cache_input_tokens") or 0
+        )
+        usage_context = UsageContext(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_input_tokens=cache_input_tokens,
+        )
         video_resolution = request.query_params.get("video_resolution") or ""
         display_currency = (
             request.query_params.get("display_currency") or "CNY"
@@ -3445,12 +3459,16 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
                     override,
                     price_item_indexes,
                 )
-                unit_prices = resolve_channel_model_price(
+                schedule = resolve_channel_price_schedule(
                     channel,
                     model,
                     override=override,
                     source_items=price_items,
                     video_resolution=video_resolution,
+                )
+                unit_prices = resolve_usage_unit_prices(
+                    schedule,
+                    usage_context,
                 )
                 if not _has_procurement_text_price(unit_prices):
                     continue
@@ -3463,6 +3481,7 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
                     unit_prices,
                     input_tokens=input_tokens,
                     output_tokens=output_tokens,
+                    cache_input_tokens=cache_input_tokens,
                 )
                 option = {
                     "channel_id": channel.id,
@@ -3664,6 +3683,7 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
                 overrides=overrides,
                 price_item_indexes=price_item_indexes,
                 rows_by_model=rows_by_model,
+                usage_context=usage_context,
                 video_resolution=video_resolution,
             )
         )


### PR DESCRIPTION
## Summary

- resolve complete channel price schedules without flattening usage tiers
- select all tiered dimensions by the shared request-input-token contract and calculate actual input, output, and cached-token cost
- align cost and retail boundaries and calculate canonical fee-, tax-, settlement-, and FX-aware profit intervals
- reject tiered data in the legacy scalar interface and preserve existing video-resolution precedence
- make channel price-item synchronization atomic and persist cached reconciliation usage

## Dependencies and integration

- Depends on #229; its four contract commits are included because no dependency PR exists yet.
- #230 also introduces an `llm_ops` migration numbered `0009`; whichever PR lands second must rebase and renumber its migration before merge.

## Verification

- `220 passed, 16 subtests passed`
- Django system check: no issues
- `makemigrations llm_ops --check --dry-run`: no changes detected
- Black/isort/flake8 checks passed for new kernel files
- `git diff --check` and Python compileall passed

Closes #231