### PR TITLE
fix(ci): disable OCI attestations for ACR

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -91,6 +91,8 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64
+          provenance: false
+          sbom: false
 
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Disable Buildx provenance attestations that Alibaba Cloud Registry rejects.
- Disable SBOM attestations for the same registry compatibility boundary.

Closes #273

## Verification

- [x] Workflow YAML parses successfully.
- [x] `git diff --check` passes.
- [ ] Re-run Build and Deploy for version `1.21.0` after merge.