### PR TITLE
Paginate Quote Desk parsed quotation form history

### DIFF
--- a/backend/quotation/serializers.py
+++ b/backend/quotation/serializers.py
@@ -110,6 +110,17 @@ class QuotationListQuerySerializer(serializers.Serializer):
         return attrs
 
 
+class QuotationFormContextQuerySerializer(serializers.Serializer):
+    """Validate paginated parsed quotation history requests."""
+
+    page = serializers.IntegerField(default=1, min_value=1, required=False)
+    page_size = serializers.ChoiceField(
+        choices=(20, 50, 100),
+        default=20,
+        required=False,
+    )
+
+
 class CatalogObjectListField(serializers.ListField):
     child = serializers.DictField()
 
@@ -371,6 +382,18 @@ class QuotationFormContextSerializer(serializers.ModelSerializer):
             "created_at",
         ]
         read_only_fields = fields
+
+
+class QuotationLineItemHistorySerializer(serializers.Serializer):
+    """Serialize parsed line-item history used by the create form."""
+
+    type = serializers.CharField()
+    description = serializers.CharField()
+    list_price = serializers.DecimalField(
+        max_digits=18,
+        decimal_places=2,
+    )
+    currency = serializers.CharField()
 
 
 class QuotationSerializer(serializers.ModelSerializer):

--- a/backend/quotation/services/form_context.py
+++ b/backend/quotation/services/form_context.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from django.db.models import QuerySet
+
+from quotation.models import (
+    Quotation,
+    QuotationItem,
+    QuotationSourceType,
+)
+
+
+LINE_ITEM_HISTORY_LIMIT = 300
+LINE_ITEM_HISTORY_SCAN_LIMIT = 1000
+
+
+def parsed_quotation_queryset() -> QuerySet[Quotation]:
+    """Return all quotations created by document parsing."""
+    return Quotation.objects.filter(
+        source_type=QuotationSourceType.DOCUMENT_IMPORT,
+    )
+
+
+def build_line_item_description_history(
+    quotations: QuerySet[Quotation],
+) -> list[dict]:
+    """Return bounded, deduplicated parsed line-item descriptions."""
+    queryset = (
+        QuotationItem.objects.filter(quotation__in=quotations)
+        .select_related("quotation")
+        .order_by(
+            "-quotation__created_at",
+            "-quotation_id",
+            "line_no",
+        )[:LINE_ITEM_HISTORY_SCAN_LIMIT]
+    )
+    history: list[dict] = []
+    seen: set[tuple[str, str, str]] = set()
+
+    for item in queryset:
+        description = (item.description or item.name or "").strip()
+        if not description:
+            continue
+        item_type = "Software" if item.type == "Software" else "Other"
+        currency = item.quotation.currency
+        key = (
+            currency.casefold(),
+            item_type.casefold(),
+            description.casefold(),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        history.append(
+            {
+                "type": item_type,
+                "description": description,
+                "list_price": item.list_price,
+                "currency": currency,
+            }
+        )
+        if len(history) >= LINE_ITEM_HISTORY_LIMIT:
+            break
+
+    return history

--- a/backend/quotation/test_quotation_list.py
+++ b/backend/quotation/test_quotation_list.py
@@ -22,6 +22,7 @@ from quotation.models import (
 
 class QuotationListAPITests(TestCase):
     url = "/api/v1/quotation/quotations"
+    form_context_url = "/api/v1/quotation/quotations/form-context"
 
     def setUp(self):
         self.user = User.objects.create_user(
@@ -85,6 +86,40 @@ class QuotationListAPITests(TestCase):
                 created_at=now + timedelta(seconds=index),
             )
             for index in range(count)
+        ]
+
+    def test_form_context_returns_all_imported_quotes(self):
+        imported = self._quote(
+            1,
+            owner="other@example.com",
+            source_type=QuotationSourceType.DOCUMENT_IMPORT,
+        )
+        QuotationItem.objects.create(
+            quotation=imported,
+            line_no=1,
+            type="Software",
+            description="Parsed HyperBDR License",
+            list_price=35,
+        )
+        self._quote(
+            2,
+            owner="other@example.com",
+            source_type=QuotationSourceType.MANUAL,
+        )
+
+        response = self.api.get(self.form_context_url)
+
+        assert response.status_code == 200
+        assert [item["id"] for item in response.data["items"]] == [
+            imported.id
+        ]
+        assert response.data["line_item_history"] == [
+            {
+                "type": "Software",
+                "description": "Parsed HyperBDR License",
+                "list_price": "35.00",
+                "currency": "USD",
+            }
         ]
 
     def test_default_page_size_and_stable_second_page(self):

--- a/backend/quotation/views/quotations.py
+++ b/backend/quotation/views/quotations.py
@@ -24,12 +24,18 @@ from quotation.models import Quotation, QuotationSourceType, QuoteStatus
 from quotation.permissions import user_display_email
 from quotation.serializers import (
     QuotationCreateSerializer,
+    QuotationFormContextQuerySerializer,
     QuotationFormContextSerializer,
     QuotationGenerateSerializer,
+    QuotationLineItemHistorySerializer,
     QuotationListQuerySerializer,
     QuotationListSerializer,
     QuotationSerializer,
     QuotationUpdateSerializer,
+)
+from quotation.services.form_context import (
+    build_line_item_description_history,
+    parsed_quotation_queryset,
 )
 from quotation.services.quotation_queries import (
     annotate_quotation_list,
@@ -258,20 +264,42 @@ class QuotationListCreateView(APIView):
 
 
 class QuotationFormContextView(APIView):
-    """Return narrow quotation history used by the create form."""
+    """Return paginated parsed quotation history used by the create form."""
 
     permission_classes = [IsAuthenticated]
 
     def get(self, request):
-        queryset = filter_accessible_quotations(
-            request.user,
-            Quotation.objects.all(),
-        ).order_by("-created_at", "-id")
+        query_serializer = QuotationFormContextQuerySerializer(
+            data=request.query_params,
+        )
+        query_serializer.is_valid(raise_exception=True)
+        page = query_serializer.validated_data["page"]
+        page_size = int(query_serializer.validated_data["page_size"])
+        queryset = parsed_quotation_queryset().order_by(
+            "-created_at",
+            "-id",
+        )
+        total = queryset.count()
+        page_start = (page - 1) * page_size
+        page_queryset = queryset[page_start : page_start + page_size]
         items = QuotationFormContextSerializer(
-            queryset,
+            page_queryset,
             many=True,
         ).data
-        return Response({"items": items})
+        line_item_history = QuotationLineItemHistorySerializer(
+            build_line_item_description_history(page_queryset),
+            many=True,
+        ).data
+        return Response(
+            {
+                "items": items,
+                "line_item_history": line_item_history,
+                "page": page,
+                "page_size": page_size,
+                "total": total,
+                "has_more": page_start + page_size < total,
+            }
+        )
 
 
 class QuotationDetailView(APIView):

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "typecheck": "vue-tsc --noEmit",
     "test:quotation": "node --test scripts/quotation-*.test.mjs",
     "preview": "vite preview",
-    "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --fix --ignore-path .gitignore",
+    "lint": "eslint . --ext .js,.jsx,.cjs,.mjs --fix",
     "test:unit": "node --test tests/*.test.js",
     "sync:provider-icons": "node scripts/sync-lobehub-provider-icons.mjs",
     "generate-favicons": "node scripts/generate-favicons.mjs",

--- a/frontend/src/modules/quotation/App.vue
+++ b/frontend/src/modules/quotation/App.vue
@@ -38,9 +38,12 @@ import {
   loadProductLineOptions,
   saveCustomProductLineOptions,
 } from './utils/quotationNumbering'
-import { filterQuotationsByUser, ensureQuoteOwnership } from './utils/quoteOwnership'
+import { ensureQuoteOwnership } from './utils/quoteOwnership'
 import { clearCreateQuoteDraft } from './utils/createDraftStorage'
-import { upsertDescriptionsToCatalog } from './utils/descriptionCatalog'
+import {
+  upsertDescriptionsToCatalog,
+  type LineItemDescriptionHistory,
+} from './utils/descriptionCatalog'
 import { PAYMENT_TERM_OPTIONS } from './utils/paymentTerms'
 import {
   getCatalog,
@@ -166,6 +169,10 @@ const activeQuote = ref<Quotation | null>(null)
 const drawerQuoteId = ref<string | null>(null)
 const editingQuote = ref<Quotation | null>(null)
 const quotationFormContext = ref<Quotation[]>([])
+const lineItemDescriptionHistory = ref<LineItemDescriptionHistory[]>([])
+const quotationFormContextPage = ref(0)
+const quotationFormContextHasMore = ref(false)
+const quotationFormContextLoading = ref(false)
 let quotationListRequestId = 0
 
 function shouldUseStoredCatalog() {
@@ -379,16 +386,40 @@ async function loadEditingQuote(id: string | null) {
   }
 }
 
-async function loadQuotationFormContext() {
+async function loadQuotationFormContext(reset = true) {
+  if (quotationFormContextLoading.value) return
+  const nextPage = reset ? 1 : quotationFormContextPage.value + 1
+  if (!reset && !quotationFormContextHasMore.value) return
+  quotationFormContextLoading.value = true
   try {
-    quotationFormContext.value = await getQuotationFormContext()
+    const context = await getQuotationFormContext(nextPage)
+    quotationFormContext.value = reset
+      ? context.quotations
+      : [...quotationFormContext.value, ...context.quotations]
+    lineItemDescriptionHistory.value = reset
+      ? context.lineItemHistory
+      : [
+          ...lineItemDescriptionHistory.value,
+          ...context.lineItemHistory,
+        ]
+    quotationFormContextPage.value = context.page
+    quotationFormContextHasMore.value = context.hasMore
   } catch (error) {
-    quotationFormContext.value = []
+    if (reset) {
+      quotationFormContext.value = []
+      lineItemDescriptionHistory.value = []
+    }
     triggerToast(
       error instanceof Error ? error.message : t('quotation.app.loadFailed'),
       'error',
     )
+  } finally {
+    quotationFormContextLoading.value = false
   }
+}
+
+function loadMoreQuotationFormContext() {
+  void loadQuotationFormContext(false)
 }
 
 async function loadCurrentQuotationTab() {
@@ -467,19 +498,13 @@ async function handleLogout() {
   drawerQuoteId.value = null
   editingQuote.value = null
   quotationFormContext.value = []
+  lineItemDescriptionHistory.value = []
+  quotationFormContextPage.value = 0
+  quotationFormContextHasMore.value = false
   currentTab.value = 'dashboard'
   selectedQuotationId.value = null
   editingQuoteId.value = null
 }
-
-const userQuotations = computed(() =>
-  auth.currentUser
-    ? filterQuotationsByUser(
-        quotationFormContext.value,
-        auth.currentUser,
-      )
-    : [],
-)
 
 const userInitials = computed(() => {
   if (!auth.currentUser) return ''
@@ -1084,7 +1109,10 @@ function reloadPage() {
           :services="services"
           :discounts="discounts"
           :quotations="quotationFormContext"
-          :history-quotations="userQuotations"
+          :history-quotations="quotationFormContext"
+          :line-item-history="lineItemDescriptionHistory"
+          :history-has-more="quotationFormContextHasMore"
+          :history-loading="quotationFormContextLoading"
           :editing-quote="editingQuote"
           :current-user="auth.currentUser"
           :product-line-options="productLineOptions"
@@ -1092,6 +1120,7 @@ function reloadPage() {
           @navigate-to-tab="handleNavigateToTab"
           @add-product-line="handleAddProductLine"
           @delete-product-line="handleDeleteProductLine"
+          @load-history-more="loadMoreQuotationFormContext"
         />
 
         <QuotationDetails

--- a/frontend/src/modules/quotation/api/quotations.ts
+++ b/frontend/src/modules/quotation/api/quotations.ts
@@ -1,4 +1,5 @@
 import type { Quotation, QuotationLineItem, QuoteVersion } from '../types';
+import type { LineItemDescriptionHistory } from '../utils/descriptionCatalog';
 import { apiRequest } from './client';
 
 interface ApiQuotationItem {
@@ -135,6 +136,18 @@ interface ApiQuotationFormContextItem {
   issuer_contact_email: string;
   created_by_email?: string | null;
   created_at: string;
+}
+
+interface ApiLineItemDescriptionHistory {
+  type: 'Software' | 'Other';
+  description: string;
+  list_price: number | string;
+  currency: Quotation['currency'];
+}
+
+export interface QuotationFormContextResult {
+  quotations: Quotation[];
+  lineItemHistory: LineItemDescriptionHistory[];
 }
 
 export interface QuotationListParams {
@@ -588,11 +601,27 @@ export async function getQuotation(quoteId: string): Promise<Quotation> {
   return mapApiQuotation(data);
 }
 
-export async function getQuotationFormContext(): Promise<Quotation[]> {
+export async function getQuotationFormContext(
+  page = 1,
+  pageSize = 20,
+): Promise<QuotationFormContextResult & { hasMore: boolean; page: number }> {
   const data = await apiRequest<{
     items: ApiQuotationFormContextItem[];
-  }>('/quotations/form-context');
-  return data.items.map(mapApiQuotationFormContextItem);
+    line_item_history: ApiLineItemDescriptionHistory[];
+    page: number;
+    has_more: boolean;
+  }>(`/quotations/form-context?page=${page}&page_size=${pageSize}`);
+  return {
+    quotations: data.items.map(mapApiQuotationFormContextItem),
+    lineItemHistory: (data.line_item_history || []).map((item) => ({
+      type: item.type,
+      description: item.description,
+      listPrice: toNumber(item.list_price),
+      currency: item.currency,
+    })),
+    hasMore: data.has_more,
+    page: data.page,
+  };
 }
 
 export async function createQuotation(quote: Quotation): Promise<Quotation> {

--- a/frontend/src/modules/quotation/components/HistoryTextInput.vue
+++ b/frontend/src/modules/quotation/components/HistoryTextInput.vue
@@ -38,6 +38,8 @@ const props = withDefaults(
     error?: string
     helperText?: string
     testId?: string
+    hasMore?: boolean
+    loadingMore?: boolean
   }>(),
   {
     type: 'text',
@@ -45,6 +47,8 @@ const props = withDefaults(
     rows: 2,
     className: '',
     inputClassName: '',
+    hasMore: false,
+    loadingMore: false,
   },
 )
 
@@ -52,6 +56,7 @@ const emit = defineEmits<{
   'update:modelValue': [value: string]
   change: [value: string]
   selectOption: [option: NormalizedHistoryOption]
+  loadMore: []
 }>()
 
 const open = ref(false)
@@ -126,6 +131,14 @@ function toggleChevron() {
   }
   openDropdown()
 }
+
+function handleDropdownScroll(event: Event) {
+  if (props.loadingMore || !props.hasMore) return
+  const element = event.currentTarget as HTMLElement
+  if (element.scrollTop + element.clientHeight >= element.scrollHeight - 24) {
+    emit('loadMore')
+  }
+}
 </script>
 
 <template>
@@ -160,7 +173,11 @@ function toggleChevron() {
       @click="toggleChevron"
     />
 
-    <DropdownPanel v-if="showDropdown" :test-id="testId ? `${testId}-history` : undefined">
+    <DropdownPanel
+      v-if="showDropdown"
+      :test-id="testId ? `${testId}-history` : undefined"
+      @scroll.passive="handleDropdownScroll"
+    >
       <li v-for="option in filteredOptions" :key="option.key">
         <DropdownOption
           :selected="option.value === currentValue.trim()"

--- a/frontend/src/modules/quotation/components/QuotationCreate.vue
+++ b/frontend/src/modules/quotation/components/QuotationCreate.vue
@@ -31,7 +31,10 @@ import SignaturePicker from './SignaturePicker.vue'
 import BaseDatePicker from '@/components/ui/BaseDatePicker.vue'
 import HistoryTextInput, { type NormalizedHistoryOption } from './HistoryTextInput.vue'
 import FormSelect from './FormSelect.vue'
-import { buildDescriptionHistoryOptions } from '../utils/descriptionCatalog'
+import {
+  buildDescriptionHistoryOptions,
+  type LineItemDescriptionHistory,
+} from '../utils/descriptionCatalog'
 import {
   DEFAULT_ISSUER_COMPANY_NAME,
   DEFAULT_REMARKS_DISCLAIMER,
@@ -99,6 +102,9 @@ const props = withDefaults(
     discounts: DiscountOption[]
     quotations: Quotation[]
     historyQuotations?: Quotation[]
+    lineItemHistory?: LineItemDescriptionHistory[]
+    historyHasMore?: boolean
+    historyLoading?: boolean
     editingQuote?: Quotation | null
     currentUser?: {
       name: string
@@ -110,6 +116,9 @@ const props = withDefaults(
   }>(),
   {
     historyQuotations: undefined,
+    lineItemHistory: () => [],
+    historyHasMore: false,
+    historyLoading: false,
     editingQuote: null,
   },
 )
@@ -119,6 +128,7 @@ const emit = defineEmits<{
   navigateToTab: [tab: string]
   addProductLine: [option: ProductLineOption]
   deleteProductLine: [productLine: QuoteProductLine]
+  loadHistoryMore: []
 }>()
 
 const { t } = useQuotationI18n()
@@ -784,6 +794,7 @@ function descriptionOptionsFor(itemType: QuotationLineItem['type']) {
     props.services,
     historySourceQuotations.value,
     currency.value,
+    props.lineItemHistory,
   )
 }
 
@@ -1334,6 +1345,9 @@ const itemErrorEntries = computed(() =>
                   :error="errors.clientCompany"
                   @update:model-value="handleClientCompanyInput"
                   @select-option="handleClientCompanySelect"
+                  :has-more="historyHasMore"
+                  :loading-more="historyLoading"
+                  @load-more="$emit('loadHistoryMore')"
                 />
               </div>
 
@@ -1357,6 +1371,9 @@ const itemErrorEntries = computed(() =>
                   :error="errors.contactPerson"
                   @update:model-value="handleContactPersonInput"
                   @select-option="handleContactPersonSelect"
+                  :has-more="historyHasMore"
+                  :loading-more="historyLoading"
+                  @load-more="$emit('loadHistoryMore')"
                 />
               </div>
 
@@ -1381,6 +1398,9 @@ const itemErrorEntries = computed(() =>
                   :error="errors.email"
                   @update:model-value="handleEmailInput"
                   @select-option="handleEmailSelect"
+                  :has-more="historyHasMore"
+                  :loading-more="historyLoading"
+                  @load-more="$emit('loadHistoryMore')"
                 />
               </div>
 
@@ -1423,6 +1443,9 @@ const itemErrorEntries = computed(() =>
                     :placeholder="t('quotation.pages.create.billToCompanyPlaceholder')"
                     @update:model-value="handleBillingCompanyInput"
                     @select-option="handleBillingCompanySelect"
+                    :has-more="historyHasMore"
+                    :loading-more="historyLoading"
+                    @load-more="$emit('loadHistoryMore')"
                   />
                 </div>
                 <div>
@@ -1443,6 +1466,9 @@ const itemErrorEntries = computed(() =>
                     :placeholder="t('quotation.pages.create.billToContactPlaceholder')"
                     @update:model-value="handleBillingContactInput"
                     @select-option="handleBillingContactSelect"
+                    :has-more="historyHasMore"
+                    :loading-more="historyLoading"
+                    @load-more="$emit('loadHistoryMore')"
                   />
                 </div>
                 <div>
@@ -1464,6 +1490,9 @@ const itemErrorEntries = computed(() =>
                     :placeholder="t('quotation.pages.create.billToEmailPlaceholder')"
                     @update:model-value="handleBillingEmailInput"
                     @select-option="handleBillingEmailSelect"
+                    :has-more="historyHasMore"
+                    :loading-more="historyLoading"
+                    @load-more="$emit('loadHistoryMore')"
                   />
                 </div>
               </div>
@@ -1678,6 +1707,9 @@ const itemErrorEntries = computed(() =>
                           })
                       "
                       @select-option="(option) => handleDescriptionSelect(item, option)"
+                      :has-more="historyHasMore"
+                      :loading-more="historyLoading"
+                      @load-more="$emit('loadHistoryMore')"
                     />
                   </div>
 

--- a/frontend/src/modules/quotation/pages/QuotationCreatePage.vue
+++ b/frontend/src/modules/quotation/pages/QuotationCreatePage.vue
@@ -27,6 +27,7 @@ import {
 } from '../api/quotations'
 import { useAuthStore } from '../stores/auth'
 import { clearCreateQuoteDraft } from '../utils/createDraftStorage'
+import type { LineItemDescriptionHistory } from '../utils/descriptionCatalog'
 import { loadProductLineOptions, saveCustomProductLineOptions } from '../utils/quotationNumbering'
 
 const route = useRoute()
@@ -37,6 +38,10 @@ const products = ref<Product[]>([...MOCK_PRODUCTS])
 const services = ref<Service[]>([...MOCK_SERVICES])
 const discounts = ref<DiscountOption[]>([...MOCK_DISCOUNTS])
 const quotations = ref<Quotation[]>([])
+const lineItemHistory = ref<LineItemDescriptionHistory[]>([])
+const historyPage = ref(0)
+const historyHasMore = ref(false)
+const historyLoading = ref(false)
 const productLineOptions = ref<ProductLineOption[]>(loadProductLineOptions())
 
 const editingQuote = computed(() => {
@@ -55,11 +60,34 @@ onMounted(async () => {
       getQuotationFormContext(),
       editId ? getQuotation(editId) : Promise.resolve(null),
     ])
-    quotations.value = detail ? [detail, ...context] : context
+    quotations.value = detail
+      ? [detail, ...context.quotations]
+      : context.quotations
+    lineItemHistory.value = context.lineItemHistory
+    historyPage.value = context.page
+    historyHasMore.value = context.hasMore
   } catch {
     quotations.value = []
+    lineItemHistory.value = []
   }
 })
+
+async function loadMoreHistory() {
+  if (historyLoading.value || !historyHasMore.value) return
+  historyLoading.value = true
+  try {
+    const context = await getQuotationFormContext(historyPage.value + 1)
+    quotations.value = [...quotations.value, ...context.quotations]
+    lineItemHistory.value = [
+      ...lineItemHistory.value,
+      ...context.lineItemHistory,
+    ]
+    historyPage.value = context.page
+    historyHasMore.value = context.hasMore
+  } finally {
+    historyLoading.value = false
+  }
+}
 
 async function handleSaveQuote(quote: Quotation) {
   if (editingQuote.value) {
@@ -95,6 +123,9 @@ function handleDeleteProductLine(productLine: QuoteProductLine) {
     :discounts="discounts"
     :quotations="quotations"
     :history-quotations="quotations"
+    :line-item-history="lineItemHistory"
+    :history-has-more="historyHasMore"
+    :history-loading="historyLoading"
     :editing-quote="editingQuote"
     :current-user="currentUser"
     :product-line-options="productLineOptions"
@@ -102,5 +133,6 @@ function handleDeleteProductLine(productLine: QuoteProductLine) {
     @navigate-to-tab="handleNavigateToTab"
     @add-product-line="handleAddProductLine"
     @delete-product-line="handleDeleteProductLine"
+    @load-history-more="loadMoreHistory"
   />
 </template>

--- a/frontend/src/modules/quotation/utils/descriptionCatalog.ts
+++ b/frontend/src/modules/quotation/utils/descriptionCatalog.ts
@@ -17,6 +17,13 @@ export interface DescriptionHistoryOption {
   }
 }
 
+export interface LineItemDescriptionHistory {
+  type: ItemType
+  description: string
+  listPrice: number
+  currency: Quotation['currency']
+}
+
 function normalize(value: string): string {
   return value.trim().toLowerCase()
 }
@@ -42,6 +49,7 @@ export function buildDescriptionHistoryOptions(
   services: Service[],
   quotations: Array<Pick<Quotation, 'items' | 'createdAt' | 'currency'>>,
   currency: Quotation['currency'] = 'USD',
+  lineItemHistory: LineItemDescriptionHistory[] = [],
 ): DescriptionHistoryOption[] {
   const options: DescriptionHistoryOption[] = []
   const seen = new Set<string>()
@@ -92,6 +100,27 @@ export function buildDescriptionHistoryOptions(
         : service.pricingNote)
     })
   }
+
+  lineItemHistory
+    .filter((item) =>
+      item.currency === currency
+      && (isSoftwareType(itemType)
+        ? item.type === 'Software'
+        : item.type !== 'Software'),
+    )
+    .forEach((item) => {
+      pushOption(
+        item.description,
+        {
+          listPrice: item.listPrice,
+          currency: item.currency,
+          source: 'quote',
+        },
+        item.listPrice
+          ? `${item.currency} ${item.listPrice.toLocaleString('en-US')}`
+          : undefined,
+      )
+    })
 
   const quoteItems = quotations
     .slice()

--- a/frontend/src/modules/quotation/utils/taxLabels.ts
+++ b/frontend/src/modules/quotation/utils/taxLabels.ts
@@ -34,14 +34,8 @@ export function getTaxLabelHistory(userEmail?: string): string[] {
 
 export function getTaxLabelHistoryFromQuotations(
   quotations: TaxLabelSource[],
-  userEmail?: string,
 ): string[] {
-  const normalizedEmail = userEmail?.trim().toLowerCase();
-  const scoped = normalizedEmail
-    ? quotations.filter(q => (q.createdByEmail || '').trim().toLowerCase() === normalizedEmail)
-    : quotations;
-
-  const fromQuotes = [...scoped]
+  const fromQuotes = [...quotations]
     .sort((a, b) => (b.createdAt || '').localeCompare(a.createdAt || ''))
     .map(q => normalizeTaxLabel(q.taxLabel || ''))
     .filter(Boolean);
@@ -54,7 +48,7 @@ export function getMergedTaxLabelHistory(
   quotations: TaxLabelSource[],
 ): string[] {
   const merged = [
-    ...getTaxLabelHistoryFromQuotations(quotations, userEmail),
+    ...getTaxLabelHistoryFromQuotations(quotations),
     ...getTaxLabelHistory(userEmail),
   ];
   const unique = Array.from(new Set(merged.map(label => normalizeTaxLabel(label)).filter(Boolean)));


### PR DESCRIPTION
## Summary

- Allow quotation forms to use all parsed quotations as history regardless of creator.
- Paginate parsed quotation history with 20 records per request.
- Load more customer, contact, billing, description, and price history when dropdowns reach the bottom.
- Keep the original product-line search behavior unchanged.
- Add regression coverage for the form-context API and parsed line-item history.

## Why

Large quotation datasets made the form history dropdown slow and incomplete.
The form now receives parsed quotation history in pages and loads additional
records on demand, while keeping the existing product-line search behavior
unchanged.

## Merge order

- Branch is based on the latest `main`.
- No merge conflict resolution is required.
- PR is retargeted to `main`.

## Test plan

- [x] `npm run test:quotation` (101 passed)
- [x] `npm run test:unit` (91 passed)
- [x] `npm run typecheck` (passed)
- [x] `npm run lint` (passed)
- [x] `npm run build` (passed)
- [x] Browser verification on `http://localhost:18000`
- [x] Backend quotation tests (275 passed)
- [x] `git diff --check` (passed)
