### PR TITLE
Fix Alibaba billing SDK timeout configuration

### DIFF
--- a/backend/cloud_billing/clouds/alibaba_provider.py
+++ b/backend/cloud_billing/clouds/alibaba_provider.py
@@ -140,10 +140,13 @@ class AlibabaCloud(BaseCloudProvider):
 
     def _build_client(self, endpoint: str) -> Client:
         """Build a BSS client for the given endpoint."""
+        timeout_ms = self.config.timeout * 1000
         config = Config(
             access_key_id=self.config.api_key,
             access_key_secret=self.config.api_secret,
+            connect_timeout=timeout_ms,
             endpoint=endpoint,
+            read_timeout=timeout_ms,
         )
         return Client(config)
 
@@ -224,7 +227,7 @@ class AlibabaCloud(BaseCloudProvider):
         return self.client.query_bill(request)
 
     def _calculate_total_cost(
-        self, response: Dict[str, Any]
+        self, response: Any
     ) -> Tuple[float, str, Dict[str, float]]:
         """Calculate total cost and service breakdown from API response.
 
@@ -794,7 +797,7 @@ class AlibabaCloud(BaseCloudProvider):
                     continue
 
                 items_list = data.items or []
-                merged = {}
+                merged: Dict[str, Dict[str, Any]] = {}
                 for item in items_list:
                     product = getattr(
                         item, "product_name", "Unknown"

--- a/backend/cloud_billing/tests/test_alibaba_provider.py
+++ b/backend/cloud_billing/tests/test_alibaba_provider.py
@@ -198,6 +198,27 @@ class TestAlibabaCloud:
         assert len(result["items"]) == 1
 
 
+class TestAlibabaClientConfiguration:
+    """Tests for Alibaba BSS client configuration."""
+
+    @patch("cloud_billing.clouds.alibaba_provider.Client")
+    def test_bss_client_uses_configured_timeout(self, mock_client):
+        """BSS requests should honor the provider timeout setting."""
+        config = AlibabaConfig(
+            api_key="test-ak",
+            api_secret="test-sk",
+            region="ap-southeast-1",
+            timeout=47,
+        )
+
+        client = AlibabaCloud(config).client
+
+        assert client is mock_client.return_value
+        sdk_config = mock_client.call_args.args[0]
+        assert sdk_config.connect_timeout == 47_000
+        assert sdk_config.read_timeout == 47_000
+
+
 class TestAlibabaOwnerExtraction:
     """Tests for owner extraction from Alibaba Cloud tags."""
 


### PR DESCRIPTION
## Summary
- pass the configured Alibaba provider timeout to both Tea SDK connection and read timeout fields
- convert the provider setting from seconds to the SDK millisecond contract
- add a regression test covering the BSS client configuration

Closes #267

Sentry: `TOWER-18`

## Test plan
- [x] `PYTHONPATH=backend .venv/bin/pytest backend/cloud_billing/tests/test_alibaba_provider.py --no-migrations -q` (16 passed)
- [x] `.venv/bin/ruff check backend/cloud_billing/clouds/alibaba_provider.py backend/cloud_billing/tests/test_alibaba_provider.py --select E4,E7,E9,F --isolated`
- [x] `MYPYPATH=backend .venv/bin/mypy --follow-imports=skip --ignore-missing-imports backend/cloud_billing/clouds/alibaba_provider.py backend/cloud_billing/tests/test_alibaba_provider.py`

## Repository baseline diagnostics
- Full pytest collection is currently blocked by three unrelated existing HyperBDR/SALS import conflicts.
- Full-backend Ruff reports 123 existing findings outside this two-file fix.
- No deployment was performed. Keep Sentry unresolved until the fix is deployed and verified in production.