### PR TITLE
修复 LLM Ops 挂售阶梯重复及编辑失效

### DIFF
--- a/frontend/src/components/llm-ops/ResalePublishingWorkspace.vue
+++ b/frontend/src/components/llm-ops/ResalePublishingWorkspace.vue
@@ -512,7 +512,6 @@
               :currency="currencyLabel"
               :errors="tierErrorsFor(row)"
               :model-value="tierDraftFor(row)"
-              :boundaries-locked="true"
               :preview="tierPreviewFor(row)"
               :preview-error="tierPreviewErrorFor(row)"
               :preview-loading="tierPreviewLoadingFor(row)"

--- a/frontend/src/components/llm-ops/ResaleTierCard.vue
+++ b/frontend/src/components/llm-ops/ResaleTierCard.vue
@@ -1,0 +1,173 @@
+<template>
+  <article
+    class="overflow-hidden rounded-lg border bg-white transition"
+    :class="expanded ? 'border-agione-300 shadow-sm' : 'border-slate-200'"
+  >
+    <header
+      class="flex flex-wrap items-center gap-3 px-3 py-3 sm:flex-nowrap sm:px-4"
+      :class="expanded ? 'bg-agione-50/70' : 'bg-white'"
+    >
+      <span
+        class="inline-flex shrink-0 items-center rounded-full bg-agione-600 px-2.5 py-1 text-[11px] font-bold text-white"
+      >
+        {{
+          t('llmOps.publishingWorkspace.tiers.tierLabel', { value: index + 1 })
+        }}
+      </span>
+
+      <div
+        v-if="card.flat"
+        class="min-w-0 flex-1 text-xs font-semibold text-slate-700"
+      >
+        {{ t('llmOps.publishingWorkspace.tiers.allUsage') }}
+      </div>
+      <div v-else class="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+        <span class="font-mono text-xs font-semibold text-slate-700">
+          {{ formatBoundary(card.start) }}
+        </span>
+        <span class="text-xs text-slate-400">
+          {{ t('llmOps.publishingWorkspace.tiers.to') }}
+        </span>
+        <div v-if="card.end !== null" class="flex items-center gap-1.5">
+          <input
+            :aria-label="`${t('llmOps.publishingWorkspace.tiers.end')} ${index + 1}`"
+            class="w-24 rounded-md border border-slate-300 bg-white px-2 py-1.5 text-right font-mono text-xs font-semibold text-slate-900 outline-none transition focus:border-agione-500 focus:ring-2 focus:ring-agione-100 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-500"
+            :disabled="locked"
+            min="0"
+            step="1"
+            type="number"
+            :value="endInThousands"
+            @input="emitEnd($event.target.value)"
+          />
+          <span class="whitespace-nowrap text-[11px] text-slate-500">
+            K Tokens
+          </span>
+        </div>
+        <span v-else class="font-mono text-sm font-bold text-slate-700">
+          ∞
+        </span>
+        <p v-if="errors.end" class="w-full text-xs text-rose-600">
+          {{ errors.end }}
+        </p>
+      </div>
+
+      <p
+        v-if="!expanded"
+        class="hidden truncate text-[11px] text-slate-500 lg:block"
+      >
+        {{ collapsedSummary }}
+      </p>
+      <div class="ml-auto flex shrink-0 items-center gap-1">
+        <button
+          type="button"
+          class="inline-flex h-8 w-8 items-center justify-center rounded-md text-slate-500 transition hover:bg-white hover:text-agione-700 focus:outline-none focus:ring-2 focus:ring-agione-200"
+          :aria-expanded="expanded"
+          :aria-label="
+            expanded
+              ? t('llmOps.publishingWorkspace.tiers.collapse')
+              : t('llmOps.publishingWorkspace.tiers.expand')
+          "
+          @click="$emit('toggle')"
+        >
+          <ChevronUp v-if="expanded" class="h-4 w-4" aria-hidden="true" />
+          <ChevronDown v-else class="h-4 w-4" aria-hidden="true" />
+        </button>
+        <button
+          v-if="!locked && !card.flat && canRemove"
+          type="button"
+          class="inline-flex h-8 w-8 items-center justify-center rounded-md text-slate-400 transition hover:bg-rose-50 hover:text-rose-600 focus:outline-none focus:ring-2 focus:ring-rose-200"
+          :aria-label="`${t('llmOps.publishingWorkspace.tiers.remove')} ${index + 1}`"
+          @click="$emit('remove')"
+        >
+          <Trash2 class="h-4 w-4" aria-hidden="true" />
+        </button>
+      </div>
+    </header>
+
+    <div
+      v-if="expanded"
+      class="grid gap-3 border-t border-slate-100 bg-white p-3 md:grid-cols-3 md:p-4"
+    >
+      <label
+        v-for="dimension in dimensions"
+        :key="dimension.key"
+        class="rounded-lg border border-slate-200 bg-slate-50/60 p-3"
+      >
+        <span class="flex items-center justify-between gap-2">
+          <span class="text-xs font-bold text-slate-800">
+            {{ t(dimension.label) }}
+          </span>
+          <span class="text-[10px] font-medium uppercase text-slate-400">
+            {{ currency }} / 1M
+          </span>
+        </span>
+        <input
+          :aria-label="`${t(dimension.label)} ${index + 1}`"
+          class="mt-2 w-full rounded-md border border-slate-300 bg-white px-3 py-2 font-mono text-sm font-semibold text-slate-900 outline-none transition focus:border-agione-500 focus:ring-2 focus:ring-agione-100"
+          min="0"
+          step="0.000001"
+          type="number"
+          :value="card.prices?.[dimension.key]"
+          @input="$emit('update:price', dimension.key, $event.target.value)"
+        />
+        <span
+          v-if="errors[dimension.key]"
+          class="mt-1.5 block text-xs text-rose-600"
+        >
+          {{ errors[dimension.key] }}
+        </span>
+      </label>
+    </div>
+  </article>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { ChevronDown, ChevronUp, Trash2 } from 'lucide-vue-next'
+import { useI18n } from 'vue-i18n'
+
+const props = defineProps({
+  canRemove: { type: Boolean, default: false },
+  card: { type: Object, required: true },
+  currency: { type: String, default: 'USD' },
+  dimensions: { type: Array, required: true },
+  errors: { type: Object, default: () => ({}) },
+  expanded: { type: Boolean, default: false },
+  index: { type: Number, required: true },
+  locked: { type: Boolean, default: false }
+})
+
+const emit = defineEmits(['remove', 'toggle', 'update:end', 'update:price'])
+const { locale, t } = useI18n()
+
+const endInThousands = computed(() => {
+  const value = Number(props.card.end)
+  return Number.isFinite(value) ? value / 1000 : ''
+})
+
+const collapsedSummary = computed(() =>
+  props.dimensions
+    .map((dimension) => {
+      const value = props.card.prices?.[dimension.key]
+      return `${t(dimension.label)} ${value || '—'}`
+    })
+    .join(' · ')
+)
+
+function emitEnd(value) {
+  if (value === '') {
+    emit('update:end', null)
+    return
+  }
+  const amount = Number(value)
+  emit('update:end', Number.isFinite(amount) ? String(amount * 1000) : value)
+}
+
+function formatBoundary(value) {
+  const amount = Number(value)
+  if (!Number.isFinite(amount)) return String(value ?? '—')
+  return `${new Intl.NumberFormat(locale.value, {
+    maximumFractionDigits: 3
+  }).format(amount / 1000)}K`
+}
+</script>

--- a/frontend/src/components/llm-ops/ResaleTierEditor.vue
+++ b/frontend/src/components/llm-ops/ResaleTierEditor.vue
@@ -1,336 +1,175 @@
 <template>
-  <section class="rounded-lg border border-slate-200 bg-slate-50 p-4">
+  <section class="rounded-lg border border-slate-200 bg-white p-4">
     <div class="flex flex-wrap items-start justify-between gap-3">
-      <div>
-        <h4 class="text-sm font-bold text-slate-900">
-          {{ t('llmOps.publishingWorkspace.tiers.title') }}
-        </h4>
-        <p class="mt-1 text-xs text-slate-500">
-          {{ t('llmOps.publishingWorkspace.tiers.intervalHelp') }}
-        </p>
-      </div>
-      <span
-        class="rounded bg-white px-2 py-1 text-xs font-medium text-slate-600"
-      >
-        {{ currency }} / 1M
-      </span>
-      <button
-        type="button"
-        class="text-xs font-semibold text-agione-700 hover:text-agione-800"
-        :disabled="previewLoading"
-        @click="$emit('preview')"
-      >
-        {{
-          previewLoading
-            ? t('common.loading')
-            : t('llmOps.publishingWorkspace.tiers.preview')
-        }}
-      </button>
-    </div>
-
-    <div class="mt-4 space-y-4">
-      <section
-        v-for="spec in dimensions"
-        :key="spec.key"
-        class="overflow-hidden rounded border border-slate-200 bg-white"
-      >
-        <header
-          class="flex items-center justify-between gap-3 border-b border-slate-100 px-3 py-2"
-        >
+      <div class="min-w-0">
+        <div class="flex items-center gap-2">
+          <span
+            class="inline-flex h-8 w-8 items-center justify-center rounded-full bg-slate-100 text-slate-500"
+          >
+            <SlidersHorizontal class="h-4 w-4" aria-hidden="true" />
+          </span>
           <div>
-            <h5 class="text-xs font-bold text-slate-800">
-              {{ t(spec.label) }}
-            </h5>
-            <p class="mt-0.5 text-[11px] text-slate-500">
-              {{
-                boundariesLocked
-                  ? t('llmOps.publishingWorkspace.tiers.upstreamHelp')
-                  : t('llmOps.publishingWorkspace.tiers.continuityHelp')
-              }}
+            <h4 class="text-sm font-bold text-slate-900">
+              {{ t('llmOps.publishingWorkspace.tiers.title') }}
+            </h4>
+            <p class="mt-0.5 text-xs text-slate-500">
+              {{ t('llmOps.publishingWorkspace.tiers.sharedScheduleHelp') }}
             </p>
           </div>
-          <button
-            v-if="!boundariesLocked"
-            type="button"
-            class="text-xs font-semibold text-agione-700 hover:text-agione-800"
-            @click="addTier(spec.key)"
-          >
-            {{ t('llmOps.publishingWorkspace.tiers.add') }}
-          </button>
-        </header>
-        <div class="border-b border-slate-100 bg-slate-50/70 px-3 py-3">
-          <p
-            class="text-[10px] font-semibold uppercase tracking-[0.12em] text-slate-500"
-          >
-            {{ t('llmOps.publishingWorkspace.tiers.rangePreview') }}
-          </p>
-          <div
-            class="mt-2 flex min-w-max items-center"
-            role="list"
-            :aria-label="t('llmOps.publishingWorkspace.tiers.rangePreview')"
-          >
-            <template
-              v-for="(row, index) in rowsFor(spec.key)"
-              :key="`${spec.key}-preview-${index}`"
-            >
-              <div
-                class="min-w-[148px] rounded border border-slate-200 bg-white px-3 py-2 shadow-sm"
-                role="listitem"
-              >
-                <div class="flex items-center justify-between gap-2">
-                  <span class="text-[11px] font-semibold text-slate-500">
-                    {{
-                      t('llmOps.publishingWorkspace.tiers.tierLabel', {
-                        value: index + 1
-                      })
-                    }}
-                  </span>
-                  <span class="text-[11px] font-semibold text-agione-700">
-                    {{ rangeLabel(row) }}
-                  </span>
-                </div>
-                <p class="mt-1 text-xs font-bold text-slate-900">
-                  {{ priceLabel(row) }}
-                </p>
-              </div>
-              <div
-                v-if="index < rowsFor(spec.key).length - 1"
-                class="flex items-center px-1"
-                :aria-label="t('llmOps.publishingWorkspace.tiers.connected')"
-                role="img"
-              >
-                <span class="h-0.5 w-5 bg-agione-300"></span>
-                <span class="-ml-0.5 text-sm font-bold text-agione-500">›</span>
-              </div>
-            </template>
-          </div>
         </div>
-        <div class="overflow-x-auto">
-          <table class="min-w-full text-left text-xs">
-            <thead class="bg-slate-50 text-slate-500">
-              <tr>
-                <th class="w-16 px-3 py-2 font-medium">
-                  {{ t('llmOps.publishingWorkspace.tiers.tier') }}
-                </th>
-                <th class="px-3 py-2 font-medium">
-                  {{ t('llmOps.publishingWorkspace.tiers.start') }}
-                </th>
-                <th class="px-3 py-2 font-medium">
-                  {{ t('llmOps.publishingWorkspace.tiers.end') }}
-                </th>
-                <th class="px-3 py-2 font-medium">
-                  {{ t('llmOps.publishingWorkspace.tiers.price') }}
-                </th>
-                <th class="px-3 py-2 text-right font-medium">
-                  {{ t('llmOps.publishingWorkspace.tiers.actions') }}
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr
-                v-for="(row, index) in rowsFor(spec.key)"
-                :key="`${spec.key}-${index}`"
-                class="border-t border-slate-100"
-              >
-                <td class="px-3 py-2 align-top">
-                  <span
-                    class="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-agione-50 px-1.5 text-[11px] font-bold text-agione-700"
-                  >
-                    {{ index + 1 }}
-                  </span>
-                </td>
-                <td class="px-3 py-2">
-                  <span v-if="row.flat" class="text-slate-500">{{
-                    t('llmOps.publishingWorkspace.tiers.allUsage')
-                  }}</span>
-                  <input
-                    v-else
-                    :value="row.start"
-                    :aria-label="`${t('llmOps.publishingWorkspace.tiers.start')} ${
-                      index + 1
-                    }`"
-                    class="w-28 rounded border border-slate-300 px-2 py-1 text-slate-900"
-                    min="0"
-                    :disabled="boundariesLocked"
-                    type="number"
-                    @input="
-                      updateRow(spec.key, index, 'start', $event.target.value)
-                    "
-                  />
-                  <p
-                    v-if="errorFor(spec.key, index, 'start')"
-                    class="mt-1 text-rose-600"
-                  >
-                    {{ errorFor(spec.key, index, 'start') }}
-                  </p>
-                </td>
-                <td class="px-3 py-2">
-                  <span v-if="row.flat" class="text-slate-500">—</span>
-                  <template v-else>
-                    <input
-                      :value="row.end"
-                      :aria-label="`${t('llmOps.publishingWorkspace.tiers.end')} ${
-                        index + 1
-                      }`"
-                      class="w-28 rounded border border-slate-300 px-2 py-1 text-slate-900"
-                      :disabled="boundariesLocked"
-                      min="0"
-                      :placeholder="
-                        t('llmOps.publishingWorkspace.tiers.unbounded')
-                      "
-                      type="number"
-                      @input="
-                        updateRow(
-                          spec.key,
-                          index,
-                          'end',
-                          $event.target.value || null
-                        )
-                      "
-                    />
-                    <p
-                      v-if="errorFor(spec.key, index, 'end')"
-                      class="mt-1 text-rose-600"
-                    >
-                      {{ errorFor(spec.key, index, 'end') }}
-                    </p>
-                  </template>
-                </td>
-                <td class="px-3 py-2">
-                  <input
-                    :value="row.price"
-                    :aria-label="`${t('llmOps.publishingWorkspace.tiers.price')} ${
-                      index + 1
-                    }`"
-                    class="w-28 rounded border border-slate-300 px-2 py-1 text-slate-900"
-                    min="0"
-                    step="0.000001"
-                    type="number"
-                    @input="
-                      updateRow(spec.key, index, 'price', $event.target.value)
-                    "
-                  />
-                  <p
-                    v-if="errorFor(spec.key, index, 'price')"
-                    class="mt-1 text-rose-600"
-                  >
-                    {{ errorFor(spec.key, index, 'price') }}
-                  </p>
-                </td>
-                <td class="px-3 py-2 text-right">
-                  <button
-                    v-if="
-                      !boundariesLocked &&
-                      !row.flat &&
-                      rowsFor(spec.key).length > 1
-                    "
-                    type="button"
-                    class="text-xs font-medium text-rose-600 hover:text-rose-700"
-                    @click="removeTier(spec.key, index)"
-                  >
-                    {{ t('llmOps.publishingWorkspace.tiers.remove') }}
-                  </button>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </section>
-    </div>
-    <p v-if="previewError" class="mt-3 text-xs text-rose-600">
-      {{ previewError }}
-    </p>
-    <section
-      v-if="preview"
-      class="mt-4 overflow-hidden rounded border border-agione-100 bg-agione-50/40"
-    >
-      <header
-        class="flex flex-wrap items-center justify-between gap-2 px-3 py-2 text-xs"
-      >
-        <strong class="text-slate-800">{{
-          t('llmOps.publishingWorkspace.tiers.serverPreview')
-        }}</strong>
+      </div>
+      <div class="flex items-center gap-2">
         <span
-          :class="
-            preview.approval?.eligible ? 'text-emerald-700' : 'text-amber-700'
-          "
+          class="rounded-md bg-slate-100 px-2.5 py-1.5 font-mono text-[11px] font-semibold text-slate-600"
         >
-          {{
-            preview.approval?.eligible
-              ? t('llmOps.publishingWorkspace.tiers.autoApproved')
-              : t('llmOps.publishingWorkspace.tiers.manualApproval')
-          }}
+          {{ currency }} / 1M Tokens
         </span>
-      </header>
-      <p class="border-t border-agione-100 px-3 py-2 text-xs text-slate-600">
+        <button
+          type="button"
+          class="inline-flex items-center gap-1.5 rounded-md border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 transition hover:border-agione-300 hover:text-agione-700 disabled:cursor-not-allowed disabled:opacity-50"
+          :disabled="previewLoading"
+          @click="$emit('preview')"
+        >
+          <RefreshCw
+            class="h-3.5 w-3.5"
+            :class="previewLoading ? 'animate-spin' : ''"
+            aria-hidden="true"
+          />
+          {{
+            previewLoading
+              ? t('common.loading')
+              : t('llmOps.publishingWorkspace.tiers.preview')
+          }}
+        </button>
+      </div>
+    </div>
+
+    <div
+      class="mt-4 flex flex-wrap items-center justify-between gap-2 border-t border-slate-100 pt-4"
+    >
+      <div>
+        <h5 class="text-xs font-bold text-slate-800">
+          {{ t('llmOps.publishingWorkspace.tiers.priceEntry') }}
+        </h5>
+        <p class="mt-0.5 text-[11px] text-slate-500">
+          {{
+            boundariesLocked
+              ? t('llmOps.publishingWorkspace.tiers.upstreamHelp')
+              : t('llmOps.publishingWorkspace.tiers.continuityHelp')
+          }}
+        </p>
+      </div>
+      <span class="text-[11px] text-slate-400">
         {{
-          t('llmOps.publishingWorkspace.tiers.minimumMargin', {
-            value: formatPercent(preview.profitability?.minimum_gross_margin)
+          t('llmOps.publishingWorkspace.tiers.cardCount', {
+            count: cards.length
           })
         }}
-      </p>
-      <div class="overflow-x-auto border-t border-agione-100">
-        <table class="min-w-full text-left text-xs text-slate-600">
-          <thead class="bg-white/70 text-slate-500">
-            <tr>
-              <th class="px-3 py-2 font-medium">
-                {{ t('llmOps.publishingWorkspace.tiers.interval') }}
-              </th>
-              <th class="px-3 py-2 font-medium">
-                {{ t('llmOps.publishingWorkspace.tiers.oldCost') }}
-              </th>
-              <th class="px-3 py-2 font-medium">
-                {{ t('llmOps.publishingWorkspace.tiers.newCost') }}
-              </th>
-              <th class="px-3 py-2 font-medium">
-                {{ t('llmOps.publishingWorkspace.tiers.oldPrice') }}
-              </th>
-              <th class="px-3 py-2 font-medium">
-                {{ t('llmOps.publishingWorkspace.tiers.newPrice') }}
-              </th>
-              <th class="px-3 py-2 font-medium">
-                {{ t('llmOps.publishingWorkspace.tiers.marginChange') }}
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr
-              v-for="interval in preview.profitability?.intervals || []"
-              :key="intervalKey(interval)"
-              class="border-t border-agione-100"
-            >
-              <td class="px-3 py-2">{{ intervalLabel(interval) }}</td>
-              <td class="px-3 py-2">
-                {{ money(previousIntervalFor(interval)?.cost) }}
-              </td>
-              <td class="px-3 py-2">{{ money(interval.cost) }}</td>
-              <td class="px-3 py-2">
-                {{ money(previousIntervalFor(interval)?.gross_revenue) }}
-              </td>
-              <td class="px-3 py-2">{{ money(interval.gross_revenue) }}</td>
-              <td class="px-3 py-2">
-                {{
-                  formatPercent(
-                    previousIntervalFor(interval)?.gross_margin_rate
-                  )
-                }}
-                → {{ formatPercent(interval.gross_margin_rate) }}
-              </td>
-            </tr>
-          </tbody>
-        </table>
+      </span>
+    </div>
+
+    <div class="mt-3 space-y-2.5">
+      <ResaleTierCard
+        v-for="(card, index) in cards"
+        :key="index"
+        :can-remove="cards.length > 1"
+        :card="card"
+        :currency="currency"
+        :dimensions="dimensions"
+        :errors="errorsForCard(index)"
+        :expanded="expandedIndex === index"
+        :index="index"
+        :locked="boundariesLocked"
+        @remove="removeCard(index)"
+        @toggle="toggleCard(index)"
+        @update:end="updateCard(index, 'end', $event)"
+        @update:price="
+          (dimension, value) => updateCardPrice(index, dimension, value)
+        "
+      />
+    </div>
+
+    <button
+      v-if="!boundariesLocked"
+      type="button"
+      class="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-lg border border-dashed border-agione-300 bg-agione-50/40 px-3 py-2.5 text-xs font-bold text-agione-700 transition hover:border-agione-500 hover:bg-agione-50 focus:outline-none focus:ring-2 focus:ring-agione-200"
+      @click="addCard"
+    >
+      <Plus class="h-4 w-4" aria-hidden="true" />
+      {{ t('llmOps.publishingWorkspace.tiers.add') }}
+    </button>
+
+    <section
+      class="mt-4 rounded-lg border border-slate-200 bg-slate-50/70 p-3"
+      aria-live="polite"
+    >
+      <div class="flex flex-wrap items-center justify-between gap-2">
+        <div class="flex items-center gap-2">
+          <Eye class="h-4 w-4 text-slate-500" aria-hidden="true" />
+          <h5 class="text-xs font-bold text-slate-800">
+            {{ t('llmOps.publishingWorkspace.tiers.customerPreview') }}
+          </h5>
+        </div>
+        <span class="text-[10px] uppercase tracking-[0.12em] text-slate-400">
+          {{ t('llmOps.publishingWorkspace.tiers.rangePreview') }}
+        </span>
+      </div>
+      <div class="mt-3 grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
+        <article
+          v-for="(card, index) in cards"
+          :key="`preview-${card.start}-${card.end}-${index}`"
+          class="rounded-md border border-slate-200 bg-white p-3"
+        >
+          <div class="flex items-center justify-between gap-2">
+            <span class="text-[11px] font-bold text-agione-700">
+              {{
+                t('llmOps.publishingWorkspace.tiers.tierLabel', {
+                  value: index + 1
+                })
+              }}
+            </span>
+            <span class="font-mono text-[11px] text-slate-500">
+              {{ rangeLabel(card) }}
+            </span>
+          </div>
+          <dl class="mt-2 grid grid-cols-3 gap-2">
+            <div v-for="dimension in dimensions" :key="dimension.key">
+              <dt class="truncate text-[10px] text-slate-400">
+                {{ t(dimension.label) }}
+              </dt>
+              <dd
+                class="mt-0.5 truncate font-mono text-xs font-bold text-slate-800"
+              >
+                {{ priceLabel(card.prices?.[dimension.key]) }}
+              </dd>
+            </div>
+          </dl>
+        </article>
       </div>
     </section>
+
+    <ResaleTierProfitPreview
+      :currency="currency"
+      :error="previewError"
+      :previous-preview="previousPreview"
+      :preview="preview"
+    />
   </section>
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, ref, watch } from 'vue'
+import { Eye, Plus, RefreshCw, SlidersHorizontal } from 'lucide-vue-next'
 import { useI18n } from 'vue-i18n'
 
+import ResaleTierCard from '@/components/llm-ops/ResaleTierCard.vue'
+import ResaleTierProfitPreview from '@/components/llm-ops/ResaleTierProfitPreview.vue'
 import {
-  removeResaleTierRow,
-  updateResaleTierRows
+  addResaleTierCard,
+  buildResaleTierCards,
+  buildResaleTierDraftFromCards,
+  removeResaleTierCard,
+  updateResaleTierCard
 } from '@/utils/resaleTierDraft'
 
 const props = defineProps({
@@ -346,97 +185,81 @@ const props = defineProps({
 
 const emit = defineEmits(['preview', 'update:modelValue'])
 const { locale, t } = useI18n()
+const expandedIndex = ref(0)
 
 const dimensions = computed(() => [
   { key: 'input', label: 'llmOps.publishingWorkspace.metrics.input' },
   { key: 'output', label: 'llmOps.publishingWorkspace.metrics.output' },
   { key: 'cache', label: 'llmOps.publishingWorkspace.metrics.cacheInput' }
 ])
+const cards = computed(() => buildResaleTierCards(props.modelValue))
 
-function rowsFor(key) {
-  return props.modelValue?.[key] || []
-}
-
-function setRows(key, rows) {
-  emit('update:modelValue', { ...props.modelValue, [key]: rows })
-}
-
-function updateRow(key, index, field, value) {
-  setRows(key, updateResaleTierRows(rowsFor(key), index, field, value))
-}
-
-function addTier(key) {
-  const rows = rowsFor(key)
-  if (rows.length === 1 && rows[0].flat) {
-    const price = rows[0].price
-    setRows(key, [
-      { end: '1000000', flat: false, price, start: '0' },
-      { end: null, flat: false, price, start: '1000000' }
-    ])
-    return
+watch(
+  () => cards.value.length,
+  (length) => {
+    if (expandedIndex.value >= length)
+      expandedIndex.value = Math.max(0, length - 1)
   }
-  const last = rows[rows.length - 1]
-  const start = Number(last?.start || 0) + 1000000
-  setRows(key, [
-    ...rows.slice(0, -1),
-    { ...last, end: String(start), flat: false },
-    { end: null, flat: false, price: last?.price || '', start: String(start) }
-  ])
+)
+
+function commitCards(nextCards) {
+  emit('update:modelValue', buildResaleTierDraftFromCards(nextCards))
 }
 
-function removeTier(key, index) {
-  setRows(key, removeResaleTierRow(rowsFor(key), index))
+function addCard() {
+  const nextCards = addResaleTierCard(cards.value)
+  expandedIndex.value = Math.max(0, nextCards.length - 1)
+  commitCards(nextCards)
 }
 
-function errorFor(key, index, field) {
-  return props.errors?.[`${key}:${index}:${field}`] || ''
+function removeCard(index) {
+  commitCards(removeResaleTierCard(cards.value, index))
 }
 
-function formatPercent(value) {
-  const amount = Number(value)
-  return Number.isFinite(amount) ? `${(amount * 100).toFixed(2)}%` : '—'
+function toggleCard(index) {
+  expandedIndex.value = expandedIndex.value === index ? -1 : index
+}
+
+function updateCard(index, field, value) {
+  commitCards(updateResaleTierCard(cards.value, index, field, value))
+}
+
+function updateCardPrice(index, dimension, value) {
+  commitCards(updateResaleTierCard(cards.value, index, dimension, value))
+}
+
+function errorsForCard(index) {
+  const rangeError = dimensions.value
+    .map(
+      ({ key }) =>
+        props.errors?.[`${key}:${index}:end`] ||
+        props.errors?.[`${key}:${index}:start`]
+    )
+    .find(Boolean)
+  return {
+    cache: props.errors?.[`cache:${index}:price`] || '',
+    end: rangeError || '',
+    input: props.errors?.[`input:${index}:price`] || '',
+    output: props.errors?.[`output:${index}:price`] || ''
+  }
 }
 
 function formatUsage(value) {
+  const amount = Number(value)
+  if (!Number.isFinite(amount)) return String(value ?? '—')
+  return `${new Intl.NumberFormat(locale.value, {
+    maximumFractionDigits: 3
+  }).format(amount / 1000)}K`
+}
+
+function rangeLabel(card) {
+  if (card.flat) return t('llmOps.publishingWorkspace.tiers.allUsage')
+  return `${formatUsage(card.start)} - ${card.end === null ? '∞' : formatUsage(card.end)}`
+}
+
+function priceLabel(value) {
   if (value === null || value === undefined || value === '') return '—'
   const amount = Number(value)
-  return Number.isFinite(amount)
-    ? new Intl.NumberFormat(locale.value, {
-        maximumFractionDigits: 6
-      }).format(amount)
-    : String(value)
-}
-
-function rangeLabel(row) {
-  if (row.flat) return t('llmOps.publishingWorkspace.tiers.allUsage')
-  const end = row.end === null ? '∞' : formatUsage(row.end)
-  return `[${formatUsage(row.start)}, ${end})`
-}
-
-function priceLabel(row) {
-  const amount = Number(row.price)
-  const price = Number.isFinite(amount) ? amount.toFixed(6) : row.price || '—'
-  return `${props.currency} ${price} / 1M`
-}
-
-function money(value) {
-  const amount = Number(value)
-  return Number.isFinite(amount)
-    ? `${props.currency} ${amount.toFixed(6)}`
-    : '—'
-}
-
-function intervalKey(interval) {
-  return [interval.dimension, interval.tier_start, interval.tier_end].join(':')
-}
-
-function intervalLabel(interval) {
-  const end = interval.tier_end === null ? '∞' : interval.tier_end
-  return `${interval.dimension}: [${interval.tier_start}, ${end})`
-}
-
-function previousIntervalFor(interval) {
-  const intervals = props.previousPreview?.profitability?.intervals || []
-  return intervals.find((item) => intervalKey(item) === intervalKey(interval))
+  return Number.isFinite(amount) ? amount.toFixed(4) : value || '—'
 }
 </script>

--- a/frontend/src/components/llm-ops/ResaleTierProfitPreview.vue
+++ b/frontend/src/components/llm-ops/ResaleTierProfitPreview.vue
@@ -1,0 +1,123 @@
+<template>
+  <p v-if="error" class="mt-3 text-xs text-rose-600">
+    {{ error }}
+  </p>
+  <section
+    v-if="preview"
+    class="mt-4 overflow-hidden rounded-lg border border-agione-100 bg-agione-50/40"
+  >
+    <header
+      class="flex flex-wrap items-center justify-between gap-2 px-3 py-2.5 text-xs"
+    >
+      <strong class="text-slate-800">
+        {{ t('llmOps.publishingWorkspace.tiers.serverPreview') }}
+      </strong>
+      <span
+        :class="
+          preview.approval?.eligible ? 'text-emerald-700' : 'text-amber-700'
+        "
+      >
+        {{
+          preview.approval?.eligible
+            ? t('llmOps.publishingWorkspace.tiers.autoApproved')
+            : t('llmOps.publishingWorkspace.tiers.manualApproval')
+        }}
+      </span>
+    </header>
+    <p class="border-t border-agione-100 px-3 py-2 text-xs text-slate-600">
+      {{
+        t('llmOps.publishingWorkspace.tiers.minimumMargin', {
+          value: formatPercent(preview.profitability?.minimum_gross_margin)
+        })
+      }}
+    </p>
+    <div class="overflow-x-auto border-t border-agione-100">
+      <table class="min-w-full text-left text-xs text-slate-600">
+        <thead class="bg-white/70 text-slate-500">
+          <tr>
+            <th class="px-3 py-2 font-medium">
+              {{ t('llmOps.publishingWorkspace.tiers.interval') }}
+            </th>
+            <th class="px-3 py-2 font-medium">
+              {{ t('llmOps.publishingWorkspace.tiers.oldCost') }}
+            </th>
+            <th class="px-3 py-2 font-medium">
+              {{ t('llmOps.publishingWorkspace.tiers.newCost') }}
+            </th>
+            <th class="px-3 py-2 font-medium">
+              {{ t('llmOps.publishingWorkspace.tiers.oldPrice') }}
+            </th>
+            <th class="px-3 py-2 font-medium">
+              {{ t('llmOps.publishingWorkspace.tiers.newPrice') }}
+            </th>
+            <th class="px-3 py-2 font-medium">
+              {{ t('llmOps.publishingWorkspace.tiers.marginChange') }}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="interval in preview.profitability?.intervals || []"
+            :key="intervalKey(interval)"
+            class="border-t border-agione-100"
+          >
+            <td class="px-3 py-2">{{ intervalLabel(interval) }}</td>
+            <td class="px-3 py-2">
+              {{ money(previousIntervalFor(interval)?.cost) }}
+            </td>
+            <td class="px-3 py-2">{{ money(interval.cost) }}</td>
+            <td class="px-3 py-2">
+              {{ money(previousIntervalFor(interval)?.gross_revenue) }}
+            </td>
+            <td class="px-3 py-2">{{ money(interval.gross_revenue) }}</td>
+            <td class="px-3 py-2">
+              {{
+                formatPercent(previousIntervalFor(interval)?.gross_margin_rate)
+              }}
+              → {{ formatPercent(interval.gross_margin_rate) }}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { useI18n } from 'vue-i18n'
+
+const props = defineProps({
+  currency: { type: String, default: 'USD' },
+  error: { type: String, default: '' },
+  previousPreview: { type: Object, default: null },
+  preview: { type: Object, default: null }
+})
+
+const { t } = useI18n()
+
+function formatPercent(value) {
+  const amount = Number(value)
+  return Number.isFinite(amount) ? `${(amount * 100).toFixed(2)}%` : '—'
+}
+
+function money(value) {
+  const amount = Number(value)
+  return Number.isFinite(amount)
+    ? `${props.currency} ${amount.toFixed(6)}`
+    : '—'
+}
+
+function intervalKey(interval) {
+  return [interval.dimension, interval.tier_start, interval.tier_end].join(':')
+}
+
+function intervalLabel(interval) {
+  const end = interval.tier_end === null ? '∞' : interval.tier_end
+  return `${interval.dimension}: [${interval.tier_start}, ${end})`
+}
+
+function previousIntervalFor(interval) {
+  const intervals = props.previousPreview?.profitability?.intervals || []
+  return intervals.find((item) => intervalKey(item) === intervalKey(interval))
+}
+</script>

--- a/frontend/src/composables/useResaleWorkspaceOptions.js
+++ b/frontend/src/composables/useResaleWorkspaceOptions.js
@@ -2,6 +2,7 @@ import { computed } from 'vue'
 
 import { channelPriceItemKey } from '@/composables/useResaleChainRows'
 import { resolveCanonicalMetaOwner } from '@/utils/llmOpsMeta'
+import { selectPreferredChannelPriceItems } from '@/utils/resaleTierDraft'
 
 export function useResaleWorkspaceOptions({ form, props, t }) {
   const metaModelRows = computed(() =>
@@ -34,12 +35,25 @@ export function useResaleWorkspaceOptions({ form, props, t }) {
 
   const channelPriceItemsByKey = computed(() => {
     const map = new Map()
+    const variants = new Map()
     ;(props.channelPriceItems || []).forEach((item) => {
       if (!item?.channel || !item?.model || !item?.dimension) return
-      const key = channelPriceItemKey(item.channel, item.model, item.dimension)
-      const items = map.get(key) || []
+      const key = [item.channel, item.model].map(String).join(':')
+      const items = variants.get(key) || []
       items.push(item)
-      map.set(key, items)
+      variants.set(key, items)
+    })
+    variants.forEach((items) => {
+      selectPreferredChannelPriceItems(items).forEach((item) => {
+        const key = channelPriceItemKey(
+          item.channel,
+          item.model,
+          item.dimension
+        )
+        const dimensionItems = map.get(key) || []
+        dimensionItems.push(item)
+        map.set(key, dimensionItems)
+      })
     })
     map.forEach((items) => {
       items.sort((left, right) => {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1119,6 +1119,13 @@
       },
       "tiers": {
         "title": "Tiered resale prices",
+        "sharedScheduleHelp": "Each tier shares one token range, with separate input, output, and cache-hit prices.",
+        "priceEntry": "Price entry",
+        "cardCount": "{count} tiers",
+        "collapse": "Collapse tier",
+        "expand": "Expand tier",
+        "customerPreview": "Customer preview",
+        "to": "to",
         "intervalHelp": "Intervals use [start, end); leave the end blank for no upper limit.",
         "continuityHelp": "Adjacent tiers stay connected when you edit a boundary.",
         "upstreamHelp": "Ranges follow upstream procurement; only tier prices are editable.",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1127,6 +1127,13 @@
       },
       "tiers": {
         "title": "阶梯挂售价",
+        "sharedScheduleHelp": "一个阶梯共用同一 Token 区间，分别设置输入、输出与缓存命中售价。",
+        "priceEntry": "价格录入",
+        "cardCount": "共 {count} 个阶梯",
+        "collapse": "收起阶梯",
+        "expand": "展开阶梯",
+        "customerPreview": "用户端展示样例",
+        "to": "至",
         "intervalHelp": "区间采用 [起始, 结束)；结束留空表示无上限。",
         "continuityHelp": "修改边界时，相邻阶梯会自动接续。",
         "upstreamHelp": "区间跟随上游采购价，只可修改每段挂售价。",

--- a/frontend/src/utils/resaleTierDraft.js
+++ b/frontend/src/utils/resaleTierDraft.js
@@ -75,18 +75,21 @@ export function selectPreferredChannelPriceItems(items = []) {
     group.push(item)
     groups.set(key, group)
   })
-  const ranked = [...groups.entries()].sort(([leftKey, left], [rightKey, right]) => {
-    const leftDimensions = new Set(left.map((item) => item.dimension)).size
-    const rightDimensions = new Set(right.map((item) => item.dimension)).size
-    const dimensionScore = rightDimensions - leftDimensions
-    if (dimensionScore) return dimensionScore
-    const emptySpecScore = Number(rightKey === '{}') - Number(leftKey === '{}')
-    if (emptySpecScore) return emptySpecScore
-    if (right.length !== left.length) return right.length - left.length
-    const leftId = Math.min(...left.map((item) => Number(item.id || 0)))
-    const rightId = Math.min(...right.map((item) => Number(item.id || 0)))
-    return leftId - rightId
-  })
+  const ranked = [...groups.entries()].sort(
+    ([leftKey, left], [rightKey, right]) => {
+      const leftDimensions = new Set(left.map((item) => item.dimension)).size
+      const rightDimensions = new Set(right.map((item) => item.dimension)).size
+      const dimensionScore = rightDimensions - leftDimensions
+      if (dimensionScore) return dimensionScore
+      const emptySpecScore =
+        Number(rightKey === '{}') - Number(leftKey === '{}')
+      if (emptySpecScore) return emptySpecScore
+      if (right.length !== left.length) return right.length - left.length
+      const leftId = Math.min(...left.map((item) => Number(item.id || 0)))
+      const rightId = Math.min(...right.map((item) => Number(item.id || 0)))
+      return leftId - rightId
+    }
+  )
   const selected = ranked[0]?.[1] || []
   const boundaries = new Set()
   return selected.filter((item) => {
@@ -216,6 +219,17 @@ export function updateResaleTierCard(cards = [], index, field, value) {
   if (DIMENSIONS.some(([key]) => key === field)) {
     card.prices[field] = value
     return nextCards
+  }
+  if (field === 'end') {
+    const amount = decimal(value)
+    const start = decimal(card.start)
+    const nextCard = nextCards[index + 1]
+    const nextEnd = decimal(nextCard?.end)
+    if (nextCard && amount === null) return nextCards
+    if (amount !== null && start !== null && amount <= start) return nextCards
+    if (amount !== null && nextEnd !== null && amount >= nextEnd) {
+      return nextCards
+    }
   }
   card[field] = value
   if (field === 'end' && nextCards[index + 1]) {

--- a/frontend/src/utils/resaleTierDraft.js
+++ b/frontend/src/utils/resaleTierDraft.js
@@ -31,6 +31,218 @@ function isFlatRows(rows) {
   return rows.length === 1 && (rows[0].flat || rows[0].start === null)
 }
 
+function stableObjectKey(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableObjectKey).join(',')}]`
+  }
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableObjectKey(value[key])}`)
+      .join(',')}}`
+  }
+  return JSON.stringify(value)
+}
+
+function tierBoundaryKey(item) {
+  return [
+    item.dimension,
+    item.billing_unit,
+    item.currency,
+    item.tier_type,
+    comparableDecimal(item.tier_start),
+    comparableDecimal(item.tier_end)
+  ].join(':')
+}
+
+function priceAtUsage(rows, usage) {
+  const flatRow = rows.find((row) => row.flat || row.start === null)
+  if (flatRow) return String(flatRow.price ?? '')
+  const match = sortRows(rows).find((row) => {
+    const start = decimal(row.start)
+    const end = decimal(row.end)
+    return start !== null && start <= usage && (end === null || usage < end)
+  })
+  return String(match?.price ?? '')
+}
+
+/** Keep one complete pricing variant when stale current specs overlap. */
+export function selectPreferredChannelPriceItems(items = []) {
+  const groups = new Map()
+  items.forEach((item) => {
+    const key = stableObjectKey(item?.spec || {})
+    const group = groups.get(key) || []
+    group.push(item)
+    groups.set(key, group)
+  })
+  const ranked = [...groups.entries()].sort(([leftKey, left], [rightKey, right]) => {
+    const leftDimensions = new Set(left.map((item) => item.dimension)).size
+    const rightDimensions = new Set(right.map((item) => item.dimension)).size
+    const dimensionScore = rightDimensions - leftDimensions
+    if (dimensionScore) return dimensionScore
+    const emptySpecScore = Number(rightKey === '{}') - Number(leftKey === '{}')
+    if (emptySpecScore) return emptySpecScore
+    if (right.length !== left.length) return right.length - left.length
+    const leftId = Math.min(...left.map((item) => Number(item.id || 0)))
+    const rightId = Math.min(...right.map((item) => Number(item.id || 0)))
+    return leftId - rightId
+  })
+  const selected = ranked[0]?.[1] || []
+  const boundaries = new Set()
+  return selected.filter((item) => {
+    const key = tierBoundaryKey(item)
+    if (boundaries.has(key)) return false
+    boundaries.add(key)
+    return true
+  })
+}
+
+/** Merge dimension-specific ranges into AGIOne-style shared tier cards. */
+export function buildResaleTierCards(draft = {}) {
+  const rowsByKey = Object.fromEntries(
+    DIMENSIONS.map(([key]) => [
+      key,
+      Array.isArray(draft?.[key]) ? draft[key] : []
+    ])
+  )
+  const hasTieredRows = DIMENSIONS.some(([key]) =>
+    rowsByKey[key].some((row) => !row.flat && row.start !== null)
+  )
+  if (!hasTieredRows) {
+    return [
+      {
+        end: null,
+        flat: true,
+        prices: Object.fromEntries(
+          DIMENSIONS.map(([key]) => [
+            key,
+            String(rowsByKey[key][0]?.price ?? '')
+          ])
+        ),
+        start: null
+      }
+    ]
+  }
+
+  const boundaries = new Set([0])
+  let hasUnboundedTier = false
+  DIMENSIONS.forEach(([key]) => {
+    rowsByKey[key].forEach((row) => {
+      if (row.flat || row.start === null) return
+      const start = decimal(row.start)
+      const end = decimal(row.end)
+      if (start !== null) boundaries.add(start)
+      if (end === null) hasUnboundedTier = true
+      else boundaries.add(end)
+    })
+  })
+  const sortedBoundaries = [...boundaries].sort((left, right) => left - right)
+  const intervals = sortedBoundaries.slice(0, -1).map((start, index) => ({
+    end: sortedBoundaries[index + 1],
+    start
+  }))
+  if (hasUnboundedTier) {
+    intervals.push({ end: null, start: sortedBoundaries.at(-1) })
+  }
+
+  return intervals.map(({ end, start }) => ({
+    end: end === null ? null : String(end),
+    flat: false,
+    prices: Object.fromEntries(
+      DIMENSIONS.map(([key]) => [key, priceAtUsage(rowsByKey[key], start)])
+    ),
+    start: String(start)
+  }))
+}
+
+/** Convert shared tier cards back to the editable dimension draft. */
+export function buildResaleTierDraftFromCards(cards = []) {
+  return Object.fromEntries(
+    DIMENSIONS.map(([key]) => [
+      key,
+      cards.map((card) => ({
+        end: card.flat ? null : stringValue(card.end),
+        flat: Boolean(card.flat),
+        price: String(card.prices?.[key] ?? ''),
+        start: card.flat ? null : stringValue(card.start)
+      }))
+    ])
+  )
+}
+
+/** Add a shared tier while keeping the terminal range unbounded. */
+export function addResaleTierCard(cards = [], step = 1000000) {
+  const nextCards = cards.map((card) => ({
+    ...card,
+    prices: { ...card.prices }
+  }))
+  if (!nextCards.length) return nextCards
+  if (nextCards.length === 1 && nextCards[0].flat) {
+    const prices = { ...nextCards[0].prices }
+    return [
+      { end: String(step), flat: false, prices, start: '0' },
+      { end: null, flat: false, prices: { ...prices }, start: String(step) }
+    ]
+  }
+  const last = nextCards.at(-1)
+  if (last.end !== null) {
+    nextCards.push({
+      end: null,
+      flat: false,
+      prices: { ...last.prices },
+      start: String(last.end)
+    })
+    return nextCards
+  }
+  const split = String((decimal(last.start) || 0) + step)
+  nextCards[nextCards.length - 1] = { ...last, end: split }
+  nextCards.push({
+    end: null,
+    flat: false,
+    prices: { ...last.prices },
+    start: split
+  })
+  return nextCards
+}
+
+/** Update one shared boundary or price and preserve adjacent continuity. */
+export function updateResaleTierCard(cards = [], index, field, value) {
+  const nextCards = cards.map((card) => ({
+    ...card,
+    prices: { ...card.prices }
+  }))
+  const card = nextCards[index]
+  if (!card) return nextCards
+  if (DIMENSIONS.some(([key]) => key === field)) {
+    card.prices[field] = value
+    return nextCards
+  }
+  card[field] = value
+  if (field === 'end' && nextCards[index + 1]) {
+    nextCards[index + 1].start = value
+  }
+  if (field === 'start' && nextCards[index - 1]) {
+    nextCards[index - 1].end = value
+  }
+  return nextCards
+}
+
+/** Remove a shared tier and bridge the remaining interval cards. */
+export function removeResaleTierCard(cards = [], index) {
+  const nextCards = cards
+    .filter((_, cardIndex) => cardIndex !== index)
+    .map((card) => ({ ...card, prices: { ...card.prices } }))
+  if (!nextCards.length) return nextCards
+  if (index === 0) {
+    nextCards[0].start = '0'
+  } else if (index < cards.length - 1) {
+    nextCards[index - 1].end = cards[index].end
+  } else {
+    nextCards[nextCards.length - 1].end = null
+  }
+  return nextCards
+}
+
 function itemForRow(row, dimension, currency, tierType) {
   return {
     billing_unit: BILLING_UNIT,

--- a/frontend/tests/llmOpsResaleTierDraft.test.js
+++ b/frontend/tests/llmOpsResaleTierDraft.test.js
@@ -2,11 +2,17 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+  addResaleTierCard,
+  buildResaleTierCards,
   buildFlatResalePriceItems,
+  buildResaleTierDraftFromCards,
   hasTieredResalePrices,
   normalizeResalePriceDraft,
+  removeResaleTierCard,
   removeResaleTierRow,
+  selectPreferredChannelPriceItems,
   shouldRestoreSavedResalePriceDraft,
+  updateResaleTierCard,
   updateResaleTierRows,
   validateResalePriceDraft
 } from '../src/utils/resaleTierDraft.js'
@@ -225,4 +231,143 @@ test('uses upstream ranges for a published price when boundaries changed', () =>
     ),
     false
   )
+})
+
+test('selects one coherent channel price variant before displaying tiers', () => {
+  const items = [
+    {
+      dimension: 'text_input',
+      id: 4,
+      spec: { deployment_scope: '国际' },
+      tier_end: '100',
+      tier_start: '0'
+    },
+    {
+      dimension: 'text_output',
+      id: 5,
+      spec: { deployment_scope: '国际' },
+      tier_end: '100',
+      tier_start: '0'
+    },
+    {
+      dimension: 'cache_input',
+      id: 6,
+      spec: { deployment_scope: '国际' },
+      tier_end: '100',
+      tier_start: '0'
+    },
+    {
+      dimension: 'text_input',
+      id: 1,
+      spec: {},
+      tier_end: '100',
+      tier_start: '0'
+    },
+    {
+      dimension: 'text_output',
+      id: 2,
+      spec: {},
+      tier_end: '100',
+      tier_start: '0'
+    },
+    {
+      dimension: 'cache_input',
+      id: 3,
+      spec: {},
+      tier_end: '100',
+      tier_start: '0'
+    }
+  ]
+
+  assert.deepEqual(
+    selectPreferredChannelPriceItems(items).map((item) => item.id),
+    [1, 2, 3]
+  )
+})
+
+test('builds one shared card for each aligned input output and cache tier', () => {
+  const cards = buildResaleTierCards({
+    cache: [
+      { end: '100', flat: false, price: '0.1', start: '0' },
+      { end: null, flat: false, price: '0.2', start: '100' }
+    ],
+    input: [
+      { end: '100', flat: false, price: '1', start: '0' },
+      { end: null, flat: false, price: '2', start: '100' }
+    ],
+    output: [
+      { end: '100', flat: false, price: '3', start: '0' },
+      { end: null, flat: false, price: '4', start: '100' }
+    ]
+  })
+
+  assert.deepEqual(cards, [
+    {
+      end: '100',
+      flat: false,
+      prices: { cache: '0.1', input: '1', output: '3' },
+      start: '0'
+    },
+    {
+      end: null,
+      flat: false,
+      prices: { cache: '0.2', input: '2', output: '4' },
+      start: '100'
+    }
+  ])
+})
+
+test('uses the union of dimension boundaries in the shared tier cards', () => {
+  const cards = buildResaleTierCards({
+    cache: [
+      { end: '200', flat: false, price: '0.1', start: '0' },
+      { end: null, flat: false, price: '0.2', start: '200' }
+    ],
+    input: [
+      { end: '100', flat: false, price: '1', start: '0' },
+      { end: null, flat: false, price: '2', start: '100' }
+    ],
+    output: [{ end: null, flat: true, price: '3', start: null }]
+  })
+
+  assert.deepEqual(
+    cards.map((card) => [card.start, card.end, card.prices]),
+    [
+      ['0', '100', { cache: '0.1', input: '1', output: '3' }],
+      ['100', '200', { cache: '0.1', input: '2', output: '3' }],
+      ['200', null, { cache: '0.2', input: '2', output: '3' }]
+    ]
+  )
+})
+
+test('adds edits and removes shared tiers across all price dimensions', () => {
+  const flatCards = buildResaleTierCards({
+    cache: [{ end: null, flat: true, price: '0.1', start: null }],
+    input: [{ end: null, flat: true, price: '1', start: null }],
+    output: [{ end: null, flat: true, price: '3', start: null }]
+  })
+  const added = addResaleTierCard(flatCards)
+  const updated = updateResaleTierCard(added, 0, 'end', '250')
+  const removed = removeResaleTierCard(updated, 0)
+  const draft = buildResaleTierDraftFromCards(removed)
+
+  assert.deepEqual(
+    added.map((card) => [card.start, card.end]),
+    [
+      ['0', '1000000'],
+      ['1000000', null]
+    ]
+  )
+  assert.deepEqual(
+    updated.map((card) => [card.start, card.end]),
+    [
+      ['0', '250'],
+      ['250', null]
+    ]
+  )
+  assert.deepEqual(draft, {
+    cache: [{ end: null, flat: false, price: '0.1', start: '0' }],
+    input: [{ end: null, flat: false, price: '1', start: '0' }],
+    output: [{ end: null, flat: false, price: '3', start: '0' }]
+  })
 })

--- a/frontend/tests/llmOpsResaleTierDraft.test.js
+++ b/frontend/tests/llmOpsResaleTierDraft.test.js
@@ -371,3 +371,30 @@ test('adds edits and removes shared tiers across all price dimensions', () => {
     output: [{ end: null, flat: false, price: '3', start: '0' }]
   })
 })
+
+test('rejects shared boundaries that would collapse adjacent tiers', () => {
+  const cards = [
+    {
+      end: '100',
+      flat: false,
+      prices: { cache: '0.1', input: '1', output: '3' },
+      start: '0'
+    },
+    {
+      end: '200',
+      flat: false,
+      prices: { cache: '0.2', input: '2', output: '4' },
+      start: '100'
+    },
+    {
+      end: null,
+      flat: false,
+      prices: { cache: '0.3', input: '3', output: '5' },
+      start: '200'
+    }
+  ]
+
+  assert.deepEqual(updateResaleTierCard(cards, 0, 'end', ''), cards)
+  assert.deepEqual(updateResaleTierCard(cards, 0, 'end', '0'), cards)
+  assert.deepEqual(updateResaleTierCard(cards, 0, 'end', '200'), cards)
+})


### PR DESCRIPTION
## Summary

- 过滤旧多 spec 渠道价格项，只选择一套完整 coherent variant，避免重复阶梯
- 参考 AGIOne 发布模型页面，将 Input、Output、Cache 合并为共享 Token 区间阶梯卡片
- 恢复阶梯新增、删除、边界编辑、折叠和用户端预览
- 保持相邻区间连续，并拒绝会使相邻阶梯坍缩的非法边界

Closes #258

## Test plan

- [x] 前端 110 项单元测试通过
- [x] Vue typecheck 通过
- [x] 定向 ESLint 通过
- [x] Vite 生产构建通过
- [x] ego-browser task space 1 验证新增、删除、边界联动和折叠
- [x] ego-browser 390px 验证价格输入纵向排列且无横向溢出
- [x] 浏览器验收未捕获控制台异常
