### PR TITLE
Optimize LLM Ops resale page loading

### DIFF
--- a/backend/cloud_billing/dashboard.py
+++ b/backend/cloud_billing/dashboard.py
@@ -1188,7 +1188,10 @@ def _build_fallback_exchange_rate_info() -> dict[str, object]:
     }
 
 
-def _build_exchange_rate_info() -> dict[str, object]:
+def _build_exchange_rate_info(
+    *,
+    allow_remote: bool = True,
+) -> dict[str, object]:
     api_key = os.getenv('EXCHANGE_RATE_API_KEY', '').strip()
     if not api_key:
         return _build_fallback_exchange_rate_info()
@@ -1198,6 +1201,8 @@ def _build_exchange_rate_info() -> dict[str, object]:
     cached_value = _cache_get_safely(cache_key)
     if cached_value:
         return cached_value
+    if not allow_remote:
+        return _build_fallback_exchange_rate_info()
 
     request_url = EXCHANGE_RATE_API_URL.format(api_key=api_key)
     timeout = int(os.getenv('EXCHANGE_RATE_API_TIMEOUT', '10'))

--- a/backend/cloud_billing/tests/test_dashboard.py
+++ b/backend/cloud_billing/tests/test_dashboard.py
@@ -75,6 +75,24 @@ class ExchangeRateInfoTests(SimpleTestCase):
         self.assertEqual(result['exchange_rate'], 7.15)
         self.assertEqual(result['rate_source_url'], '')
 
+    @patch('cloud_billing.dashboard.requests.get')
+    @patch('cloud_billing.dashboard._cache_get_safely', return_value=None)
+    def test_cached_only_lookup_never_waits_for_remote_api(
+        self,
+        _mock_cache_get,
+        mock_get,
+    ):
+        with patch.dict(
+            'os.environ',
+            {'EXCHANGE_RATE_API_KEY': 'test-api-key'},
+            clear=True,
+        ):
+            result = _build_exchange_rate_info(allow_remote=False)
+
+        self.assertEqual(result['rate_source_label'], 'Internal baseline rate')
+        self.assertEqual(result['exchange_rate'], 7.15)
+        mock_get.assert_not_called()
+
 
 class PaymentTypeTests(SimpleTestCase):
     def test_yunce_is_classified_as_an_llm_provider(self):

--- a/backend/llm_ops/services.py
+++ b/backend/llm_ops/services.py
@@ -554,7 +554,7 @@ def build_currency_conversion_context(
     if target_currency not in SUPPORTED_DISPLAY_CURRENCIES:
         target_currency = "CNY"
 
-    exchange_info = _build_exchange_rate_info()
+    exchange_info = _build_exchange_rate_info(allow_remote=False)
     rate = decimal_or_zero(exchange_info.get("exchange_rate")) or ONE
     return CurrencyConversionContext(
         display_currency=target_currency,

--- a/backend/llm_ops/tests/test_services.py
+++ b/backend/llm_ops/tests/test_services.py
@@ -2,7 +2,7 @@ from decimal import Decimal
 from unittest import mock
 
 from django.db import connection
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 from django.test.utils import CaptureQueriesContext
 
 from llm_ops.models import (
@@ -23,6 +23,7 @@ from llm_ops.models import (
 )
 from llm_ops.price_table_validation import usage_range_spec
 from llm_ops.services import (
+    build_currency_conversion_context,
     calculate_channel_model_cost,
     import_manual_model_prices,
     match_meta_model_by_alias_or_name,
@@ -37,6 +38,25 @@ from llm_ops.services import (
     sync_dependent_channel_price_items_for_price_items,
 )
 from llm_ops.tier_pricing import TieredPriceNotSupportedError
+
+
+class CurrencyConversionContextTests(SimpleTestCase):
+    @mock.patch("llm_ops.services._build_exchange_rate_info")
+    def test_builds_context_without_remote_exchange_rate_lookup(
+        self,
+        mock_exchange_rate_info,
+    ):
+        mock_exchange_rate_info.return_value = {
+            "exchange_rate": 7.23,
+            "rate_source_label": "ExchangeRate API",
+            "rate_source_url": "https://www.exchangerate-api.com/",
+            "rate_collected_at": "2026-08-11T00:00:00+00:00",
+        }
+
+        context = build_currency_conversion_context("CNY")
+
+        self.assertEqual(context.usd_to_cny_rate, Decimal("7.23"))
+        mock_exchange_rate_info.assert_called_once_with(allow_remote=False)
 
 
 class LLMOpsPricingServiceTests(TestCase):

--- a/frontend/src/components/llm-ops/AgioneListingStatusBoard.vue
+++ b/frontend/src/components/llm-ops/AgioneListingStatusBoard.vue
@@ -461,10 +461,6 @@ const props = defineProps({
     type: Array,
     required: true
   },
-  priceItems: {
-    type: Array,
-    default: () => []
-  },
   listings: {
     type: Array,
     required: true
@@ -516,7 +512,6 @@ const rows = useAgioneListingRows({
   agionePlatformRef: toRef(props, 'agionePlatform'),
   providersRef: toRef(props, 'providers'),
   modelsRef: toRef(props, 'models'),
-  priceItemsRef: toRef(props, 'priceItems'),
   listingsRef: toRef(props, 'listings'),
   summaryRef: toRef(props, 'summary'),
   displayCurrencyRef: toRef(props, 'displayCurrency'),

--- a/frontend/src/composables/useLLMOpsData.js
+++ b/frontend/src/composables/useLLMOpsData.js
@@ -11,7 +11,10 @@ import {
   fetchFirstPage,
   fetchList
 } from '@/utils/llmOpsPagination'
-import { dataGroupsForSection } from '@/utils/llmOpsSectionData'
+import {
+  dataGroupsForResalePublishing,
+  dataGroupsForSection
+} from '@/utils/llmOpsSectionData'
 import { userFacingApiError } from '@/utils/llmOpsErrors'
 
 const PRICE_HISTORY_PAGE_SIZE = 120
@@ -202,22 +205,25 @@ export function useLLMOpsData() {
   }
 
   function preloadResalePublishingData() {
-    const tasks = [refreshChannelPricingData(), refreshSummary()]
-    if (!asArray(metaModels.value).length) {
-      tasks.push(
-        fetchList(llmOpsApi.listMetaModels).then((items) => {
-          metaModels.value = asArray(items)
-        })
-      )
+    const groupValues = {
+      channels,
+      listings,
+      metaModels,
+      modelPrices: modelPriceItems
     }
-    if (!asArray(modelPriceItems.value).length) {
-      tasks.push(refreshModelPriceItems())
-    }
-    if (!asArray(listings.value).length) {
-      tasks.push(refreshResaleListings())
-    }
+    const tasks = dataGroupsForResalePublishing()
+      .filter((group) => {
+        if (group === 'channelPricing') {
+          return (
+            !asArray(channelPrices.value).length ||
+            !asArray(channelPriceItems.value).length
+          )
+        }
+        return !asArray(groupValues[group]?.value).length
+      })
+      .map((group) => loadDataGroup(group, 'reseller', {}))
 
-    Promise.all(tasks).catch((error) => {
+    return Promise.all(tasks).catch((error) => {
       showError(errorMessage(error, t('llmOps.dataErrors.loadPublishing')))
     })
   }

--- a/frontend/src/pages/LLMOps.vue
+++ b/frontend/src/pages/LLMOps.vue
@@ -141,7 +141,6 @@
                 :agione-platform="agionePlatform"
                 :providers="providers"
                 :models="models"
-                :price-items="modelPriceItems"
                 :listings="listings"
                 :summary="summary"
                 :platform-count="activeResalePlatforms.length"

--- a/frontend/src/utils/llmOpsSectionData.js
+++ b/frontend/src/utils/llmOpsSectionData.js
@@ -33,17 +33,7 @@ const SECTION_DATA_GROUPS = {
     'modelPrices'
   ],
   reconciler: ['channels', 'models', 'records'],
-  reseller: [
-    'platforms',
-    'providers',
-    'metaModels',
-    'models',
-    'channels',
-    'channelPricing',
-    'modelPrices',
-    'listings',
-    'summary'
-  ],
+  reseller: ['platforms', 'providers', 'models', 'listings', 'summary'],
   taskLogs: ['sources', 'runs'],
   workflow: ['platforms']
 }
@@ -69,6 +59,18 @@ const GLOBAL_REFRESH_SECTIONS = new Set([
   'reconciler',
   'reseller'
 ])
+
+const RESALE_PUBLISHING_DATA_GROUPS = [
+  'metaModels',
+  'channels',
+  'channelPricing',
+  'modelPrices',
+  'listings'
+]
+
+export function dataGroupsForResalePublishing() {
+  return [...RESALE_PUBLISHING_DATA_GROUPS]
+}
 
 export function dataGroupsForSection(section) {
   return [...(SECTION_DATA_GROUPS[section] || [])]

--- a/frontend/tests/llmOpsResilience.test.js
+++ b/frontend/tests/llmOpsResilience.test.js
@@ -4,6 +4,7 @@ import test from 'node:test'
 
 import { userFacingApiError } from '../src/utils/llmOpsErrors.js'
 import {
+  dataGroupsForResalePublishing,
   dataGroupsForSection,
   toolbarForSection
 } from '../src/utils/llmOpsSectionData.js'
@@ -95,6 +96,34 @@ test('loads only the data groups required by each section', () => {
   assert.ok(dataGroupsForSection('modelWorkbench').includes('records'))
   assert.ok(!dataGroupsForSection('taskLogs').includes('summary'))
   assert.ok(!dataGroupsForSection('audit').includes('models'))
+  assert.deepEqual(dataGroupsForSection('reseller'), [
+    'platforms',
+    'providers',
+    'models',
+    'listings',
+    'summary'
+  ])
+})
+
+test('loads publishing-only data when the resale workspace opens', () => {
+  assert.deepEqual(dataGroupsForResalePublishing(), [
+    'metaModels',
+    'channels',
+    'channelPricing',
+    'modelPrices',
+    'listings'
+  ])
+})
+
+test('does not pass unused model price items to the listing status board', () => {
+  const boardUsage = llmOpsPageSource.match(
+    /<AgioneListingStatusBoard[\s\S]*?\/>/
+  )?.[0]
+
+  assert.ok(boardUsage)
+  assert.doesNotMatch(boardUsage, /:price-items=/)
+  assert.doesNotMatch(listingBoardSource, /\bpriceItems\b/)
+  assert.doesNotMatch(listingBoardSource, /\bpriceItemsRef\b/)
 })
 
 test('shows page toolbar controls only where they are meaningful', () => {


### PR DESCRIPTION
## Summary

- limit the resale status board to its five required startup data groups
- load meta models, channels, channel pricing, and model prices only when the publishing workspace opens
- stop passing unused model price items into the status board
- keep LLM Ops currency conversion on cached or baseline exchange rates instead of waiting for a remote API
- add backend and frontend regression coverage

Closes #256

## Test plan

- [x] `python manage.py test cloud_billing.tests.test_dashboard llm_ops.tests.test_services --noinput` (60 tests, PostgreSQL dev container)
- [x] `npm run test:unit` (105 tests)
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] targeted ESLint for changed frontend files
