### PR TITLE
Derive DeepSeek consumption history from balance deltas

### DIFF
--- a/backend/cloud_billing/clouds/deepseek_provider.py
+++ b/backend/cloud_billing/clouds/deepseek_provider.py
@@ -157,7 +157,13 @@ class DeepSeekCloud(BaseCloudProvider):
         self,
         period: Optional[str] = None,
     ) -> Dict[str, Any]:
-        """Return the current balance in the common billing response shape."""
+        """Return the current balance in the common billing response shape.
+
+        DeepSeek's public API exposes only the account balance; there is no
+        consumption history endpoint. The collection task derives a cost
+        history from balance deltas between snapshots when the response is
+        marked with ``balance_only``.
+        """
         del period
         try:
             balance, currency, debug = self._request_balance()
@@ -172,6 +178,7 @@ class DeepSeekCloud(BaseCloudProvider):
                     "account_id": self.get_account_id(),
                     "service_costs": {},
                     "items": [],
+                    "balance_only": True,
                 },
                 "error": None,
             }

--- a/backend/cloud_billing/tasks.py
+++ b/backend/cloud_billing/tasks.py
@@ -887,7 +887,30 @@ def collect_billing_data(
                     current_hour=current_hour,
                 )
 
-                if previous_billing is None:
+                balance_only = bool(billing_data.get("balance_only"))
+
+                if balance_only:
+                    # Providers without a consumption history API (e.g.
+                    # DeepSeek) derive hourly cost from the balance delta
+                    # between snapshots. Top-ups make the delta negative,
+                    # which is clamped to zero.
+                    if (
+                        previous_billing is not None
+                        and previous_billing.balance is not None
+                        and balance is not None
+                        and previous_billing.period == current_period
+                    ):
+                        derived_hourly = previous_billing.balance - balance
+                        hourly_cost = (
+                            derived_hourly
+                            if derived_hourly > 0
+                            else Decimal("0")
+                        )
+                        total_cost = previous_billing.total_cost + hourly_cost
+                    else:
+                        hourly_cost = Decimal("0")
+                        total_cost = Decimal("0")
+                elif previous_billing is None:
                     hourly_cost = total_cost
                 else:
                     if previous_billing.period == current_period:

--- a/backend/cloud_billing/tests/test_deepseek_provider.py
+++ b/backend/cloud_billing/tests/test_deepseek_provider.py
@@ -88,6 +88,7 @@ class TestDeepSeekCloud:
         assert result["data"]["items"] == []
         assert result["data"]["account_id"] == "deepseek"
         assert result["data"]["is_available"] is False
+        assert result["data"]["balance_only"] is True
 
     @patch("cloud_billing.clouds.deepseek_provider.requests.Session.get")
     def test_get_billing_info_accepts_negative_balance(self, mock_get):

--- a/backend/cloud_billing/tests/test_tasks.py
+++ b/backend/cloud_billing/tests/test_tasks.py
@@ -896,6 +896,122 @@ class TestCollectBillingData:
 
     @patch("cloud_billing.tasks.check_alert_for_provider.delay")
     @patch("cloud_billing.tasks.ProviderService")
+    def test_balance_only_provider_derives_hourly_cost_from_balance_delta(
+        self,
+        mock_provider_service_class,
+        mock_check_alert_delay,
+        cloud_provider,
+    ):
+        """Derive DeepSeek consumption history from balance deltas."""
+        cloud_provider.provider_type = "deepseek"
+        cloud_provider.save(update_fields=["provider_type"])
+        current_period = timezone.now().strftime("%Y-%m")
+        previous_hour = max(timezone.now().hour - 1, 0)
+        BillingData.objects.create(
+            provider=cloud_provider,
+            period=current_period,
+            hour=previous_hour,
+            total_cost=Decimal("0.00"),
+            balance=Decimal("500.00"),
+            hourly_cost=Decimal("0.00"),
+            currency="CNY",
+            service_costs={},
+            account_id="deepseek",
+        )
+
+        mock_provider_service = MagicMock()
+        mock_provider_service.get_billing_info.return_value = {
+            "status": "success",
+            "data": {
+                "total_cost": 0.0,
+                "balance": 480.00,
+                "is_available": True,
+                "balance_only": True,
+                "currency": "CNY",
+                "account_id": "deepseek",
+                "service_costs": {},
+            },
+        }
+        mock_provider_service_class.return_value = mock_provider_service
+
+        result = collect_billing_data(
+            provider_id=cloud_provider.id,
+            user_id=1,
+        )
+
+        assert len(result["success"]) == 1
+        record = BillingData.objects.get(
+            provider=cloud_provider,
+            account_id="deepseek",
+            period=current_period,
+            hour=timezone.now().hour,
+        )
+        assert record.hourly_cost == Decimal("20.00")
+        assert record.total_cost == Decimal("20.00")
+        assert record.balance == Decimal("480.00")
+        mock_check_alert_delay.assert_called_once_with(
+            cloud_provider.id,
+            cloud_provider.provider_type,
+        )
+
+    @patch("cloud_billing.tasks.check_alert_for_provider.delay")
+    @patch("cloud_billing.tasks.ProviderService")
+    def test_balance_only_provider_clamps_top_up_to_zero_consumption(
+        self,
+        mock_provider_service_class,
+        mock_check_alert_delay,
+        cloud_provider,
+    ):
+        """Do not report negative consumption when the balance increases."""
+        cloud_provider.provider_type = "deepseek"
+        cloud_provider.save(update_fields=["provider_type"])
+        current_period = timezone.now().strftime("%Y-%m")
+        previous_hour = max(timezone.now().hour - 1, 0)
+        BillingData.objects.create(
+            provider=cloud_provider,
+            period=current_period,
+            hour=previous_hour,
+            total_cost=Decimal("0.00"),
+            balance=Decimal("500.00"),
+            hourly_cost=Decimal("0.00"),
+            currency="CNY",
+            service_costs={},
+            account_id="deepseek",
+        )
+
+        mock_provider_service = MagicMock()
+        mock_provider_service.get_billing_info.return_value = {
+            "status": "success",
+            "data": {
+                "total_cost": 0.0,
+                "balance": 620.00,
+                "is_available": True,
+                "balance_only": True,
+                "currency": "CNY",
+                "account_id": "deepseek",
+                "service_costs": {},
+            },
+        }
+        mock_provider_service_class.return_value = mock_provider_service
+
+        result = collect_billing_data(
+            provider_id=cloud_provider.id,
+            user_id=1,
+        )
+
+        assert len(result["success"]) == 1
+        record = BillingData.objects.get(
+            provider=cloud_provider,
+            account_id="deepseek",
+            period=current_period,
+            hour=timezone.now().hour,
+        )
+        assert record.hourly_cost == Decimal("0.00")
+        assert record.total_cost == Decimal("0.00")
+        assert record.balance == Decimal("620.00")
+
+    @patch("cloud_billing.tasks.check_alert_for_provider.delay")
+    @patch("cloud_billing.tasks.ProviderService")
     def test_failed_sync_tracks_consecutive_failures(
         self,
         mock_provider_service_class,


### PR DESCRIPTION
## Summary

DeepSeek's public API exposes only the account balance — there is no
consumption history endpoint. This PR:

- Marks DeepSeek billing responses with ``balance_only: True``
- Derives hourly cost from balance deltas between snapshots
  (previous balance − current balance, clamped to zero for top-ups)
- Accumulates hourly cost into the running ``total_cost`` within the
  current calendar month

Closes #240

## Changes

- **`backend/cloud_billing/clouds/deepseek_provider.py`**: Add
  ``balance_only`` marker and docstring explaining the balance-only nature.
- **`backend/cloud_billing/tasks.py`**: Derive hourly cost from balance
  deltas for balance-only providers.
- **`backend/cloud_billing/tests/test_deepseek_provider.py`**: Test for
  ``balance_only`` in response.
- **`backend/cloud_billing/tests/test_tasks.py`**: Two new tests covering
  balance-delta cost derivation and top-up clamping.

## Test plan

- [x] `Django check` clean (zero issues)
- [x] DeepSeek provider tests pass (11/11)
- [ ] Full test suite on CI (local environment has pre-existing
  migration/Redis auth issues blocking DB tests — see issue for details)