### PR TITLE
Fix tiered resale pricing and final credit display

### DIFF
--- a/frontend/src/components/llm-ops/ResalePublishingWorkspace.vue
+++ b/frontend/src/components/llm-ops/ResalePublishingWorkspace.vue
@@ -356,6 +356,7 @@
               :currency="currencyLabel"
               :errors="tierErrorsFor(row)"
               :model-value="tierDraftFor(row)"
+              :point-label="formatCredit"
               :preview="tierPreviewFor(row)"
               :preview-error="tierPreviewErrorFor(row)"
               :preview-loading="tierPreviewLoadingFor(row)"

--- a/frontend/src/components/llm-ops/ResalePublishingWorkspace.vue
+++ b/frontend/src/components/llm-ops/ResalePublishingWorkspace.vue
@@ -351,7 +351,19 @@
               </div>
             </div>
 
-            <div class="pricing-matrix">
+            <ResaleTierEditor
+              v-if="hasTieredDraft(row)"
+              :currency="currencyLabel"
+              :errors="tierErrorsFor(row)"
+              :model-value="tierDraftFor(row)"
+              :preview="tierPreviewFor(row)"
+              :preview-error="tierPreviewErrorFor(row)"
+              :preview-loading="tierPreviewLoadingFor(row)"
+              :previous-preview="previousTierPreviewFor(row)"
+              @preview="requestTierPreview(row)"
+              @update:model-value="updateTierDraft(row, $event)"
+            />
+            <div v-else class="pricing-matrix">
               <div class="pricing-matrix-head pricing-matrix-label" />
               <div class="pricing-matrix-head">
                 {{ t('llmOps.publishingWorkspace.pricing.cost') }}
@@ -508,17 +520,6 @@
                 </div>
               </template>
             </div>
-            <ResaleTierEditor
-              :currency="currencyLabel"
-              :errors="tierErrorsFor(row)"
-              :model-value="tierDraftFor(row)"
-              :preview="tierPreviewFor(row)"
-              :preview-error="tierPreviewErrorFor(row)"
-              :preview-loading="tierPreviewLoadingFor(row)"
-              :previous-preview="previousTierPreviewFor(row)"
-              @preview="requestTierPreview(row)"
-              @update:model-value="updateTierDraft(row, $event)"
-            />
             <div class="pricing-axis-block compact-pricing-axis">
               <BulletChart
                 :min="marginAxisRangeFor(row).min"
@@ -574,6 +575,7 @@ import { useResaleWorkspaceOptions } from '@/composables/useResaleWorkspaceOptio
 import { useResizableSidebar } from '@/composables/useResizableSidebar'
 import { RESALE_PRICE_DIMENSION_SPECS } from '@/utils/resalePricing'
 import {
+  applyResaleTierMargin,
   buildFlatResalePriceItems,
   hasTieredResalePrices,
   normalizeResalePriceDraft,
@@ -864,6 +866,10 @@ function tierDraftFor(row) {
   return upstreamTierDraftFor(row)
 }
 
+function hasTieredDraft(row) {
+  return hasTieredResalePrices(tierDraftFor(row))
+}
+
 function displayDraftFromItems(items) {
   const displayItems = (items || []).map((item) => ({
     ...item,
@@ -872,13 +878,13 @@ function displayDraftFromItems(items) {
   return resaleTierDraftFromItems(displayItems)
 }
 
-function upstreamTierDraftFor(row) {
+function upstreamCostDraftFor(row) {
   const fallback = resaleTierDraftFromItems(
     buildFlatResalePriceItems(
       {
-        cache: row.priceCacheInRaw,
-        input: row.priceInRaw,
-        output: row.priceOutRaw
+        cache: row.costCacheInRaw,
+        input: row.costInRaw,
+        output: row.costOutRaw
       },
       currencyLabel.value
     )
@@ -900,10 +906,7 @@ function upstreamTierDraftFor(row) {
         : null,
       flat: !tiered,
       price: formatEditablePrice(
-        priceFromMargin(
-          convertToDisplay(item.unit_price, item.currency) ?? 0,
-          row.margin
-        )
+        convertToDisplay(item.unit_price, item.currency) ?? 0
       ),
       start: tiered
         ? item.tier_start === null
@@ -913,6 +916,10 @@ function upstreamTierDraftFor(row) {
     }))
   })
   return draft
+}
+
+function upstreamTierDraftFor(row) {
+  return applyResaleTierMargin(upstreamCostDraftFor(row), row.margin)
 }
 
 function listingDraftFor(row, listing) {
@@ -939,11 +946,7 @@ function tierErrorsFor(row) {
 
 function updateTierDraft(row, tierDraft) {
   const errors = validateResalePriceDraft(tierDraft)
-  const flatValues = {
-    priceCacheInRaw: tierDraft.cache?.[0]?.price ?? row.priceCacheInRaw,
-    priceInRaw: tierDraft.input?.[0]?.price ?? row.priceInRaw,
-    priceOutRaw: tierDraft.output?.[0]?.price ?? row.priceOutRaw
-  }
+  const flatValues = tierSummaryValues(tierDraft, row)
   flatValues.margin = normalizeMargin(
     marginFromRowPrices(row, flatValues) ?? row.margin
   )
@@ -955,6 +958,26 @@ function updateTierDraft(row, tierDraft) {
     tierPreviewError: ''
   })
   emitChange()
+}
+
+function tierSummaryValues(tierDraft, row) {
+  return {
+    priceCacheInRaw: tierDraft.cache?.[0]?.price ?? row.priceCacheInRaw,
+    priceInRaw: tierDraft.input?.[0]?.price ?? row.priceInRaw,
+    priceOutRaw: tierDraft.output?.[0]?.price ?? row.priceOutRaw
+  }
+}
+
+function tierMarginPatch(row, margin) {
+  const tierDraft = applyResaleTierMargin(upstreamCostDraftFor(row), margin)
+  return {
+    ...tierSummaryValues(tierDraft, row),
+    margin,
+    tierDraft,
+    tierErrors: validateResalePriceDraft(tierDraft),
+    tierPreview: null,
+    tierPreviewError: ''
+  }
 }
 
 function tierPreviewFor(row) {
@@ -1160,6 +1183,10 @@ function onMarginInput(row, event) {
   }
   const value = Number(rawValue)
   const margin = Number.isFinite(value) ? value : 0
+  if (hasTieredDraft(row)) {
+    updateChainState(row, tierMarginPatch(row, normalizeMargin(margin)))
+    return
+  }
   const patch = pricePatchForMargin(row, margin, {
     clampToReference: false
   })
@@ -1169,6 +1196,13 @@ function onMarginInput(row, event) {
 function onMarginCommit(row, event) {
   const value = Number(event?.target?.value)
   const margin = Number.isFinite(value) ? value : row.margin
+  if (hasTieredDraft(row)) {
+    const nextMargin = normalizeMargin(margin)
+    updateChainState(row, tierMarginPatch(row, nextMargin))
+    if (event?.target) event.target.value = nextMargin
+    emitChange()
+    return
+  }
   const patch = pricePatchForMargin(row, margin)
   updateChainState(row, patch)
   if (event?.target) event.target.value = patch.margin
@@ -1256,6 +1290,11 @@ const { marketAvg } = useResaleMarketAverages({
 
 function onMarginAxisChange(row, rawMargin) {
   const nextMargin = normalizeMargin(rawMargin)
+  if (hasTieredDraft(row)) {
+    updateChainState(row, tierMarginPatch(row, nextMargin))
+    emitChange()
+    return
+  }
   updateChainState(row, pricePatchForMargin(row, nextMargin))
   emitChange()
 }

--- a/frontend/src/components/llm-ops/ResaleTierCard.vue
+++ b/frontend/src/components/llm-ops/ResaleTierCard.vue
@@ -110,6 +110,13 @@
           :value="card.prices?.[dimension.key]"
           @input="$emit('update:price', dimension.key, $event.target.value)"
         />
+        <span class="mt-1.5 block text-[11px] font-semibold text-agione-700">
+          {{
+            t('llmOps.publishingWorkspace.tiers.finalPoint', {
+              point: pointLabel(card.prices?.[dimension.key])
+            })
+          }}
+        </span>
         <span
           v-if="errors[dimension.key]"
           class="mt-1.5 block text-xs text-rose-600"
@@ -134,7 +141,8 @@ const props = defineProps({
   errors: { type: Object, default: () => ({}) },
   expanded: { type: Boolean, default: false },
   index: { type: Number, required: true },
-  locked: { type: Boolean, default: false }
+  locked: { type: Boolean, default: false },
+  pointLabel: { type: Function, default: () => '—' }
 })
 
 const emit = defineEmits(['remove', 'toggle', 'update:end', 'update:price'])

--- a/frontend/src/components/llm-ops/ResaleTierEditor.vue
+++ b/frontend/src/components/llm-ops/ResaleTierEditor.vue
@@ -50,6 +50,7 @@
       :currency="currency"
       :errors="errors"
       :model-value="modelValue"
+      :point-label="pointLabel"
       @update:model-value="$emit('update:modelValue', $event)"
     />
 
@@ -125,6 +126,7 @@ const props = defineProps({
   currency: { type: String, default: 'USD' },
   errors: { type: Object, default: () => ({}) },
   modelValue: { type: Object, required: true },
+  pointLabel: { type: Function, default: () => '—' },
   previousPreview: { type: Object, default: null },
   preview: { type: Object, default: null },
   previewError: { type: String, default: '' },

--- a/frontend/src/components/llm-ops/TierPriceEditor.vue
+++ b/frontend/src/components/llm-ops/TierPriceEditor.vue
@@ -36,6 +36,7 @@
         :expanded="expandedIndex === index"
         :index="index"
         :locked="boundariesLocked"
+        :point-label="pointLabel"
         @remove="removeCard(index)"
         @toggle="toggleCard(index)"
         @update:end="updateCard(index, 'end', $event)"
@@ -75,7 +76,8 @@ const props = defineProps({
   boundariesLocked: { type: Boolean, default: false },
   currency: { type: String, default: 'USD' },
   errors: { type: Object, default: () => ({}) },
-  modelValue: { type: Object, required: true }
+  modelValue: { type: Object, required: true },
+  pointLabel: { type: Function, default: () => '—' }
 })
 
 const emit = defineEmits(['update:modelValue'])

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1133,6 +1133,7 @@
         "connected": "Adjacent tiers are connected",
         "tier": "Tier",
         "tierLabel": "Tier {value}",
+        "finalPoint": "Final points {point}",
         "add": "Add tier",
         "start": "Usage start",
         "end": "Usage end",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1141,6 +1141,7 @@
         "connected": "相邻阶梯已接续",
         "tier": "阶梯",
         "tierLabel": "阶梯 {value}",
+        "finalPoint": "最终积分 {point}",
         "add": "新增阶梯",
         "start": "起始用量",
         "end": "结束用量",

--- a/frontend/src/utils/resaleTierDraft.js
+++ b/frontend/src/utils/resaleTierDraft.js
@@ -178,6 +178,24 @@ export function buildResaleTierDraftFromCards(cards = []) {
   )
 }
 
+/** Apply a uniform margin to every price in a flat or tiered cost schedule. */
+export function applyResaleTierMargin(draft = {}, margin) {
+  const marginValue = Number(margin)
+  const multiplier = 1 + (Number.isFinite(marginValue) ? marginValue : 0) / 100
+
+  return Object.fromEntries(
+    DIMENSIONS.map(([key]) => [
+      key,
+      (Array.isArray(draft?.[key]) ? draft[key] : []).map((row) => {
+        const cost = decimal(row.price)
+        const price =
+          cost === null ? '' : Number((cost * multiplier).toFixed(2))
+        return { ...row, price: String(price) }
+      })
+    ])
+  )
+}
+
 /** Add a shared tier while keeping the terminal range unbounded. */
 export function addResaleTierCard(cards = [], step = 1000000) {
   const nextCards = cards.map((card) => ({

--- a/frontend/tests/llmOpsResaleTierDraft.test.js
+++ b/frontend/tests/llmOpsResaleTierDraft.test.js
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+  applyResaleTierMargin,
   addResaleTierCard,
   buildResaleTierCards,
   buildFlatResalePriceItems,
@@ -176,6 +177,35 @@ test('keeps a single unbounded usage range on the tiered API path', () => {
     normalizeResalePriceDraft(draft, 'USD').map((item) => item.tier_type),
     ['usage_range', 'usage_range', 'usage_range']
   )
+})
+
+test('applies one margin to every upstream price tier without flattening it', () => {
+  const costs = {
+    cache: [
+      { end: '1000000', flat: false, price: '0.4', start: '0' },
+      { end: null, flat: false, price: '0.2', start: '1000000' }
+    ],
+    input: [
+      { end: '1000000', flat: false, price: '4', start: '0' },
+      { end: null, flat: false, price: '2', start: '1000000' }
+    ],
+    output: [
+      { end: '1000000', flat: false, price: '16', start: '0' },
+      { end: null, flat: false, price: '8', start: '1000000' }
+    ]
+  }
+
+  const prices = applyResaleTierMargin(costs, 31.7)
+
+  assert.equal(hasTieredResalePrices(prices), true)
+  assert.deepEqual(prices.input, [
+    { end: '1000000', flat: false, price: '5.27', start: '0' },
+    { end: null, flat: false, price: '2.63', start: '1000000' }
+  ])
+  assert.deepEqual(prices.output, [
+    { end: '1000000', flat: false, price: '21.07', start: '0' },
+    { end: null, flat: false, price: '10.54', start: '1000000' }
+  ])
 })
 
 test('accepts an unbounded final tier without a terminal error', () => {

--- a/frontend/tests/llmOpsSourcePriceCatalog.test.js
+++ b/frontend/tests/llmOpsSourcePriceCatalog.test.js
@@ -39,6 +39,21 @@ const llmOpsPageSource = readFileSync(
   new URL('../src/pages/LLMOps.vue', import.meta.url),
   'utf8'
 )
+const resaleTierEditorSource = readFileSync(
+  new URL('../src/components/llm-ops/ResaleTierEditor.vue', import.meta.url),
+  'utf8'
+)
+const resaleWorkspaceSource = readFileSync(
+  new URL(
+    '../src/components/llm-ops/ResalePublishingWorkspace.vue',
+    import.meta.url
+  ),
+  'utf8'
+)
+const resaleTierCardSource = readFileSync(
+  new URL('../src/components/llm-ops/ResaleTierCard.vue', import.meta.url),
+  'utf8'
+)
 
 test('searches the complete source catalogue through the API', () => {
   assert.match(apiSource, /price-catalog/)
@@ -245,4 +260,11 @@ test('keeps every channel price tier when summarizing one dimension', () => {
     ]
   )
   assert.equal(channelPriceItemLabel(items[3]), '[32,000, 96,000) Input')
+})
+
+test('shows final point values for every resale tier price', () => {
+  assert.match(resaleTierEditorSource, /:point-label="pointLabel"/)
+  assert.match(resaleTierCardSource, /tiers\.finalPoint/)
+  assert.match(resaleTierCardSource, /pointLabel\(card\.prices/)
+  assert.match(resaleWorkspaceSource, /:point-label="formatCredit"/)
 })

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -8,6 +8,10 @@ const packageJson = JSON.parse(
 )
 
 const appVersion = process.env.VITE_APP_VERSION || packageJson.version
+const proxyTarget =
+  process.env.VITE_PROXY_TARGET ||
+  process.env.VITE_API_BASE_URL ||
+  'http://localhost:8000'
 
 export default defineConfig({
   plugins: [vue()],
@@ -60,7 +64,7 @@ export default defineConfig({
     },
     proxy: {
       '/api': {
-        target: process.env.VITE_API_BASE_URL || 'http://localhost:8000',
+        target: proxyTarget,
         changeOrigin: true,
         secure: false,
         configure:
@@ -79,7 +83,7 @@ export default defineConfig({
             : undefined
       },
       '/accounts': {
-        target: process.env.VITE_API_BASE_URL || 'http://localhost:8000',
+        target: proxyTarget,
         changeOrigin: true,
         secure: false
       }


### PR DESCRIPTION
## Summary
- Preserve each upstream tier while applying a unified resale margin
- Display the converted final credit value below every tier Input, Output, and Cache price
- Add an explicit Vite dev-proxy target for validating local UI against a selected backend

Closes #277

## Test plan
- [x] `npm run test:unit -- --test-name-pattern="shows final point|applies one margin"`
- [x] `npm run typecheck`
- [x] Targeted ESLint
- [x] `npm run build`
- [x] Read-only browser verification against Agione GLM-4.5 tiered data