### PR TITLE
Show parsed quotations to all authenticated users

### DIFF
--- a/backend/quotation/access.py
+++ b/backend/quotation/access.py
@@ -4,7 +4,11 @@ from django.db.models import Q, QuerySet
 from rest_framework import status
 from rest_framework.response import Response
 
-from quotation.models import DocumentAsset, Quotation
+from quotation.models import (
+    DocumentAsset,
+    Quotation,
+    QuotationSourceType,
+)
 from quotation.permissions import (
     can_delete_any_quotation_document,
     can_view_all_quotations,
@@ -36,6 +40,8 @@ def can_access_quotation(
 ) -> bool:
     if quotation is None:
         return False
+    if quotation.source_type == QuotationSourceType.DOCUMENT_IMPORT:
+        return True
     if can_view_all_quotations(user):
         return True
     owner = (quotation.created_by_email or "").lower()
@@ -49,7 +55,10 @@ def filter_accessible_quotations(
 ):
     if can_view_all_quotations(user):
         return qs
-    return qs.filter(created_by_email__iexact=user_display_email(user))
+    return qs.filter(
+        Q(source_type=QuotationSourceType.DOCUMENT_IMPORT)
+        | Q(created_by_email__iexact=user_display_email(user))
+    )
 
 
 def get_accessible_quotation(
@@ -76,7 +85,8 @@ def filter_accessible_documents(
         return qs
     email = user_display_email(user)
     return qs.filter(
-        Q(created_by_email__iexact=email)
+        Q(quotation__source_type=QuotationSourceType.DOCUMENT_IMPORT)
+        | Q(created_by_email__iexact=email)
         | Q(quotation__created_by_email__iexact=email)
     )
 

--- a/backend/quotation/test_quotation_list.py
+++ b/backend/quotation/test_quotation_list.py
@@ -306,21 +306,30 @@ class QuotationListAPITests(TestCase):
             product_line="Private",
             product_line_name="Private Line",
         )
+        imported = self._quote(
+            3,
+            owner="other@example.com",
+            source_type=QuotationSourceType.DOCUMENT_IMPORT,
+            product_line="Parsed",
+            product_line_name="Parsed Line",
+        )
 
         owner_response = self.api.get(self.url)
         self.user.is_staff = True
         self.user.save(update_fields=["is_staff"])
         staff_response = self.api.get(self.url)
 
-        assert [row["id"] for row in owner_response.data["items"]] == [
-            own.id
-        ]
         assert "Private Line" not in owner_response.data["facets"][
             "product_lines"
         ]
+        assert {row["id"] for row in owner_response.data["items"]} == {
+            own.id,
+            imported.id,
+        }
         assert {row["id"] for row in staff_response.data["items"]} == {
             own.id,
             other.id,
+            imported.id,
         }
         assert "Private Line" in staff_response.data["facets"][
             "product_lines"


### PR DESCRIPTION
## Summary

- Show all parsed quotations to every authenticated user.
- Keep manually created quotations restricted to their existing owners.
- Allow associated parsed documents to appear in lists and open through quotation detail flows.
- Add regression coverage for cross-account visibility of parsed quotations.

## Why

Parsed quotations are shared business data rather than user-private drafts.
The previous access filter applied the quotation creator restriction to parsed
records, so users could only see files parsed by their own account. This
change keeps manual quotation ownership unchanged while making parsed
quotations and their associated documents available to all authenticated
users.

## Merge order

- Branch is based directly on the latest `main` at `f501960`.
- This PR contains only the parsed-quotation visibility fix.
- Existing PR #254 is not included in this branch and remains independent.
- PR is retargeted to `main`.

## Test plan

- [x] `npm run test:quotation` (101 passed)
- [x] `npm run test:unit` (91 passed)
- [x] `npm run typecheck` (passed)
- [x] `npm run lint` (passed)
- [x] `npm run build` (passed)
- [x] `pytest quotation/test_quotation_list.py` (17 passed)
- [x] `pytest quotation/test_dashboard.py` (13 passed)
- [x] `pytest quotation/test_document_storage_endpoints.py` (23 passed)
- [x] `git diff --check` (passed)
