### PR TITLE
fix(sals): retry transient incident sync failures

### DIFF
--- a/backend/sals/services/etl.py
+++ b/backend/sals/services/etl.py
@@ -201,7 +201,14 @@ def _build_headers(token: str) -> Dict[str, str]:
 
 def _is_transient_request_error(exc: Exception) -> bool:
     """Return whether a request failure looks transient."""
-    if isinstance(exc, (requests.ConnectionError, requests.Timeout)):
+    if isinstance(
+        exc,
+        (
+            requests.ConnectionError,
+            requests.Timeout,
+            requests.exceptions.ChunkedEncodingError,
+        ),
+    ):
         return True
 
     detail = str(exc).lower()
@@ -618,24 +625,22 @@ def sync_from_api(full_sync: bool = True) -> Dict[str, Any]:
 
     def _fetch_page(fr: int) -> tuple[int, list]:
         """Fetch a single page; returns (first_row, records)."""
-        try:
-            params = {
-                "sysparm_first_row": fr,
-                "sysparm_rowcount": batch_size,
-                "sysparm_display_value": "true",
-            }
-            # 添加排除公司的查询条件
-            query = _build_query_param()
-            if query:
-                params["sysparm_query"] = query
-            resp = requests.get(
-                url, headers=headers, params=params,
-                timeout=60, verify=False,
-            )
-        except Exception as e:
-            logger.error(
-                "Request exception first_row=%s: %s", fr, e,
-            )
+        params = {
+            "sysparm_first_row": fr,
+            "sysparm_rowcount": batch_size,
+            "sysparm_display_value": "true",
+        }
+        query = _build_query_param()
+        if query:
+            params["sysparm_query"] = query
+        resp = _request_with_retry(
+            url=url,
+            headers=headers,
+            params=params,
+            context=f"Request exception first_row={fr}",
+            partial_ok=False,
+        )
+        if resp is None:
             return fr, []
         if resp.status_code != 200:
             logger.error(

--- a/backend/sals/test_etl.py
+++ b/backend/sals/test_etl.py
@@ -111,3 +111,51 @@ def test_fetch_users_logs_error_when_initial_page_fails():
 
     assert records == []
     mock_logger.error.assert_called_once()
+
+
+def test_incomplete_read_is_a_transient_request_error():
+    """Incomplete response bodies should be eligible for retry."""
+    error = requests.exceptions.ChunkedEncodingError(
+        "Connection broken: IncompleteRead"
+    )
+
+    assert etl._is_transient_request_error(error)
+
+
+@patch.object(etl, "API_REQUEST_MAX_ATTEMPTS", 2)
+def test_incident_sync_retries_transient_first_page_failure():
+    """Incident sync should retry a transient initial page failure."""
+    request_counts: dict[int, int] = {}
+
+    def get_incident_page(*args, **kwargs):
+        first_row = kwargs["params"]["sysparm_first_row"]
+        request_counts[first_row] = request_counts.get(first_row, 0) + 1
+        if first_row == 1 and request_counts[first_row] == 1:
+            raise requests.ReadTimeout("read timed out")
+        return _build_response([])
+
+    with (
+        patch("sals.services.etl.login_api", return_value="token"),
+        patch(
+            "sals.services.etl.sync_companies_from_api",
+            return_value={"status": "ok"},
+        ),
+        patch(
+            "sals.services.etl._get_excluded_company_sys_ids",
+            return_value=[],
+        ),
+        patch.object(etl.Company.objects, "all", return_value=[]),
+        patch.object(etl.Incident.objects, "count", return_value=0),
+        patch(
+            "sals.services.etl.sync_users_from_api",
+            return_value={"status": "ok"},
+        ),
+        patch("sals.services.etl.requests.get", side_effect=get_incident_page),
+        patch("sals.services.etl.logger") as mock_logger,
+    ):
+        result = etl.sync_from_api(full_sync=False)
+
+    assert result["status"] == "ok"
+    assert request_counts[1] == 2
+    mock_logger.warning.assert_called()
+    mock_logger.error.assert_not_called()


### PR DESCRIPTION
## Summary

- reuse the SALS request retry helper for incident pagination
- classify incomplete chunked responses as transient request failures
- keep exhausted incident-page failures at error level to protect full-sync integrity
- add regressions for first-page read timeouts and incomplete responses

Closes #250

Sentry: TOWER-M

## Test plan

- [x] `pytest --no-migrations backend/sals/test_etl.py backend/sals/test_tasks.py -q` (13 passed)
- [x] changed-file `ruff` (E4/E7/E9/F/I)
- [x] changed-file `mypy`
- [x] `git diff --check`

## Repository baseline

Repository-wide pytest collection is blocked by three unrelated existing HyperBDR/SALS import issues. Repository-wide ruff reports 2709 existing findings, and repository-wide mypy is blocked by duplicate top-level `tools` modules. The changed-file gates above pass.

## Operations

- No deployment was performed.
- Sentry TOWER-M remains unresolved pending production verification.
- No Jira issue was identified or closed.