### PR TITLE
fix(llm-ops): display tiered prices in channel configuration

### DIFF
--- a/frontend/src/components/llm-ops/ChannelModelDrawer.vue
+++ b/frontend/src/components/llm-ops/ChannelModelDrawer.vue
@@ -635,7 +635,7 @@
                         :class="comparisonTone(item.comparison_status)"
                         :title="comparisonTitle(item)"
                       >
-                        {{ dimensionLabel(item.dimension) }}
+                        {{ channelPriceItemLabel(item) }}
                         {{ moneyOrStatus(item.unit_price, item.currency) }}
                       </span>
                     </div>
@@ -1016,11 +1016,11 @@ const {
 const {
   batchPendingDraftPriceSummary,
   batchUpstreamPriceSummary,
+  channelPriceItemLabel,
   channelRowSourceLabel,
   compactCostSummary,
   comparisonTitle,
   comparisonTone,
-  dimensionLabel,
   hasKnownSourceCategory,
   modalityLabel,
   moneyOrStatus,

--- a/frontend/src/composables/useChannelModelPricing.js
+++ b/frontend/src/composables/useChannelModelPricing.js
@@ -1,3 +1,8 @@
+import {
+  channelPriceItemLabel,
+  channelPriceSummaryRows
+} from '@/utils/channelPriceCatalog'
+
 export function useChannelModelPricing({
   customPriceFields,
   normalizeSearch,
@@ -58,11 +63,9 @@ export function useChannelModelPricing({
   function compactCostSummary(row) {
     if (row?.priceItems?.length) {
       return priceSummaryText(
-        sortPriceItems(row.priceItems).map((item) => ({
-          label: priceItemDisplayLabel(item.dimension),
-          value: item.unit_price,
-          currency: item.currency
-        }))
+        channelPriceSummaryRows(row.priceItems),
+        null,
+        Number.POSITIVE_INFINITY
       )
     }
     const previewItems = draftPricePreview(row?.draft, row?.model)
@@ -83,7 +86,7 @@ export function useChannelModelPricing({
   function upstreamPriceSummary(model) {
     const rows = providerPriceSummary(model)
     if (!rows.length) return '-'
-    return priceSummaryText(rows, model)
+    return priceSummaryText(rows, model, Number.POSITIVE_INFINITY)
   }
 
   function priceSummaryText(rows, model = null, limit = 3) {
@@ -226,13 +229,7 @@ export function useChannelModelPricing({
   function providerPriceSummary(model) {
     const itemRows = providerPriceItemsForModel(model)
     if (itemRows.length) {
-      return compactPriceRows(
-        itemRows.map((item) => [
-          providerPriceItemLabel(item.dimension),
-          item.unit_price,
-          item.currency
-        ])
-      )
+      return channelPriceSummaryRows(itemRows)
     }
 
     if (model.modality === 'video') {
@@ -352,25 +349,6 @@ export function useChannelModelPricing({
     return `${String(score).padStart(3, '0')}-${item?.tier_start || ''}-${dimension}`
   }
 
-  function providerPriceItemLabel(dimension) {
-    const labels = {
-      text_input: 'Input',
-      text_output: 'Output',
-      cache_input: 'Cache',
-      image_input: 'Image In',
-      image_output: 'Image Out',
-      audio_input: 'Audio In',
-      audio_output: 'Audio Out',
-      video_input: 'Video In',
-      video_output: 'Video Out'
-    }
-    return labels[dimension] || dimensionLabel(dimension)
-  }
-
-  function priceItemDisplayLabel(dimension) {
-    return providerPriceItemLabel(dimension)
-  }
-
   function previewPriceLabel(label) {
     const normalized = String(label || '').trim()
     const labels = {
@@ -463,14 +441,6 @@ export function useChannelModelPricing({
         }
       })
       .filter((item) => item.value !== null)
-  }
-
-  function compactPriceRows(rows) {
-    return rows
-      .filter(
-        ([, value]) => value !== null && value !== undefined && value !== ''
-      )
-      .map(([label, value, currency]) => ({ label, value, currency }))
   }
 
   function dimensionLabel(dimension) {
@@ -587,6 +557,7 @@ export function useChannelModelPricing({
   return {
     batchPendingDraftPriceSummary,
     batchUpstreamPriceSummary,
+    channelPriceItemLabel,
     channelRowSourceLabel,
     compactCostSummary,
     comparisonTitle,

--- a/frontend/src/utils/channelPriceCatalog.js
+++ b/frontend/src/utils/channelPriceCatalog.js
@@ -1,0 +1,57 @@
+import { tierRangeLabel } from './sourcePriceCatalog.js'
+
+export function channelPriceSummaryRows(priceItems = []) {
+  return priceItems
+    .slice()
+    .sort(channelPriceItemSort)
+    .map((item) => ({
+      label: channelPriceItemLabel(item),
+      value: item.unit_price,
+      currency: item.currency
+    }))
+}
+
+export function channelPriceItemLabel(item = {}) {
+  const label = priceDimensionLabel(item.dimension)
+  if (item.tier_type !== 'usage_range') return label
+  return `${tierRangeLabel(item)} ${label}`
+}
+
+function channelPriceItemSort(left, right) {
+  const tierComparison =
+    Number(left.tier_start || 0) - Number(right.tier_start || 0)
+  if (tierComparison !== 0) return tierComparison
+  return (
+    priceDimensionOrder(left.dimension) - priceDimensionOrder(right.dimension)
+  )
+}
+
+function priceDimensionLabel(dimension) {
+  const labels = {
+    text_input: 'Input',
+    text_output: 'Output',
+    cache_input: 'Cache',
+    image_input: 'Image In',
+    image_output: 'Image Out',
+    audio_input: 'Audio In',
+    audio_output: 'Audio Out',
+    video_input: 'Video In',
+    video_output: 'Video Out'
+  }
+  return labels[dimension] || dimension || '-'
+}
+
+function priceDimensionOrder(dimension) {
+  const order = {
+    text_input: 10,
+    text_output: 20,
+    cache_input: 30,
+    image_input: 40,
+    image_output: 50,
+    audio_input: 60,
+    audio_output: 70,
+    video_input: 80,
+    video_output: 90
+  }
+  return order[dimension] || 999
+}

--- a/frontend/tests/llmOpsSourcePriceCatalog.test.js
+++ b/frontend/tests/llmOpsSourcePriceCatalog.test.js
@@ -6,6 +6,10 @@ import {
   buildSourcePriceSchedules,
   tierRangeLabel
 } from '../src/utils/sourcePriceCatalog.js'
+import {
+  channelPriceItemLabel,
+  channelPriceSummaryRows
+} from '../src/utils/channelPriceCatalog.js'
 
 const providerManagementSource = readFileSync(
   new URL('../src/components/llm-ops/ProviderManagement.vue', import.meta.url),
@@ -208,4 +212,37 @@ test('labels flat and usage-range prices explicitly', () => {
     }),
     '[0, ∞)'
   )
+})
+
+test('keeps every channel price tier when summarizing one dimension', () => {
+  const items = [
+    ['text_input', '3', '0', '32000'],
+    ['text_output', '14', '0', '32000'],
+    ['cache_input', '0.3', '0', '32000'],
+    ['text_input', '4', '32000', '96000'],
+    ['text_output', '16', '32000', '96000'],
+    ['cache_input', '0.4', '32000', '96000']
+  ].map(([dimension, unit_price, tier_start, tier_end]) => ({
+    dimension,
+    unit_price,
+    currency: 'CNY',
+    tier_type: 'usage_range',
+    tier_start,
+    tier_end
+  }))
+
+  const rows = channelPriceSummaryRows(items)
+
+  assert.deepEqual(
+    rows.map((item) => item.label),
+    [
+      '[0, 32,000) Input',
+      '[0, 32,000) Output',
+      '[0, 32,000) Cache',
+      '[32,000, 96,000) Input',
+      '[32,000, 96,000) Output',
+      '[32,000, 96,000) Cache'
+    ]
+  )
+  assert.equal(channelPriceItemLabel(items[3]), '[32,000, 96,000) Input')
 })


### PR DESCRIPTION
## Summary

- Preserve all channel cost tiers rather than de-duplicating input, output, and cache dimensions.
- Include the usage range in channel configuration cost labels and upstream summaries.
- Add a two-tier GLM-4.5 regression test across input, output, and cache prices.

Closes #275

## Verification

- [x] `npm run test:unit`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] Targeted ESLint
- [ ] Browser check: local app requires sign-in; verified with the regression fixture.