### PR TITLE
fix: collect Zhipu pricing from CDN bundles

### DIFF
--- a/backend/llm_ops/price_collectors/parsers/zhipu.py
+++ b/backend/llm_ops/price_collectors/parsers/zhipu.py
@@ -5,7 +5,7 @@ import re
 from decimal import Decimal, InvalidOperation
 from html import unescape
 from typing import Any
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
 import requests
 
@@ -17,6 +17,7 @@ from .common import (
 
 PRICING_URL = "https://bigmodel.cn/pricing"
 DEFAULT_CURRENCY = "CNY"
+TRUSTED_SCRIPT_HOSTS = {"bigmodel.cn", "static.bigmodel.cn"}
 
 
 class ZhipuPriceCatalogCollector:
@@ -100,7 +101,7 @@ def fetch_text(url: str) -> str:
 
 
 def fetch_linked_pricing_scripts(url: str, content: str) -> list[str]:
-    """Fetch same-origin JS bundles that contain BigModel pricing rows."""
+    """Fetch trusted BigModel JS bundles that contain pricing rows."""
     scripts = []
     for path in re.findall(
         r'<script[^>]+src=["\']([^"\']+\.js)["\']',
@@ -108,7 +109,11 @@ def fetch_linked_pricing_scripts(url: str, content: str) -> list[str]:
         flags=re.IGNORECASE,
     ):
         script_url = urljoin(url, path)
-        if not script_url.startswith("https://bigmodel.cn/"):
+        parsed_url = urlparse(script_url)
+        if (
+            parsed_url.scheme != "https"
+            or parsed_url.hostname not in TRUSTED_SCRIPT_HOSTS
+        ):
             continue
         try:
             response = requests.get(

--- a/backend/llm_ops/tests/test_zhipu_price_collector.py
+++ b/backend/llm_ops/tests/test_zhipu_price_collector.py
@@ -1,4 +1,5 @@
 import json
+from unittest.mock import Mock, patch
 
 from django.test import SimpleTestCase
 
@@ -75,6 +76,21 @@ newModel:{model:[{
 }]}
 """
 
+ZHIPU_CDN_SCRIPT_URL = (
+    "https://static.bigmodel.cn/"
+    "wd-paas-front/js/app.a4a9eb95.js"
+)
+
+ZHIPU_CDN_SHELL_HTML = f"""
+<!DOCTYPE html>
+<html>
+  <body>
+    <div id="app"></div>
+    <script src="{ZHIPU_CDN_SCRIPT_URL}"></script>
+  </body>
+</html>
+"""
+
 
 class ZhipuPriceCatalogCollectorTests(SimpleTestCase):
     def test_extract_models_from_structured_pricing_json(self):
@@ -120,6 +136,35 @@ class ZhipuPriceCatalogCollectorTests(SimpleTestCase):
         self.assertEqual(payload["provider"]["currency"], "CNY")
         self.assertEqual(payload["total_models"], 0)
         self.assertEqual(payload["models"], [])
+
+    @patch("llm_ops.price_collectors.parsers.zhipu.requests.get")
+    def test_collects_models_from_trusted_bigmodel_cdn_bundle(
+        self,
+        mocked_get,
+    ):
+        page_response = Mock()
+        page_response.text = ZHIPU_CDN_SHELL_HTML
+        page_response.encoding = "utf-8"
+        bundle_response = Mock()
+        bundle_response.text = ZHIPU_BUNDLE_MODEL_LIST
+        bundle_response.encoding = "utf-8"
+        mocked_get.side_effect = [page_response, bundle_response]
+
+        payload = collect_vendor_price_catalog(
+            "zhipu",
+            {"source_url": "https://bigmodel.cn/pricing"},
+        )
+
+        self.assertEqual(payload["total_models"], 1)
+        self.assertEqual(payload["models"][0]["model_id"], "glm-5.2")
+        requested_urls = [call.args[0] for call in mocked_get.call_args_list]
+        self.assertEqual(
+            requested_urls,
+            [
+                "https://bigmodel.cn/pricing",
+                ZHIPU_CDN_SCRIPT_URL,
+            ],
+        )
 
     def test_collect_vendor_price_catalog_returns_zhipu_payload(self):
         payload = collect_vendor_price_catalog(


### PR DESCRIPTION
## Summary
- Allow the Zhipu collector to fetch pricing bundles from the trusted `static.bigmodel.cn` CDN.
- Keep HTTPS and exact-host validation to avoid fetching arbitrary external scripts.
- Add a regression test covering the CDN bundle model list.

Closes #246

## Test plan
- [x] `./.venv/bin/pytest -q backend/llm_ops/tests/test_zhipu_price_collector.py backend/llm_ops/tests/test_google_price_collector.py backend/llm_ops/tests/test_skill_runner.py backend/llm_ops/tests/test_price_table_validation.py backend/llm_ops/tests/test_tier_pricing.py` (56 passed)
- [x] `git diff --check`
- [ ] Production validation after deployment

Commit: `ae0a21e`