### PR TITLE
Fix saved resale tier draft restoration

### DIFF
--- a/frontend/src/components/llm-ops/ResalePublishingWorkspace.vue
+++ b/frontend/src/components/llm-ops/ResalePublishingWorkspace.vue
@@ -581,7 +581,7 @@ import {
   resalePriceItemsForListing,
   resalePriceItemsMatch,
   resaleTierDraftFromItems,
-  resaleTierDraftRangesMatch,
+  shouldRestoreSavedResalePriceDraft,
   validateResalePriceDraft
 } from '@/utils/resaleTierDraft'
 import { errorMessage, extract } from '@/utils/llmOpsPagination'
@@ -925,7 +925,10 @@ function listingDraftFor(row, listing) {
 function initialTierDraftFor(row, listing) {
   const upstreamDraft = upstreamTierDraftFor(row)
   const savedDraft = listingDraftFor(row, listing)
-  if (savedDraft && resaleTierDraftRangesMatch(savedDraft, upstreamDraft)) {
+  if (
+    savedDraft &&
+    shouldRestoreSavedResalePriceDraft(listing, savedDraft, upstreamDraft)
+  ) {
     return savedDraft
   }
   return upstreamDraft

--- a/frontend/src/utils/resaleTierDraft.js
+++ b/frontend/src/utils/resaleTierDraft.js
@@ -206,6 +206,19 @@ export function resaleTierDraftRangesMatch(left = {}, right = {}) {
   })
 }
 
+/** Restore explicit draft work even when upstream boundaries changed later. */
+export function shouldRestoreSavedResalePriceDraft(
+  listing = {},
+  savedDraft = {},
+  upstreamDraft = {}
+) {
+  const pendingItems = Array.isArray(listing.pending_price_items)
+    ? listing.pending_price_items
+    : []
+  if (pendingItems.length) return true
+  return resaleTierDraftRangesMatch(savedDraft, upstreamDraft)
+}
+
 /** Prefer an unapproved draft when restoring a listing for further editing. */
 export function resalePriceItemsForListing(listing = {}) {
   const pending = Array.isArray(listing.pending_price_items)

--- a/frontend/tests/llmOpsResaleTierDraft.test.js
+++ b/frontend/tests/llmOpsResaleTierDraft.test.js
@@ -6,6 +6,7 @@ import {
   hasTieredResalePrices,
   normalizeResalePriceDraft,
   removeResaleTierRow,
+  shouldRestoreSavedResalePriceDraft,
   updateResaleTierRows,
   validateResalePriceDraft
 } from '../src/utils/resaleTierDraft.js'
@@ -178,4 +179,50 @@ test('bridges adjacent ranges when a middle tier is removed', () => {
     { end: '200', price: '1', start: '0' },
     { end: null, price: '0.6', start: '200' }
   ])
+})
+
+test('restores a saved pending draft when upstream ranges have changed', () => {
+  const savedDraft = {
+    cache: [{ end: null, flat: true, price: '0.25', start: null }],
+    input: [
+      { end: '100', flat: false, price: '1', start: '0' },
+      { end: null, flat: false, price: '0.8', start: '100' }
+    ],
+    output: [{ end: null, flat: true, price: '2', start: null }]
+  }
+  const upstreamDraft = {
+    cache: [{ end: null, flat: true, price: '0.20', start: null }],
+    input: [{ end: null, flat: true, price: '0.9', start: null }],
+    output: [{ end: null, flat: true, price: '1.8', start: null }]
+  }
+
+  assert.equal(
+    shouldRestoreSavedResalePriceDraft(
+      { pending_price_items: [{ id: 1 }] },
+      savedDraft,
+      upstreamDraft
+    ),
+    true
+  )
+})
+
+test('uses upstream ranges for a published price when boundaries changed', () => {
+  const savedDraft = {
+    input: [
+      { end: '100', flat: false, price: '1', start: '0' },
+      { end: null, flat: false, price: '0.8', start: '100' }
+    ]
+  }
+  const upstreamDraft = {
+    input: [{ end: null, flat: true, price: '0.9', start: null }]
+  }
+
+  assert.equal(
+    shouldRestoreSavedResalePriceDraft(
+      { current_price_items: [{ id: 1 }], pending_price_items: [] },
+      savedDraft,
+      upstreamDraft
+    ),
+    false
+  )
 })


### PR DESCRIPTION
## Summary

- Preserve pending revision items even when upstream tier ranges change.
- Keep current and published price fallback behavior unchanged when no pending draft exists.
- Add regression coverage for saved tier drafts and changed upstream ranges.

## Verification

- 103 frontend unit tests passed
- Vue typecheck passed
- Targeted ESLint passed
- Production build passed
- ego-browser task space 26: edited a tier, saved, refreshed, and verified UI/API retained both usage-range items with no browser errors

Closes #252