### PR TITLE
Preserve official LLM price usage tiers

### DIFF
--- a/backend/llm_ops/price_collectors/parsers/baidu.py
+++ b/backend/llm_ops/price_collectors/parsers/baidu.py
@@ -10,9 +10,9 @@ import requests
 from .common import (
     build_text_token_standard_catalog,
     filter_models_by_codes,
+    merge_fallback_into_tiered_rows,
     sync_official_vendor_catalog,
 )
-
 
 PAGE_DATA_URL = (
     "https://bce.bdstatic.com/p3m/bce-doc/online/qianfan/doc/qianfan/s/"
@@ -139,7 +139,7 @@ def extract_models(html: str) -> list[dict[str, Any]]:
                 )
 
     return [
-        {key: value for key, value in item.items() if not key.startswith("_")}
+        finalize_model(item)
         for item in sorted(
             models.values(),
             key=lambda candidate: candidate["model_name"].lower(),
@@ -323,9 +323,13 @@ def merge_price(
     service_clean = service.replace(" ", "")
     pricing_context = f"{service_clean} {subitem_clean}".strip()
     subitem_kind = subitem_kind_from_text(subitem_clean, pricing_context)
+    token_range = token_range_from_service(service_clean)
+    tier_row = tier_row_for_range(model, token_range)
     score = subitem_score(pricing_context)
     if subitem_clean.startswith("命中缓存"):
         model["cache_hit_price_per_million"] = normalized_price
+        if tier_row is not None:
+            tier_row["cache_hit_price_per_million"] = normalized_price
         return
     if subitem_kind == "input" and should_replace_price(
         current_price=model["input_price_per_million"],
@@ -335,6 +339,8 @@ def merge_price(
     ):
         model["input_price_per_million"] = normalized_price
         model["_meta"]["input_score"] = score
+    if subitem_kind == "input" and tier_row is not None:
+        tier_row["input_price_per_million"] = normalized_price
     if subitem_kind == "output" and should_replace_price(
         current_price=model["output_price_per_million"],
         current_score=model["_meta"]["output_score"],
@@ -343,6 +349,8 @@ def merge_price(
     ):
         model["output_price_per_million"] = normalized_price
         model["_meta"]["output_score"] = score
+    if subitem_kind == "output" and tier_row is not None:
+        tier_row["output_price_per_million"] = normalized_price
     notes = ["Extracted from Baidu Qianfan official pricing table."]
     if model["cache_hit_price_per_million"] is not None:
         notes.append(
@@ -350,6 +358,83 @@ def merge_price(
             f"{model['cache_hit_price_per_million']} CNY/1M tokens"
         )
     model["notes"] = "; ".join(notes)
+
+
+def token_range_from_service(value: str) -> str:
+    """Normalize a Baidu input-token service condition to a range."""
+    text = (
+        str(value or "")
+        .lower()
+        .replace("，", ",")
+        .replace("：", ":")
+        .replace("［", "[")
+        .replace("］", "]")
+        .replace("（", "(")
+        .replace("）", ")")
+    )
+    unbounded = re.search(
+        r"输入token数\s*[:：]?\s*(?:>|&gt;)\s*"
+        r"([0-9.]+)\s*k?",
+        text,
+    )
+    if unbounded:
+        start = token_boundary(unbounded.group(1))
+        return f"{start}+" if start else ""
+    match = re.search(
+        r"输入token数\s*[:：]?\s*[\[(]\s*([0-9.]+)\s*k?"
+        r"\s*,\s*([0-9.]+)\s*k?\s*[\])]",
+        text,
+    )
+    if not match:
+        return ""
+    start = token_boundary(match.group(1))
+    end = token_boundary(match.group(2))
+    if not start or not end:
+        return ""
+    return f"{start}-{end}"
+
+
+def token_boundary(value: str) -> str:
+    """Convert a Baidu thousand-token boundary to a raw token count."""
+    try:
+        amount = Decimal(str(value)) * Decimal("1000")
+    except (InvalidOperation, TypeError, ValueError):
+        return ""
+    return format_decimal(amount)
+
+
+def tier_row_for_range(
+    model: dict[str, Any],
+    token_range: str,
+) -> dict[str, Any] | None:
+    """Return the aggregate price row for one explicit token range."""
+    if not token_range:
+        return None
+    rows = model.setdefault("_price_rows", {})
+    return rows.setdefault(
+        token_range,
+        {
+            "input_token_range": token_range,
+            "output_token_range": token_range,
+            "currency": DEFAULT_CURRENCY,
+        },
+    )
+
+
+def finalize_model(model: dict[str, Any]) -> dict[str, Any]:
+    """Expose explicit Baidu context tiers without leaking parser metadata."""
+    result = {
+        key: value
+        for key, value in model.items()
+        if not key.startswith("_")
+    }
+    rows = list((model.get("_price_rows") or {}).values())
+    if rows:
+        result["price_rows"] = merge_fallback_into_tiered_rows(
+            rows,
+            scope_field="billing_scope",
+        )
+    return result
 
 
 def subitem_kind_from_text(subitem: str, pricing_context: str = "") -> str:

--- a/backend/llm_ops/price_collectors/parsers/google.py
+++ b/backend/llm_ops/price_collectors/parsers/google.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import re
 from html import unescape
 from typing import Any
-import re
 
 import requests
 
@@ -11,7 +11,6 @@ from .common import (
     filter_models_by_codes,
     sync_official_vendor_catalog,
 )
-
 
 PRICING_URL = (
     "https://cloud.google.com/gemini-enterprise-agent-platform/"
@@ -154,6 +153,7 @@ def models_from_table(
 ) -> list[dict[str, Any]]:
     """Build Google model price items from one table."""
     rows = expand_rows(table_html)
+    token_ranges = token_ranges_from_header(rows)
     grouped: dict[str, dict[str, Any]] = {}
     for row in rows:
         if len(row) < 3 or is_header_row(row):
@@ -181,6 +181,7 @@ def models_from_table(
             },
         )
         item["_prices"][price_kind] = prices
+        item["_token_ranges"] = token_ranges
 
     models = []
     for item in grouped.values():
@@ -281,6 +282,37 @@ def is_header_row(row: list[str]) -> bool:
     return "model" in joined and ("price" in joined or "input" in joined)
 
 
+def token_ranges_from_header(rows: list[list[str]]) -> list[str]:
+    """Return input-context ranges declared by a Google table header."""
+    for row in rows:
+        if not is_header_row(row):
+            continue
+        ranges = [token_range_from_header_cell(cell) for cell in row[2:]]
+        ranges = [token_range for token_range in ranges if token_range]
+        if len(ranges) >= 2:
+            return ranges
+    return []
+
+
+def token_range_from_header_cell(value: str) -> str:
+    """Convert a Google context-tier header cell to a standard range."""
+    text = normalize_label(value)
+    if "cached" in text:
+        return ""
+    match = re.search(r"(?:<=|=<|≤)\s*(\d+(?:\.\d+)?)\s*k", text)
+    if match:
+        return f"0-{tokens_from_thousands(match.group(1))}"
+    match = re.search(r"(?:>|&gt;)\s*(\d+(?:\.\d+)?)\s*k", text)
+    if match:
+        return f"{tokens_from_thousands(match.group(1))}+"
+    return ""
+
+
+def tokens_from_thousands(value: str) -> int:
+    """Convert a compact token count in thousands to an integer."""
+    return int(float(value) * 1000)
+
+
 def model_id_from_name(value: str) -> str:
     """Normalize a Google model display name into a model ID."""
     text = display_name_from_cell(value).lower()
@@ -361,7 +393,11 @@ def build_model(item: dict[str, Any]) -> dict[str, Any]:
         cache_price = cache_hit_price(input_prices, index)
         if cache_price:
             row["cache_hit_price_per_million"] = cache_price
-        token_range = token_range_for_index(index, row_count)
+        token_range = token_range_for_index(
+            index,
+            row_count,
+            list(item.get("_token_ranges") or []),
+        )
         if token_range:
             row["input_token_range"] = token_range
             row["output_token_range"] = token_range
@@ -400,8 +436,14 @@ def cache_hit_price(input_prices: list[str], index: int) -> str:
     return ""
 
 
-def token_range_for_index(index: int, row_count: int) -> str:
+def token_range_for_index(
+    index: int,
+    row_count: int,
+    token_ranges: list[str],
+) -> str:
     """Return the Google context-window tier for a price row."""
+    if index < len(token_ranges):
+        return token_ranges[index]
     if row_count < 2:
         return ""
     return "0-200000" if index == 0 else "200000+"

--- a/backend/llm_ops/price_collectors/parsers/volcengine.py
+++ b/backend/llm_ops/price_collectors/parsers/volcengine.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import re
+from decimal import Decimal, InvalidOperation
 from typing import Any
 
 import requests
@@ -11,7 +12,6 @@ from .common import (
     filter_models_by_codes,
     sync_official_vendor_catalog,
 )
-
 
 PRICING_URL = "https://www.volcengine.com/docs/82379/1544106?lang=zh"
 DEFAULT_CURRENCY = "CNY"
@@ -222,7 +222,7 @@ def build_row(
         notes_parts.append(f"cache_hit_input={cache_hit_price} CNY/1M tokens")
     if extra_note:
         notes_parts.append(extra_note)
-    return {
+    row = {
         "model_id": model_name,
         "model_name": model_name,
         "aliases": [model_name],
@@ -231,8 +231,14 @@ def build_row(
         "cache_hit_price_per_million": cache_hit_price,
         "currency": DEFAULT_CURRENCY,
         "notes": "; ".join(notes_parts),
+        "_section_name": section_name,
         "_section_priority": 2 if section_name == "online_inference" else 1,
     }
+    token_range = token_range_from_condition(condition)
+    if token_range:
+        row["input_token_range"] = token_range
+        row["output_token_range"] = token_range
+    return row
 
 
 def decode_insert(raw: str) -> str:
@@ -289,15 +295,93 @@ def parse_price(text: str) -> str | None:
     return match.group(1) if match else None
 
 
+def token_range_from_condition(value: str) -> str:
+    """Normalize a VolcEngine input-length condition to a token range."""
+    text = normalize_whitespace(value).lower()
+    unbounded = re.search(
+        r"(?:输入长度|input\s*length)\s*(?:>|&gt;)\s*"
+        r"([0-9]+(?:\.[0-9]+)?)\s*k?",
+        text,
+    )
+    if unbounded:
+        start = token_boundary(unbounded.group(1))
+        return f"{start}+" if start else ""
+    match = re.search(
+        r"(?:输入长度|input\s*length)\s*[\[(]"
+        r"\s*([0-9]+(?:\.[0-9]+)?)\s*k?"
+        r"\s*,\s*([0-9]+(?:\.[0-9]+)?)\s*k?"
+        r"\s*[\])]",
+        text,
+    )
+    if not match:
+        return ""
+    start = token_boundary(match.group(1))
+    end = token_boundary(match.group(2))
+    if not start or not end:
+        return ""
+    return f"{start}-{end}"
+
+
+def token_boundary(value: str) -> str:
+    """Convert one VolcEngine token boundary in thousands to raw tokens."""
+    try:
+        amount = Decimal(str(value)) * Decimal("1000")
+    except (InvalidOperation, TypeError, ValueError):
+        return ""
+    return format(amount.normalize(), "f")
+
+
 def upsert_model(
     models: dict[str, dict[str, Any]],
     item: dict[str, Any],
 ) -> None:
-    """Keep the preferred row for one VolcEngine model."""
+    """Merge VolcEngine rows while retaining distinct token-length tiers."""
     key = item["model_name"].strip().lower()
     existing = models.get(key)
-    if existing is None or candidate_score(item) > candidate_score(existing):
+    if existing is None:
         models[key] = item
+        return
+    if same_price_scenario(existing, item):
+        if candidate_score(item) > candidate_score(existing):
+            models[key] = item
+        return
+    existing_rows = existing.setdefault(
+        "price_rows",
+        [price_row_from_item(existing)],
+    )
+    existing_rows.append(price_row_from_item(item))
+    if candidate_score(item) > candidate_score(existing):
+        for key, value in item.items():
+            if key not in {"price_rows", "_section_priority"}:
+                existing[key] = value
+
+
+def same_price_scenario(
+    first: dict[str, Any],
+    second: dict[str, Any],
+) -> bool:
+    """Return whether two rows describe the same pricing scenario."""
+    if first.get("_section_name") != second.get("_section_name"):
+        return True
+    return (
+        first.get("input_token_range", "")
+        == second.get("input_token_range", "")
+        and first.get("output_token_range", "")
+        == second.get("output_token_range", "")
+    )
+
+
+def price_row_from_item(item: dict[str, Any]) -> dict[str, Any]:
+    """Return one normalized price row from a parsed VolcEngine item."""
+    keys = (
+        "input_price_per_million",
+        "output_price_per_million",
+        "cache_hit_price_per_million",
+        "input_token_range",
+        "output_token_range",
+        "currency",
+    )
+    return {key: item[key] for key in keys if item.get(key) is not None}
 
 
 def candidate_score(item: dict[str, Any]) -> tuple[int, int, float]:

--- a/backend/llm_ops/tests/test_baidu_price_collector.py
+++ b/backend/llm_ops/tests/test_baidu_price_collector.py
@@ -1,8 +1,9 @@
 from django.test import SimpleTestCase
-
+from llm_ops.collection_services import parse_price_range, price_item_payload
+from llm_ops.models import ModelPriceItem
 from llm_ops.price_collectors import collect_vendor_price_catalog
 from llm_ops.price_collectors.parsers.baidu import extract_models
-
+from llm_ops.price_table_validation import validate_price_table_groups
 
 BAIDU_PRICING_HTML = """
 <table>
@@ -50,7 +51,95 @@ BAIDU_CACHE_PRICING_HTML = """
 """
 
 
+BAIDU_TIERED_PRICING_HTML = """
+<table>
+  <tr>
+    <th>模型名称</th><th>版本</th><th>服务</th><th>计费项</th>
+    <th>在线价格</th><th>预留</th><th>预留</th><th>预留</th>
+    <th>单位</th>
+  </tr>
+  <tr><td>文本</td><td>ERNIE-X1-Turbo</td>
+    <td>推理服务 输入Token数：[0,128K]</td><td>输入</td>
+    <td>0.001</td><td>-</td><td>-</td><td>-</td><td>千Token</td></tr>
+  <tr><td>文本</td><td>ERNIE-X1-Turbo</td>
+    <td>推理服务 输入Token数：[0,128K]</td><td>输出</td>
+    <td>0.004</td><td>-</td><td>-</td><td>-</td><td>千Token</td></tr>
+  <tr><td>文本</td><td>ERNIE-X1-Turbo</td>
+    <td>推理服务 输入Token数：(128K,256K]</td><td>输入</td>
+    <td>0.002</td><td>-</td><td>-</td><td>-</td><td>千Token</td></tr>
+  <tr><td>文本</td><td>ERNIE-X1-Turbo</td>
+    <td>推理服务 输入Token数：(128K,256K]</td><td>输出</td>
+    <td>0.008</td><td>-</td><td>-</td><td>-</td><td>千Token</td></tr>
+</table>
+"""
+
+
+BAIDU_COMPLETE_TIERED_PRICING_HTML = BAIDU_TIERED_PRICING_HTML.replace(
+    "</table>",
+    """
+  <tr><td>文本</td><td>ERNIE-X1-Turbo</td>
+    <td>推理服务 输入Token数：>256K</td><td>输入</td>
+    <td>0.003</td><td>-</td><td>-</td><td>-</td><td>千Token</td></tr>
+  <tr><td>文本</td><td>ERNIE-X1-Turbo</td>
+    <td>推理服务 输入Token数：>256K</td><td>输出</td>
+    <td>0.012</td><td>-</td><td>-</td><td>-</td><td>千Token</td></tr>
+</table>""",
+)
+
+
 class BaiduPriceCatalogCollectorTests(SimpleTestCase):
+    def test_extract_models_preserves_official_input_token_tiers(self):
+        models = extract_models(BAIDU_TIERED_PRICING_HTML)
+
+        rows = models[0]["price_rows"]
+
+        self.assertEqual(
+            [row["input_token_range"] for row in rows],
+            ["0-128000", "128000-256000"],
+        )
+        self.assertEqual(
+            [row["output_price_per_million"] for row in rows],
+            ["4", "8"],
+        )
+
+    def test_extract_models_preserves_unbounded_official_tier(self):
+        models = extract_models(BAIDU_COMPLETE_TIERED_PRICING_HTML)
+
+        rows = models[0]["price_rows"]
+
+        self.assertEqual(
+            [row["input_token_range"] for row in rows],
+            ["0-128000", "128000-256000", "256000+"],
+        )
+
+        payloads = []
+        for row in rows:
+            tier_start, tier_end = parse_price_range(
+                row["input_token_range"]
+            )
+            payloads.append(
+                price_item_payload(
+                    {},
+                    dimension=ModelPriceItem.DIMENSION_TEXT_INPUT,
+                    billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
+                    unit_price=row["input_price_per_million"],
+                    tier_start=tier_start,
+                    tier_end=tier_end,
+                )
+            )
+            payloads.append(
+                price_item_payload(
+                    {},
+                    dimension=ModelPriceItem.DIMENSION_TEXT_OUTPUT,
+                    billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
+                    unit_price=row["output_price_per_million"],
+                    tier_start=tier_start,
+                    tier_end=tier_end,
+                )
+            )
+
+        validate_price_table_groups(payloads)
+
     def test_extract_models_from_qianfan_pricing_table(self):
         models = extract_models(BAIDU_PRICING_HTML)
 

--- a/backend/llm_ops/tests/test_google_price_collector.py
+++ b/backend/llm_ops/tests/test_google_price_collector.py
@@ -1,7 +1,6 @@
 from decimal import Decimal
 
 from django.test import SimpleTestCase, TestCase
-
 from llm_ops.collection_services import (
     sync_model_price_items,
     upsert_collected_offering,
@@ -15,7 +14,6 @@ from llm_ops.models import (
 from llm_ops.price_collectors import collect_vendor_price_catalog
 from llm_ops.price_collectors.parsers.google import extract_models
 from llm_ops.skill_runner import standard_catalog_to_collected_catalog
-
 
 GOOGLE_PRICING_HTML = """
 <h3>Gemini 2.5</h3>
@@ -75,7 +73,45 @@ GOOGLE_PRICING_HTML = """
 """
 
 
+GOOGLE_128K_PRICING_HTML = """
+<h3>Gemini 2.0</h3>
+<table>
+  <tr>
+    <th>Model</th>
+    <th>Type</th>
+    <th>Price ( =&lt; 128K input tokens)</th>
+    <th>Price ( &gt; 128K input tokens)</th>
+  </tr>
+  <tr>
+    <td rowspan="2">Gemini 2.0 Flash</td>
+    <td>Input (text)</td>
+    <td>$1.25</td>
+    <td>$2.50</td>
+  </tr>
+  <tr>
+    <td>Output (text)</td>
+    <td>$5.00</td>
+    <td>$10.00</td>
+  </tr>
+</table>
+"""
+
+
 class GooglePriceCatalogCollectorTests(SimpleTestCase):
+    def test_extract_models_uses_context_boundary_from_table_header(self):
+        models = extract_models(GOOGLE_128K_PRICING_HTML)
+
+        pro = next(
+            item
+            for item in models
+            if item["model_id"] == "gemini-2.0-flash"
+        )
+
+        self.assertEqual(
+            [row["input_token_range"] for row in pro["price_rows"]],
+            ["0-128000", "128000+"],
+        )
+
     def test_extract_models_preserves_standard_context_tiers(self):
         models = extract_models(GOOGLE_PRICING_HTML)
 
@@ -190,8 +226,7 @@ class GooglePriceCatalogPersistenceTests(TestCase):
             (
                 price_item
                 for price_item in price_items
-                if price_item.dimension
-                == ModelPriceItem.DIMENSION_TEXT_INPUT
+                if price_item.dimension == ModelPriceItem.DIMENSION_TEXT_INPUT
             ),
             key=lambda price_item: price_item.tier_start,
         )

--- a/backend/llm_ops/tests/test_volcengine_price_collector.py
+++ b/backend/llm_ops/tests/test_volcengine_price_collector.py
@@ -1,30 +1,206 @@
 from django.test import SimpleTestCase
-
+from llm_ops.collection_services import parse_price_range, price_item_payload
+from llm_ops.models import ModelPriceItem
 from llm_ops.price_collectors import collect_vendor_price_catalog
 from llm_ops.price_collectors.parsers.volcengine import extract_models
+from llm_ops.price_table_validation import validate_price_table_groups
 from llm_ops.skill_runner import standard_catalog_run_metadata
 
-
 VOLCENGINE_HTML = (
-    r'\"ops\":[{\"insert\":\"doubao-1.5-pro-32k\"}],'
-    r'\"zoneId\":\"row01nj2n42rlpl8e7b6tvpmvqhysnzfp89bh\",'
-    r'\"zoneType\":\"Z\"'
-    r'\"ops\":[{\"insert\":\"2\"}],'
-    r'\"zoneId\":\"row01s303uu1c1g40de7oaoizn05md89iimb6\",'
-    r'\"zoneType\":\"Z\"'
-    r'\"ops\":[{\"insert\":\"8\"}],'
-    r'\"zoneId\":\"row015wt3pecycob8so1pho26k692zw2cgbsm\",'
-    r'\"zoneType\":\"Z\"'
-    r'\"ops\":[{\"insert\":\"0.4\"}],'
-    r'\"zoneId\":\"row01cvklbb5m01p5jfrmdhooit6bknkyawsj\",'
-    r'\"zoneType\":\"Z\"'
-    r'\"ops\":[{\"insert\":\"标准推理\"}],'
-    r'\"zoneId\":\"row01gagtwd6h2ui45oj1di8jtwno5ytnfdt6\",'
-    r'\"zoneType\":\"Z\"'
+    r"\"ops\":[{\"insert\":\"doubao-1.5-pro-32k\"}],"
+    r"\"zoneId\":\"row01nj2n42rlpl8e7b6tvpmvqhysnzfp89bh\","
+    r"\"zoneType\":\"Z\""
+    r"\"ops\":[{\"insert\":\"2\"}],"
+    r"\"zoneId\":\"row01s303uu1c1g40de7oaoizn05md89iimb6\","
+    r"\"zoneType\":\"Z\""
+    r"\"ops\":[{\"insert\":\"8\"}],"
+    r"\"zoneId\":\"row015wt3pecycob8so1pho26k692zw2cgbsm\","
+    r"\"zoneType\":\"Z\""
+    r"\"ops\":[{\"insert\":\"0.4\"}],"
+    r"\"zoneId\":\"row01cvklbb5m01p5jfrmdhooit6bknkyawsj\","
+    r"\"zoneType\":\"Z\""
+    r"\"ops\":[{\"insert\":\"标准推理\"}],"
+    r"\"zoneId\":\"row01gagtwd6h2ui45oj1di8jtwno5ytnfdt6\","
+    r"\"zoneType\":\"Z\""
+)
+
+
+VOLCENGINE_FIRST_TIER_HTML = (
+    r"\"ops\":[{\"insert\":\"doubao-seed-1-6\"}],"
+    r"\"zoneId\":\"tier01nj2n42rlpl8e7b6tvpmvqhysnzfp89bh\","
+    r"\"zoneType\":\"Z\""
+    r"\"ops\":[{\"insert\":\"2.4\"}],"
+    r"\"zoneId\":\"tier01s303uu1c1g40de7oaoizn05md89iimb6\","
+    r"\"zoneType\":\"Z\""
+    r"\"ops\":[{\"insert\":\"24\"}],"
+    r"\"zoneId\":\"tier015wt3pecycob8so1pho26k692zw2cgbsm\","
+    r"\"zoneType\":\"Z\""
+    r"\"ops\":[{\"insert\":\"输入长度 (0, 128]\"}],"
+    r"\"zoneId\":\"tier01gagtwd6h2ui45oj1di8jtwno5ytnfdt6\","
+    r"\"zoneType\":\"Z\""
+)
+
+
+VOLCENGINE_MULTI_TIER_HTML = (
+    VOLCENGINE_FIRST_TIER_HTML
+    + r"\"ops\":[{\"insert\":\"doubao-seed-1-6\"}],"
+    r"\"zoneId\":\"tier02nj2n42rlpl8e7b6tvpmvqhysnzfp89bh\","
+    r"\"zoneType\":\"Z\""
+    r"\"ops\":[{\"insert\":\"4.8\"}],"
+    r"\"zoneId\":\"tier02s303uu1c1g40de7oaoizn05md89iimb6\","
+    r"\"zoneType\":\"Z\""
+    r"\"ops\":[{\"insert\":\"48\"}],"
+    r"\"zoneId\":\"tier025wt3pecycob8so1pho26k692zw2cgbsm\","
+    r"\"zoneType\":\"Z\""
+    r"\"ops\":[{\"insert\":\"输入长度 (128, 256]\"}],"
+    r"\"zoneId\":\"tier02gagtwd6h2ui45oj1di8jtwno5ytnfdt6\","
+    r"\"zoneType\":\"Z\""
+)
+
+
+VOLCENGINE_SECTION_DUPLICATE_HTML = (
+    VOLCENGINE_FIRST_TIER_HTML
+    + r"\"ops\":[{\"insert\":\"doubao-seed-1-6\"}],"
+    r"\"zoneId\":\"batch1sd9qqqvyjh64sfk1ym6h608eym82d47r\","
+    r"\"zoneType\":\"Z\""
+    r"\"ops\":[{\"insert\":\"1.2\"}],"
+    r"\"zoneId\":\"batch1g1jev13gq4vtdf1u98drambg5e4iydrp\","
+    r"\"zoneType\":\"Z\""
+    r"\"ops\":[{\"insert\":\"12\"}],"
+    r"\"zoneId\":\"batch1r0s2ipdcp1is8youke6te708kops5in5\","
+    r"\"zoneType\":\"Z\""
+    r"\"ops\":[{\"insert\":\"输入长度 (0, 128]\"}],"
+    r"\"zoneId\":\"batch18tq8h7zdnkenawut121k9pl3482469oc\","
+    r"\"zoneType\":\"Z\""
+)
+
+
+VOLCENGINE_COMPLETE_TIER_HTML = (
+    VOLCENGINE_MULTI_TIER_HTML
+    + r"\"ops\":[{\"insert\":\"doubao-seed-1-6\"}],"
+    r"\"zoneId\":\"tier03nj2n42rlpl8e7b6tvpmvqhysnzfp89bh\","
+    r"\"zoneType\":\"Z\""
+    r"\"ops\":[{\"insert\":\"9.6\"}],"
+    r"\"zoneId\":\"tier03s303uu1c1g40de7oaoizn05md89iimb6\","
+    r"\"zoneType\":\"Z\""
+    r"\"ops\":[{\"insert\":\"96\"}],"
+    r"\"zoneId\":\"tier035wt3pecycob8so1pho26k692zw2cgbsm\","
+    r"\"zoneType\":\"Z\""
+    r"\"ops\":[{\"insert\":\"输入长度 > 256\"}],"
+    r"\"zoneId\":\"tier03gagtwd6h2ui45oj1di8jtwno5ytnfdt6\","
+    r"\"zoneType\":\"Z\""
 )
 
 
 class VolcEnginePriceCatalogCollectorTests(SimpleTestCase):
+    def test_complete_tiers_support_an_unbounded_final_range(self):
+        models = extract_models(VOLCENGINE_COMPLETE_TIER_HTML)
+
+        model = models[0]
+
+        self.assertEqual(
+            [row["input_token_range"] for row in model["price_rows"]],
+            ["0-128000", "128000-256000", "256000+"],
+        )
+
+        payloads = []
+        for row in model["price_rows"]:
+            tier_start, tier_end = parse_price_range(
+                row["input_token_range"]
+            )
+            payloads.append(
+                price_item_payload(
+                    {},
+                    dimension=ModelPriceItem.DIMENSION_TEXT_INPUT,
+                    billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
+                    unit_price=row["input_price_per_million"],
+                    tier_start=tier_start,
+                    tier_end=tier_end,
+                )
+            )
+            payloads.append(
+                price_item_payload(
+                    {},
+                    dimension=ModelPriceItem.DIMENSION_TEXT_OUTPUT,
+                    billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
+                    unit_price=row["output_price_per_million"],
+                    tier_start=tier_start,
+                    tier_end=tier_end,
+                )
+            )
+
+        validate_price_table_groups(payloads)
+
+    def test_extract_models_keeps_online_price_when_batch_has_same_tier(self):
+        models = extract_models(VOLCENGINE_SECTION_DUPLICATE_HTML)
+
+        model = models[0]
+
+        self.assertEqual(model["input_price_per_million"], "2.4")
+        self.assertNotIn("price_rows", model)
+
+    def test_extract_models_keeps_each_official_token_length_tier(self):
+        models = extract_models(VOLCENGINE_MULTI_TIER_HTML)
+
+        model = models[0]
+
+        self.assertEqual(
+            [row["input_token_range"] for row in model["price_rows"]],
+            ["0-128000", "128000-256000"],
+        )
+        self.assertEqual(
+            [row["output_price_per_million"] for row in model["price_rows"]],
+            ["24", "48"],
+        )
+
+    def test_catalog_preserves_each_official_token_length_tier(self):
+        payload = collect_vendor_price_catalog(
+            "volcengine",
+            {
+                "raw_html": VOLCENGINE_MULTI_TIER_HTML,
+                "provider_name": "火山方舟",
+            },
+        )
+
+        rows = payload["models"][0]["price_rows"]
+
+        self.assertEqual(
+            [row["values"]["input_token_range"] for row in rows],
+            ["0-128000", "128000-256000"],
+        )
+
+    def test_catalog_preserves_complete_official_token_length_tiers(self):
+        payload = collect_vendor_price_catalog(
+            "volcengine",
+            {
+                "raw_html": VOLCENGINE_COMPLETE_TIER_HTML,
+                "provider_name": "火山方舟",
+            },
+        )
+        model = payload["models"][0]
+
+        self.assertEqual(
+            [
+                row["values"]["input_token_range"]
+                for row in model["price_rows"]
+            ],
+            ["0-128000", "128000-256000", "256000+"],
+        )
+
+    def test_extract_models_preserves_official_token_length_tier(self):
+        models = extract_models(VOLCENGINE_FIRST_TIER_HTML)
+
+        model = models[0]
+
+        self.assertEqual(
+            model["input_token_range"],
+            "0-128000",
+        )
+        self.assertEqual(
+            model["output_token_range"],
+            "0-128000",
+        )
+
     def test_extract_models_reads_document_zone_prices(self):
         models = extract_models(VOLCENGINE_HTML)
 


### PR DESCRIPTION
## Summary

- Read Google context boundaries from official pricing table headers, supporting both 128K and 200K tiers.
- Preserve verified Baidu Qianfan and VolcEngine request input-token tiers, including unbounded final tiers.
- Keep batch pricing separate and preserve source semantics where no verified request-tier rule exists.

Closes #271

## Test plan

- [x] `pytest backend/llm_ops/tests/test_baidu_price_collector.py backend/llm_ops/tests/test_volcengine_price_collector.py -q`
- [x] `pytest backend/llm_ops/tests/test_google_price_collector.py -k "not Persistence" -q`
- [x] `python backend/manage.py check`
- [x] `isort`, `flake8`, and `git diff --check`