### PR TITLE
Fix mixed flat/tiered price tables in official collection

### DIFF
--- a/backend/llm_ops/collection_services.py
+++ b/backend/llm_ops/collection_services.py
@@ -3607,6 +3607,9 @@ def parse_price_range(value) -> tuple[Decimal | None, Decimal | None]:
     text = str(value or "").strip()
     if not text or text in {"-", "不限"}:
         return None, None
+    unbounded = re.match(r"^([0-9.]+)\s*\+$", text)
+    if unbounded:
+        return to_decimal(unbounded.group(1)), None
     match = re.match(r"^([0-9.]+)\s*-\s*([0-9.]+)$", text)
     if not match:
         return None, None

--- a/backend/llm_ops/price_collectors/parsers/aliyun.py
+++ b/backend/llm_ops/price_collectors/parsers/aliyun.py
@@ -10,6 +10,7 @@ import requests
 from .common import (
     build_text_token_standard_catalog,
     filter_models_by_codes,
+    merge_fallback_into_tiered_rows,
     sync_official_vendor_catalog,
 )
 
@@ -145,12 +146,21 @@ def extract_models(page_html: str) -> list[dict[str, Any]]:
             )
 
     return [
-        {key: value for key, value in item.items() if not key.startswith("_")}
+        _merge_model_rows(item)
         for item in sorted(
             models.values(),
             key=lambda candidate: candidate["model_name"].lower(),
         )
     ]
+
+
+def _merge_model_rows(item: dict[str, Any]) -> dict[str, Any]:
+    """Merge flat fallback rows into tiered rows per deployment scope."""
+    merged = merge_fallback_into_tiered_rows(
+        item["price_rows"],
+        scope_field="deployment_scope",
+    )
+    return {**item, "price_rows": merged}
 
 
 def expand_rows(table_html: str) -> list[list[str]]:

--- a/backend/llm_ops/price_collectors/parsers/common.py
+++ b/backend/llm_ops/price_collectors/parsers/common.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import re
 from decimal import Decimal, InvalidOperation
+from html import unescape
 from typing import Any
 
 from llm_ops.collectors import (
@@ -13,6 +15,70 @@ from llm_ops.collectors.official import (
     collect_official_pricing_catalog,
 )
 from llm_ops.skill_runner import collected_catalog_to_standard_catalog
+
+
+def merge_fallback_into_tiered_rows(
+    rows: list[dict[str, Any]],
+    *,
+    scope_field: str,
+) -> list[dict[str, Any]]:
+    """Merge flat fallback rows into tiered rows as an unbounded tail.
+
+    Official pricing pages sometimes quote a discounted context window with
+    explicit token ranges while charging a flat fallback price beyond that
+    window. Without merging, one model/scenario yields both flat and tiered
+    rows in the same table, which the price table contract rejects.
+    """
+    scoped: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        scope = str(row.get(scope_field) or "").strip()
+        scoped.setdefault(scope, []).append(row)
+    merged: list[dict[str, Any]] = []
+    for scope_rows in scoped.values():
+        merged.extend(_merge_scope_rows(scope_rows))
+    return merged
+
+
+def _merge_scope_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Merge flat rows of one scenario into its tiered table."""
+    tiered = [
+        row
+        for row in rows
+        if row.get("input_token_range") or row.get("output_token_range")
+    ]
+    flat = [
+        row
+        for row in rows
+        if not (row.get("input_token_range") or row.get("output_token_range"))
+    ]
+    if not tiered or not flat:
+        return rows
+    input_end = max(
+        (_range_end(row.get("input_token_range")) for row in tiered),
+        default=None,
+    )
+    output_end = max(
+        (_range_end(row.get("output_token_range")) for row in tiered),
+        default=None,
+    )
+    for row in flat:
+        if input_end is not None:
+            row["input_token_range"] = f"{input_end}+"
+        if output_end is not None:
+            row["output_token_range"] = f"{output_end}+"
+    return rows
+
+
+def _range_end(value: Any) -> Decimal | None:
+    """Return the end bound of a normalized token range string."""
+    text = unescape(str(value or "")).strip()
+    match = re.search(r"([0-9]+(?:\.[0-9]+)?)\s*$", text)
+    if not match:
+        return None
+    try:
+        return Decimal(match.group(1))
+    except (InvalidOperation, TypeError, ValueError):
+        return None
 
 
 def sync_official_vendor_catalog(

--- a/backend/llm_ops/price_collectors/parsers/google.py
+++ b/backend/llm_ops/price_collectors/parsers/google.py
@@ -404,7 +404,7 @@ def token_range_for_index(index: int, row_count: int) -> str:
     """Return the Google context-window tier for a price row."""
     if row_count < 2:
         return ""
-    return "0-200000" if index == 0 else "200001-"
+    return "0-200000" if index == 0 else "200000+"
 
 
 def upsert_model(

--- a/backend/llm_ops/price_collectors/parsers/siliconflow.py
+++ b/backend/llm_ops/price_collectors/parsers/siliconflow.py
@@ -18,7 +18,10 @@ from llm_ops.skill_runner import (
     collected_catalog_to_standard_catalog,
 )
 
-from .common import filter_models_by_codes
+from .common import (
+    filter_models_by_codes,
+    merge_fallback_into_tiered_rows,
+)
 
 
 PRICING_URL = "https://siliconflow.cn/pricing"
@@ -315,6 +318,10 @@ def normalize_grouped_model(item: dict[str, Any]) -> dict[str, Any]:
             normalized["input_token_range"] = token_range
             normalized["output_token_range"] = token_range
         rows.append(normalized)
+    rows = merge_fallback_into_tiered_rows(
+        rows,
+        scope_field="billing_scope",
+    )
     return {
         "model_id": item["model_id"],
         "model_name": item["model_name"],

--- a/backend/llm_ops/tests/test_google_price_collector.py
+++ b/backend/llm_ops/tests/test_google_price_collector.py
@@ -78,7 +78,7 @@ class GooglePriceCatalogCollectorTests(SimpleTestCase):
         )
         self.assertEqual(
             pro["price_rows"][1]["input_token_range"],
-            "200001-",
+            "200000+",
         )
         self.assertEqual(
             pro["price_rows"][0]["cache_hit_price_per_million"],

--- a/backend/llm_ops/tests/test_skill_runner.py
+++ b/backend/llm_ops/tests/test_skill_runner.py
@@ -248,6 +248,36 @@ ALIYUN_PREFIXED_MODEL_HTML = """
 </table>
 """
 
+ALIYUN_MIXED_FLAT_TIERED_HTML = """
+<table>
+  <tr>
+    <th>模型 ID（Model ID）</th><th>模式</th>
+    <th>单次请求的输入 Token 数</th>
+    <th>输入单价（每百万 Token）</th>
+    <th>输出单价（每百万 Token）</th><th>免费额度</th>
+  </tr>
+  <tr>
+    <td>ZHIPU/GLM-5</td><td>非思考和思考模式</td>
+    <td>0&lt;Token≤32K</td><td>4 元</td><td>18 元</td><td>-</td>
+  </tr>
+  <tr>
+    <td>ZHIPU/GLM-5</td><td>非思考和思考模式</td>
+    <td>32K&lt;Token≤198K</td><td>6 元</td><td>22 元</td><td>-</td>
+  </tr>
+</table>
+<table>
+  <tr>
+    <th>模型 ID（Model ID）</th><th>模式</th>
+    <th>输入单价（每百万 Token）</th>
+    <th>输出单价（每百万 Token）</th><th>免费额度</th>
+  </tr>
+  <tr>
+    <td>ZHIPU/GLM-5</td><td>非思考和思考模式</td>
+    <td>6 元</td><td>22 元</td><td>无</td>
+  </tr>
+</table>
+"""
+
 
 def siliconflow_html(pricing_items):
     payload = json.dumps(
@@ -591,6 +621,76 @@ class ModelPriceSkillRunnerTests(SimpleTestCase):
             "deepseek-ai/DeepSeek-V4-Pro",
         )
 
+    def test_siliconflow_fallback_price_merges_into_tiered_table(self):
+        payload = collect_vendor_price_catalog(
+            "siliconflow",
+            {
+                "provider_name": "SiliconFlow",
+                "currency": "CNY",
+                "raw_html": siliconflow_html(
+                    [
+                        {
+                            "playgroundName": "Qwen/Qwen3.5-9B",
+                            "playgroundSort": 50000,
+                            "skuName": "Qwen/Qwen3.5-9B",
+                            "componentCode": "input-tokens",
+                            "coordinateDesc": "[0, 128k)",
+                            "price_scenario": "兜底价",
+                            "realTimePriceCnyUnit": "0.0005",
+                            "unitZhCnName": "K tokens",
+                        },
+                        {
+                            "playgroundName": "Qwen/Qwen3.5-9B",
+                            "playgroundSort": 50000,
+                            "skuName": "Qwen/Qwen3.5-9B",
+                            "componentCode": "output-tokens",
+                            "coordinateDesc": "[0, 128k)",
+                            "price_scenario": "兜底价",
+                            "realTimePriceCnyUnit": "0.004",
+                            "unitZhCnName": "K tokens",
+                        },
+                        {
+                            "playgroundName": "Qwen/Qwen3.5-9B",
+                            "playgroundSort": 50000,
+                            "skuName": "Qwen/Qwen3.5-9B",
+                            "componentCode": "input-tokens",
+                            "coordinateDesc": "[128k, +∞)",
+                            "price_scenario": "兜底价",
+                            "realTimePriceCnyUnit": "0.0015",
+                            "unitZhCnName": "K tokens",
+                        },
+                        {
+                            "playgroundName": "Qwen/Qwen3.5-9B",
+                            "playgroundSort": 50000,
+                            "skuName": "Qwen/Qwen3.5-9B",
+                            "componentCode": "output-tokens",
+                            "coordinateDesc": "[128k, +∞)",
+                            "price_scenario": "兜底价",
+                            "realTimePriceCnyUnit": "0.012",
+                            "unitZhCnName": "K tokens",
+                        },
+                    ]
+                ),
+            },
+        )
+
+        self.assertEqual(payload["total_models"], 1)
+        model = payload["models"][0]
+        self.assertEqual(model["model_id"], "Qwen/Qwen3.5-9B")
+        rows = {
+            str(row["values"].get("input_token_range")): row["values"]
+            for row in model["price_rows"]
+        }
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows["0-128000"]["input_price"], "0.5")
+        self.assertEqual(rows["0-128000"]["output_price"], "4")
+        self.assertEqual(rows["128000+"]["input_price"], "1.5")
+        self.assertEqual(rows["128000+"]["output_price"], "12")
+        self.assertEqual(
+            rows["128000+"]["output_token_range"],
+            "128000+",
+        )
+
     def test_aliyun_vendor_skill_extracts_unconfigured_page_rows(self):
         payload = run_vendor_pricing_skill(
             "aliyun",
@@ -679,6 +779,25 @@ class ModelPriceSkillRunnerTests(SimpleTestCase):
         values = payload["models"][0]["price_rows"][0]["values"]
         self.assertEqual(values["input_price"], "8")
         self.assertEqual(values["output_price"], "28")
+
+    def test_aliyun_vendor_skill_merges_flat_fallback_into_tiered(self):
+        payload = run_vendor_pricing_skill(
+            "aliyun",
+            {
+                "provider_name": "阿里云",
+                "currency": "CNY",
+                "raw_html": ALIYUN_MIXED_FLAT_TIERED_HTML,
+            },
+        )
+
+        self.assertEqual(payload["total_models"], 1)
+        rows = payload["models"][0]["price_rows"]
+        self.assertEqual(len(rows), 3)
+        self.assertEqual(rows[0]["values"]["input_token_range"], "0-32000")
+        self.assertEqual(rows[0]["values"]["input_price"], "4")
+        self.assertEqual(rows[1]["values"]["input_token_range"], "32000-198000")  # noqa: E501
+        self.assertEqual(rows[1]["values"]["input_price"], "6")
+        self.assertEqual(rows[2]["values"]["input_token_range"], "198000+")
 
     def test_volcengine_vendor_skill_returns_standard_catalog_json(self):
         payload = run_vendor_pricing_skill(

--- a/backend/llm_ops/tests/test_source_collectors.py
+++ b/backend/llm_ops/tests/test_source_collectors.py
@@ -646,6 +646,100 @@ class PriceCollectionSkuPersistenceTests(TestCase):
         self.assertEqual(input_item.model.sku, sku)
         self.assertEqual(input_item.unit_price, Decimal("1.000000"))
 
+    def test_siliconflow_mixed_flat_tiered_rows_persist_as_tiers(self):
+        from llm_ops.price_collectors.parsers import siliconflow
+        from llm_ops.tests.test_skill_runner import siliconflow_html
+
+        meta_model = MetaModel.objects.create(
+            code="qwen3.5-9b",
+            name="Qwen3.5 9B",
+            owner_code="qwen",
+            owner_name="Qwen",
+        )
+        models = siliconflow.extract_models(
+            siliconflow_html(
+                [
+                    {
+                        "playgroundName": "Qwen/Qwen3.5-9B",
+                        "playgroundSort": 50000,
+                        "skuName": "Qwen/Qwen3.5-9B",
+                        "componentCode": "input-tokens",
+                        "coordinateDesc": "[0, 128k)",
+                        "price_scenario": "兜底价",
+                        "realTimePriceCnyUnit": "0.0005",
+                        "unitZhCnName": "K tokens",
+                    },
+                    {
+                        "playgroundName": "Qwen/Qwen3.5-9B",
+                        "playgroundSort": 50000,
+                        "skuName": "Qwen/Qwen3.5-9B",
+                        "componentCode": "output-tokens",
+                        "coordinateDesc": "[0, 128k)",
+                        "price_scenario": "兜底价",
+                        "realTimePriceCnyUnit": "0.004",
+                        "unitZhCnName": "K tokens",
+                    },
+                    {
+                        "playgroundName": "Qwen/Qwen3.5-9B",
+                        "playgroundSort": 50000,
+                        "skuName": "Qwen/Qwen3.5-9B",
+                        "componentCode": "input-tokens",
+                        "coordinateDesc": "[128k, +∞)",
+                        "price_scenario": "兜底价",
+                        "realTimePriceCnyUnit": "0.0015",
+                        "unitZhCnName": "K tokens",
+                    },
+                    {
+                        "playgroundName": "Qwen/Qwen3.5-9B",
+                        "playgroundSort": 50000,
+                        "skuName": "Qwen/Qwen3.5-9B",
+                        "componentCode": "output-tokens",
+                        "coordinateDesc": "[128k, +∞)",
+                        "price_scenario": "兜底价",
+                        "realTimePriceCnyUnit": "0.012",
+                        "unitZhCnName": "K tokens",
+                    },
+                ]
+            )
+        )
+        self.assertEqual(len(models), 1)
+        item = siliconflow.collected_model_from_item(
+            models[0],
+            source_url=self.source.endpoint_url,
+        )
+        offering, _ = upsert_collected_offering(
+            item,
+            source=self.source,
+            source_url=self.source.endpoint_url,
+            meta_model=meta_model,
+        )
+        price_items = sync_model_price_items(
+            item,
+            source=self.source,
+            offering=offering,
+            source_url=self.source.endpoint_url,
+        )
+
+        input_items = [
+            price_item
+            for price_item in price_items
+            if price_item.dimension == ModelPriceItem.DIMENSION_TEXT_INPUT
+        ]
+        self.assertEqual(len(input_items), 2)
+        input_by_start = {}
+        for price_item in input_items:
+            input_by_start[str(price_item.tier_start)] = price_item
+        self.assertEqual(str(input_by_start["0"].tier_end), "128000")
+        self.assertEqual(str(input_by_start["0"].unit_price), "0.5")
+        self.assertIsNone(input_by_start["128000"].tier_end)
+        self.assertEqual(str(input_by_start["128000"].unit_price), "1.5")
+        output_items = [
+            price_item
+            for price_item in price_items
+            if price_item.dimension == ModelPriceItem.DIMENSION_TEXT_OUTPUT
+        ]
+        self.assertEqual(len(output_items), 2)
+
     def test_collected_price_does_not_overwrite_locked_sku(self):
         item = self.collected_item()
         offering, _ = upsert_collected_offering(


### PR DESCRIPTION
## Summary
- Merge flat fallback price rows into tiered tables as an unbounded tail (`N+`) for SiliconFlow, Google and Aliyun official collectors
- Extract shared `merge_fallback_into_tiered_rows` helper into `parsers/common.py`
- Support `N+` notation in shared `parse_price_range`
- Add regression tests for SiliconFlow, Aliyun and Google

## Test plan
- [x] 44 focused tests pass (skill_runner, google, price_table_validation, tier_pricing)
- [x] Real-page validation: google 21 models / aliyun 201 models, 0 validation errors, 0 mixed scopes
- [x] flake8 clean on touched files
- [ ] DB-backed test needs CI (local `data_source` migration blocker is pre-existing)

Made with [Orca](https://github.com/stablyai/orca) 🐋
