### PR TITLE
Expose LLM Ops source tier pricing catalog

### DIFF
--- a/backend/llm_ops/migrations/0011_modelpriceitem_source_current_meta_index.py
+++ b/backend/llm_ops/migrations/0011_modelpriceitem_source_current_meta_index.py
@@ -1,0 +1,17 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("llm_ops", "0010_resalelisting_pricing_format"),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name="modelpriceitem",
+            index=models.Index(
+                fields=["source", "is_current", "meta_model"],
+                name="llmops_pi_src_cur_meta_idx",
+            ),
+        ),
+    ]

--- a/backend/llm_ops/models.py
+++ b/backend/llm_ops/models.py
@@ -882,6 +882,10 @@ class ModelPriceItem(models.Model):
             "id",
         ]
         indexes = [
+            models.Index(
+                fields=["source", "is_current", "meta_model"],
+                name="llmops_pi_src_cur_meta_idx",
+            ),
             models.Index(fields=["meta_model", "dimension", "is_current"]),
             models.Index(fields=["sku", "dimension", "is_current"]),
             models.Index(fields=["offering", "dimension", "is_current"]),

--- a/backend/llm_ops/tests/test_views.py
+++ b/backend/llm_ops/tests/test_views.py
@@ -186,6 +186,167 @@ class LLMOpsViewTests(TestCase):
             {"gpt-4o"},
         )
 
+    def test_source_price_catalog_searches_before_meta_model_pagination(self):
+        provider = LLMProvider.objects.create(
+            name="Alibaba Cloud",
+            code="aliyun",
+        )
+        source = PriceCollectionSource.objects.create(
+            name="Alibaba Cloud Official",
+            slug="aliyun-official",
+            provider=provider,
+            source_type=PriceCollectionSource.SOURCE_TYPE_CUSTOM,
+            currency="CNY",
+        )
+        for index in range(12):
+            meta_model = MetaModel.objects.create(
+                code=f"model-{index:02d}",
+                name=f"Model {index:02d}",
+                owner_code="alibaba",
+                owner_name="Alibaba",
+            )
+            ModelPriceItem.objects.create(
+                provider=provider,
+                meta_model=meta_model,
+                source=source,
+                dimension=ModelPriceItem.DIMENSION_TEXT_INPUT,
+                billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
+                currency="CNY",
+                unit_price=Decimal("1"),
+                price_fingerprint=f"model-{index:02d}-input",
+            )
+        target = MetaModel.objects.create(
+            code="qwen3.8-max",
+            name="Qwen3.8 Max",
+            owner_code="alibaba",
+            owner_name="Alibaba",
+        )
+        ModelPriceItem.objects.create(
+            provider=provider,
+            meta_model=target,
+            source=source,
+            dimension=ModelPriceItem.DIMENSION_TEXT_INPUT,
+            billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
+            currency="CNY",
+            unit_price=Decimal("12"),
+            price_fingerprint="qwen3.8-max-input",
+        )
+
+        response = self.client.get(
+            reverse(
+                "collection-source-price-catalog",
+                kwargs={"pk": source.id},
+            ),
+            {"search": "qwen3.8-max", "page": 1, "page_size": 10},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(
+            response.data["results"][0]["meta_model_code"],
+            "qwen3.8-max",
+        )
+
+    def test_source_price_catalog_returns_compact_tier_schedules_and_stats(
+        self,
+    ):
+        provider = LLMProvider.objects.create(
+            name="Alibaba Cloud",
+            code="aliyun",
+        )
+        source = PriceCollectionSource.objects.create(
+            name="Alibaba Cloud Official",
+            slug="aliyun-official",
+            provider=provider,
+            source_type=PriceCollectionSource.SOURCE_TYPE_CUSTOM,
+            currency="CNY",
+        )
+        meta_model = MetaModel.objects.create(
+            code="qwen3.8-max",
+            name="Qwen3.8 Max",
+            owner_code="alibaba",
+            owner_name="Alibaba",
+        )
+        tier_spec = {
+            **usage_range_spec(),
+            "region": "global",
+            "deployment_scope": "Global",
+        }
+        for dimension, price in (
+            (ModelPriceItem.DIMENSION_TEXT_INPUT, "12"),
+            (ModelPriceItem.DIMENSION_TEXT_OUTPUT, "36"),
+            (ModelPriceItem.DIMENSION_CACHE_INPUT, "1.2"),
+        ):
+            ModelPriceItem.objects.create(
+                provider=provider,
+                meta_model=meta_model,
+                source=source,
+                dimension=dimension,
+                billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
+                currency="CNY",
+                unit_price=Decimal(price),
+                tier_type=ModelPriceItem.TIER_USAGE_RANGE,
+                tier_start=Decimal("0"),
+                tier_end=Decimal("1000000"),
+                spec=tier_spec,
+                raw_payload={"large": "payload that must not be returned"},
+                price_fingerprint=f"qwen3.8-max-{dimension}",
+            )
+        PriceCollectionRun.objects.create(
+            source=source,
+            status=PriceCollectionRun.STATUS_SUCCEEDED,
+            collected_count=131,
+            skipped_count=70,
+            metadata={"total_models": 201},
+        )
+
+        response = self.client.get(
+            reverse(
+                "collection-source-price-catalog",
+                kwargs={"pk": source.id},
+            ),
+            {"page_size": 10},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data["summary"],
+            {
+                "catalog_model_count": 201,
+                "collected_sku_count": 131,
+                "covered_meta_model_count": 1,
+                "current_price_item_count": 3,
+                "skipped_model_count": 70,
+            },
+        )
+        row = response.data["results"][0]
+        self.assertEqual(row["meta_model_code"], "qwen3.8-max")
+        self.assertEqual(row["price_item_count"], 3)
+        self.assertEqual(
+            {item["dimension"] for item in row["price_items"]},
+            {"text_input", "text_output", "cache_input"},
+        )
+        self.assertTrue(
+            all(
+                item["tier_type"] == "usage_range"
+                for item in row["price_items"]
+            )
+        )
+        self.assertTrue(
+            all(
+                item["tier_start"] == "0.000000"
+                for item in row["price_items"]
+            )
+        )
+        self.assertTrue(
+            all(
+                item["tier_end"] == "1000000.000000"
+                for item in row["price_items"]
+            )
+        )
+        self.assertNotIn("raw_payload", row["price_items"][0])
+        self.assertNotIn("source_name", row["price_items"][0])
+
     def test_resale_listing_list_filters_by_platform_and_status(self):
         provider = LLMProvider.objects.create(name="OpenAI", code="openai")
         meta_model = MetaModel.objects.create(

--- a/backend/llm_ops/views.py
+++ b/backend/llm_ops/views.py
@@ -238,6 +238,100 @@ class AuditModelViewSetMixin:
         instance.delete()
 
 
+def compact_source_price_item(item):
+    """Serialize only fields required by the source catalogue drawer."""
+    return {
+        "id": item.id,
+        "sku_code": (
+            item.sku.canonical_sku_code if item.sku_id else ""
+        ),
+        "sku_name": item.sku.display_name if item.sku_id else "",
+        "dimension": item.dimension,
+        "billing_unit": item.billing_unit,
+        "currency": item.currency,
+        "unit_price": format(item.unit_price, "f"),
+        "tier_type": item.tier_type,
+        "tier_start": (
+            format(item.tier_start, "f")
+            if item.tier_start is not None
+            else None
+        ),
+        "tier_end": (
+            format(item.tier_end, "f")
+            if item.tier_end is not None
+            else None
+        ),
+        "spec": item.spec or {},
+        "updated_at": item.updated_at.isoformat(),
+    }
+
+
+def compact_source_price_catalog_row(meta_model, price_items):
+    """Build one meta-model row for the compact source catalogue."""
+    sku_codes = sorted(
+        {
+            item["sku_code"]
+            for item in price_items
+            if item.get("sku_code")
+        }
+    )
+    updated_values = [
+        item["updated_at"]
+        for item in price_items
+        if item.get("updated_at")
+    ]
+    return {
+        "meta_model_id": meta_model.id,
+        "meta_model_code": meta_model.code,
+        "meta_model_name": meta_model.name,
+        "owner_code": meta_model.owner_code,
+        "owner_name": meta_model.owner_name,
+        "modality": meta_model.modality,
+        "sku_codes": sku_codes,
+        "price_item_count": len(price_items),
+        "updated_at": max(updated_values, default=""),
+        "price_items": price_items,
+    }
+
+
+def source_price_catalog_summary(source, current_items):
+    """Return source coverage counters and the latest collection run."""
+    latest_run = (
+        PriceCollectionRun.objects.filter(source=source)
+        .order_by("-started_at", "-id")
+        .first()
+    )
+    metadata = latest_run.metadata if latest_run else {}
+    price_stats = current_items.aggregate(
+        covered_meta_model_count=Count("meta_model_id", distinct=True),
+        current_price_item_count=Count("id"),
+    )
+    summary = {
+        "catalog_model_count": int(metadata.get("total_models") or 0),
+        "collected_sku_count": (
+            int(latest_run.collected_count) if latest_run else 0
+        ),
+        "covered_meta_model_count": price_stats["covered_meta_model_count"],
+        "current_price_item_count": price_stats["current_price_item_count"],
+        "skipped_model_count": (
+            int(latest_run.skipped_count) if latest_run else 0
+        ),
+    }
+    latest_run_payload = None
+    if latest_run:
+        latest_run_payload = {
+            "id": latest_run.id,
+            "status": latest_run.status,
+            "started_at": latest_run.started_at.isoformat(),
+            "finished_at": (
+                latest_run.finished_at.isoformat()
+                if latest_run.finished_at
+                else None
+            ),
+        }
+    return summary, latest_run_payload
+
+
 class PriceCollectionSourceViewSet(
     AuditModelViewSetMixin,
     LLMOpsPermissionMixin,
@@ -249,6 +343,11 @@ class PriceCollectionSourceViewSet(
     serializer_class = PriceCollectionSourceSerializer
 
     def get_queryset(self):
+        if self.action == "price_catalog":
+            return PriceCollectionSource.objects.select_related(
+                "provider",
+                "channel",
+            )
         price_items_by_source = (
             ModelPriceItem.objects.filter(source=OuterRef("pk"))
             .order_by()
@@ -384,6 +483,97 @@ class PriceCollectionSourceViewSet(
             {"results": supported_auto_sync_source_options()},
             status=status.HTTP_200_OK,
         )
+
+    @action(
+        detail=True,
+        methods=["get"],
+        url_path="price-catalog",
+        url_name="price-catalog",
+    )
+    def price_catalog(self, request, pk=None):
+        """Return a compact, searchable price catalogue for one source."""
+        source = self.get_object()
+        current_items = ModelPriceItem.objects.filter(
+            source=source,
+            is_current=True,
+        )
+        meta_models = MetaModel.objects.filter(
+            id__in=current_items.values("meta_model_id"),
+        )
+        search = str(request.query_params.get("search") or "").strip()
+        if search:
+            matching_sku_meta_models = current_items.filter(
+                Q(sku__display_name__icontains=search)
+                | Q(sku__canonical_sku_code__icontains=search)
+            ).values("meta_model_id")
+            meta_models = meta_models.filter(
+                Q(name__icontains=search)
+                | Q(code__icontains=search)
+                | Q(owner_name__icontains=search)
+                | Q(owner_code__icontains=search)
+                | Q(id__in=matching_sku_meta_models)
+            )
+        meta_models = meta_models.distinct().order_by("name", "code", "id")
+        page = self.paginate_queryset(meta_models)
+        selected_meta_models = page if page is not None else meta_models
+        selected_ids = [meta_model.id for meta_model in selected_meta_models]
+        page_items = list(
+            current_items.filter(meta_model_id__in=selected_ids)
+            .select_related("sku")
+            .only(
+                "id",
+                "meta_model_id",
+                "sku__canonical_sku_code",
+                "sku__display_name",
+                "dimension",
+                "billing_unit",
+                "currency",
+                "unit_price",
+                "tier_type",
+                "tier_start",
+                "tier_end",
+                "spec",
+                "updated_at",
+            )
+            .order_by(
+                "meta_model_id",
+                "sku__display_name",
+                "dimension",
+                "tier_start",
+                "id",
+            )
+        )
+        items_by_meta_model = {}
+        for item in page_items:
+            items_by_meta_model.setdefault(item.meta_model_id, []).append(
+                compact_source_price_item(item)
+            )
+        results = [
+            compact_source_price_catalog_row(
+                meta_model,
+                items_by_meta_model.get(meta_model.id, []),
+            )
+            for meta_model in selected_meta_models
+        ]
+        summary, latest_run = source_price_catalog_summary(
+            source,
+            current_items,
+        )
+        if page is None:
+            return Response(
+                {
+                    "count": len(results),
+                    "next": None,
+                    "previous": None,
+                    "results": results,
+                    "summary": summary,
+                    "latest_run": latest_run,
+                }
+            )
+        response = self.get_paginated_response(results)
+        response.data["summary"] = summary
+        response.data["latest_run"] = latest_run
+        return response
 
     @action(
         detail=False,

--- a/frontend/src/api/llmOps.js
+++ b/frontend/src/api/llmOps.js
@@ -19,6 +19,13 @@ export const llmOpsApi = {
     return apiClient.get(`${base}/collection-sources/`, paramsOrEmpty(params))
   },
 
+  getCollectionSourcePriceCatalog(id, params) {
+    return apiClient.get(
+      `${base}/collection-sources/${id}/price-catalog/`,
+      paramsOrEmpty(params)
+    )
+  },
+
   listOfficialProviderSourceOptions() {
     return apiClient.get(
       `${base}/collection-sources/official-provider-options/`

--- a/frontend/src/components/llm-ops/ChannelManagement.vue
+++ b/frontend/src/components/llm-ops/ChannelManagement.vue
@@ -140,10 +140,11 @@
               <td class="table-cell">
                 <div class="inline-flex items-center justify-center gap-2">
                   <OperationIconButton
+                    :disabled="Boolean(openingChannelId)"
                     icon="config"
                     :label="t('llmOps.channelManagement.actions.manageModels')"
                     tone="primary"
-                    @click="selectedChannelForModels = channel"
+                    @click="openChannelModelManagement(channel)"
                   />
                   <OperationIconButton
                     icon="edit"
@@ -292,6 +293,10 @@ const props = defineProps({
     type: Array,
     default: () => []
   },
+  prepareModelManagement: {
+    type: Function,
+    default: null
+  },
   displayCurrency: {
     type: String,
     default: 'CNY'
@@ -313,6 +318,7 @@ const deleteTarget = ref(null)
 const searchKeyword = ref('')
 const statusFilter = ref('all')
 const deletingChannelId = ref(null)
+const openingChannelId = ref(null)
 
 const statusFilterOptions = computed(() => [
   { label: t('llmOps.channelManagement.filters.allStatus'), value: 'all' },
@@ -364,6 +370,21 @@ function handleChannelSaved() {
 function handleChannelModelsSaved() {
   selectedChannelForModels.value = null
   emit('refresh')
+}
+
+async function openChannelModelManagement(channel) {
+  if (openingChannelId.value) return
+  openingChannelId.value = channel.id
+  try {
+    if (props.prepareModelManagement) {
+      await props.prepareModelManagement()
+    }
+    selectedChannelForModels.value = channel
+  } catch (error) {
+    showError(errorMessage(error, t('llmOps.dataErrors.refreshChannels')))
+  } finally {
+    openingChannelId.value = null
+  }
 }
 
 function openDeleteConfirm(channel) {

--- a/frontend/src/components/llm-ops/MetaModelManagement.vue
+++ b/frontend/src/components/llm-ops/MetaModelManagement.vue
@@ -417,21 +417,9 @@ import {
 } from '@/utils/llmOpsPagination'
 
 const props = defineProps({
-  metaModels: {
-    type: Array,
-    required: true
-  },
   providers: {
     type: Array,
     required: true
-  },
-  models: {
-    type: Array,
-    required: true
-  },
-  priceItems: {
-    type: Array,
-    default: () => []
   }
 })
 

--- a/frontend/src/components/llm-ops/ProviderManagement.vue
+++ b/frontend/src/components/llm-ops/ProviderManagement.vue
@@ -384,8 +384,8 @@
     />
     <SourcePriceDrawer
       :source="selectedProvider?.primary_source || null"
-      :models="[]"
-      :price-items="selectedProviderPriceItems"
+      :catalog="selectedProviderCatalog"
+      :search="selectedProviderSearch"
       :deleting="
         String(deletingSourceId || '') ===
         String(selectedProvider?.primary_source?.id || '')
@@ -394,6 +394,7 @@
       :page="selectedProviderPage"
       :page-size="selectedProviderPageSize"
       :total-items="selectedProviderTotal"
+      @search="handleSelectedProviderSearch"
       @close="selectedProvider = null"
       @delete="deleteSource"
       @page-change="loadSelectedProviderPriceItems"
@@ -431,14 +432,6 @@ const props = defineProps({
     type: Array,
     required: true
   },
-  metaModels: {
-    type: Array,
-    default: () => []
-  },
-  models: {
-    type: Array,
-    required: true
-  },
   sources: {
     type: Array,
     required: true
@@ -446,18 +439,6 @@ const props = defineProps({
   collectionRuns: {
     type: Array,
     default: () => []
-  },
-  priceItems: {
-    type: Array,
-    default: () => []
-  },
-  displayCurrency: {
-    type: String,
-    default: 'CNY'
-  },
-  exchangeRate: {
-    type: Number,
-    default: 7.15
   }
 })
 
@@ -488,18 +469,16 @@ const selectedProviderLoading = ref(false)
 const selectedProviderPage = ref(1)
 const selectedProviderPageSize = ref(10)
 const selectedProviderTotal = ref(0)
-const selectedProviderPriceItems = ref([])
+const selectedProviderCatalog = ref({ results: [], summary: {} })
+const selectedProviderSearch = ref('')
+let selectedProviderRequestId = 0
 const openedFocusSourceId = ref(null)
 const localPriceEntryMetaModels = ref([])
 const localPriceEntryModels = ref([])
 
-const priceEntryMetaModels = computed(() =>
-  props.metaModels.length ? props.metaModels : localPriceEntryMetaModels.value
-)
+const priceEntryMetaModels = computed(() => localPriceEntryMetaModels.value)
 
-const priceEntryModels = computed(() =>
-  props.models.length ? props.models : localPriceEntryModels.value
-)
+const priceEntryModels = computed(() => localPriceEntryModels.value)
 
 const {
   filteredSourceProviderRows,
@@ -609,9 +588,11 @@ function handlePriceEntrySaved(payload) {
 }
 
 async function openSourceDetail(provider) {
+  selectedProviderRequestId += 1
   selectedProvider.value = provider
   selectedProviderPage.value = 1
-  selectedProviderPriceItems.value = []
+  selectedProviderCatalog.value = { results: [], summary: {} }
+  selectedProviderSearch.value = ''
   selectedProviderTotal.value = 0
   await loadSelectedProviderPriceItems(1)
 }
@@ -621,23 +602,31 @@ async function loadSelectedProviderPriceItems(
 ) {
   const source = selectedProvider.value?.primary_source
   if (!source?.id) return
+  const requestId = ++selectedProviderRequestId
   selectedProviderLoading.value = true
   try {
-    const response = await llmOpsApi.listModelPriceItems({
-      source: source.id,
-      is_current: 'true',
-      group_by: 'meta_model',
-      page,
-      page_size: selectedProviderPageSize.value
-    })
+    const response = await llmOpsApi.getCollectionSourcePriceCatalog(
+      source.id,
+      {
+        page,
+        page_size: selectedProviderPageSize.value,
+        search: selectedProviderSearch.value || undefined
+      }
+    )
+    if (requestId !== selectedProviderRequestId) return
     const payload = paginationPayload(response)
-    selectedProviderPriceItems.value = paginationResults(payload)
+    selectedProviderCatalog.value = {
+      results: paginationResults(payload),
+      summary: payload?.summary || {},
+      latest_run: payload?.latest_run || null
+    }
     selectedProviderTotal.value = Number(
-      payload?.count || selectedProviderPriceItems.value.length
+      payload?.count || selectedProviderCatalog.value.results.length
     )
     selectedProviderPage.value = page
   } catch (error) {
-    selectedProviderPriceItems.value = []
+    if (requestId !== selectedProviderRequestId) return
+    selectedProviderCatalog.value = { results: [], summary: {} }
     selectedProviderTotal.value = 0
     showError(
       errorMessage(
@@ -646,8 +635,16 @@ async function loadSelectedProviderPriceItems(
       )
     )
   } finally {
-    selectedProviderLoading.value = false
+    if (requestId === selectedProviderRequestId) {
+      selectedProviderLoading.value = false
+    }
   }
+}
+
+async function handleSelectedProviderSearch(value) {
+  selectedProviderSearch.value = value
+  selectedProviderPage.value = 1
+  await loadSelectedProviderPriceItems(1)
 }
 
 async function handleSelectedProviderPageSizeChange(pageSize) {

--- a/frontend/src/components/llm-ops/SourcePriceDrawer.vue
+++ b/frontend/src/components/llm-ops/SourcePriceDrawer.vue
@@ -5,9 +5,12 @@
     @click.self="$emit('close')"
   >
     <aside
-      class="h-full w-full max-w-[72rem] overflow-y-auto bg-white shadow-xl"
+      class="h-full w-full max-w-[78rem] overflow-y-auto bg-white shadow-xl"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="source-price-drawer-title"
     >
-      <div
+      <header
         class="sticky top-0 z-10 border-b border-slate-200 bg-white px-5 py-4"
       >
         <div class="flex items-start justify-between gap-4">
@@ -15,9 +18,12 @@
             <p
               class="text-xs font-semibold uppercase tracking-[0.18em] text-indigo-600"
             >
-              Supplier Source
+              {{ t('llmOps.sourcePriceDrawer.catalogLabel') }}
             </p>
-            <h3 class="mt-2 truncate text-xl font-semibold text-slate-900">
+            <h3
+              id="source-price-drawer-title"
+              class="mt-2 truncate text-xl font-semibold text-slate-900"
+            >
               {{ source.name }}
             </h3>
             <p class="mt-1 truncate font-mono text-xs text-slate-500">
@@ -27,7 +33,7 @@
           <div class="flex shrink-0 items-center gap-2">
             <button
               type="button"
-              class="btn-danger btn-action-danger"
+              class="btn-danger"
               :disabled="deleting"
               @click="$emit('delete', source)"
             >
@@ -38,43 +44,43 @@
               }}
             </button>
             <button
+              ref="closeButtonRef"
               type="button"
-              class="btn-secondary btn-action-cancel"
-              @click="$emit('close')"
+              class="btn-secondary"
+              @click="closeDrawer"
             >
               {{ t('llmOps.sourcePriceDrawer.actions.close') }}
             </button>
           </div>
         </div>
-      </div>
+      </header>
 
       <div class="space-y-5 px-5 py-5">
-        <div class="grid gap-3 md:grid-cols-4">
-          <div class="summary-card">
-            <p>{{ t('llmOps.sourcePriceDrawer.summary.metaModels') }}</p>
-            <strong>{{ modelRows.length }}</strong>
-          </div>
-          <div class="summary-card">
-            <p>{{ t('llmOps.sourcePriceDrawer.summary.currentItems') }}</p>
-            <strong>{{ totalItems || sourceItemRows.length }}</strong>
-          </div>
-          <div class="summary-card">
-            <p>{{ t('llmOps.sourcePriceDrawer.summary.currency') }}</p>
-            <strong>{{ source.currency || '-' }}</strong>
-          </div>
-          <div class="summary-card">
-            <p>{{ t('llmOps.sourcePriceDrawer.summary.status') }}</p>
-            <strong>
-              {{
-                source.is_enabled
-                  ? t('llmOps.sourcePriceDrawer.status.enabled')
-                  : t('llmOps.sourcePriceDrawer.status.disabled')
-              }}
-            </strong>
-          </div>
-        </div>
+        <section class="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+          <SummaryMetric
+            :label="t('llmOps.sourcePriceDrawer.summary.catalogModelCount')"
+            :value="summary.catalog_model_count"
+          />
+          <SummaryMetric
+            :label="t('llmOps.sourcePriceDrawer.summary.collectedSkuCount')"
+            :value="summary.collected_sku_count"
+          />
+          <SummaryMetric
+            :label="t('llmOps.sourcePriceDrawer.summary.coveredMetaModelCount')"
+            :value="summary.covered_meta_model_count"
+          />
+          <SummaryMetric
+            :label="t('llmOps.sourcePriceDrawer.summary.currentPriceItemCount')"
+            :value="summary.current_price_item_count"
+          />
+          <SummaryMetric
+            :label="t('llmOps.sourcePriceDrawer.summary.skippedModelCount')"
+            :value="summary.skipped_model_count"
+            tone="warning"
+          />
+        </section>
 
-        <div class="source-info-grid">
+        <section class="source-info-grid">
           <div>
             <span>{{ t('llmOps.sourcePriceDrawer.info.owner') }}</span>
             <strong>{{ relationName }}</strong>
@@ -84,6 +90,12 @@
             <strong>{{ sourceConfigSummary }}</strong>
           </div>
           <div>
+            <span>{{ t('llmOps.sourcePriceDrawer.info.latestRun') }}</span>
+            <strong>
+              {{ latestRunLabel }}
+            </strong>
+          </div>
+          <div>
             <span>{{ t('llmOps.sourcePriceDrawer.info.priceUrl') }}</span>
             <a
               v-if="source.endpoint_url"
@@ -91,95 +103,121 @@
               :href="source.endpoint_url"
               rel="noopener noreferrer"
               target="_blank"
-              :title="source.endpoint_url"
             >
               {{ sourceAddressLabel }}
             </a>
-            <strong v-else class="text-slate-400">-</strong>
+            <strong v-else>-</strong>
           </div>
-        </div>
+        </section>
 
-        <div class="panel overflow-hidden p-0">
+        <section class="panel overflow-hidden p-0">
           <div class="table-toolbar">
             <div>
               <h3 class="panel-title">
                 {{ t('llmOps.sourcePriceDrawer.title') }}
               </h3>
+              <p class="mt-1 text-xs text-slate-500">
+                {{ t('llmOps.sourcePriceDrawer.subtitle') }}
+              </p>
             </div>
             <input
-              v-model="search"
-              class="field-input w-full md:w-72"
+              :value="search"
+              class="field-input w-full md:w-80"
+              type="search"
               :placeholder="t('llmOps.sourcePriceDrawer.searchPlaceholder')"
+              @input="queueSearch($event.target.value)"
             />
           </div>
-          <div class="overflow-x-auto">
-            <table class="data-table source-price-table">
-              <colgroup>
-                <col class="model-col" />
-                <col class="price-col" />
-                <col class="time-col" />
-              </colgroup>
-              <thead>
-                <tr>
-                  <th class="table-head">
-                    {{ t('llmOps.sourcePriceDrawer.table.metaModel') }}
-                  </th>
-                  <th class="table-head">{{ priceHeaderLabel }}</th>
-                  <th class="table-head">
-                    {{ t('llmOps.sourcePriceDrawer.table.updatedAt') }}
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr v-if="loading">
-                  <td class="table-cell text-slate-500" colspan="3">
-                    {{ t('common.loading') }}
-                  </td>
-                </tr>
-                <template v-for="row in filteredModelRows" :key="row.key">
-                  <tr>
-                    <td class="table-cell">
-                      <p class="truncate font-medium text-slate-900">
-                        {{ row.meta_model_name }}
-                      </p>
-                      <p class="mt-1 font-mono text-xs text-slate-400">
-                        {{ row.meta_model_code }}
-                        <span v-if="row.modality_label">
-                          · {{ row.modality_label }}
-                        </span>
-                      </p>
-                    </td>
-                    <td class="table-cell">
+
+          <div v-if="loading" class="space-y-3 p-4" aria-busy="true">
+            <div
+              v-for="index in 3"
+              :key="index"
+              class="h-28 animate-pulse rounded-lg bg-slate-100"
+            />
+          </div>
+          <div v-else-if="rows.length" class="divide-y divide-slate-100">
+            <article v-for="row in rows" :key="row.meta_model_id" class="p-4">
+              <div class="flex flex-col gap-4 xl:flex-row xl:items-start">
+                <div class="min-w-0 xl:w-64 xl:shrink-0">
+                  <h4 class="truncate font-semibold text-slate-900">
+                    {{ row.meta_model_name }}
+                  </h4>
+                  <p class="mt-1 truncate font-mono text-xs text-slate-400">
+                    {{ row.meta_model_code }} ·
+                    {{ modalityLabel(row.modality) }}
+                  </p>
+                  <p class="mt-2 text-xs text-slate-500">
+                    {{
+                      t('llmOps.sourcePriceDrawer.priceItemCount', {
+                        count: row.price_item_count
+                      })
+                    }}
+                  </p>
+                  <p class="mt-1 text-xs text-slate-400">
+                    {{ formatDateTime(row.updated_at) }}
+                  </p>
+                </div>
+
+                <div class="min-w-0 flex-1 space-y-3 price-schedule">
+                  <section
+                    v-for="variant in schedules(row.price_items)"
+                    :key="variant.key"
+                    class="overflow-hidden rounded-lg border border-slate-200"
+                  >
+                    <div
+                      class="flex flex-wrap items-center justify-between gap-2 bg-slate-50 px-3 py-2"
+                    >
+                      <strong class="text-xs text-slate-700">
+                        {{ variant.scope_label }}
+                      </strong>
+                      <span class="text-[11px] text-slate-400">
+                        {{
+                          t('llmOps.sourcePriceDrawer.tierCount', {
+                            count: variant.tiers.length
+                          })
+                        }}
+                      </span>
+                    </div>
+                    <div class="divide-y divide-slate-100">
                       <div
-                        v-if="row.token_price_rows.length"
-                        class="token-price-list"
+                        v-for="tier in variant.tiers"
+                        :key="tier.key"
+                        class="grid gap-2 px-3 py-2.5 lg:grid-cols-[13rem_minmax(0,1fr)] lg:items-center"
                       >
-                        <div
-                          v-for="item in row.token_price_rows"
-                          :key="`${row.key}-${item.label}`"
-                          class="token-price-row"
+                        <span
+                          class="font-mono text-xs font-semibold text-slate-600"
                         >
-                          <span>{{ item.label }}</span>
-                          <strong>{{ item.value }}</strong>
+                          {{ tier.range_label }} ·
+                          {{ billingUnitLabel(tier.billing_unit) }}
+                        </span>
+                        <div class="flex flex-wrap gap-2">
+                          <span
+                            v-for="price in tier.prices"
+                            :key="price.dimension"
+                            class="price-chip"
+                          >
+                            <span>{{ dimensionLabel(price.dimension) }}</span>
+                            <strong>{{
+                              money(price.unit_price, price.currency)
+                            }}</strong>
+                          </span>
                         </div>
                       </div>
-                      <span v-else class="text-xs text-slate-400">
-                        {{ t('llmOps.sourcePriceDrawer.empty.noPrice') }}
-                      </span>
-                    </td>
-                    <td class="table-cell">
-                      {{ formatDateTime(row.updated_at) }}
-                    </td>
-                  </tr>
-                </template>
-                <tr v-if="!loading && !filteredModelRows.length">
-                  <td class="table-cell text-slate-500" colspan="3">
-                    {{ t('llmOps.sourcePriceDrawer.empty.noRows') }}
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+                    </div>
+                  </section>
+                </div>
+              </div>
+            </article>
           </div>
+          <div v-else class="px-4 py-12 text-center text-sm text-slate-500">
+            {{
+              search
+                ? t('llmOps.sourcePriceDrawer.empty.noSearchResults')
+                : t('llmOps.sourcePriceDrawer.empty.noRows')
+            }}
+          </div>
+
           <div v-if="totalItems" class="pagination-bar">
             <p class="text-xs text-slate-500">
               {{
@@ -192,9 +230,9 @@
             </p>
             <div class="flex flex-wrap items-center gap-2">
               <label class="page-size-control">
-                <span>
-                  {{ t('llmOps.sourcePriceDrawer.pagination.pageSize') }}
-                </span>
+                <span>{{
+                  t('llmOps.sourcePriceDrawer.pagination.pageSize')
+                }}</span>
                 <select
                   class="page-size-select"
                   :value="pageSize"
@@ -230,143 +268,67 @@
               </button>
             </div>
           </div>
-        </div>
+        </section>
       </div>
     </aside>
   </div>
 </template>
 
 <script setup>
-import { computed, ref } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+
+import SummaryMetric from '@/components/llm-ops/SourcePriceSummaryMetric.vue'
 import {
   priceSourceCollectionMethod,
   priceSourceOwnerType
 } from '@/utils/llmOpsPriceSources'
+import { buildSourcePriceSchedules } from '@/utils/sourcePriceCatalog'
 
-defineEmits(['close', 'delete', 'refresh', 'page-change', 'page-size-change'])
+const emit = defineEmits([
+  'close',
+  'delete',
+  'page-change',
+  'page-size-change',
+  'search'
+])
 
 const props = defineProps({
-  source: {
-    type: Object,
-    default: null
-  },
-  models: {
-    type: Array,
-    default: () => []
-  },
-  priceItems: {
-    type: Array,
-    default: () => []
-  },
-  deleting: {
-    type: Boolean,
-    default: false
-  },
-  loading: {
-    type: Boolean,
-    default: false
-  },
-  page: {
-    type: Number,
-    default: 1
-  },
-  pageSize: {
-    type: Number,
-    default: 50
-  },
-  totalItems: {
-    type: Number,
-    default: 0
-  }
+  source: { type: Object, default: null },
+  catalog: { type: Object, default: () => ({ results: [], summary: {} }) },
+  search: { type: String, default: '' },
+  deleting: { type: Boolean, default: false },
+  loading: { type: Boolean, default: false },
+  page: { type: Number, default: 1 },
+  pageSize: { type: Number, default: 10 },
+  totalItems: { type: Number, default: 0 }
 })
 
 const pageSizeOptions = [10, 20, 50]
 const { t, locale } = useI18n()
-const search = ref('')
+const closeButtonRef = ref(null)
+let searchTimer = null
 
-const tokenPriceDimensions = [
-  { dimension: 'text_input', label: 'Input' },
-  { dimension: 'text_output', label: 'Output' },
-  { dimension: 'cache_input', label: 'Cache' }
-]
-
-const modelMap = computed(() => {
-  const entries = props.models.map((model) => [String(model.id), model])
-  return new Map(entries)
-})
-
-const sourceItemRows = computed(() =>
-  props.priceItems
-    .filter(
-      (item) =>
-        String(item.source) === String(props.source?.id) &&
-        item.is_current !== false
-    )
-    .slice()
-    .sort((left, right) => {
-      const leftModel = modelName(left).localeCompare(modelName(right))
-      if (leftModel !== 0) return leftModel
-      return dimensionSort(left, right)
-    })
-    .map((item) => buildRawItemRow(item))
+const rows = computed(() => props.catalog?.results || [])
+const summary = computed(() => props.catalog?.summary || {})
+const totalPages = computed(() =>
+  Math.max(1, Math.ceil(Number(props.totalItems || 0) / props.pageSize))
 )
-
-const modelRows = computed(() => {
-  const grouped = new Map()
-  const rows = []
-
-  sourceItemRows.value.forEach((row) => {
-    const key = String(row.meta_model_id || row.meta_model_code || row.id)
-    if (!grouped.has(key)) grouped.set(key, [])
-    grouped.get(key).push(row)
-  })
-
-  Array.from(grouped.entries()).forEach(([key, groupedRows]) => {
-    rows.push(buildModelRow(key, groupedRows))
-  })
-
-  sourceBoundModels.value.forEach((model) => {
-    const key = String(model.meta_model || model.meta_model_code || model.id)
-    if (!grouped.has(key)) {
-      rows.push(buildFallbackModelRow(model, key))
-      grouped.set(key, [])
-    }
-  })
-
-  return rows.sort((left, right) =>
-    left.meta_model_name.localeCompare(right.meta_model_name)
-  )
-})
-
-const sourceBoundModels = computed(() =>
-  props.models.filter(
-    (model) => String(model.source) === String(props.source?.id)
-  )
+const relationName = computed(
+  () =>
+    props.source?.provider_name ||
+    props.source?.channel_name ||
+    t('llmOps.sourcePriceDrawer.fallback.unbound')
 )
-
-const filteredModelRows = computed(() => {
-  const keyword = search.value.trim().toLowerCase()
-  if (!keyword) return modelRows.value
-  return modelRows.value.filter((row) => row.search_text.includes(keyword))
-})
-
-const relationName = computed(() => {
-  if (props.source?.provider_name) return props.source.provider_name
-  if (props.source?.channel_name) return props.source.channel_name
-  return t('llmOps.sourcePriceDrawer.fallback.unbound')
-})
-
 const sourceConfigSummary = computed(() =>
   [
-    sourceOwnerTypeLabel(sourceOwnerType(props.source)),
+    sourceOwnerTypeLabel(priceSourceOwnerType(props.source)),
     sourceModeLabel(props.source),
     props.source?.currency
   ]
     .filter(Boolean)
     .join(' · ')
 )
-
 const sourceAddressLabel = computed(() => {
   const value = props.source?.endpoint_url
   if (!value) return ''
@@ -377,190 +339,51 @@ const sourceAddressLabel = computed(() => {
     return String(value)
   }
 })
+const latestRunLabel = computed(() => {
+  const run = props.catalog?.latest_run
+  if (!run) return '-'
+  return `${run.status} · ${formatDateTime(run.finished_at || run.started_at)}`
+})
 
-const priceHeaderLabel = computed(() =>
-  t('llmOps.sourcePriceDrawer.table.price')
+function closeDrawer() {
+  emit('close')
+}
+
+function handleKeydown(event) {
+  if (event.key === 'Escape' && props.source) closeDrawer()
+}
+
+onMounted(() => document.addEventListener('keydown', handleKeydown))
+
+onBeforeUnmount(() => {
+  clearTimeout(searchTimer)
+  document.removeEventListener('keydown', handleKeydown)
+})
+
+watch(
+  () => props.source,
+  async (source) => {
+    if (!source) return
+    await nextTick()
+    closeButtonRef.value?.focus()
+  }
 )
 
-const totalPages = computed(() =>
-  Math.max(1, Math.ceil(Number(props.totalItems || 0) / props.pageSize))
-)
-
-function buildRawItemRow(item) {
-  const model = modelMap.value.get(String(item.model)) || {}
-  return {
-    key: `source-price-${item.id}`,
-    id: item.id,
-    model_id: item.model,
-    meta_model_id: item.meta_model || model.meta_model || '',
-    raw: item,
-    meta_model_name:
-      item.meta_model_name ||
-      model.meta_model_name ||
-      t('llmOps.sourcePriceDrawer.fallback.unknownMetaModel'),
-    meta_model_code: item.meta_model_code || model.meta_model_code || '-',
-    provider_name:
-      item.meta_model_owner_name ||
-      model.meta_model_owner_name ||
-      item.provider_name ||
-      model.provider_name ||
-      t('llmOps.sourcePriceDrawer.fallback.unboundProvider'),
-    sku_name: item.model_name || model.name || '',
-    sku_code: item.model_code || model.code || '',
-    modality_label: modalityLabel(model.modality),
-    dimension_label: `${dimensionLabel(item.dimension)} ${billingUnitLabel(item.billing_unit)}`,
-    price: money(item.unit_price, item.currency),
-    unit_price: item.unit_price,
-    currency: item.currency,
-    dimension: item.dimension,
-    billing_unit: item.billing_unit,
-    tier_type: item.tier_type,
-    tier_start: item.tier_start,
-    tier_end: item.tier_end,
-    spec: item.spec || {},
-    updated_at: item.updated_at || item.effective_from
-  }
+function queueSearch(value) {
+  clearTimeout(searchTimer)
+  searchTimer = setTimeout(() => emit('search', String(value).trim()), 250)
 }
 
-function buildModelRow(key, rows) {
-  const sortedRows = rows.slice().sort(dimensionSort)
-  const firstRow = sortedRows[0]
-
-  return {
-    key,
-    meta_model_name: firstRow.meta_model_name,
-    meta_model_code: firstRow.meta_model_code,
-    provider_name: firstRow.provider_name,
-    modality_label: firstRow.modality_label,
-    token_price_rows: tokenPriceRowsFromRawRows(sortedRows),
-    price_count: sortedRows.length,
-    updated_at: latestUpdatedAt(sortedRows),
-    raw_rows: sortedRows,
-    search_text: [
-      firstRow.meta_model_name,
-      firstRow.meta_model_code,
-      firstRow.provider_name,
-      ...sortedRows.map((row) => row.sku_name),
-      ...sortedRows.map((row) => row.sku_code),
-      firstRow.modality_label,
-      ...sortedRows.map((row) => row.dimension_label)
-    ]
-      .filter(Boolean)
-      .join(' ')
-      .toLowerCase()
-  }
-}
-
-function buildFallbackModelRow(model, key) {
-  return {
-    key,
-    meta_model_name:
-      model.meta_model_name ||
-      model.name ||
-      t('llmOps.sourcePriceDrawer.fallback.unknownMetaModel'),
-    meta_model_code: model.meta_model_code || model.code || '-',
-    provider_name:
-      model.meta_model_owner_name ||
-      model.provider_name ||
-      t('llmOps.sourcePriceDrawer.fallback.unboundProvider'),
-    modality_label: modalityLabel(model.modality),
-    token_price_rows: tokenPriceRowsFromModel(model),
-    price_count: 0,
-    updated_at: model.last_price_updated_at || model.updated_at || '',
-    raw_rows: [],
-    search_text: [
-      model.meta_model_name,
-      model.name,
-      model.meta_model_code,
-      model.code,
-      model.provider_name,
-      modalityLabel(model.modality)
-    ]
-      .filter(Boolean)
-      .join(' ')
-      .toLowerCase()
-  }
-}
-
-function tokenPriceRowsFromRawRows(rows) {
-  return tokenPriceDimensions.map((item) => {
-    const matchedRow = rows.find(
-      (row) =>
-        row.dimension === item.dimension && row.billing_unit === 'per_1m_tokens'
-    )
-    return {
-      label: item.label,
-      value: matchedRow?.price || '-'
-    }
+function schedules(priceItems) {
+  return buildSourcePriceSchedules(priceItems, {
+    defaultScope: t('llmOps.sourcePriceDrawer.defaultScope'),
+    flat: t('llmOps.sourcePriceDrawer.allUsage')
   })
-}
-
-function tokenPriceRowsFromModel(model) {
-  return [
-    {
-      label: 'Input',
-      value: legacyPriceValue(model.input_price_per_million, model.currency)
-    },
-    {
-      label: 'Output',
-      value: legacyPriceValue(model.output_price_per_million, model.currency)
-    },
-    {
-      label: 'Cache',
-      value: legacyPriceValue(
-        model.cache_input_price_per_million,
-        model.currency
-      )
-    }
-  ]
-}
-
-function legacyPriceValue(value, currency) {
-  if (!hasValue(value)) return '-'
-  return money(value, currency)
-}
-
-function modelName(item) {
-  const model = modelMap.value.get(String(item.model)) || {}
-  return item.meta_model_name || model.meta_model_name || item.model_name || ''
-}
-
-function latestUpdatedAt(rows) {
-  const values = rows.map((row) => row.updated_at).filter(Boolean)
-  if (!values.length) return ''
-  return values.sort(
-    (left, right) => new Date(right).getTime() - new Date(left).getTime()
-  )[0]
-}
-
-function dimensionSort(left, right) {
-  const order = [
-    'text_input',
-    'text_output',
-    'cache_input',
-    'audio_input',
-    'audio_output',
-    'image_input',
-    'image_output',
-    'video_input',
-    'video_output'
-  ]
-  const leftIndex = order.indexOf(left.dimension)
-  const rightIndex = order.indexOf(right.dimension)
-  if (leftIndex !== rightIndex) return leftIndex - rightIndex
-
-  const leftKey = `${left.dimension}-${left.tier_start || ''}`
-  const rightKey = `${right.dimension}-${right.tier_start || ''}`
-  return leftKey.localeCompare(rightKey)
 }
 
 function money(value, currency = 'USD') {
   if (value === null || value === undefined || value === '') return '-'
   return `${currency || 'USD'} ${Number(value).toFixed(4)}`
-}
-
-function hasValue(value) {
-  return value !== null && value !== undefined && value !== ''
 }
 
 function dimensionLabel(dimension) {
@@ -585,7 +408,7 @@ function billingUnitLabel(unit) {
     per_second: t('llmOps.sourcePriceDrawer.billingUnits.perSecond'),
     per_generation: t('llmOps.sourcePriceDrawer.billingUnits.perGeneration')
   }
-  return labels[unit] || ''
+  return labels[unit] || unit || '-'
 }
 
 function modalityLabel(modality) {
@@ -596,10 +419,6 @@ function modalityLabel(modality) {
     multimodal: t('llmOps.sourcePriceDrawer.modalities.multimodal')
   }
   return labels[modality] || modality || ''
-}
-
-function sourceOwnerType(source) {
-  return priceSourceOwnerType(source)
 }
 
 function sourceOwnerTypeLabel(ownerType) {
@@ -618,30 +437,14 @@ function sourceOwnerTypeLabel(ownerType) {
 }
 
 function sourceModeLabel(source) {
-  const method = sourceCollectionMethod(source)
-  if (String(source?.endpoint_url || '').includes('models.dev/api.json')) {
-    return t('llmOps.sourcePriceDrawer.sourceMode.aggregateSync')
+  const method = priceSourceCollectionMethod(source)
+  const labels = {
+    auto_collect: 'autoCollect',
+    manual_entry: 'manualMaintenance',
+    manual_import: 'manualImport',
+    api_sync: 'apiSync'
   }
-  if (method === 'auto_collect') {
-    return t('llmOps.sourcePriceDrawer.sourceMode.autoCollect')
-  }
-  if (method === 'manual_entry') {
-    return t('llmOps.sourcePriceDrawer.sourceMode.manualMaintenance')
-  }
-  if (method === 'manual_import') {
-    return t('llmOps.sourcePriceDrawer.sourceMode.manualImport')
-  }
-  if (method === 'api_sync') {
-    return t('llmOps.sourcePriceDrawer.sourceMode.apiSync')
-  }
-  if (source?.source_type === 'yunce') {
-    return t('llmOps.sourcePriceDrawer.sourceMode.dedicatedCollect')
-  }
-  return t('llmOps.sourcePriceDrawer.sourceMode.pending')
-}
-
-function sourceCollectionMethod(source) {
-  return priceSourceCollectionMethod(source)
+  return t(`llmOps.sourcePriceDrawer.sourceMode.${labels[method] || 'pending'}`)
 }
 
 function formatDateTime(value) {
@@ -656,120 +459,44 @@ function formatDateTime(value) {
 </script>
 
 <style scoped>
-.panel {
-  @apply rounded-lg border border-slate-200 bg-white p-4 shadow-sm;
-}
-
-.panel-title {
-  @apply text-sm font-semibold text-slate-900;
-}
-
-.summary-card {
-  @apply rounded-lg bg-slate-50 px-3 py-2;
-}
-
-.summary-card p {
-  @apply text-xs text-slate-500;
-}
-
-.summary-card strong {
-  @apply mt-1 block font-mono text-sm text-slate-800;
-}
-
 .source-info-grid {
-  @apply grid gap-3 md:grid-cols-3;
+  @apply grid gap-3 sm:grid-cols-2 xl:grid-cols-4;
 }
-
 .source-info-grid div {
   @apply min-w-0 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2;
 }
-
 .source-info-grid span {
   @apply block text-xs text-slate-500;
 }
-
 .source-info-grid strong,
 .source-info-grid a {
   @apply mt-1 block truncate text-sm font-medium text-slate-800;
 }
-
 .source-link {
   @apply text-indigo-600 hover:text-indigo-700 hover:underline;
 }
-
 .table-toolbar {
-  @apply flex flex-col gap-3 border-b border-slate-200 bg-white px-4 py-3 md:flex-row md:items-center md:justify-between;
+  @apply flex flex-col gap-3 border-b border-slate-200 px-4 py-3 md:flex-row md:items-center md:justify-between;
 }
-
-.data-table {
-  @apply min-w-full table-fixed divide-y divide-slate-200;
+.price-chip {
+  @apply inline-flex items-center gap-2 rounded-md border border-slate-200 bg-white px-2 py-1 text-xs;
 }
-
-.data-table tbody {
-  @apply divide-y divide-slate-100 bg-white;
-}
-
-.table-head {
-  @apply whitespace-nowrap bg-slate-50 px-4 py-3 text-center text-xs font-semibold uppercase tracking-wide text-slate-500;
-}
-
-.table-cell {
-  @apply min-w-0 px-4 py-3 text-sm text-slate-600;
-}
-
-.source-price-table .model-col {
-  width: 38%;
-}
-
-.source-price-table .price-col {
-  width: 44%;
-}
-
-.source-price-table .time-col {
-  width: 18%;
-}
-
-.token-price-list {
-  @apply grid max-w-md gap-1.5;
-}
-
-.token-price-row {
-  @apply grid grid-cols-[4.5rem_minmax(0,1fr)] items-center gap-3 text-xs;
-}
-
-.token-price-row span {
+.price-chip span {
   @apply text-slate-400;
 }
-
-.token-price-row strong {
-  @apply truncate text-right font-mono font-semibold text-slate-800;
+.price-chip strong {
+  @apply font-mono font-semibold text-slate-800;
 }
-
 .pagination-bar {
   @apply flex flex-col gap-3 border-t border-slate-100 px-4 py-3 sm:flex-row sm:items-center sm:justify-between;
 }
-
 .pagination-btn {
   @apply px-3 py-1.5 text-xs;
 }
-
 .page-size-control {
   @apply inline-flex items-center gap-2 text-xs font-medium text-slate-500;
 }
-
 .page-size-select {
-  @apply h-8 rounded-lg border border-slate-200 bg-white px-2 text-xs text-slate-700 outline-none transition focus:border-indigo-300 focus:ring-4 focus:ring-indigo-50 disabled:cursor-not-allowed disabled:opacity-60;
-}
-
-.btn-secondary {
-  @apply inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60;
-}
-
-.btn-danger {
-  @apply inline-flex items-center gap-2 rounded-lg border border-rose-100 bg-rose-50 px-3 py-2 text-sm font-medium text-rose-700 transition hover:border-rose-200 hover:bg-rose-100 disabled:cursor-not-allowed disabled:opacity-60;
-}
-
-.field-input {
-  @apply w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-800 outline-none transition focus:border-indigo-300 focus:ring-4 focus:ring-indigo-50;
+  @apply h-8 rounded-lg border border-slate-200 bg-white px-2 text-xs text-slate-700;
 }
 </style>

--- a/frontend/src/components/llm-ops/SourcePriceSummaryMetric.vue
+++ b/frontend/src/components/llm-ops/SourcePriceSummaryMetric.vue
@@ -1,0 +1,23 @@
+<template>
+  <div
+    class="rounded-lg border px-3 py-2"
+    :class="
+      tone === 'warning'
+        ? 'border-amber-200 bg-amber-50'
+        : 'border-slate-200 bg-slate-50'
+    "
+  >
+    <p class="text-xs text-slate-500">{{ label }}</p>
+    <strong class="mt-1 block font-mono text-lg text-slate-800">
+      {{ value ?? 0 }}
+    </strong>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  label: { type: String, required: true },
+  value: { type: [Number, String], default: 0 },
+  tone: { type: String, default: 'default' }
+})
+</script>

--- a/frontend/src/composables/useLLMOpsData.js
+++ b/frontend/src/composables/useLLMOpsData.js
@@ -12,6 +12,7 @@ import {
   fetchList
 } from '@/utils/llmOpsPagination'
 import {
+  dataGroupsForChannelModelManagement,
   dataGroupsForResalePublishing,
   dataGroupsForSection
 } from '@/utils/llmOpsSectionData'
@@ -228,6 +229,28 @@ export function useLLMOpsData() {
     })
   }
 
+  function preloadChannelModelData() {
+    const groupValues = {
+      metaModels,
+      modelPrices: modelPriceItems,
+      models,
+      providers
+    }
+    const tasks = dataGroupsForChannelModelManagement()
+      .filter((group) => {
+        if (group === 'channelPricing') {
+          return (
+            !asArray(channelPrices.value).length ||
+            !asArray(channelPriceItems.value).length
+          )
+        }
+        return !asArray(groupValues[group]?.value).length
+      })
+      .map((group) => loadDataGroup(group, 'channels', {}))
+
+    return Promise.all(tasks)
+  }
+
   async function refreshReconciliationRecords() {
     records.value = asArray(
       await fetchFirstPage(llmOpsApi.listReconciliationRecords, {
@@ -289,18 +312,14 @@ export function useLLMOpsData() {
 
   async function refreshProviderManagementData() {
     try {
-      const [sourceData, runData, providerData, summaryRes] = await Promise.all(
-        [
-          fetchList(llmOpsApi.listCollectionSources),
-          fetchRecentCollectionRuns(),
-          fetchList(llmOpsApi.listProviders),
-          llmOpsApi.getSummary(summaryParams())
-        ]
-      )
+      const [sourceData, runData, providerData] = await Promise.all([
+        fetchList(llmOpsApi.listCollectionSources),
+        fetchRecentCollectionRuns(),
+        fetchList(llmOpsApi.listProviders)
+      ])
       sources.value = asArray(sourceData)
       collectionRuns.value = asArray(runData)
       providers.value = asArray(providerData)
-      summary.value = normalizeSummary(extract(summaryRes))
     } catch (error) {
       showError(errorMessage(error, t('llmOps.dataErrors.refreshProviders')))
     }
@@ -308,14 +327,12 @@ export function useLLMOpsData() {
 
   async function refreshMetaModelManagementData() {
     try {
-      const [providerData, metaModelData, summaryRes] = await Promise.all([
+      const [providerData, metaModelData] = await Promise.all([
         fetchList(llmOpsApi.listProviders),
-        fetchList(llmOpsApi.listMetaModels),
-        llmOpsApi.getSummary(summaryParams())
+        fetchList(llmOpsApi.listMetaModels)
       ])
       providers.value = asArray(providerData)
       metaModels.value = asArray(metaModelData)
-      summary.value = normalizeSummary(extract(summaryRes))
     } catch (error) {
       showError(errorMessage(error, t('llmOps.dataErrors.refreshMetaModels')))
     }
@@ -323,13 +340,11 @@ export function useLLMOpsData() {
 
   async function refreshChannelManagementData() {
     try {
-      const [channelData, summaryRes] = await Promise.all([
+      const [channelData] = await Promise.all([
         fetchList(llmOpsApi.listChannels),
-        llmOpsApi.getSummary(summaryParams()),
         refreshChannelPricingData()
       ])
       channels.value = asArray(channelData)
-      summary.value = normalizeSummary(extract(summaryRes))
       refreshResaleListings().catch((error) => {
         showError(errorMessage(error, t('llmOps.dataErrors.refreshListings')))
       })
@@ -419,6 +434,7 @@ export function useLLMOpsData() {
     normalizeDisplayCurrency,
     pageError,
     pointConversion,
+    preloadChannelModelData,
     preloadResalePublishingData,
     procurementRows,
     providerCollectionSources,

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -2466,18 +2466,25 @@
       }
     },
     "sourcePriceDrawer": {
+      "catalogLabel": "Price source catalog",
       "title": "Meta Model Prices Under Supplier",
+      "subtitle": "Complete prices by region, specification, and token range without collapsing tiers.",
       "searchPlaceholder": "Search meta model, provider, or code",
+      "allUsage": "All usage",
+      "defaultScope": "Mainland China / default",
+      "priceItemCount": "{count} current price items",
+      "tierCount": "{count} tiers",
       "actions": {
         "close": "Close",
         "delete": "Delete",
         "deleting": "Deleting"
       },
       "summary": {
-        "currency": "Default currency",
-        "currentItems": "Total meta models",
-        "metaModels": "Meta models on page",
-        "status": "Status"
+        "catalogModelCount": "Parsed catalog models",
+        "collectedSkuCount": "Synced SKUs",
+        "coveredMetaModelCount": "Covered meta models",
+        "currentPriceItemCount": "Current price items",
+        "skippedModelCount": "Skipped models"
       },
       "pagination": {
         "pageSize": "Per page",
@@ -2488,6 +2495,7 @@
         "enabled": "Active"
       },
       "info": {
+        "latestRun": "Latest sync",
         "owner": "Source owner",
         "priceUrl": "Price URL",
         "updateMode": "Update mode"
@@ -2499,7 +2507,8 @@
       },
       "empty": {
         "noPrice": "No price",
-        "noRows": "This price source has no model price records yet."
+        "noRows": "This price source has no model price records yet.",
+        "noSearchResults": "No matching meta model. Try a name, code, or SKU."
       },
       "fallback": {
         "unbound": "Unbound",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -2474,18 +2474,25 @@
       }
     },
     "sourcePriceDrawer": {
+      "catalogLabel": "价格源目录",
       "title": "供货商下的元模型价格",
+      "subtitle": "按地区、规格和 Token 区间展示完整价格，不折叠阶梯。",
       "searchPlaceholder": "搜索元模型、厂商或 code",
+      "allUsage": "全部用量",
+      "defaultScope": "中国内地 / 默认",
+      "priceItemCount": "{count} 条当前价格项",
+      "tierCount": "{count} 个阶梯",
       "actions": {
         "close": "关闭",
         "delete": "删除",
         "deleting": "删除中"
       },
       "summary": {
-        "currency": "默认币种",
-        "currentItems": "全部元模型",
-        "metaModels": "本页元模型",
-        "status": "状态"
+        "catalogModelCount": "官方解析模型",
+        "collectedSkuCount": "成功同步 SKU",
+        "coveredMetaModelCount": "覆盖元模型",
+        "currentPriceItemCount": "当前价格项",
+        "skippedModelCount": "跳过模型"
       },
       "pagination": {
         "pageSize": "每页",
@@ -2496,6 +2503,7 @@
         "enabled": "启用"
       },
       "info": {
+        "latestRun": "最近同步",
         "owner": "来源归属",
         "priceUrl": "价格地址",
         "updateMode": "更新方式"
@@ -2507,7 +2515,8 @@
       },
       "empty": {
         "noPrice": "暂无价格",
-        "noRows": "当前价格源还没有模型价格记录。"
+        "noRows": "当前价格源还没有模型价格记录。",
+        "noSearchResults": "没有匹配的元模型，请尝试名称、code 或 SKU。"
       },
       "fallback": {
         "unbound": "未绑定",

--- a/frontend/src/pages/LLMOps.vue
+++ b/frontend/src/pages/LLMOps.vue
@@ -216,23 +216,15 @@
               v-else-if="activeSection === 'providers'"
               :focus-source-id="operationTargetSourceId"
               :providers="providers"
-              :meta-models="metaModels"
-              :models="models"
               :sources="providerCollectionSources"
               :collection-runs="collectionRuns"
-              :price-items="modelPriceItems"
-              :display-currency="displayCurrency"
-              :exchange-rate="exchangeRate"
               @refresh="refreshProviderManagementData"
               @manual-price-saved="handleManualPriceSaved"
             />
 
             <MetaModelManagement
               v-else-if="activeSection === 'metaModels'"
-              :meta-models="metaModels"
               :providers="providers"
-              :models="models"
-              :price-items="modelPriceItems"
               @refresh="refreshMetaModelManagementData"
             />
 
@@ -248,6 +240,7 @@
               :price-items="modelPriceItems"
               :display-currency="displayCurrency"
               :exchange-rate="exchangeRate"
+              :prepare-model-management="preloadChannelModelData"
               @refresh="refreshChannelManagementData"
             />
 
@@ -304,32 +297,21 @@ import '@/components/llm-ops/llmOpsSelects.css'
 import '@/components/llm-ops/llmOpsTables.css'
 import '@/components/llm-ops/llmOpsShell.css'
 
-import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import {
+  computed,
+  defineAsyncComponent,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  watch
+} from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import AppLayout from '@/components/layout/AppLayout.vue'
 import BaseLoading from '@/components/ui/BaseLoading.vue'
-import AgioneListingStatusBoard from '@/components/llm-ops/AgioneListingStatusBoard.vue'
-import AuditLogPanel from '@/components/llm-ops/AuditLogPanel.vue'
-import ChannelManagement from '@/components/llm-ops/ChannelManagement.vue'
-import ChannelPriceMatrixPanel from '@/components/llm-ops/ChannelPriceMatrixPanel.vue'
-import CollectionHealthPanel from '@/components/llm-ops/CollectionHealthPanel.vue'
-import CollectionRunLogPanel from '@/components/llm-ops/CollectionRunLogPanel.vue'
-import GlobalConfigPanel from '@/components/llm-ops/GlobalConfigPanel.vue'
-import ListingRiskPanel from '@/components/llm-ops/ListingRiskPanel.vue'
 import LLMOpsErrorState from '@/components/llm-ops/LLMOpsErrorState.vue'
 import LLMOpsHeader from '@/components/llm-ops/LLMOpsHeader.vue'
-import LLMOpsMonitorDashboard from '@/components/llm-ops/LLMOpsMonitorDashboard.vue'
 import LLMOpsSidebar from '@/components/llm-ops/LLMOpsSidebar.vue'
-import ModelWorkbenchPanel from '@/components/llm-ops/ModelWorkbenchPanel.vue'
-import MetaModelManagement from '@/components/llm-ops/MetaModelManagement.vue'
-import PriceChangePanel from '@/components/llm-ops/PriceChangePanel.vue'
-import ProviderManagement from '@/components/llm-ops/ProviderManagement.vue'
-import ReconciliationPanel from '@/components/llm-ops/ReconciliationPanel.vue'
-import ResalePlatformModal from '@/components/llm-ops/ResalePlatformModal.vue'
-import ResalePublishingDrawer from '@/components/llm-ops/ResalePublishingDrawer.vue'
-import ResalePublishingWorkspace from '@/components/llm-ops/ResalePublishingWorkspace.vue'
-import ResaleWorkflowConfigPanel from '@/components/llm-ops/ResaleWorkflowConfigPanel.vue'
 import { useLLMOpsData } from '@/composables/useLLMOpsData'
 import { useLLMOpsMonitor } from '@/composables/useLLMOpsMonitor'
 import {
@@ -338,6 +320,69 @@ import {
 } from '@/composables/useLLMOpsNavigation'
 import { useLLMOpsResalePublishing } from '@/composables/useLLMOpsResalePublishing'
 import { parseLLMOpsOperationTarget } from '@/utils/llmOpsOperationEntry'
+
+const asyncPanel = (loader) =>
+  defineAsyncComponent({
+    loader,
+    loadingComponent: BaseLoading,
+    delay: 120,
+    timeout: 30000
+  })
+
+const AgioneListingStatusBoard = asyncPanel(
+  () => import('@/components/llm-ops/AgioneListingStatusBoard.vue')
+)
+const AuditLogPanel = asyncPanel(
+  () => import('@/components/llm-ops/AuditLogPanel.vue')
+)
+const ChannelManagement = asyncPanel(
+  () => import('@/components/llm-ops/ChannelManagement.vue')
+)
+const ChannelPriceMatrixPanel = asyncPanel(
+  () => import('@/components/llm-ops/ChannelPriceMatrixPanel.vue')
+)
+const CollectionHealthPanel = asyncPanel(
+  () => import('@/components/llm-ops/CollectionHealthPanel.vue')
+)
+const CollectionRunLogPanel = asyncPanel(
+  () => import('@/components/llm-ops/CollectionRunLogPanel.vue')
+)
+const GlobalConfigPanel = asyncPanel(
+  () => import('@/components/llm-ops/GlobalConfigPanel.vue')
+)
+const ListingRiskPanel = asyncPanel(
+  () => import('@/components/llm-ops/ListingRiskPanel.vue')
+)
+const LLMOpsMonitorDashboard = asyncPanel(
+  () => import('@/components/llm-ops/LLMOpsMonitorDashboard.vue')
+)
+const ModelWorkbenchPanel = asyncPanel(
+  () => import('@/components/llm-ops/ModelWorkbenchPanel.vue')
+)
+const MetaModelManagement = asyncPanel(
+  () => import('@/components/llm-ops/MetaModelManagement.vue')
+)
+const PriceChangePanel = asyncPanel(
+  () => import('@/components/llm-ops/PriceChangePanel.vue')
+)
+const ProviderManagement = asyncPanel(
+  () => import('@/components/llm-ops/ProviderManagement.vue')
+)
+const ReconciliationPanel = asyncPanel(
+  () => import('@/components/llm-ops/ReconciliationPanel.vue')
+)
+const ResalePlatformModal = asyncPanel(
+  () => import('@/components/llm-ops/ResalePlatformModal.vue')
+)
+const ResalePublishingDrawer = asyncPanel(
+  () => import('@/components/llm-ops/ResalePublishingDrawer.vue')
+)
+const ResalePublishingWorkspace = asyncPanel(
+  () => import('@/components/llm-ops/ResalePublishingWorkspace.vue')
+)
+const ResaleWorkflowConfigPanel = asyncPanel(
+  () => import('@/components/llm-ops/ResaleWorkflowConfigPanel.vue')
+)
 
 const { t } = useI18n()
 
@@ -373,6 +418,7 @@ const {
   normalizeDisplayCurrency,
   pageError,
   pointConversion,
+  preloadChannelModelData,
   preloadResalePublishingData,
   procurementRows,
   providerCollectionSources,

--- a/frontend/src/utils/llmOpsSectionData.js
+++ b/frontend/src/utils/llmOpsSectionData.js
@@ -1,18 +1,11 @@
 const SECTION_DATA_GROUPS = {
   audit: ['channels'],
   channelMatrix: ['channels', 'summary'],
-  channels: [
-    'channels',
-    'providers',
-    'metaModels',
-    'models',
-    'channelPricing',
-    'modelPrices'
-  ],
+  channels: ['channels'],
   collectionHealth: ['sources', 'runs'],
   globalConfig: ['sources'],
   listingRisk: ['summary'],
-  metaModels: ['providers', 'metaModels', 'models', 'modelPrices'],
+  metaModels: ['providers'],
   modelWorkbench: [
     'models',
     'channels',
@@ -24,14 +17,7 @@ const SECTION_DATA_GROUPS = {
   ],
   monitor: ['platforms', 'summary'],
   priceChanges: ['modelPrices', 'priceHistory'],
-  providers: [
-    'sources',
-    'runs',
-    'providers',
-    'metaModels',
-    'models',
-    'modelPrices'
-  ],
+  providers: ['sources', 'runs', 'providers'],
   reconciler: ['channels', 'models', 'records'],
   reseller: ['platforms', 'providers', 'models', 'listings', 'summary'],
   taskLogs: ['sources', 'runs'],
@@ -68,8 +54,20 @@ const RESALE_PUBLISHING_DATA_GROUPS = [
   'listings'
 ]
 
+const CHANNEL_MODEL_DATA_GROUPS = [
+  'providers',
+  'metaModels',
+  'models',
+  'channelPricing',
+  'modelPrices'
+]
+
 export function dataGroupsForResalePublishing() {
   return [...RESALE_PUBLISHING_DATA_GROUPS]
+}
+
+export function dataGroupsForChannelModelManagement() {
+  return [...CHANNEL_MODEL_DATA_GROUPS]
 }
 
 export function dataGroupsForSection(section) {

--- a/frontend/src/utils/sourcePriceCatalog.js
+++ b/frontend/src/utils/sourcePriceCatalog.js
@@ -1,0 +1,132 @@
+const TIER_SPEC_KEYS = new Set([
+  'aggregation_period',
+  'tier_charge_mode',
+  'tier_metric'
+])
+
+const DIMENSION_ORDER = [
+  'text_input',
+  'text_output',
+  'cache_input',
+  'image_input',
+  'image_output',
+  'audio_input',
+  'audio_output',
+  'video_input',
+  'video_output'
+]
+
+export function buildSourcePriceSchedules(priceItems = [], labels = {}) {
+  const variants = new Map()
+  priceItems.forEach((item) => {
+    const identity = variantIdentity(item)
+    if (!variants.has(identity.key)) {
+      variants.set(identity.key, {
+        key: identity.key,
+        scope_label: identity.label || labels.defaultScope || 'Default',
+        sku_code: item.sku_code || '',
+        tiers: []
+      })
+    }
+    const variant = variants.get(identity.key)
+    const tierKey = [
+      item.billing_unit,
+      item.tier_type,
+      item.tier_start ?? '',
+      item.tier_end ?? '',
+      stableJson(priceSpec(item.spec))
+    ].join('|')
+    let tier = variant.tiers.find((candidate) => candidate.key === tierKey)
+    if (!tier) {
+      tier = {
+        key: tierKey,
+        billing_unit: item.billing_unit,
+        range_label: tierRangeLabel(item, labels),
+        prices: []
+      }
+      variant.tiers.push(tier)
+    }
+    tier.prices.push({
+      dimension: item.dimension,
+      currency: item.currency,
+      unit_price: item.unit_price
+    })
+  })
+
+  return Array.from(variants.values())
+    .map((variant) => ({
+      ...variant,
+      tiers: variant.tiers
+        .map((tier) => ({
+          ...tier,
+          prices: tier.prices.sort(dimensionSort)
+        }))
+        .sort(tierSort)
+    }))
+    .sort((left, right) => left.scope_label.localeCompare(right.scope_label))
+}
+
+export function tierRangeLabel(item, labels = {}) {
+  if (item.tier_type !== 'usage_range') {
+    return labels.flat || 'All usage'
+  }
+  const start = compactNumber(item.tier_start ?? 0)
+  const end = item.tier_end === null ? '∞' : compactNumber(item.tier_end)
+  return `[${start}, ${end})`
+}
+
+function variantIdentity(item) {
+  const spec = priceSpec(item.spec)
+  const scopeParts = [
+    item.spec?.deployment_scope,
+    item.spec?.region,
+    ...Object.entries(spec).map(([key, value]) => `${key}: ${value}`)
+  ].filter(Boolean)
+  const uniqueParts = Array.from(new Set(scopeParts.map(String)))
+  const key = [item.sku_code || '', stableJson(spec), ...uniqueParts].join('|')
+  return {
+    key,
+    label: [item.sku_code, ...uniqueParts].filter(Boolean).join(' · ')
+  }
+}
+
+function priceSpec(spec = {}) {
+  return Object.fromEntries(
+    Object.entries(spec || {})
+      .filter(([key, value]) => {
+        return (
+          !TIER_SPEC_KEYS.has(key) &&
+          !['currency', 'deployment_scope', 'region'].includes(key) &&
+          value !== '' &&
+          value !== null &&
+          value !== undefined
+        )
+      })
+      .sort(([left], [right]) => left.localeCompare(right))
+  )
+}
+
+function compactNumber(value) {
+  const number = Number(value)
+  if (!Number.isFinite(number)) return String(value ?? '')
+  return new Intl.NumberFormat('en-US', {
+    maximumFractionDigits: 6
+  }).format(number)
+}
+
+function stableJson(value) {
+  return JSON.stringify(value || {})
+}
+
+function dimensionSort(left, right) {
+  return (
+    DIMENSION_ORDER.indexOf(left.dimension) -
+    DIMENSION_ORDER.indexOf(right.dimension)
+  )
+}
+
+function tierSort(left, right) {
+  const leftStart = Number(left.key.split('|')[2] || 0)
+  const rightStart = Number(right.key.split('|')[2] || 0)
+  return leftStart - rightStart
+}

--- a/frontend/tests/llmOpsResilience.test.js
+++ b/frontend/tests/llmOpsResilience.test.js
@@ -4,6 +4,7 @@ import test from 'node:test'
 
 import { userFacingApiError } from '../src/utils/llmOpsErrors.js'
 import {
+  dataGroupsForChannelModelManagement,
   dataGroupsForResalePublishing,
   dataGroupsForSection,
   toolbarForSection
@@ -113,6 +114,21 @@ test('loads publishing-only data when the resale workspace opens', () => {
     'modelPrices',
     'listings'
   ])
+})
+
+test('loads channel model data only when opening its management drawer', () => {
+  assert.deepEqual(dataGroupsForSection('channels'), ['channels'])
+  assert.deepEqual(dataGroupsForChannelModelManagement(), [
+    'providers',
+    'metaModels',
+    'models',
+    'channelPricing',
+    'modelPrices'
+  ])
+  assert.match(
+    llmOpsPageSource,
+    /:prepare-model-management="preloadChannelModelData"/
+  )
 })
 
 test('does not pass unused model price items to the listing status board', () => {

--- a/frontend/tests/llmOpsSourcePriceCatalog.test.js
+++ b/frontend/tests/llmOpsSourcePriceCatalog.test.js
@@ -1,0 +1,211 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+import {
+  buildSourcePriceSchedules,
+  tierRangeLabel
+} from '../src/utils/sourcePriceCatalog.js'
+
+const providerManagementSource = readFileSync(
+  new URL('../src/components/llm-ops/ProviderManagement.vue', import.meta.url),
+  'utf8'
+)
+const sourceDrawerSource = readFileSync(
+  new URL('../src/components/llm-ops/SourcePriceDrawer.vue', import.meta.url),
+  'utf8'
+)
+const apiSource = readFileSync(
+  new URL('../src/api/llmOps.js', import.meta.url),
+  'utf8'
+)
+const sectionDataSource = readFileSync(
+  new URL('../src/utils/llmOpsSectionData.js', import.meta.url),
+  'utf8'
+)
+const dataComposableSource = readFileSync(
+  new URL('../src/composables/useLLMOpsData.js', import.meta.url),
+  'utf8'
+)
+const channelManagementSource = readFileSync(
+  new URL('../src/components/llm-ops/ChannelManagement.vue', import.meta.url),
+  'utf8'
+)
+const llmOpsPageSource = readFileSync(
+  new URL('../src/pages/LLMOps.vue', import.meta.url),
+  'utf8'
+)
+
+test('searches the complete source catalogue through the API', () => {
+  assert.match(apiSource, /price-catalog/)
+  assert.match(providerManagementSource, /search:\s*selectedProviderSearch/)
+  assert.match(sourceDrawerSource, /emit\('search'/)
+  assert.doesNotMatch(
+    sourceDrawerSource,
+    /row\.search_text\.includes\(keyword\)/
+  )
+})
+
+test('keeps the newest source catalogue response during fast searches', () => {
+  assert.match(providerManagementSource, /selectedProviderRequestId/)
+  assert.match(
+    providerManagementSource,
+    /requestId !== selectedProviderRequestId/
+  )
+})
+
+test('renders all source tiers instead of selecting one price per dimension', () => {
+  assert.match(sourceDrawerSource, /price-schedule/)
+  assert.match(sourceDrawerSource, /tier\.range_label/)
+  assert.match(sourceDrawerSource, /billingUnitLabel\(tier\.billing_unit\)/)
+  assert.match(sourceDrawerSource, /variant\.scope_label/)
+  assert.match(sourceDrawerSource, /variant\.tiers/)
+  assert.doesNotMatch(sourceDrawerSource, /rows\.find\(/)
+})
+
+test('shows collection and coverage counts with distinct labels', () => {
+  assert.match(sourceDrawerSource, /catalogModelCount/)
+  assert.match(sourceDrawerSource, /collectedSkuCount/)
+  assert.match(sourceDrawerSource, /coveredMetaModelCount/)
+  assert.match(sourceDrawerSource, /currentPriceItemCount/)
+})
+
+test('does not preload full model and price catalogues for the source page', () => {
+  const providersGroup = sectionDataSource.match(
+    /providers:\s*\[([^\]]+)\]/
+  )?.[1]
+
+  assert.ok(providersGroup)
+  assert.match(providersGroup, /'sources'/)
+  assert.match(providersGroup, /'runs'/)
+  assert.match(providersGroup, /'providers'/)
+  assert.doesNotMatch(providersGroup, /'metaModels'/)
+  assert.doesNotMatch(providersGroup, /'models'/)
+  assert.doesNotMatch(providersGroup, /'modelPrices'/)
+})
+
+test('loads only provider owners before opening the meta model manager', () => {
+  const metaModelsGroup = sectionDataSource.match(
+    /metaModels:\s*\[([^\]]+)\]/
+  )?.[1]
+
+  assert.equal(metaModelsGroup?.trim(), "'providers'")
+})
+
+test('does not refresh the full summary for isolated management updates', () => {
+  for (const name of [
+    'refreshProviderManagementData',
+    'refreshMetaModelManagementData',
+    'refreshChannelManagementData'
+  ]) {
+    const body = dataComposableSource.match(
+      new RegExp(`async function ${name}\\(\\) \\{([\\s\\S]*?)\\n  \\}`)
+    )?.[1]
+
+    assert.ok(body, `${name} should exist`)
+    assert.doesNotMatch(body, /getSummary/)
+  }
+})
+
+test('loads LLM Ops panels and publishing workspaces on demand', () => {
+  assert.match(llmOpsPageSource, /defineAsyncComponent/)
+  assert.match(llmOpsPageSource, /const asyncPanel/)
+
+  for (const component of [
+    'ProviderManagement',
+    'MetaModelManagement',
+    'ChannelManagement',
+    'ResalePublishingDrawer',
+    'ResalePublishingWorkspace'
+  ]) {
+    assert.match(
+      llmOpsPageSource,
+      new RegExp(`const ${component} = asyncPanel`)
+    )
+    assert.doesNotMatch(
+      llmOpsPageSource,
+      new RegExp(`import ${component} from`)
+    )
+  }
+})
+
+test('waits for deferred channel model data before opening its drawer', () => {
+  assert.match(channelManagementSource, /prepareModelManagement/)
+  assert.match(
+    channelManagementSource,
+    /await props\.prepareModelManagement\(\)/
+  )
+  assert.match(channelManagementSource, /openingChannelId/)
+})
+
+test('keeps the price source drawer localized and keyboard accessible', () => {
+  assert.match(sourceDrawerSource, /role="dialog"/)
+  assert.match(sourceDrawerSource, /aria-modal="true"/)
+  assert.match(
+    sourceDrawerSource,
+    /aria-labelledby="source-price-drawer-title"/
+  )
+  assert.match(sourceDrawerSource, /event\.key === 'Escape'/)
+  assert.match(sourceDrawerSource, /closeButtonRef\.value\?\.focus\(\)/)
+  assert.match(sourceDrawerSource, /sourcePriceDrawer\.catalogLabel/)
+  assert.match(sourceDrawerSource, /sourcePriceDrawer\.tierCount/)
+})
+
+test('groups dimensions into complete regional tier schedules', () => {
+  const items = [
+    ['text_input', '12', '0', '1000000', '全球'],
+    ['text_output', '36', '0', '1000000', '全球'],
+    ['cache_input', '1.2', '0', '1000000', '全球'],
+    ['text_input', '16', '1000000', null, '全球'],
+    ['text_output', '48', '1000000', null, '全球'],
+    ['cache_input', '1.6', '1000000', null, '全球'],
+    ['text_input', '14.988', '0', '1000000', '国际']
+  ].map(([dimension, unit_price, tier_start, tier_end, region]) => ({
+    sku_code: 'qwen3.8-max',
+    dimension,
+    billing_unit: 'per_1m_tokens',
+    currency: 'CNY',
+    unit_price,
+    tier_type: 'usage_range',
+    tier_start,
+    tier_end,
+    spec: {
+      region,
+      deployment_scope: region,
+      tier_metric: 'request_input_tokens'
+    }
+  }))
+
+  const schedules = buildSourcePriceSchedules(items)
+
+  assert.equal(schedules.length, 2)
+  const global = schedules.find((variant) =>
+    variant.scope_label.includes('全球')
+  )
+  assert.ok(global)
+  assert.equal(global.tiers.length, 2)
+  assert.deepEqual(
+    global.tiers.map((tier) => tier.prices.map((price) => price.dimension)),
+    [
+      ['text_input', 'text_output', 'cache_input'],
+      ['text_input', 'text_output', 'cache_input']
+    ]
+  )
+  assert.equal(global.tiers[0].range_label, '[0, 1,000,000)')
+  assert.equal(global.tiers[1].range_label, '[1,000,000, ∞)')
+})
+
+test('labels flat and usage-range prices explicitly', () => {
+  assert.equal(
+    tierRangeLabel({ tier_type: 'flat' }, { flat: '全部用量' }),
+    '全部用量'
+  )
+  assert.equal(
+    tierRangeLabel({
+      tier_type: 'usage_range',
+      tier_start: '0',
+      tier_end: null
+    }),
+    '[0, ∞)'
+  )
+})


### PR DESCRIPTION
## Summary

- Add a searchable source-price catalog API that groups every price tier by regional and specification variant.
- Render full tier ranges, billing units, and coverage metrics in the source drawer.
- Defer heavyweight LLM Ops panels and pricing datasets until their workspaces open, with an index supporting current source catalog queries.
- Add API and frontend regression coverage for tier schedules, deferred loading, and resilience.

Closes #269

## Test plan

- [x] `DJANGO_SETTINGS_MODULE=llm_ops.tests.settings .venv/bin/pytest backend/llm_ops/tests/test_views.py -q`
- [x] `npm run test:unit`
- [x] `npm run typecheck`
- [x] `npm run build`