### PR TITLE
Define and enforce tiered price table contract

### DIFF
--- a/backend/llm_ops/collection_services.py
+++ b/backend/llm_ops/collection_services.py
@@ -46,6 +46,10 @@ from .price_collectors import (
     registered_vendor_price_collector_codes,
     vendor_price_collector_exists,
 )
+from .price_table_validation import (
+    validate_price_table_groups,
+    with_usage_range_spec,
+)
 from .services import (
     find_aggregated_model,
     match_meta_model_by_alias_or_name,
@@ -3181,6 +3185,8 @@ def sync_model_price_items(
     if not payloads:
         return []
 
+    validate_price_table_groups(payloads)
+
     now = timezone.now()
     current_filter = {
         "offering": offering,
@@ -3582,6 +3588,7 @@ def price_item_payload(
     tier_type = ModelPriceItem.TIER_FLAT
     if tier_start is not None or tier_end is not None:
         tier_type = ModelPriceItem.TIER_USAGE_RANGE
+        spec = with_usage_range_spec(spec)
     return {
         **common,
         "dimension": dimension,

--- a/backend/llm_ops/price_table_validation.py
+++ b/backend/llm_ops/price_table_validation.py
@@ -1,4 +1,12 @@
-"""Shared executable contract for normalized tiered price tables."""
+"""Shared executable contract for normalized tiered price tables.
+
+A table represents one model, source/platform variant, billing dimension,
+currency, and billing unit. Usage-range tiers use ``[tier_start, tier_end)``;
+``tier_end=None`` means that the final tier is unbounded. The first-phase
+metric is the input token count of one request, and the matched tier prices
+the whole request. Volume tiers remain disabled until cumulative periods and
+graduated-versus-matched charging are defined.
+"""
 
 from __future__ import annotations
 
@@ -136,7 +144,7 @@ def validate_price_table_groups(rows: Sequence[Any]) -> None:
     for row in rows:
         key = (
             str(_value(row, "dimension") or ""),
-            _variant_spec_key(_value(row, "spec")),
+            price_table_variant_key(row),
         )
         tables.setdefault(key, []).append(row)
     for table in tables.values():
@@ -160,6 +168,11 @@ def match_usage_range_tier(rows: Sequence[Any], metric_value: Any) -> Any:
             if end is None or value < end:
                 return row
     return None
+
+
+def price_table_variant_key(row: Any) -> str:
+    """Return display metadata that identifies an independent table."""
+    return _variant_spec_key(_value(row, "spec"))
 
 
 def _validate_flat_table(rows: Sequence[Any]) -> None:

--- a/backend/llm_ops/price_table_validation.py
+++ b/backend/llm_ops/price_table_validation.py
@@ -1,0 +1,318 @@
+"""Shared executable contract for normalized tiered price tables."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from decimal import Decimal, InvalidOperation
+import json
+from typing import Any
+
+
+TIER_FLAT = "flat"
+TIER_USAGE_RANGE = "usage_range"
+TIER_VOLUME = "volume"
+
+TIER_METRIC_REQUEST_INPUT_TOKENS = "request_input_tokens"
+TIER_CHARGE_MODE_MATCHED_TIER = "matched_tier"
+AGGREGATION_PERIOD_REQUEST = "request"
+
+TIER_CONTRACT_SPEC_KEYS = frozenset(
+    {
+        "tier_metric",
+        "tier_charge_mode",
+        "aggregation_period",
+    }
+)
+SUPPORTED_TIER_DIMENSIONS = frozenset(
+    {
+        "text_input",
+        "text_output",
+        "cache_input",
+    }
+)
+
+ERROR_MIXED_FLAT_AND_TIERED = "price_table_mixed_flat_and_tiered"
+ERROR_INCONSISTENT_DIMENSION = "price_table_inconsistent_dimension"
+ERROR_INCONSISTENT_CURRENCY = "price_table_inconsistent_currency"
+ERROR_INCONSISTENT_UNIT = "price_table_inconsistent_billing_unit"
+ERROR_INCONSISTENT_TIER_TYPE = "price_table_inconsistent_tier_type"
+ERROR_INCONSISTENT_METRIC = "price_table_inconsistent_tier_metric"
+ERROR_INCONSISTENT_CHARGE_MODE = (
+    "price_table_inconsistent_tier_charge_mode"
+)
+ERROR_INCONSISTENT_AGGREGATION_PERIOD = (
+    "price_table_inconsistent_aggregation_period"
+)
+ERROR_UNSUPPORTED_DIMENSION = "price_table_unsupported_tier_dimension"
+ERROR_INVALID_USAGE_RANGE_SPEC = "price_table_invalid_usage_range_spec"
+ERROR_TIER_MUST_START_AT_ZERO = "price_table_first_tier_must_start_at_zero"
+ERROR_INVALID_BOUNDARY = "price_table_invalid_boundary"
+ERROR_DUPLICATE_RANGE = "price_table_duplicate_range"
+ERROR_GAP = "price_table_gap"
+ERROR_UNBOUNDED_TIER_NOT_LAST = "price_table_unbounded_tier_not_last"
+ERROR_VOLUME_UNSUPPORTED = "price_table_volume_unsupported"
+
+
+class PriceTableValidationError(ValueError):
+    """Machine-readable price table contract violation."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+def usage_range_spec() -> dict[str, str]:
+    """Return the first-phase executable usage-range contract."""
+    return {
+        "tier_metric": TIER_METRIC_REQUEST_INPUT_TOKENS,
+        "tier_charge_mode": TIER_CHARGE_MODE_MATCHED_TIER,
+        "aggregation_period": AGGREGATION_PERIOD_REQUEST,
+    }
+
+
+def with_usage_range_spec(spec: Mapping[str, Any] | None) -> dict:
+    """Add the canonical usage-range contract to display metadata."""
+    return {**dict(spec or {}), **usage_range_spec()}
+
+
+def validate_price_table(rows: Sequence[Any]) -> None:
+    """Validate one flat or tiered table using the shared contract."""
+    if not rows:
+        return
+
+    tier_types = {_value(row, "tier_type") or TIER_FLAT for row in rows}
+    if TIER_FLAT in tier_types and len(tier_types) > 1:
+        _raise(
+            ERROR_MIXED_FLAT_AND_TIERED,
+            "A price table cannot mix flat and tiered rows.",
+        )
+
+    _require_consistent(
+        rows,
+        "dimension",
+        ERROR_INCONSISTENT_DIMENSION,
+        "All rows must use the same dimension.",
+    )
+    _require_consistent(
+        rows,
+        "currency",
+        ERROR_INCONSISTENT_CURRENCY,
+        "All rows must use the same currency.",
+    )
+    _require_consistent(
+        rows,
+        "billing_unit",
+        ERROR_INCONSISTENT_UNIT,
+        "All rows must use the same billing unit.",
+    )
+    if len(tier_types) > 1:
+        _raise(
+            ERROR_INCONSISTENT_TIER_TYPE,
+            "All rows must use the same tier type.",
+        )
+
+    tier_type = next(iter(tier_types))
+    if tier_type == TIER_FLAT:
+        _validate_flat_table(rows)
+        return
+    if tier_type == TIER_VOLUME:
+        _raise(
+            ERROR_VOLUME_UNSUPPORTED,
+            "Volume tiers are disabled until their billing contract is set.",
+        )
+    if tier_type != TIER_USAGE_RANGE:
+        _raise(
+            ERROR_INVALID_BOUNDARY,
+            f"Unsupported tier type: {tier_type}.",
+        )
+
+    _validate_usage_range_table(rows)
+
+
+def validate_price_table_groups(rows: Sequence[Any]) -> None:
+    """Validate independent dimension and variant tables in one catalog."""
+    tables: dict[tuple[str, str], list[Any]] = {}
+    for row in rows:
+        key = (
+            str(_value(row, "dimension") or ""),
+            _variant_spec_key(_value(row, "spec")),
+        )
+        tables.setdefault(key, []).append(row)
+    for table in tables.values():
+        validate_price_table(table)
+
+
+def match_usage_range_tier(rows: Sequence[Any], metric_value: Any) -> Any:
+    """Return the row containing a request metric under ``[start, end)``."""
+    validate_price_table(rows)
+    value = _decimal(metric_value)
+    if value is None or value < Decimal("0"):
+        _raise(
+            ERROR_INVALID_BOUNDARY,
+            "The tier metric value must be a non-negative number.",
+        )
+
+    for row in _sorted_tiers(rows):
+        start = _decimal(_value(row, "tier_start"))
+        end = _decimal(_value(row, "tier_end"))
+        if start is not None and start <= value:
+            if end is None or value < end:
+                return row
+    return None
+
+
+def _validate_flat_table(rows: Sequence[Any]) -> None:
+    for row in rows:
+        if (
+            _value(row, "tier_start") is not None
+            or _value(row, "tier_end") is not None
+        ):
+            _raise(
+                ERROR_INVALID_BOUNDARY,
+                "Flat price rows cannot define tier boundaries.",
+            )
+
+
+def _validate_usage_range_table(rows: Sequence[Any]) -> None:
+    dimension = str(_value(rows[0], "dimension") or "")
+    if dimension not in SUPPORTED_TIER_DIMENSIONS:
+        _raise(
+            ERROR_UNSUPPORTED_DIMENSION,
+            "Usage-range tiers only support text and cached input prices.",
+        )
+
+    specs = [dict(_value(row, "spec") or {}) for row in rows]
+    _require_spec_consistent(
+        specs,
+        "tier_metric",
+        ERROR_INCONSISTENT_METRIC,
+        "All rows must use the same tier metric.",
+    )
+    _require_spec_consistent(
+        specs,
+        "tier_charge_mode",
+        ERROR_INCONSISTENT_CHARGE_MODE,
+        "All rows must use the same tier charge mode.",
+    )
+    _require_spec_consistent(
+        specs,
+        "aggregation_period",
+        ERROR_INCONSISTENT_AGGREGATION_PERIOD,
+        "All rows must use the same aggregation period.",
+    )
+    expected = usage_range_spec()
+    if any(
+        any(spec.get(key) != value for key, value in expected.items())
+        for spec in specs
+    ):
+        _raise(
+            ERROR_INVALID_USAGE_RANGE_SPEC,
+            "Usage-range rows must use the request input token contract.",
+        )
+
+    tiers = _sorted_tiers(rows)
+    first_start = _decimal(_value(tiers[0], "tier_start"))
+    if first_start != Decimal("0"):
+        _raise(
+            ERROR_TIER_MUST_START_AT_ZERO,
+            "The first tier must start at zero.",
+        )
+
+    seen_ranges = set()
+    previous_end = None
+    for index, row in enumerate(tiers):
+        start = _decimal(_value(row, "tier_start"))
+        end = _decimal(_value(row, "tier_end"))
+        range_key = (start, end)
+        if range_key in seen_ranges:
+            _raise(ERROR_DUPLICATE_RANGE, "Tier ranges must be unique.")
+        seen_ranges.add(range_key)
+
+        if start is None or start < Decimal("0"):
+            _raise(
+                ERROR_INVALID_BOUNDARY,
+                "Tier boundaries must be non-negative numbers.",
+            )
+        if end is not None and end <= start:
+            _raise(
+                ERROR_INVALID_BOUNDARY,
+                "A tier end must be greater than its start.",
+            )
+        if end is None and index != len(tiers) - 1:
+            _raise(
+                ERROR_UNBOUNDED_TIER_NOT_LAST,
+                "Only the final tier may have no upper bound.",
+            )
+        if index:
+            if previous_end is None:
+                _raise(
+                    ERROR_UNBOUNDED_TIER_NOT_LAST,
+                    "Only the final tier may have no upper bound.",
+                )
+            if start < previous_end:
+                _raise(ERROR_INVALID_BOUNDARY, "Tier ranges overlap.")
+            if start > previous_end:
+                _raise(ERROR_GAP, "Tier ranges must not contain gaps.")
+        previous_end = end
+
+
+def _require_consistent(
+    rows: Sequence[Any],
+    field: str,
+    code: str,
+    message: str,
+) -> None:
+    values = {_value(row, field) for row in rows}
+    if len(values) > 1:
+        _raise(code, message)
+
+
+def _require_spec_consistent(
+    specs: Sequence[Mapping[str, Any]],
+    field: str,
+    code: str,
+    message: str,
+) -> None:
+    values = {spec.get(field) for spec in specs}
+    if len(values) > 1:
+        _raise(code, message)
+
+
+def _sorted_tiers(rows: Sequence[Any]) -> list[Any]:
+    try:
+        return sorted(
+            rows,
+            key=lambda row: (
+                _decimal(_value(row, "tier_start")) is None,
+                _decimal(_value(row, "tier_start")) or Decimal("0"),
+            ),
+        )
+    except (InvalidOperation, TypeError, ValueError):
+        _raise(ERROR_INVALID_BOUNDARY, "Tier boundaries must be numbers.")
+
+
+def _variant_spec_key(spec: Any) -> str:
+    values = dict(spec or {})
+    for key in TIER_CONTRACT_SPEC_KEYS:
+        values.pop(key, None)
+    return json.dumps(values, default=str, sort_keys=True)
+
+
+def _decimal(value: Any) -> Decimal | None:
+    if value is None or value == "":
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        _raise(ERROR_INVALID_BOUNDARY, "Tier boundaries must be numbers.")
+
+
+def _value(row: Any, field: str) -> Any:
+    if isinstance(row, Mapping):
+        return row.get(field)
+    return getattr(row, field, None)
+
+
+def _raise(code: str, message: str) -> None:
+    raise PriceTableValidationError(code, message)

--- a/backend/llm_ops/price_table_validation.py
+++ b/backend/llm_ops/price_table_validation.py
@@ -81,6 +81,11 @@ def usage_range_spec() -> dict[str, str]:
 
 def with_usage_range_spec(spec: Mapping[str, Any] | None) -> dict:
     """Add the canonical usage-range contract to display metadata."""
+    if spec is not None and not isinstance(spec, Mapping):
+        _raise(
+            ERROR_INVALID_USAGE_RANGE_SPEC,
+            "Tier spec must be a JSON object.",
+        )
     return {**dict(spec or {}), **usage_range_spec()}
 
 
@@ -332,9 +337,12 @@ def _decimal(value: Any) -> Decimal | None:
     if value is None or value == "":
         return None
     try:
-        return Decimal(str(value))
+        result = Decimal(str(value))
     except (InvalidOperation, TypeError, ValueError):
         _raise(ERROR_INVALID_BOUNDARY, "Tier boundaries must be numbers.")
+    if not result.is_finite():
+        _raise(ERROR_INVALID_BOUNDARY, "Tier boundaries must be finite.")
+    return result
 
 
 def _value(row: Any, field: str) -> Any:

--- a/backend/llm_ops/price_table_validation.py
+++ b/backend/llm_ops/price_table_validation.py
@@ -195,7 +195,7 @@ def _validate_usage_range_table(rows: Sequence[Any]) -> None:
             "Usage-range tiers only support text and cached input prices.",
         )
 
-    specs = [dict(_value(row, "spec") or {}) for row in rows]
+    specs = [_price_spec(row) for row in rows]
     _require_spec_consistent(
         specs,
         "tier_metric",
@@ -306,10 +306,26 @@ def _sorted_tiers(rows: Sequence[Any]) -> list[Any]:
 
 
 def _variant_spec_key(spec: Any) -> str:
+    if spec is not None and not isinstance(spec, Mapping):
+        return json.dumps(
+            {"invalid_spec": spec},
+            default=str,
+            sort_keys=True,
+        )
     values = dict(spec or {})
     for key in TIER_CONTRACT_SPEC_KEYS:
         values.pop(key, None)
     return json.dumps(values, default=str, sort_keys=True)
+
+
+def _price_spec(row: Any) -> dict:
+    value = _value(row, "spec")
+    if value is not None and not isinstance(value, Mapping):
+        _raise(
+            ERROR_INVALID_USAGE_RANGE_SPEC,
+            "Tier spec must be a JSON object.",
+        )
+    return dict(value or {})
 
 
 def _decimal(value: Any) -> Decimal | None:

--- a/backend/llm_ops/serializers.py
+++ b/backend/llm_ops/serializers.py
@@ -1298,7 +1298,10 @@ def validate_serializer_price_table(rows) -> None:
     try:
         validate_price_table(rows)
     except PriceTableValidationError as exc:
-        error = serializers.ErrorDetail(exc.message, code=exc.code)
+        error = {
+            "code": serializers.ErrorDetail(exc.code, code=exc.code),
+            "message": serializers.ErrorDetail(exc.message, code=exc.code),
+        }
         raise serializers.ValidationError({"price_table": error}) from exc
 
 

--- a/backend/llm_ops/serializers.py
+++ b/backend/llm_ops/serializers.py
@@ -38,6 +38,11 @@ from .models import (
     ResaleWorkflowConfig,
     UsageReconciliationRecord,
 )
+from .price_table_validation import (
+    PriceTableValidationError,
+    price_table_variant_key,
+    validate_price_table,
+)
 from .services import (
     SUPPORTED_DISPLAY_CURRENCIES,
     calculate_channel_model_cost,
@@ -874,6 +879,11 @@ class ModelPriceItemSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError("unit_price must be >= 0.")
         return value
 
+    def validate(self, attrs):
+        rows = model_price_table_rows(attrs, instance=self.instance)
+        validate_serializer_price_table(rows)
+        return attrs
+
     def create(self, validated_data):
         meta_model = price_item_meta_model(validated_data)
         source = price_item_source(validated_data)
@@ -1264,6 +1274,94 @@ def related_id(data: dict, field: str, instance) -> int | None:
     return value.id if value is not None else None
 
 
+PRICE_TABLE_FIELDS = (
+    "dimension",
+    "billing_unit",
+    "currency",
+    "tier_type",
+    "tier_start",
+    "tier_end",
+    "spec",
+)
+
+
+def price_table_candidate(data: dict, instance=None) -> dict:
+    """Merge serializer input with persisted values for table validation."""
+    return {
+        field: data.get(field, getattr(instance, field, None))
+        for field in PRICE_TABLE_FIELDS
+    }
+
+
+def validate_serializer_price_table(rows) -> None:
+    """Translate the shared contract error to a stable DRF error code."""
+    try:
+        validate_price_table(rows)
+    except PriceTableValidationError as exc:
+        error = serializers.ErrorDetail(exc.message, code=exc.code)
+        raise serializers.ValidationError({"price_table": error}) from exc
+
+
+def model_price_table_rows(data: dict, *, instance=None) -> list:
+    """Return the current official table plus a serializer candidate."""
+    candidate = price_table_candidate(data, instance)
+    queryset = ModelPriceItem.objects.none()
+    offering = data.get("offering", getattr(instance, "offering", None))
+    model = data.get("model", getattr(instance, "model", None))
+    sku = data.get("sku", getattr(instance, "sku", None))
+    source = data.get("source", getattr(instance, "source", None))
+    dimension = candidate["dimension"]
+    if offering is not None:
+        queryset = ModelPriceItem.objects.filter(
+            offering=offering,
+            dimension=dimension,
+            is_current=True,
+        )
+    elif model is not None:
+        queryset = ModelPriceItem.objects.filter(
+            model=model,
+            source=source,
+            dimension=dimension,
+            is_current=True,
+        )
+    elif sku is not None:
+        queryset = ModelPriceItem.objects.filter(
+            sku=sku,
+            source=source,
+            dimension=dimension,
+            is_current=True,
+        )
+    if instance is not None and instance.pk:
+        queryset = queryset.exclude(pk=instance.pk)
+    variant_key = price_table_variant_key(candidate)
+    rows = [
+        row for row in queryset if price_table_variant_key(row) == variant_key
+    ]
+    return [*rows, candidate]
+
+
+def channel_price_table_rows(data: dict, *, instance=None) -> list:
+    """Return the current channel table plus a serializer candidate."""
+    candidate = price_table_candidate(data, instance)
+    channel = data.get("channel", getattr(instance, "channel", None))
+    model = data.get("model", getattr(instance, "model", None))
+    queryset = ChannelPriceItem.objects.none()
+    if channel is not None and model is not None:
+        queryset = ChannelPriceItem.objects.filter(
+            channel=channel,
+            model=model,
+            dimension=candidate["dimension"],
+            is_current=True,
+        )
+    if instance is not None and instance.pk:
+        queryset = queryset.exclude(pk=instance.pk)
+    variant_key = price_table_variant_key(candidate)
+    rows = [
+        row for row in queryset if price_table_variant_key(row) == variant_key
+    ]
+    return [*rows, candidate]
+
+
 class ProcurementChannelSerializer(serializers.ModelSerializer):
     """Serializer for upstream procurement channels."""
 
@@ -1465,6 +1563,11 @@ class ChannelPriceItemSerializer(serializers.ModelSerializer):
         if value < Decimal("0"):
             raise serializers.ValidationError("unit_price must be >= 0.")
         return value
+
+    def validate(self, attrs):
+        rows = channel_price_table_rows(attrs, instance=self.instance)
+        validate_serializer_price_table(rows)
+        return attrs
 
     def create(self, validated_data):
         validated_data["meta_model"] = validated_data["model"].meta_model

--- a/backend/llm_ops/services.py
+++ b/backend/llm_ops/services.py
@@ -29,6 +29,10 @@ from .models import (
     ResaleListing,
     ResaleListingPriceHistory,
 )
+from .price_table_validation import (
+    validate_price_table_groups,
+    with_usage_range_spec,
+)
 
 
 ZERO = Decimal("0")
@@ -1425,6 +1429,7 @@ def sync_channel_price_items(
     """Sync normalized channel price items from one channel/model config."""
     source = price.price_source
     payloads = channel_price_item_payloads(price, source=source)
+    validate_price_table_groups(payloads)
     now = timezone.now()
     ChannelPriceItem.objects.filter(
         channel=price.channel,
@@ -1767,6 +1772,9 @@ def channel_price_payload_from_base_item(
         currency,
         base_item,
     )
+    spec = base_item.spec or {}
+    if base_item.tier_type == ModelPriceItem.TIER_USAGE_RANGE:
+        spec = with_usage_range_spec(spec)
     return {
         "channel": price.channel,
         "model": price.model,
@@ -1780,7 +1788,7 @@ def channel_price_payload_from_base_item(
         "tier_type": base_item.tier_type,
         "tier_start": base_item.tier_start,
         "tier_end": base_item.tier_end,
-        "spec": base_item.spec or {},
+        "spec": spec,
         "price_source_type": source_type,
         "settlement_ratio": price.settlement_ratio,
         "comparison_status": comparison["status"],

--- a/backend/llm_ops/tests/test_price_table_integrations.py
+++ b/backend/llm_ops/tests/test_price_table_integrations.py
@@ -14,6 +14,7 @@ from llm_ops.models import (
     SourceSkuOffering,
 )
 from llm_ops.price_table_validation import (
+    ERROR_INVALID_USAGE_RANGE_SPEC,
     ERROR_MIXED_FLAT_AND_TIERED,
     ERROR_VOLUME_UNSUPPORTED,
     usage_range_spec,
@@ -129,6 +130,16 @@ class PriceTableIntegrationTests(TestCase):
         )
 
         self.assert_price_table_error(serializer, ERROR_VOLUME_UNSUPPORTED)
+
+    def test_model_serializer_rejects_non_object_tier_spec(self):
+        serializer = ModelPriceItemSerializer(
+            data=self.model_payload(spec=["request_input_tokens"])
+        )
+
+        self.assert_price_table_error(
+            serializer,
+            ERROR_INVALID_USAGE_RANGE_SPEC,
+        )
 
     def test_channel_serializer_returns_same_volume_error_code(self):
         serializer = ChannelPriceItemSerializer(

--- a/backend/llm_ops/tests/test_price_table_integrations.py
+++ b/backend/llm_ops/tests/test_price_table_integrations.py
@@ -102,8 +102,10 @@ class PriceTableIntegrationTests(TestCase):
         """Assert the DRF boundary preserves the shared error code."""
         self.assertFalse(serializer.is_valid())
         self.assertIn("price_table", serializer.errors, serializer.errors)
-        error = serializer.errors["price_table"][0]
-        self.assertEqual(error.code, expected_code)
+        error = serializer.errors["price_table"]
+        self.assertEqual(str(error["code"]), expected_code)
+        self.assertEqual(error["code"].code, expected_code)
+        self.assertTrue(str(error["message"]))
 
     def test_collected_usage_range_payload_adds_contract_spec(self):
         payload = price_item_payload(

--- a/backend/llm_ops/tests/test_price_table_integrations.py
+++ b/backend/llm_ops/tests/test_price_table_integrations.py
@@ -1,0 +1,172 @@
+from decimal import Decimal
+
+from django.test import TestCase
+
+from llm_ops.collection_services import price_item_payload
+from llm_ops.models import (
+    ChannelPriceItem,
+    LLMModel,
+    LLMProvider,
+    ModelPriceItem,
+    ModelSku,
+    PriceCollectionSource,
+    ProcurementChannel,
+    SourceSkuOffering,
+)
+from llm_ops.price_table_validation import (
+    ERROR_MIXED_FLAT_AND_TIERED,
+    ERROR_VOLUME_UNSUPPORTED,
+    usage_range_spec,
+)
+from llm_ops.serializers import (
+    ChannelPriceItemSerializer,
+    ModelPriceItemSerializer,
+)
+
+
+class PriceTableIntegrationTests(TestCase):
+    def setUp(self):
+        self.provider = LLMProvider.objects.create(
+            name="OpenAI",
+            code="openai",
+        )
+        self.model = LLMModel.objects.create(
+            provider=self.provider,
+            name="GPT-5",
+            code="gpt-5",
+        )
+        self.source = PriceCollectionSource.objects.create(
+            provider=self.provider,
+            name="OpenAI Official",
+            slug="openai-official",
+        )
+        self.sku = ModelSku.objects.create(
+            meta_model=self.model.meta_model,
+            provider=self.provider,
+            canonical_sku_code=self.model.code,
+            upstream_model_name=self.model.code,
+            display_name=self.model.name,
+        )
+        self.offering = SourceSkuOffering.objects.create(
+            source=self.source,
+            sku=self.sku,
+            provider=self.provider,
+            exposed_model_name=self.model.code,
+        )
+        self.channel = ProcurementChannel.objects.create(
+            name="Supplier A",
+            code="supplier-a",
+        )
+
+    def model_payload(self, **overrides):
+        """Build one model price serializer payload."""
+        payload = {
+            "provider": self.provider.id,
+            "model": self.model.id,
+            "sku": self.sku.id,
+            "offering": self.offering.id,
+            "source": self.source.id,
+            "dimension": ModelPriceItem.DIMENSION_TEXT_INPUT,
+            "billing_unit": ModelPriceItem.UNIT_PER_1M_TOKENS,
+            "currency": "USD",
+            "unit_price": "1.000000",
+            "tier_type": ModelPriceItem.TIER_USAGE_RANGE,
+            "tier_start": "0",
+            "tier_end": None,
+            "spec": usage_range_spec(),
+            "price_fingerprint": "model-tier",
+        }
+        payload.update(overrides)
+        return payload
+
+    def channel_payload(self, **overrides):
+        """Build one channel price serializer payload."""
+        payload = {
+            "channel": self.channel.id,
+            "model": self.model.id,
+            "dimension": ModelPriceItem.DIMENSION_TEXT_INPUT,
+            "billing_unit": ModelPriceItem.UNIT_PER_1M_TOKENS,
+            "currency": "USD",
+            "unit_price": "0.800000",
+            "tier_type": ModelPriceItem.TIER_USAGE_RANGE,
+            "tier_start": "0",
+            "tier_end": None,
+            "spec": usage_range_spec(),
+            "price_fingerprint": "channel-tier",
+        }
+        payload.update(overrides)
+        return payload
+
+    def assert_price_table_error(self, serializer, expected_code):
+        """Assert the DRF boundary preserves the shared error code."""
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("price_table", serializer.errors, serializer.errors)
+        error = serializer.errors["price_table"][0]
+        self.assertEqual(error.code, expected_code)
+
+    def test_collected_usage_range_payload_adds_contract_spec(self):
+        payload = price_item_payload(
+            {},
+            dimension=ModelPriceItem.DIMENSION_TEXT_INPUT,
+            billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
+            unit_price=Decimal("1"),
+            spec={"region": "cn-beijing"},
+            tier_start=Decimal("0"),
+            tier_end=Decimal("1000000"),
+        )
+
+        self.assertEqual(payload["spec"]["region"], "cn-beijing")
+        self.assertEqual(
+            payload["spec"]["tier_metric"],
+            "request_input_tokens",
+        )
+        self.assertEqual(payload["spec"]["tier_charge_mode"], "matched_tier")
+        self.assertEqual(payload["spec"]["aggregation_period"], "request")
+
+    def test_model_serializer_returns_stable_volume_error_code(self):
+        serializer = ModelPriceItemSerializer(
+            data=self.model_payload(tier_type=ModelPriceItem.TIER_VOLUME)
+        )
+
+        self.assert_price_table_error(serializer, ERROR_VOLUME_UNSUPPORTED)
+
+    def test_channel_serializer_returns_same_volume_error_code(self):
+        serializer = ChannelPriceItemSerializer(
+            data=self.channel_payload(tier_type=ModelPriceItem.TIER_VOLUME)
+        )
+
+        self.assert_price_table_error(serializer, ERROR_VOLUME_UNSUPPORTED)
+
+    def test_model_serializer_rejects_mixed_current_table(self):
+        ModelPriceItem.objects.create(
+            provider=self.provider,
+            model=self.model,
+            meta_model=self.model.meta_model,
+            sku=self.sku,
+            offering=self.offering,
+            source=self.source,
+            dimension=ModelPriceItem.DIMENSION_TEXT_INPUT,
+            billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
+            currency="USD",
+            unit_price=Decimal("1"),
+            tier_type=ModelPriceItem.TIER_FLAT,
+            price_fingerprint="existing-flat",
+        )
+        serializer = ModelPriceItemSerializer(data=self.model_payload())
+
+        self.assert_price_table_error(
+            serializer,
+            ERROR_MIXED_FLAT_AND_TIERED,
+        )
+
+    def test_channel_serializer_accepts_valid_usage_range_contract(self):
+        serializer = ChannelPriceItemSerializer(data=self.channel_payload())
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        item = serializer.save()
+
+        self.assertEqual(item.meta_model_id, self.model.meta_model_id)
+        self.assertEqual(
+            item.spec["tier_metric"],
+            "request_input_tokens",
+        )

--- a/backend/llm_ops/tests/test_price_table_validation.py
+++ b/backend/llm_ops/tests/test_price_table_validation.py
@@ -1,0 +1,193 @@
+from decimal import Decimal
+from unittest import TestCase
+
+from llm_ops.price_table_validation import (
+    AGGREGATION_PERIOD_REQUEST,
+    ERROR_DUPLICATE_RANGE,
+    ERROR_GAP,
+    ERROR_INCONSISTENT_CURRENCY,
+    ERROR_INCONSISTENT_DIMENSION,
+    ERROR_INCONSISTENT_METRIC,
+    ERROR_INCONSISTENT_TIER_TYPE,
+    ERROR_INCONSISTENT_UNIT,
+    ERROR_INVALID_BOUNDARY,
+    ERROR_MIXED_FLAT_AND_TIERED,
+    ERROR_TIER_MUST_START_AT_ZERO,
+    ERROR_UNBOUNDED_TIER_NOT_LAST,
+    ERROR_VOLUME_UNSUPPORTED,
+    TIER_CHARGE_MODE_MATCHED_TIER,
+    TIER_METRIC_REQUEST_INPUT_TOKENS,
+    PriceTableValidationError,
+    match_usage_range_tier,
+    usage_range_spec,
+    validate_price_table,
+)
+
+
+def price_row(
+    start,
+    end,
+    *,
+    dimension="text_input",
+    currency="USD",
+    billing_unit="per_1m_tokens",
+    tier_type="usage_range",
+    spec=None,
+):
+    """Build one normalized price row for contract tests."""
+    return {
+        "dimension": dimension,
+        "currency": currency,
+        "billing_unit": billing_unit,
+        "tier_type": tier_type,
+        "tier_start": None if start is None else Decimal(str(start)),
+        "tier_end": None if end is None else Decimal(str(end)),
+        "spec": usage_range_spec() if spec is None else spec,
+    }
+
+
+class PriceTableValidationTests(TestCase):
+    def assert_error_code(self, expected_code, rows):
+        """Assert deterministic validation failure codes."""
+        with self.assertRaises(PriceTableValidationError) as raised:
+            validate_price_table(rows)
+        self.assertEqual(raised.exception.code, expected_code)
+
+    def test_usage_range_contract_is_explicit(self):
+        self.assertEqual(
+            usage_range_spec(),
+            {
+                "tier_metric": TIER_METRIC_REQUEST_INPUT_TOKENS,
+                "tier_charge_mode": TIER_CHARGE_MODE_MATCHED_TIER,
+                "aggregation_period": AGGREGATION_PERIOD_REQUEST,
+            },
+        )
+
+    def test_matches_zero_exact_boundary_and_unbounded_last_tier(self):
+        rows = [
+            price_row("0", "1000000"),
+            price_row("1000000", None),
+        ]
+
+        first = match_usage_range_tier(rows, Decimal("0"))
+        boundary = match_usage_range_tier(rows, Decimal("1000000"))
+        unbounded = match_usage_range_tier(rows, Decimal("9000000"))
+
+        self.assertEqual(first["tier_start"], Decimal("0"))
+        self.assertEqual(boundary["tier_start"], Decimal("1000000"))
+        self.assertEqual(unbounded["tier_start"], Decimal("1000000"))
+
+    def test_same_validator_accepts_all_price_surfaces(self):
+        tables = (
+            [
+                {
+                    **price_row("0", None),
+                    "provider": "openai",
+                    "source": "official",
+                }
+            ],
+            [
+                {
+                    **price_row("0", None),
+                    "channel": "supplier-a",
+                }
+            ],
+            [
+                {
+                    **price_row("0", None),
+                    "platform": "agione",
+                    "listing": "gpt-5",
+                }
+            ],
+        )
+
+        for table in tables:
+            with self.subTest(table=table):
+                validate_price_table(table)
+
+    def test_rejects_mixed_flat_and_tiered_rows(self):
+        rows = [
+            price_row(None, None, tier_type="flat", spec={}),
+            price_row("0", None),
+        ]
+
+        self.assert_error_code(ERROR_MIXED_FLAT_AND_TIERED, rows)
+
+    def test_rejects_first_tier_that_does_not_start_at_zero(self):
+        self.assert_error_code(
+            ERROR_TIER_MUST_START_AT_ZERO,
+            [price_row("1", None)],
+        )
+
+    def test_rejects_inverted_range(self):
+        self.assert_error_code(
+            ERROR_INVALID_BOUNDARY,
+            [price_row("0", "0")],
+        )
+
+    def test_rejects_duplicate_range(self):
+        rows = [price_row("0", "10"), price_row("0", "10")]
+
+        self.assert_error_code(ERROR_DUPLICATE_RANGE, rows)
+
+    def test_rejects_overlapping_range(self):
+        rows = [price_row("0", "10"), price_row("9", None)]
+
+        self.assert_error_code(ERROR_INVALID_BOUNDARY, rows)
+
+    def test_rejects_gap_between_ranges(self):
+        rows = [price_row("0", "10"), price_row("11", None)]
+
+        self.assert_error_code(ERROR_GAP, rows)
+
+    def test_rejects_unbounded_tier_before_last_tier(self):
+        rows = [price_row("0", None), price_row("10", None)]
+
+        self.assert_error_code(ERROR_UNBOUNDED_TIER_NOT_LAST, rows)
+
+    def test_rejects_inconsistent_dimension(self):
+        rows = [
+            price_row("0", "10"),
+            price_row("10", None, dimension="text_output"),
+        ]
+
+        self.assert_error_code(ERROR_INCONSISTENT_DIMENSION, rows)
+
+    def test_rejects_inconsistent_currency(self):
+        rows = [
+            price_row("0", "10"),
+            price_row("10", None, currency="CNY"),
+        ]
+
+        self.assert_error_code(ERROR_INCONSISTENT_CURRENCY, rows)
+
+    def test_rejects_inconsistent_billing_unit(self):
+        rows = [
+            price_row("0", "10"),
+            price_row("10", None, billing_unit="per_generation"),
+        ]
+
+        self.assert_error_code(ERROR_INCONSISTENT_UNIT, rows)
+
+    def test_rejects_inconsistent_tier_type(self):
+        rows = [
+            price_row("0", "10"),
+            price_row("10", None, tier_type="volume"),
+        ]
+
+        self.assert_error_code(ERROR_INCONSISTENT_TIER_TYPE, rows)
+
+    def test_rejects_inconsistent_metric(self):
+        other_spec = usage_range_spec()
+        other_spec["tier_metric"] = "monthly_tokens"
+        rows = [
+            price_row("0", "10"),
+            price_row("10", None, spec=other_spec),
+        ]
+
+        self.assert_error_code(ERROR_INCONSISTENT_METRIC, rows)
+
+    def test_rejects_volume_until_business_contract_is_defined(self):
+        rows = [price_row("0", None, tier_type="volume")]
+
+        self.assert_error_code(ERROR_VOLUME_UNSUPPORTED, rows)

--- a/backend/llm_ops/tests/test_price_table_validation.py
+++ b/backend/llm_ops/tests/test_price_table_validation.py
@@ -11,6 +11,7 @@ from llm_ops.price_table_validation import (
     ERROR_INCONSISTENT_TIER_TYPE,
     ERROR_INCONSISTENT_UNIT,
     ERROR_INVALID_BOUNDARY,
+    ERROR_INVALID_USAGE_RANGE_SPEC,
     ERROR_MIXED_FLAT_AND_TIERED,
     ERROR_TIER_MUST_START_AT_ZERO,
     ERROR_UNBOUNDED_TIER_NOT_LAST,
@@ -186,6 +187,11 @@ class PriceTableValidationTests(TestCase):
         ]
 
         self.assert_error_code(ERROR_INCONSISTENT_METRIC, rows)
+
+    def test_rejects_non_object_usage_range_spec(self):
+        rows = [price_row("0", None, spec=["request_input_tokens"])]
+
+        self.assert_error_code(ERROR_INVALID_USAGE_RANGE_SPEC, rows)
 
     def test_rejects_volume_until_business_contract_is_defined(self):
         rows = [price_row("0", None, tier_type="volume")]

--- a/backend/llm_ops/tests/test_price_table_validation.py
+++ b/backend/llm_ops/tests/test_price_table_validation.py
@@ -22,6 +22,7 @@ from llm_ops.price_table_validation import (
     match_usage_range_tier,
     usage_range_spec,
     validate_price_table,
+    with_usage_range_spec,
 )
 
 
@@ -126,6 +127,12 @@ class PriceTableValidationTests(TestCase):
             [price_row("0", "0")],
         )
 
+    def test_rejects_non_finite_boundary(self):
+        self.assert_error_code(
+            ERROR_INVALID_BOUNDARY,
+            [price_row("NaN", None)],
+        )
+
     def test_rejects_duplicate_range(self):
         rows = [price_row("0", "10"), price_row("0", "10")]
 
@@ -192,6 +199,15 @@ class PriceTableValidationTests(TestCase):
         rows = [price_row("0", None, spec=["request_input_tokens"])]
 
         self.assert_error_code(ERROR_INVALID_USAGE_RANGE_SPEC, rows)
+
+    def test_rejects_non_object_spec_when_adding_contract(self):
+        with self.assertRaises(PriceTableValidationError) as raised:
+            with_usage_range_spec(["request_input_tokens"])
+
+        self.assertEqual(
+            raised.exception.code,
+            ERROR_INVALID_USAGE_RANGE_SPEC,
+        )
 
     def test_rejects_volume_until_business_contract_is_defined(self):
         rows = [price_row("0", None, tier_type="volume")]


### PR DESCRIPTION
## Summary
- Define the canonical `[tier_start, tier_end)` usage-range contract for text input, text output, and cached input prices.
- Add stable machine-readable validation codes and reject volume tiers until aggregation and charging semantics are defined.
- Enforce the shared validator in official collection, channel synchronization, and DRF price-item writes while keeping it reusable for resale pricing.

Closes #229

## Test plan
- [x] 19 shared contract unit tests pass.
- [x] 6 serializer and collection integration tests pass.
- [x] 124 affected serializer, service, Yunce, and official collector regression tests pass.
- [x] Django system check and migration drift check pass.

## Known existing test issue
- The broader suite has one unrelated existing failure: `test_explicit_source_ids_skip_non_auto_sources`; the remaining 374 tests pass.