### PR TITLE
支持来源模型阶梯价格录入与同步

### DIFF
--- a/backend/llm_ops/serializers.py
+++ b/backend/llm_ops/serializers.py
@@ -44,6 +44,7 @@ from .price_table_validation import (
     PriceTableValidationError,
     price_table_variant_key,
     validate_price_table,
+    validate_price_table_groups,
 )
 from .services import (
     SUPPORTED_DISPLAY_CURRENCIES,
@@ -2052,6 +2053,42 @@ class YunceCollectionRequestSerializer(serializers.Serializer):
     base_url = serializers.URLField(required=False)
 
 
+class ManualPriceItemInputSerializer(serializers.Serializer):
+    """Validate one normalized source price item from manual entry."""
+
+    dimension = serializers.ChoiceField(
+        choices=ModelPriceItem.DIMENSION_CHOICES,
+    )
+    billing_unit = serializers.ChoiceField(
+        choices=ModelPriceItem.BILLING_UNIT_CHOICES,
+    )
+    unit_price = serializers.DecimalField(
+        max_digits=14,
+        decimal_places=6,
+        min_value=Decimal("0"),
+    )
+    tier_type = serializers.ChoiceField(
+        choices=(
+            ModelPriceItem.TIER_FLAT,
+            ModelPriceItem.TIER_USAGE_RANGE,
+        ),
+        default=ModelPriceItem.TIER_FLAT,
+    )
+    tier_start = serializers.DecimalField(
+        max_digits=18,
+        decimal_places=6,
+        allow_null=True,
+        required=False,
+    )
+    tier_end = serializers.DecimalField(
+        max_digits=18,
+        decimal_places=6,
+        allow_null=True,
+        required=False,
+    )
+    spec = serializers.JSONField(required=False, default=dict)
+
+
 class ManualPriceImportRowSerializer(serializers.Serializer):
     """Validate one manually imported model pricing row."""
 
@@ -2116,6 +2153,10 @@ class ManualPriceImportRowSerializer(serializers.Serializer):
         required=False,
         allow_null=True,
     )
+    price_items = ManualPriceItemInputSerializer(
+        many=True,
+        required=False,
+    )
 
     def validate_currency(self, value):
         return validate_currency_code(value, required=False)
@@ -2132,7 +2173,37 @@ class ManualPriceImportRowSerializer(serializers.Serializer):
             "video_output_price_per_second",
         )
         validate_non_negative_prices(attrs, price_fields)
-        if not any(attrs.get(field) is not None for field in price_fields):
+        has_legacy_prices = any(
+            attrs.get(field) is not None for field in price_fields
+        )
+        price_items = attrs.get("price_items") or []
+        if has_legacy_prices and price_items:
+            raise serializers.ValidationError(
+                {
+                    "price_items": (
+                        "Cannot combine price_items with legacy price fields."
+                    )
+                }
+            )
+        if price_items:
+            try:
+                validate_price_table_groups(price_items)
+            except PriceTableValidationError as exc:
+                raise serializers.ValidationError(
+                    {
+                        "price_items": {
+                            "code": serializers.ErrorDetail(
+                                exc.code,
+                                code=exc.code,
+                            ),
+                            "message": serializers.ErrorDetail(
+                                exc.message,
+                                code=exc.code,
+                            ),
+                        }
+                    }
+                ) from exc
+        if not has_legacy_prices and not price_items:
             raise serializers.ValidationError(
                 "At least one price field is required."
             )

--- a/backend/llm_ops/services.py
+++ b/backend/llm_ops/services.py
@@ -941,40 +941,18 @@ def sync_manual_model_price_items(
     """Replace current manual price items for one model/source pair."""
     currency = normalize_currency(row.get("currency") or default_currency)
     now = timezone.now()
-    payloads = []
-    for field, (dimension, billing_unit) in MANUAL_MODEL_PRICE_FIELDS.items():
-        if field not in row or row.get(field) is None:
-            continue
-        payloads.append(
-            {
-                "provider": provider,
-                "model": model,
-                "meta_model": model.meta_model,
-                "source": source,
-                "price_role": price_role_for_source(
-                    source,
-                    meta_model=model.meta_model,
-                ),
-                "dimension": dimension,
-                "billing_unit": billing_unit,
-                "currency": currency,
-                "unit_price": row[field],
-                "tier_type": ModelPriceItem.TIER_FLAT,
-                "tier_start": None,
-                "tier_end": None,
-                "spec": {
-                    "import_mode": "manual_table",
-                    "row_index": row_index,
-                    "source_field": field,
-                },
-                "source_url": row.get("source_url") or source.endpoint_url,
-                "raw_payload": json_safe_payload(row),
-                "is_current": True,
-            }
-        )
+    payloads = manual_model_price_item_payloads(
+        source=source,
+        provider=provider,
+        model=model,
+        row=row,
+        row_index=row_index,
+        currency=currency,
+    )
     if not payloads:
         return {"current_items": [], "deactivated_item_ids": []}
 
+    validate_price_table_groups(payloads)
     current_queryset = ModelPriceItem.objects.filter(
         model=model,
         source=source,
@@ -993,8 +971,16 @@ def sync_manual_model_price_items(
                     "currency": payload["currency"],
                     "unit_price": str(payload["unit_price"]),
                     "tier_type": payload["tier_type"],
-                    "tier_start": "",
-                    "tier_end": "",
+                    "tier_start": (
+                        str(payload["tier_start"])
+                        if payload["tier_start"] is not None
+                        else ""
+                    ),
+                    "tier_end": (
+                        str(payload["tier_end"])
+                        if payload["tier_end"] is not None
+                        else ""
+                    ),
                     "spec": payload["spec"],
                 }
             )
@@ -1028,6 +1014,92 @@ def sync_manual_model_price_items(
     return {
         "current_items": current_items,
         "deactivated_item_ids": sorted(old_current_ids - current_item_ids),
+    }
+
+
+def manual_model_price_item_payloads(
+    *,
+    source: PriceCollectionSource,
+    provider: LLMProvider,
+    model: LLMModel,
+    row: dict,
+    row_index: int,
+    currency: str,
+) -> list[dict]:
+    """Build normalized manual item payloads from new or legacy inputs."""
+    normalized_items = row.get("price_items") or []
+    if normalized_items:
+        return [
+            manual_model_price_item_payload(
+                source=source,
+                provider=provider,
+                model=model,
+                row=row,
+                currency=currency,
+                item=item,
+            )
+            for item in normalized_items
+        ]
+
+    payloads = []
+    for field, (dimension, billing_unit) in MANUAL_MODEL_PRICE_FIELDS.items():
+        if field not in row or row.get(field) is None:
+            continue
+        payloads.append(
+            manual_model_price_item_payload(
+                source=source,
+                provider=provider,
+                model=model,
+                row=row,
+                currency=currency,
+                item={
+                    "dimension": dimension,
+                    "billing_unit": billing_unit,
+                    "unit_price": row[field],
+                    "tier_type": ModelPriceItem.TIER_FLAT,
+                    "tier_start": None,
+                    "tier_end": None,
+                    "spec": {
+                        "import_mode": "manual_table",
+                        "row_index": row_index,
+                        "source_field": field,
+                    },
+                },
+            )
+        )
+    return payloads
+
+
+def manual_model_price_item_payload(
+    *,
+    source: PriceCollectionSource,
+    provider: LLMProvider,
+    model: LLMModel,
+    row: dict,
+    currency: str,
+    item: dict,
+) -> dict:
+    """Add common persistence metadata to one manual normalized item."""
+    return {
+        "provider": provider,
+        "model": model,
+        "meta_model": model.meta_model,
+        "source": source,
+        "price_role": price_role_for_source(
+            source,
+            meta_model=model.meta_model,
+        ),
+        "dimension": item["dimension"],
+        "billing_unit": item["billing_unit"],
+        "currency": currency,
+        "unit_price": item["unit_price"],
+        "tier_type": item.get("tier_type") or ModelPriceItem.TIER_FLAT,
+        "tier_start": item.get("tier_start"),
+        "tier_end": item.get("tier_end"),
+        "spec": item.get("spec") or {},
+        "source_url": row.get("source_url") or source.endpoint_url,
+        "raw_payload": json_safe_payload(row),
+        "is_current": True,
     }
 
 

--- a/backend/llm_ops/tests/test_google_price_collector.py
+++ b/backend/llm_ops/tests/test_google_price_collector.py
@@ -1,7 +1,20 @@
-from django.test import SimpleTestCase
+from decimal import Decimal
 
+from django.test import SimpleTestCase, TestCase
+
+from llm_ops.collection_services import (
+    sync_model_price_items,
+    upsert_collected_offering,
+)
+from llm_ops.models import (
+    LLMProvider,
+    MetaModel,
+    ModelPriceItem,
+    PriceCollectionSource,
+)
 from llm_ops.price_collectors import collect_vendor_price_catalog
 from llm_ops.price_collectors.parsers.google import extract_models
+from llm_ops.skill_runner import standard_catalog_to_collected_catalog
 
 
 GOOGLE_PRICING_HTML = """
@@ -123,3 +136,76 @@ class GooglePriceCatalogCollectorTests(SimpleTestCase):
             payload["models"][0]["model_id"],
             "gemini-2.0-flash",
         )
+
+
+class GooglePriceCatalogPersistenceTests(TestCase):
+    def test_standard_context_tiers_persist_as_usage_ranges(self):
+        provider = LLMProvider.objects.create(
+            name="Google",
+            code="google",
+        )
+        source = PriceCollectionSource.objects.create(
+            name="Google Gemini Official",
+            slug="google-official",
+            provider=provider,
+            source_category=(
+                PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
+            ),
+            endpoint_url="https://example.com/google-pricing",
+            currency="USD",
+            is_enabled=True,
+            updates_model_prices=True,
+        )
+        meta_model = MetaModel.objects.create(
+            code="gemini-2.5-pro",
+            name="Gemini 2.5 Pro",
+            owner_code="google",
+            owner_name="Google",
+        )
+        payload = collect_vendor_price_catalog(
+            "google",
+            {
+                "raw_html": GOOGLE_PRICING_HTML,
+                "source_url": source.endpoint_url,
+                "provider_name": provider.name,
+                "model_codes": [meta_model.code],
+            },
+        )
+        item = standard_catalog_to_collected_catalog(payload).models[0]
+        offering, _ = upsert_collected_offering(
+            item,
+            source=source,
+            source_url=source.endpoint_url,
+            meta_model=meta_model,
+        )
+
+        price_items = sync_model_price_items(
+            item,
+            source=source,
+            offering=offering,
+            source_url=source.endpoint_url,
+        )
+
+        input_items = sorted(
+            (
+                price_item
+                for price_item in price_items
+                if price_item.dimension
+                == ModelPriceItem.DIMENSION_TEXT_INPUT
+            ),
+            key=lambda price_item: price_item.tier_start,
+        )
+        self.assertEqual(len(input_items), 2)
+        self.assertEqual(
+            [price_item.tier_type for price_item in input_items],
+            [
+                ModelPriceItem.TIER_USAGE_RANGE,
+                ModelPriceItem.TIER_USAGE_RANGE,
+            ],
+        )
+        self.assertEqual(input_items[0].tier_start, Decimal("0"))
+        self.assertEqual(input_items[0].tier_end, Decimal("200000"))
+        self.assertEqual(input_items[0].unit_price, Decimal("1.25"))
+        self.assertEqual(input_items[1].tier_start, Decimal("200000"))
+        self.assertIsNone(input_items[1].tier_end)
+        self.assertEqual(input_items[1].unit_price, Decimal("2.50"))

--- a/backend/llm_ops/tests/test_serializers.py
+++ b/backend/llm_ops/tests/test_serializers.py
@@ -18,6 +18,7 @@ from llm_ops.models import (
     ResalePlatform,
     SourceSkuOffering,
 )
+from llm_ops.price_table_validation import usage_range_spec
 from llm_ops.serializers import (
     LLMModelSerializer,
     LLMOpsGlobalConfigSerializer,
@@ -646,6 +647,105 @@ class LLMModelSerializerTests(TestCase):
 
 
 class ManualPriceImportRequestSerializerTests(TestCase):
+    def test_accepts_normalized_usage_range_price_items(self):
+        provider = LLMProvider.objects.create(
+            name="DeepSeek",
+            code="deepseek",
+        )
+        serializer = ManualPriceImportRequestSerializer(
+            data={
+                "provider": provider.id,
+                "source_name": "Manual Tier Sheet",
+                "currency": "CNY",
+                "rows": [
+                    {
+                        "model_code": "deepseek-v4",
+                        "price_items": self.usage_range_items(),
+                    }
+                ],
+            }
+        )
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        items = serializer.validated_data["rows"][0]["price_items"]
+        self.assertEqual(items[0]["unit_price"], Decimal("1.250000"))
+
+    def test_rejects_manual_price_items_with_a_gap(self):
+        provider = LLMProvider.objects.create(
+            name="DeepSeek",
+            code="deepseek",
+        )
+        items = self.usage_range_items()
+        items[1]["tier_start"] = "256000"
+        serializer = ManualPriceImportRequestSerializer(
+            data={
+                "provider": provider.id,
+                "source_name": "Manual Tier Sheet",
+                "rows": [
+                    {
+                        "model_code": "deepseek-v4",
+                        "price_items": items,
+                    }
+                ],
+            }
+        )
+
+        self.assertFalse(serializer.is_valid())
+        error = serializer.errors["rows"][0]["price_items"]["code"]
+        self.assertEqual(str(error), "price_table_gap")
+
+    def test_rejects_mixed_legacy_and_normalized_manual_prices(self):
+        provider = LLMProvider.objects.create(
+            name="DeepSeek",
+            code="deepseek",
+        )
+        serializer = ManualPriceImportRequestSerializer(
+            data={
+                "provider": provider.id,
+                "source_name": "Manual Tier Sheet",
+                "rows": [
+                    {
+                        "model_code": "deepseek-v4",
+                        "input_price_per_million": "1.25",
+                        "price_items": [
+                            {
+                                "dimension": "text_input",
+                                "billing_unit": "per_1m_tokens",
+                                "unit_price": "1.25",
+                                "tier_type": "flat",
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("price_items", serializer.errors["rows"][0])
+
+    @staticmethod
+    def usage_range_items():
+        return [
+            {
+                "dimension": "text_input",
+                "billing_unit": "per_1m_tokens",
+                "unit_price": "1.25",
+                "tier_type": "usage_range",
+                "tier_start": "0",
+                "tier_end": "128000",
+                "spec": usage_range_spec(),
+            },
+            {
+                "dimension": "text_input",
+                "billing_unit": "per_1m_tokens",
+                "unit_price": "2.50",
+                "tier_type": "usage_range",
+                "tier_start": "128000",
+                "tier_end": None,
+                "spec": usage_range_spec(),
+            },
+        ]
+
     def test_accepts_model_provider_different_from_source_provider(self):
         source_provider = LLMProvider.objects.create(
             name="Alibaba Cloud",

--- a/backend/llm_ops/tests/test_services.py
+++ b/backend/llm_ops/tests/test_services.py
@@ -1163,6 +1163,89 @@ class LLMOpsPricingServiceTests(TestCase):
         self.assertEqual(item.model, self.model)
         self.assertEqual(item.dimension, ModelPriceItem.DIMENSION_TEXT_INPUT)
 
+    def test_manual_import_persists_and_resyncs_usage_range_items(self):
+        source = PriceCollectionSource.objects.create(
+            provider=self.provider,
+            name="Supplier Tier Sheet",
+            slug="supplier-tier-sheet",
+            source_category=PriceCollectionSource.SOURCE_CATEGORY_SUPPLIER,
+            currency="USD",
+            updates_model_prices=False,
+        )
+        price = ChannelModelPrice.objects.create(
+            channel=self.channel,
+            model=self.model,
+            price_source=source,
+            settlement_ratio=Decimal("0.8"),
+        )
+        tier_spec = usage_range_spec()
+        rows = []
+        for dimension, first, second in (
+            ("text_input", "1", "2"),
+            ("text_output", "3", "4"),
+            ("cache_input", "0.5", "1"),
+        ):
+            rows.extend(
+                [
+                    {
+                        "dimension": dimension,
+                        "billing_unit": "per_1m_tokens",
+                        "unit_price": Decimal(first),
+                        "tier_type": "usage_range",
+                        "tier_start": Decimal("0"),
+                        "tier_end": Decimal("128000"),
+                        "spec": tier_spec,
+                    },
+                    {
+                        "dimension": dimension,
+                        "billing_unit": "per_1m_tokens",
+                        "unit_price": Decimal(second),
+                        "tier_type": "usage_range",
+                        "tier_start": Decimal("128000"),
+                        "tier_end": None,
+                        "spec": tier_spec,
+                    },
+                ]
+            )
+
+        result = import_manual_model_prices(
+            source=source,
+            provider=self.provider,
+            rows=[
+                {
+                    "model_code": "gpt-4o",
+                    "model_name": "GPT-4o",
+                    "currency": "USD",
+                    "price_items": rows,
+                }
+            ],
+            default_currency="USD",
+            updates_model_prices=False,
+        )
+
+        source_items = ModelPriceItem.objects.filter(
+            source=source,
+            is_current=True,
+        ).order_by("dimension", "tier_start")
+        channel_items = ChannelPriceItem.objects.filter(
+            channel=price.channel,
+            model=price.model,
+            is_current=True,
+        ).order_by("dimension", "tier_start")
+        self.assertEqual(source_items.count(), 6)
+        self.assertEqual(channel_items.count(), 6)
+        self.assertEqual(
+            list(source_items.values_list("tier_start", "tier_end"))[:2],
+            [
+                (Decimal("0"), Decimal("128000")),
+                (Decimal("128000"), None),
+            ],
+        )
+        self.assertEqual(
+            result["channel_price_sync"]["channel_model_prices"],
+            1,
+        )
+
     def test_manual_import_reports_incremental_refresh_records(self):
         source = PriceCollectionSource.objects.create(
             provider=self.provider,

--- a/backend/llm_ops/tests/test_views.py
+++ b/backend/llm_ops/tests/test_views.py
@@ -30,6 +30,7 @@ from llm_ops.models import (
     UsageReconciliationRecord,
 )
 from llm_ops.services import sync_channel_price_items
+from llm_ops.price_table_validation import usage_range_spec
 
 
 class LLMOpsViewTests(TestCase):
@@ -864,6 +865,61 @@ class LLMOpsViewTests(TestCase):
             AuditLog.objects.filter(target_id=str(source.id)).count(),
             1,
         )
+
+    @patch("llm_ops.views.import_manual_model_prices")
+    def test_manual_price_import_passes_normalized_tiers(self, mock_import):
+        provider = LLMProvider.objects.create(name="OpenAI", code="openai")
+        source = PriceCollectionSource.objects.create(
+            name="OpenAI Manual Tier Sheet",
+            slug="openai-manual-tier-sheet",
+            provider=provider,
+            source_category=PriceCollectionSource.SOURCE_CATEGORY_MANUAL,
+            currency="USD",
+        )
+        mock_import.return_value = {
+            "created_models": 0,
+            "updated_models": 1,
+            "created_price_items": 2,
+        }
+
+        response = self.client.post(
+            reverse("llm-ops-manual-price-import"),
+            {
+                "source": source.id,
+                "rows": [
+                    {
+                        "model_code": "gpt-5",
+                        "price_items": [
+                            {
+                                "dimension": "text_input",
+                                "billing_unit": "per_1m_tokens",
+                                "unit_price": "1",
+                                "tier_type": "usage_range",
+                                "tier_start": "0",
+                                "tier_end": "128000",
+                                "spec": usage_range_spec(),
+                            },
+                            {
+                                "dimension": "text_input",
+                                "billing_unit": "per_1m_tokens",
+                                "unit_price": "2",
+                                "tier_type": "usage_range",
+                                "tier_start": "128000",
+                                "tier_end": None,
+                                "spec": usage_range_spec(),
+                            },
+                        ],
+                    }
+                ],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200, response.data)
+        _, kwargs = mock_import.call_args
+        items = kwargs["rows"][0]["price_items"]
+        self.assertEqual(items[0]["tier_start"], Decimal("0"))
+        self.assertEqual(items[1]["tier_end"], None)
 
     @patch("llm_ops.views.import_manual_model_prices")
     def test_manual_price_import_accepts_source_without_provider(

--- a/docs/superpowers/plans/2026-08-12-llm-ops-source-tier-pricing.md
+++ b/docs/superpowers/plans/2026-08-12-llm-ops-source-tier-pricing.md
@@ -1,0 +1,32 @@
+# LLM Ops 来源阶梯价格实施计划
+
+- [x] 扩展手工录价 API 的标准 `price_items` 契约。
+  - 验收：旧标量请求继续通过，合法 usage-range 通过，非法表返回字段错误。
+  - 验证：Serializer 红绿测试。
+  - 文件：`serializers.py`、`test_serializers.py`。
+
+- [x] 让手工录价服务持久化并原子替换标准 flat/阶梯项。
+  - 验收：完整保存三维阶梯，fingerprint/历史关闭正确，渠道同步保留边界。
+  - 验证：Service 与 API 集成测试。
+  - 文件：`services.py`、`test_services.py`、`test_views.py`。
+
+- [x] 加固外部来源阶梯采集契约。
+  - 验收：阿里云、Google、SiliconFlow 的区间从解析结果贯穿至
+    `ModelPriceItem`；没有区间的来源保持 flat。
+  - 验证：采集器和 source collector 定向测试。
+  - 文件：相关 parser、`collection_services.py` 及其测试。
+
+- [x] 实现手工录价共享阶梯编辑体验。
+  - 验收：从挂售编辑器抽取共享基础阶梯组件；手工录价和挂售复用同一
+    卡片、字段布局、边界联动、增删/折叠交互及响应式样式；挂售专属利润
+    预览和审批能力保持在组合层。
+  - 验证：前端单测、typecheck、ESLint、生产构建。
+  - 文件：`ManualPriceEntryModal.vue`、`ResaleTierEditor.vue`、
+    `ResaleTierCard.vue`、共享组件/工具、locale 和测试。
+
+- [ ] 完成跨层回归与浏览器验收。
+  - 验收：桌面与 320px 下对照两个入口，基础阶梯卡片的结构、样式和交互
+    一致；完成录入保存后刷新，来源价格区间仍正确，网络和控制台无新错误。
+  - 验证：完整定向测试与 `ego-browser` task space 记录。
+  - 当前：自动化回归已通过；`ego-browser` task space 17 等待本地登录后
+    继续桌面与 320px 验收。

--- a/docs/superpowers/specs/2026-08-12-llm-ops-source-tier-pricing-design.md
+++ b/docs/superpowers/specs/2026-08-12-llm-ops-source-tier-pricing-design.md
@@ -1,0 +1,178 @@
+# LLM Ops 来源阶梯价格规格
+
+## 目标
+
+让 LLM Ops 的来源价格统一支持固定单价和请求级 Token 阶梯价：
+
+- 运营人员可以在“手动录入模型价格”中选择固定单价或阶梯价格，并维护
+  Input、Output、Cache 三个 Token 维度的共享连续区间。
+- 阿里云、Google、SiliconFlow 等官方或供应商采集器返回的 Token 区间
+  必须保留为标准化阶梯项，不得在快照、当前价、渠道同步或挂售链路中
+  折叠成固定单价。
+- 图片、音频和视频规格价继续使用现有 fixed/flat 价格项，不在本次范围内
+  引入用量阶梯。
+
+## 假设与兼容边界
+
+1. 阶梯指标沿用现有契约：单次请求的输入 Token 数；区间为左闭右开
+   `[tier_start, tier_end)`，最后一档可以无上界。
+2. 阶梯采用 matched-tier 计价，不实现累计用量 volume/graduated 计价。
+3. 手工录价 API 保留现有标量字段；新增可选 `price_items`。旧调用方不需
+   修改，后端会把旧字段转换为 flat 标准项。
+4. 同一次手工录入不能混合标量字段与 `price_items`，避免两套价格互相
+   覆盖。
+5. 外部采集器只保存来源实际给出的区间，不推断或虚构来源未声明的阶梯。
+
+## API 契约
+
+`POST /api/v1/llm-ops/manual-price-import/` 的每个 `rows[]` 新增：
+
+```json
+{
+  "model_code": "qwen-plus",
+  "model_name": "Qwen Plus",
+  "currency": "CNY",
+  "price_items": [
+    {
+      "dimension": "text_input",
+      "billing_unit": "per_1m_tokens",
+      "unit_price": "0.8",
+      "tier_type": "usage_range",
+      "tier_start": "0",
+      "tier_end": "128000",
+      "spec": {
+        "tier_metric": "request_input_tokens",
+        "tier_charge_mode": "matched_tier",
+        "aggregation_period": "request"
+      }
+    }
+  ]
+}
+```
+
+边界校验：
+
+- `dimension` 仅允许 `ModelPriceItem.DIMENSION_CHOICES`。
+- `billing_unit` 仅允许 `ModelPriceItem.BILLING_UNIT_CHOICES`。
+- `tier_type` 当前允许 `flat`、`usage_range`；`volume` 继续拒绝。
+- `unit_price` 和边界必须非负。
+- flat 项不得设置边界；usage-range 项必须满足共享价格表契约。
+- 后端以 `dimension + variant spec` 分组执行
+  `validate_price_table_groups`，拒绝缺口、重叠、重复区间和不连续尾档。
+- API 错误继续使用 DRF 字段错误格式，并包含共享契约的机器错误码。
+
+## 采集与持久化
+
+外部平台沿用现有标准目录中的 `price_rows[].values`：
+
+- `input_token_range` 对应 Input 和 Cache 的阶梯边界。
+- `output_token_range` 对应 Output 的阶梯边界。
+- `deployment_scope`、`region`、`market` 等保留在 `spec`，用于区分独立
+  价格变体。
+- `sync_model_price_items` 在写入前校验完整价格表，然后以包含阶梯边界和
+  `spec` 的 fingerprint 进行版本替换。
+
+阿里云、Google、SiliconFlow 已有区间解析能力，本次需要用端到端测试把
+“解析 → 标准目录 → 快照 → ModelPriceItem → 渠道同步”固定为契约。
+其他采集器若后续产出相同区间字段，将自动获得相同行为。
+
+## 前端交互
+
+手工录价弹窗的 Token 价格区域提供“固定单价 / 阶梯价格”切换：
+
+- 固定单价保持现有字段和交互。
+- 阶梯价格必须与挂售工作台下方的编辑样式和操作保持统一：复用同一套
+  阶梯卡片、展开/折叠、阶梯编号、Token 区间、Input/Output/Cache 三列、
+  新增/删除按钮、错误态、焦点态和移动端布局，不另做一套相似样式。
+- 一个区间同时录入 Input、Output、Cache，空价格代表该维度不产生该档
+  价格项。
+- 第一档固定从 0 开始；修改某档结束值时，下一档开始值同步更新。
+- 可以新增和删除区间；最后一档结束为空表示 `∞`。
+- 保存前在客户端执行价格、边界、连续性校验；服务端仍为最终校验边界。
+- 桌面和 320px 移动端均可操作，所有按钮和输入框具备可访问标签。
+
+### 组件复用边界
+
+- 将现有 `ResaleTierEditor` 中无业务属性的阶梯区间编辑部分抽为共享组件，
+  并继续复用 `ResaleTierCard` 与共享草稿转换/边界联动工具。
+- 手工录价直接组合共享区间编辑组件。
+- 挂售编辑继续组合同一个共享区间编辑组件，并在其下保留挂售专属的客户
+  预览、利润预览、审批快照比较和上游边界锁定。
+- 抽取完成后，两个入口的基础卡片 DOM、Tailwind class、交互事件和响应式
+  断点来自同一实现，避免仅复制视觉样式造成后续分叉。
+
+## 项目结构
+
+- `backend/llm_ops/serializers.py`：手工标准价格项输入契约。
+- `backend/llm_ops/services.py`：兼容标量转换、价格表校验与持久化。
+- `backend/llm_ops/collection_services.py`、`price_collectors/parsers/`：
+  外部来源区间归一化和持久化保障。
+- `frontend/src/components/llm-ops/ManualPriceEntryModal.vue`：录价模式。
+- `frontend/src/components/llm-ops/`：从 `ResaleTierEditor` 抽取无挂售业务
+  属性的共享阶梯编辑组件，并复用 `ResaleTierCard`。
+- `frontend/src/utils/`：复用阶梯卡片、连续边界与标准价格项转换逻辑。
+- 后端测试位于 `backend/llm_ops/tests/`；前端单测与组件/工具相邻。
+
+## 代码规范
+
+后端沿用现有 79 字符行宽、英文 docstring/注释和三段式绝对导入。输入
+在 Serializer 边界校验，服务层只消费经过校验的标准项。例如：
+
+```python
+validate_price_table_groups(price_items)
+payloads = build_manual_price_item_payloads(
+    source=source,
+    model=model,
+    rows=price_items,
+)
+```
+
+前端沿用 Vue 3 `<script setup>`、现有 LLM Ops 设计 token 与 i18n，不增加
+新的 UI 依赖。
+
+## 测试策略与命令
+
+- Serializer 单测：兼容旧 flat 输入；接受合法阶梯；拒绝混合、缺口、
+  重叠、非法边界和 volume。
+- Service/API 集成测试：一次录入完整保存三维阶梯，旧 current 项被安全
+  关闭，下游渠道同步保留边界。
+- 采集器测试：至少覆盖阿里云、Google、SiliconFlow 的区间解析与持久化。
+- 前端单测：草稿转换、连续边界、提交 payload 与校验。
+- 浏览器验收：使用 `ego-browser` 对照手工录价与挂售编辑两个入口，检查
+  卡片结构、间距、颜色、展开/折叠、增删区间、边界联动、保存、刷新后
+  来源价格展示，以及 320px 布局。
+
+```shell
+pytest backend/llm_ops/tests/test_serializers.py \
+  backend/llm_ops/tests/test_services.py \
+  backend/llm_ops/tests/test_source_collectors.py \
+  backend/llm_ops/tests/test_official_collector.py
+cd frontend && npm run test:unit
+cd frontend && npm run typecheck
+cd frontend && npm run build
+```
+
+## 边界
+
+- 始终执行：向后兼容旧请求；复用共享价格表校验；第三方响应按不可信输入
+  处理；变更后运行定向测试和构建。
+- 需要另行确认：新增累计 volume/graduated 计价；增加数据库字段或迁移；
+  修改正式外部平台账号或价格数据。
+- 禁止：把阶梯投影成一个最低/最高固定价；凭页面文案猜测未声明区间；
+  修改或删除已有 Playwright 项目文件。
+
+## 验收标准
+
+1. 手工录价可以保存、读取并展示 Input、Output、Cache 的连续阶梯价格。
+2. 旧固定单价 UI/API 行为保持兼容。
+3. 非法阶梯在前端和 API 均被拒绝，数据库不产生部分写入。
+4. 阿里云等来源返回的阶梯区间在标准目录、快照、当前价格项、渠道价格项
+   和挂售成本链路保持一致。
+5. 手工录价与挂售编辑复用同一个基础阶梯编辑实现；除挂售专属的预览、
+   审批和边界锁定外，两个入口的样式、字段布局和交互行为一致。
+6. 定向后端测试、前端单测、typecheck、构建和 ego-browser 验收通过。
+
+## 开放问题
+
+无阻塞问题。本规格默认“阿里云等平台”指所有能从可信来源解析出明确
+Token 区间的平台；不会为没有区间证据的平台制造阶梯。

--- a/frontend/src/components/llm-ops/ManualPriceEntryModal.vue
+++ b/frontend/src/components/llm-ops/ManualPriceEntryModal.vue
@@ -5,7 +5,7 @@
     @click.self="close"
   >
     <form
-      class="max-h-[calc(100vh-3rem)] w-full max-w-3xl overflow-hidden rounded-xl bg-white shadow-2xl"
+      class="max-h-[calc(100vh-3rem)] w-full max-w-5xl overflow-hidden rounded-xl bg-white shadow-2xl"
       @submit.prevent="submit"
     >
       <div class="modal-header">
@@ -169,9 +169,36 @@
             </label>
           </div>
 
-          <div class="price-grid">
+          <div v-if="supportsTokenPricing" class="mode-tabs mt-4">
+            <button
+              class="mode-tab"
+              :class="{ active: priceMode === 'flat' }"
+              type="button"
+              @click="setPriceMode('flat')"
+            >
+              {{ t('llmOps.manualPriceEntry.priceMode.flat') }}
+            </button>
+            <button
+              class="mode-tab"
+              :class="{ active: priceMode === 'tiered' }"
+              type="button"
+              @click="setPriceMode('tiered')"
+            >
+              {{ t('llmOps.manualPriceEntry.priceMode.tiered') }}
+            </button>
+          </div>
+
+          <TierPriceEditor
+            v-if="priceMode === 'tiered' && supportsTokenPricing"
+            v-model="tierDraft"
+            class="mt-4"
+            :currency="form.currency"
+            :errors="tierErrors"
+          />
+
+          <div v-if="visibleFlatPriceFields.length" class="price-grid">
             <label
-              v-for="field in activePriceFields"
+              v-for="field in visibleFlatPriceFields"
               :key="field.key"
               class="field-group"
             >
@@ -229,8 +256,16 @@ import { useI18n } from 'vue-i18n'
 import { llmOpsApi } from '@/api/llmOps'
 import { useToast } from '@/composables/useToast'
 import CompactSelect from '@/components/llm-ops/CompactSelect.vue'
+import TierPriceEditor from '@/components/llm-ops/TierPriceEditor.vue'
 import { userFacingApiError } from '@/utils/llmOpsErrors'
 import { resolveCanonicalMetaOwner } from '@/utils/llmOpsMeta'
+import {
+  addResaleTierCard,
+  buildManualPriceItems,
+  buildResaleTierCards,
+  buildResaleTierDraftFromCards,
+  validateManualPriceDraft
+} from '@/utils/resaleTierDraft'
 
 const props = defineProps({
   open: {
@@ -261,53 +296,71 @@ const { t } = useI18n()
 
 const saving = ref(false)
 const modelMode = ref('existing')
+const priceMode = ref('flat')
 const form = ref(defaults())
+const tierDraft = ref(defaultTierDraft())
 
 const priceFields = computed(() => [
   {
     key: 'input_price_per_million',
+    billingUnit: 'per_1m_tokens',
+    dimension: 'text_input',
     label: t('llmOps.manualPriceEntry.priceFields.textInput.label'),
     help: t('llmOps.manualPriceEntry.priceFields.textInput.help'),
     modalities: ['text', 'multimodal']
   },
   {
     key: 'output_price_per_million',
+    billingUnit: 'per_1m_tokens',
+    dimension: 'text_output',
     label: t('llmOps.manualPriceEntry.priceFields.textOutput.label'),
     help: t('llmOps.manualPriceEntry.priceFields.textOutput.help'),
     modalities: ['text', 'multimodal']
   },
   {
     key: 'cache_input_price_per_million',
+    billingUnit: 'per_1m_tokens',
+    dimension: 'cache_input',
     label: t('llmOps.manualPriceEntry.priceFields.cacheInput.label'),
     help: t('llmOps.manualPriceEntry.priceFields.cacheInput.help'),
     modalities: ['text', 'multimodal']
   },
   {
     key: 'image_output_price_per_image',
+    billingUnit: 'per_image',
+    dimension: 'image_output',
     label: t('llmOps.manualPriceEntry.priceFields.imageOutput.label'),
     help: t('llmOps.manualPriceEntry.priceFields.imageOutput.help'),
     modalities: ['multimodal']
   },
   {
     key: 'audio_input_price_per_second',
+    billingUnit: 'per_second',
+    dimension: 'audio_input',
     label: t('llmOps.manualPriceEntry.priceFields.audioInput.label'),
     help: t('llmOps.manualPriceEntry.priceFields.audioInput.help'),
     modalities: ['audio']
   },
   {
     key: 'audio_output_price_per_second',
+    billingUnit: 'per_second',
+    dimension: 'audio_output',
     label: t('llmOps.manualPriceEntry.priceFields.audioOutput.label'),
     help: t('llmOps.manualPriceEntry.priceFields.audioOutput.help'),
     modalities: ['audio']
   },
   {
     key: 'video_input_price_per_second',
+    billingUnit: 'per_second',
+    dimension: 'video_input',
     label: t('llmOps.manualPriceEntry.priceFields.videoInput.label'),
     help: t('llmOps.manualPriceEntry.priceFields.videoInput.help'),
     modalities: ['video']
   },
   {
     key: 'video_output_price_per_second',
+    billingUnit: 'per_second',
+    dimension: 'video_output',
     label: t('llmOps.manualPriceEntry.priceFields.videoOutput.label'),
     help: t('llmOps.manualPriceEntry.priceFields.videoOutput.help'),
     modalities: ['video']
@@ -382,6 +435,28 @@ const activePriceFields = computed(() =>
   )
 )
 
+const tokenPriceFieldKeys = new Set([
+  'input_price_per_million',
+  'output_price_per_million',
+  'cache_input_price_per_million'
+])
+
+const supportsTokenPricing = computed(() =>
+  ['text', 'multimodal'].includes(currentPriceModality.value)
+)
+
+const visibleFlatPriceFields = computed(() => {
+  if (priceMode.value === 'flat') return activePriceFields.value
+  return activePriceFields.value.filter(
+    (field) => !tokenPriceFieldKeys.has(field.key)
+  )
+})
+
+const tierErrors = computed(() => {
+  if (priceMode.value !== 'tiered') return {}
+  return translateTierErrors(validateManualPriceDraft(tierDraft.value))
+})
+
 const sourceCategoryLabel = computed(() => {
   const labels = {
     official_provider: t('llmOps.manualPriceEntry.categories.officialProvider'),
@@ -455,6 +530,9 @@ const validationMessage = computed(() => {
     }
   }
   if (!hasAnyPrice()) return t('llmOps.manualPriceEntry.validation.price')
+  if (priceMode.value === 'tiered' && Object.keys(tierErrors.value).length) {
+    return t('llmOps.manualPriceEntry.validation.tierTable')
+  }
   return ''
 })
 
@@ -463,12 +541,16 @@ watch(
   (open) => {
     if (open) {
       modelMode.value = isManualSource.value ? 'custom' : 'existing'
+      priceMode.value = 'flat'
       form.value = defaults()
+      tierDraft.value = defaultTierDraft()
     }
   }
 )
 
 watch(currentPriceModality, () => {
+  priceMode.value = 'flat'
+  tierDraft.value = defaultTierDraft()
   clearInactivePrices()
 })
 
@@ -487,6 +569,31 @@ function defaults() {
     video_input_price_per_second: '',
     video_output_price_per_second: ''
   }
+}
+
+function defaultTierDraft() {
+  return {
+    cache: [{ end: null, flat: true, price: '', start: null }],
+    input: [{ end: null, flat: true, price: '', start: null }],
+    output: [{ end: null, flat: true, price: '', start: null }]
+  }
+}
+
+function setPriceMode(mode) {
+  priceMode.value = mode
+  if (mode !== 'tiered') return
+  const flatDraft = {
+    cache: [flatTierRow(form.value.cache_input_price_per_million)],
+    input: [flatTierRow(form.value.input_price_per_million)],
+    output: [flatTierRow(form.value.output_price_per_million)]
+  }
+  tierDraft.value = buildResaleTierDraftFromCards(
+    addResaleTierCard(buildResaleTierCards(flatDraft))
+  )
+}
+
+function flatTierRow(price) {
+  return { end: null, flat: true, price: String(price || ''), start: null }
 }
 
 function close() {
@@ -560,6 +667,13 @@ function buildImportRow(model) {
   if (model.provider_name) {
     row.provider_name = model.provider_name
   }
+  if (priceMode.value === 'tiered' && supportsTokenPricing.value) {
+    row.price_items = [
+      ...buildManualPriceItems(tierDraft.value),
+      ...buildSupplementalPriceItems()
+    ]
+    return row
+  }
   activePriceFields.value.forEach((field) => {
     const value = normalizePrice(form.value[field.key])
     if (value !== null) row[field.key] = value
@@ -568,8 +682,55 @@ function buildImportRow(model) {
 }
 
 function hasAnyPrice() {
+  if (priceMode.value === 'tiered' && supportsTokenPricing.value) {
+    return (
+      buildManualPriceItems(tierDraft.value).length > 0 ||
+      buildSupplementalPriceItems().length > 0
+    )
+  }
   return activePriceFields.value.some(
     (field) => normalizePrice(form.value[field.key]) !== null
+  )
+}
+
+function buildSupplementalPriceItems() {
+  return visibleFlatPriceFields.value.flatMap((field) => {
+    const value = normalizePrice(form.value[field.key])
+    if (value === null) return []
+    return [
+      {
+        billing_unit: field.billingUnit,
+        dimension: field.dimension,
+        spec: {},
+        tier_end: null,
+        tier_start: null,
+        tier_type: 'flat',
+        unit_price: value
+      }
+    ]
+  })
+}
+
+function translateTierErrors(errors) {
+  const labels = {
+    'price_table.items_required': t('llmOps.manualPriceEntry.validation.price'),
+    'price_table.invalid_price': t(
+      'llmOps.manualPriceEntry.validation.invalidTierPrice'
+    ),
+    price_table_gap: t('llmOps.manualPriceEntry.validation.tierGap'),
+    price_table_invalid_boundary: t(
+      'llmOps.manualPriceEntry.validation.invalidTierBoundary'
+    ),
+    price_table_missing_terminal: t(
+      'llmOps.manualPriceEntry.validation.invalidTierBoundary'
+    ),
+    price_table_missing_zero_start: t(
+      'llmOps.manualPriceEntry.validation.tierZeroStart'
+    ),
+    price_table_overlap: t('llmOps.manualPriceEntry.validation.tierOverlap')
+  }
+  return Object.fromEntries(
+    Object.entries(errors).map(([key, value]) => [key, labels[value] || value])
   )
 }
 

--- a/frontend/src/components/llm-ops/ResaleTierEditor.vue
+++ b/frontend/src/components/llm-ops/ResaleTierEditor.vue
@@ -44,60 +44,14 @@
       </div>
     </div>
 
-    <div
-      class="mt-4 flex flex-wrap items-center justify-between gap-2 border-t border-slate-100 pt-4"
-    >
-      <div>
-        <h5 class="text-xs font-bold text-slate-800">
-          {{ t('llmOps.publishingWorkspace.tiers.priceEntry') }}
-        </h5>
-        <p class="mt-0.5 text-[11px] text-slate-500">
-          {{
-            boundariesLocked
-              ? t('llmOps.publishingWorkspace.tiers.upstreamHelp')
-              : t('llmOps.publishingWorkspace.tiers.continuityHelp')
-          }}
-        </p>
-      </div>
-      <span class="text-[11px] text-slate-400">
-        {{
-          t('llmOps.publishingWorkspace.tiers.cardCount', {
-            count: cards.length
-          })
-        }}
-      </span>
-    </div>
-
-    <div class="mt-3 space-y-2.5">
-      <ResaleTierCard
-        v-for="(card, index) in cards"
-        :key="index"
-        :can-remove="cards.length > 1"
-        :card="card"
-        :currency="currency"
-        :dimensions="dimensions"
-        :errors="errorsForCard(index)"
-        :expanded="expandedIndex === index"
-        :index="index"
-        :locked="boundariesLocked"
-        @remove="removeCard(index)"
-        @toggle="toggleCard(index)"
-        @update:end="updateCard(index, 'end', $event)"
-        @update:price="
-          (dimension, value) => updateCardPrice(index, dimension, value)
-        "
-      />
-    </div>
-
-    <button
-      v-if="!boundariesLocked"
-      type="button"
-      class="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-lg border border-dashed border-agione-300 bg-agione-50/40 px-3 py-2.5 text-xs font-bold text-agione-700 transition hover:border-agione-500 hover:bg-agione-50 focus:outline-none focus:ring-2 focus:ring-agione-200"
-      @click="addCard"
-    >
-      <Plus class="h-4 w-4" aria-hidden="true" />
-      {{ t('llmOps.publishingWorkspace.tiers.add') }}
-    </button>
+    <TierPriceEditor
+      class="mt-4"
+      :boundaries-locked="boundariesLocked"
+      :currency="currency"
+      :errors="errors"
+      :model-value="modelValue"
+      @update:model-value="$emit('update:modelValue', $event)"
+    />
 
     <section
       class="mt-4 rounded-lg border border-slate-200 bg-slate-50/70 p-3"
@@ -158,19 +112,13 @@
 </template>
 
 <script setup>
-import { computed, ref, watch } from 'vue'
-import { Eye, Plus, RefreshCw, SlidersHorizontal } from 'lucide-vue-next'
+import { computed } from 'vue'
+import { Eye, RefreshCw, SlidersHorizontal } from 'lucide-vue-next'
 import { useI18n } from 'vue-i18n'
 
-import ResaleTierCard from '@/components/llm-ops/ResaleTierCard.vue'
 import ResaleTierProfitPreview from '@/components/llm-ops/ResaleTierProfitPreview.vue'
-import {
-  addResaleTierCard,
-  buildResaleTierCards,
-  buildResaleTierDraftFromCards,
-  removeResaleTierCard,
-  updateResaleTierCard
-} from '@/utils/resaleTierDraft'
+import TierPriceEditor from '@/components/llm-ops/TierPriceEditor.vue'
+import { buildResaleTierCards } from '@/utils/resaleTierDraft'
 
 const props = defineProps({
   boundariesLocked: { type: Boolean, default: false },
@@ -183,9 +131,8 @@ const props = defineProps({
   previewLoading: { type: Boolean, default: false }
 })
 
-const emit = defineEmits(['preview', 'update:modelValue'])
+defineEmits(['preview', 'update:modelValue'])
 const { locale, t } = useI18n()
-const expandedIndex = ref(0)
 
 const dimensions = computed(() => [
   { key: 'input', label: 'llmOps.publishingWorkspace.metrics.input' },
@@ -193,56 +140,6 @@ const dimensions = computed(() => [
   { key: 'cache', label: 'llmOps.publishingWorkspace.metrics.cacheInput' }
 ])
 const cards = computed(() => buildResaleTierCards(props.modelValue))
-
-watch(
-  () => cards.value.length,
-  (length) => {
-    if (expandedIndex.value >= length)
-      expandedIndex.value = Math.max(0, length - 1)
-  }
-)
-
-function commitCards(nextCards) {
-  emit('update:modelValue', buildResaleTierDraftFromCards(nextCards))
-}
-
-function addCard() {
-  const nextCards = addResaleTierCard(cards.value)
-  expandedIndex.value = Math.max(0, nextCards.length - 1)
-  commitCards(nextCards)
-}
-
-function removeCard(index) {
-  commitCards(removeResaleTierCard(cards.value, index))
-}
-
-function toggleCard(index) {
-  expandedIndex.value = expandedIndex.value === index ? -1 : index
-}
-
-function updateCard(index, field, value) {
-  commitCards(updateResaleTierCard(cards.value, index, field, value))
-}
-
-function updateCardPrice(index, dimension, value) {
-  commitCards(updateResaleTierCard(cards.value, index, dimension, value))
-}
-
-function errorsForCard(index) {
-  const rangeError = dimensions.value
-    .map(
-      ({ key }) =>
-        props.errors?.[`${key}:${index}:end`] ||
-        props.errors?.[`${key}:${index}:start`]
-    )
-    .find(Boolean)
-  return {
-    cache: props.errors?.[`cache:${index}:price`] || '',
-    end: rangeError || '',
-    input: props.errors?.[`input:${index}:price`] || '',
-    output: props.errors?.[`output:${index}:price`] || ''
-  }
-}
 
 function formatUsage(value) {
   const amount = Number(value)

--- a/frontend/src/components/llm-ops/TierPriceEditor.vue
+++ b/frontend/src/components/llm-ops/TierPriceEditor.vue
@@ -1,0 +1,142 @@
+<template>
+  <div>
+    <div
+      class="flex flex-wrap items-center justify-between gap-2 border-t border-slate-100 pt-4"
+    >
+      <div>
+        <h5 class="text-xs font-bold text-slate-800">
+          {{ t('llmOps.publishingWorkspace.tiers.priceEntry') }}
+        </h5>
+        <p class="mt-0.5 text-[11px] text-slate-500">
+          {{
+            boundariesLocked
+              ? t('llmOps.publishingWorkspace.tiers.upstreamHelp')
+              : t('llmOps.publishingWorkspace.tiers.continuityHelp')
+          }}
+        </p>
+      </div>
+      <span class="text-[11px] text-slate-400">
+        {{
+          t('llmOps.publishingWorkspace.tiers.cardCount', {
+            count: cards.length
+          })
+        }}
+      </span>
+    </div>
+
+    <div class="mt-3 space-y-2.5">
+      <ResaleTierCard
+        v-for="(card, index) in cards"
+        :key="index"
+        :can-remove="cards.length > 1"
+        :card="card"
+        :currency="currency"
+        :dimensions="dimensions"
+        :errors="errorsForCard(index)"
+        :expanded="expandedIndex === index"
+        :index="index"
+        :locked="boundariesLocked"
+        @remove="removeCard(index)"
+        @toggle="toggleCard(index)"
+        @update:end="updateCard(index, 'end', $event)"
+        @update:price="
+          (dimension, value) => updateCardPrice(index, dimension, value)
+        "
+      />
+    </div>
+
+    <button
+      v-if="!boundariesLocked"
+      type="button"
+      class="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-lg border border-dashed border-agione-300 bg-agione-50/40 px-3 py-2.5 text-xs font-bold text-agione-700 transition hover:border-agione-500 hover:bg-agione-50 focus:outline-none focus:ring-2 focus:ring-agione-200"
+      @click="addCard"
+    >
+      <Plus class="h-4 w-4" aria-hidden="true" />
+      {{ t('llmOps.publishingWorkspace.tiers.add') }}
+    </button>
+  </div>
+</template>
+
+<script setup>
+import { computed, ref, watch } from 'vue'
+import { Plus } from 'lucide-vue-next'
+import { useI18n } from 'vue-i18n'
+
+import ResaleTierCard from '@/components/llm-ops/ResaleTierCard.vue'
+import {
+  addResaleTierCard,
+  buildResaleTierCards,
+  buildResaleTierDraftFromCards,
+  removeResaleTierCard,
+  updateResaleTierCard
+} from '@/utils/resaleTierDraft'
+
+const props = defineProps({
+  boundariesLocked: { type: Boolean, default: false },
+  currency: { type: String, default: 'USD' },
+  errors: { type: Object, default: () => ({}) },
+  modelValue: { type: Object, required: true }
+})
+
+const emit = defineEmits(['update:modelValue'])
+const { t } = useI18n()
+const expandedIndex = ref(0)
+
+const dimensions = computed(() => [
+  { key: 'input', label: 'llmOps.publishingWorkspace.metrics.input' },
+  { key: 'output', label: 'llmOps.publishingWorkspace.metrics.output' },
+  { key: 'cache', label: 'llmOps.publishingWorkspace.metrics.cacheInput' }
+])
+const cards = computed(() => buildResaleTierCards(props.modelValue))
+
+watch(
+  () => cards.value.length,
+  (length) => {
+    if (expandedIndex.value >= length) {
+      expandedIndex.value = Math.max(0, length - 1)
+    }
+  }
+)
+
+function commitCards(nextCards) {
+  emit('update:modelValue', buildResaleTierDraftFromCards(nextCards))
+}
+
+function addCard() {
+  const nextCards = addResaleTierCard(cards.value)
+  expandedIndex.value = Math.max(0, nextCards.length - 1)
+  commitCards(nextCards)
+}
+
+function removeCard(index) {
+  commitCards(removeResaleTierCard(cards.value, index))
+}
+
+function toggleCard(index) {
+  expandedIndex.value = expandedIndex.value === index ? -1 : index
+}
+
+function updateCard(index, field, value) {
+  commitCards(updateResaleTierCard(cards.value, index, field, value))
+}
+
+function updateCardPrice(index, dimension, value) {
+  commitCards(updateResaleTierCard(cards.value, index, dimension, value))
+}
+
+function errorsForCard(index) {
+  const rangeError = dimensions.value
+    .map(
+      ({ key }) =>
+        props.errors?.[`${key}:${index}:end`] ||
+        props.errors?.[`${key}:${index}:start`]
+    )
+    .find(Boolean)
+  return {
+    cache: props.errors?.[`cache:${index}:price`] || '',
+    end: rangeError || '',
+    input: props.errors?.[`input:${index}:price`] || '',
+    output: props.errors?.[`output:${index}:price`] || ''
+  }
+}
+</script>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -2568,6 +2568,10 @@
         "custom": "Select meta model",
         "existing": "Select existing model"
       },
+      "priceMode": {
+        "flat": "Flat price",
+        "tiered": "Tiered price"
+      },
       "fields": {
         "currency": "Currency",
         "metaModel": "Meta model",
@@ -2658,9 +2662,15 @@
         "customModelName": "Enter a custom model name.",
         "customModelProvider": "Select the model provider for the custom model.",
         "noSource": "Missing price source.",
+        "invalidTierBoundary": "Tier boundaries must exceed their starts and keep adjacent ranges connected.",
+        "invalidTierPrice": "Enter a tier price greater than or equal to 0.",
         "price": "Enter at least one price dimension.",
         "selectExistingModel": "Select an existing model.",
-        "selectMetaModel": "Select a meta model."
+        "selectMetaModel": "Select a meta model.",
+        "tierGap": "Adjacent tiers cannot leave a range gap.",
+        "tierOverlap": "Adjacent tiers cannot overlap.",
+        "tierTable": "Correct the tier ranges or prices.",
+        "tierZeroStart": "The first tier must start at 0 tokens."
       },
       "groups": {
         "currentProvider": "Default model provider",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -2576,6 +2576,10 @@
         "custom": "选择元模型",
         "existing": "选择已有模型"
       },
+      "priceMode": {
+        "flat": "固定价格",
+        "tiered": "阶梯价格"
+      },
       "fields": {
         "currency": "币种",
         "metaModel": "元模型",
@@ -2666,9 +2670,15 @@
         "customModelName": "请填写自定义模型名称。",
         "customModelProvider": "请选择自定义模型的模型厂商。",
         "noSource": "缺少价格源。",
+        "invalidTierBoundary": "阶梯边界必须大于起始值，并保持相邻区间连续。",
+        "invalidTierPrice": "请输入大于或等于 0 的阶梯价格。",
         "price": "至少填写一个价格维度。",
         "selectExistingModel": "请选择一个已有模型。",
-        "selectMetaModel": "请选择一个元模型。"
+        "selectMetaModel": "请选择一个元模型。",
+        "tierGap": "相邻阶梯之间不能留有区间缺口。",
+        "tierOverlap": "相邻阶梯之间不能出现区间重叠。",
+        "tierTable": "请修正阶梯价格中的区间或价格。",
+        "tierZeroStart": "第一档必须从 0 Token 开始。"
       },
       "groups": {
         "currentProvider": "默认模型厂商",

--- a/frontend/src/utils/resaleTierDraft.js
+++ b/frontend/src/utils/resaleTierDraft.js
@@ -7,6 +7,11 @@ const DIMENSIONS = [
 const BILLING_UNIT = 'per_1m_tokens'
 const FLAT = 'flat'
 const USAGE_RANGE = 'usage_range'
+const USAGE_RANGE_SPEC = {
+  aggregation_period: 'request',
+  tier_charge_mode: 'matched_tier',
+  tier_metric: 'request_input_tokens'
+}
 
 function decimal(value) {
   if (value === null || value === undefined || value === '') return null
@@ -288,6 +293,42 @@ export function normalizeResalePriceDraft(draft, currency) {
       itemForRow(row, dimension, currency, USAGE_RANGE)
     )
   })
+}
+
+/** Convert a manual text price schedule into the source price item contract. */
+export function buildManualPriceItems(draft) {
+  return DIMENSIONS.flatMap(([key, dimension]) => {
+    const rows = Array.isArray(draft?.[key]) ? draft[key] : []
+    const hasPrice = rows.some((row) => decimal(row.price) !== null)
+    if (!hasPrice) return []
+    const tierType = isFlatRows(rows) ? FLAT : USAGE_RANGE
+    return sortRows(rows).map((row) => {
+      const item = itemForRow(row, dimension, '', tierType)
+      delete item.currency
+      if (tierType === USAGE_RANGE) item.spec = { ...USAGE_RANGE_SPEC }
+      return item
+    })
+  })
+}
+
+/** Validate only dimensions selected for one manual price schedule. */
+export function validateManualPriceDraft(draft) {
+  const selectedDraft = Object.fromEntries(
+    DIMENSIONS.flatMap(([key]) => {
+      const rows = Array.isArray(draft?.[key]) ? draft[key] : []
+      return rows.some((row) => decimal(row.price) !== null)
+        ? [[key, rows]]
+        : []
+    })
+  )
+  if (!Object.keys(selectedDraft).length) {
+    return { 'input:0:price': 'price_table.items_required' }
+  }
+  const errors = validateResalePriceDraft(selectedDraft)
+  DIMENSIONS.forEach(([key]) => {
+    if (!selectedDraft[key]) delete errors[`${key}:0:price`]
+  })
+  return errors
 }
 
 /** Return whether a draft uses the tiered API representation. */

--- a/frontend/tests/llmOpsResaleTierDraft.test.js
+++ b/frontend/tests/llmOpsResaleTierDraft.test.js
@@ -5,6 +5,7 @@ import {
   addResaleTierCard,
   buildResaleTierCards,
   buildFlatResalePriceItems,
+  buildManualPriceItems,
   buildResaleTierDraftFromCards,
   hasTieredResalePrices,
   normalizeResalePriceDraft,
@@ -14,6 +15,7 @@ import {
   shouldRestoreSavedResalePriceDraft,
   updateResaleTierCard,
   updateResaleTierRows,
+  validateManualPriceDraft,
   validateResalePriceDraft
 } from '../src/utils/resaleTierDraft.js'
 
@@ -56,6 +58,77 @@ test('builds a flat resale price table for input, output, and cache', () => {
       }
     ]
   )
+})
+
+test('builds manual tier items without mixing legacy row fields', () => {
+  const items = buildManualPriceItems({
+    cache: [
+      { end: '1000000', flat: false, price: '', start: '0' },
+      { end: null, flat: false, price: '', start: '1000000' }
+    ],
+    input: [
+      { end: '1000000', flat: false, price: '1', start: '0' },
+      { end: null, flat: false, price: '0.8', start: '1000000' }
+    ],
+    output: [
+      { end: '1000000', flat: false, price: '3', start: '0' },
+      { end: null, flat: false, price: '2.5', start: '1000000' }
+    ]
+  })
+
+  assert.deepEqual(
+    items.map((item) => [
+      item.dimension,
+      item.billing_unit,
+      item.unit_price,
+      item.tier_start,
+      item.tier_end,
+      item.tier_type
+    ]),
+    [
+      ['text_input', 'per_1m_tokens', '1', '0', '1000000', 'usage_range'],
+      ['text_input', 'per_1m_tokens', '0.8', '1000000', null, 'usage_range'],
+      ['text_output', 'per_1m_tokens', '3', '0', '1000000', 'usage_range'],
+      ['text_output', 'per_1m_tokens', '2.5', '1000000', null, 'usage_range']
+    ]
+  )
+  assert.equal(
+    items.some((item) => 'currency' in item),
+    false
+  )
+  assert.deepEqual(items[0].spec, {
+    aggregation_period: 'request',
+    tier_charge_mode: 'matched_tier',
+    tier_metric: 'request_input_tokens'
+  })
+})
+
+test('validates only manual dimensions that contain a price', () => {
+  const valid = validateManualPriceDraft({
+    cache: [
+      { end: '100', flat: false, price: '', start: '0' },
+      { end: null, flat: false, price: '', start: '100' }
+    ],
+    input: [
+      { end: '100', flat: false, price: '1', start: '0' },
+      { end: null, flat: false, price: '0.8', start: '100' }
+    ],
+    output: [
+      { end: '100', flat: false, price: '3', start: '0' },
+      { end: null, flat: false, price: '2.5', start: '100' }
+    ]
+  })
+  const partial = validateManualPriceDraft({
+    cache: [],
+    input: [
+      { end: '100', flat: false, price: '1', start: '0' },
+      { end: null, flat: false, price: '', start: '100' }
+    ],
+    output: []
+  })
+
+  assert.deepEqual(valid, {})
+  assert.equal(partial['input:1:price'], 'price_table.invalid_price')
 })
 
 test('normalizes tier rows in stable dimension and boundary order', () => {

--- a/frontend/tests/llmOpsResilience.test.js
+++ b/frontend/tests/llmOpsResilience.test.js
@@ -220,6 +220,26 @@ test('keeps tier ranges readable in the listing table', () => {
   assert.doesNotMatch(listingBoardSource, /metric\.shape/)
 })
 
+test('manual and resale price entry compose the same tier editor', () => {
+  const manualSource = readFileSync(
+    new URL(
+      '../src/components/llm-ops/ManualPriceEntryModal.vue',
+      import.meta.url
+    ),
+    'utf8'
+  )
+  const resaleSource = readFileSync(
+    new URL('../src/components/llm-ops/ResaleTierEditor.vue', import.meta.url),
+    'utf8'
+  )
+
+  assert.match(manualSource, /<TierPriceEditor/)
+  assert.match(resaleSource, /<TierPriceEditor/)
+  assert.match(manualSource, /buildManualPriceItems/)
+  assert.doesNotMatch(manualSource, /<ResaleTierCard/)
+  assert.doesNotMatch(resaleSource, /<ResaleTierCard/)
+})
+
 test('restores saved resale tiers from the active listing revision', () => {
   const items = [
     {


### PR DESCRIPTION
## Summary

- 为手工录价新增向后兼容的标准 `price_items` 契约，校验连续 usage-range 并将阶梯边界完整保存到来源价格项和渠道价格项。
- 抽取 `TierPriceEditor`，让手工录价与挂售工作台直接复用同一阶梯卡片、Input/Output/Cache 布局、边界联动、增删、折叠和响应式样式。
- 保留挂售专属利润预览与上游边界锁定，旧固定价格输入和非文本规格价格继续兼容。
- 补齐 Google 标准目录到 `ModelPriceItem` 的阶梯持久化回归，并验证阿里云与 SiliconFlow 现有阶梯同步契约。

Closes #265

## Test plan

- [x] 后端定向回归：296 passed，16 subtests passed
- [x] 前端单测：113 passed
- [x] `npm run typecheck`
- [x] 定向 ESLint
- [x] `npm run build`
- [x] `git diff --check`
- [ ] ego-browser task space 17：本地 DevMind 登录后完成桌面与 320px 页面验收

## Notes

- 本机默认 Django settings 会受仓库已有 HyperBDR SQLite 迁移缺陷阻断；后端测试使用 `DJANGO_SETTINGS_MODULE=llm_ops.tests.settings`。
- 修改的大型 Python 文件在基线提交上已不满足当前 Black 全文件格式；新增代码区间按 79 字符检查，未引入全文件格式噪声。
