### PR TITLE
Clarify tiered channel model price display

### DIFF
--- a/frontend/src/components/llm-ops/ChannelModelDrawer.vue
+++ b/frontend/src/components/llm-ops/ChannelModelDrawer.vue
@@ -818,14 +818,73 @@
                         <em>{{ t('llmOps.channelModelDrawer.rule') }}</em>
                         <strong>{{ priceRuleSummary(row) }}</strong>
                       </p>
-                      <span>
-                        <em>{{ t('llmOps.channelModelDrawer.cost') }}</em>
-                        <strong>{{ compactCostSummary(row) }}</strong>
-                      </span>
-                      <span>
-                        <em>{{ t('llmOps.channelModelDrawer.upstream') }}</em>
-                        <strong>{{ upstreamPriceSummary(row.model) }}</strong>
-                      </span>
+                      <template v-if="priceTierComparisonRows(row).length">
+                        <div class="price-tier-list">
+                          <div
+                            v-for="tier in priceTierComparisonRows(row)"
+                            :key="tier.rangeLabel"
+                            class="price-tier"
+                          >
+                            <span class="price-tier-range">
+                              {{ tier.rangeLabel }}
+                            </span>
+                            <div class="price-tier-line">
+                              <em>{{ t('llmOps.channelModelDrawer.cost') }}</em>
+                              <div
+                                v-if="tier.costPrices.length"
+                                class="price-tier-values"
+                              >
+                                <span
+                                  v-for="price in tier.costPrices"
+                                  :key="price.label"
+                                  class="price-tier-value"
+                                >
+                                  <em>{{ price.label }}</em>
+                                  <strong>
+                                    {{ priceNumberText(price, row.model, 2) }}
+                                  </strong>
+                                </span>
+                              </div>
+                              <strong v-else class="price-tier-missing">
+                                {{ compactCostSummary(row) }}
+                              </strong>
+                            </div>
+                            <div class="price-tier-line">
+                              <em>
+                                {{ t('llmOps.channelModelDrawer.upstream') }}
+                              </em>
+                              <div
+                                v-if="tier.upstreamPrices.length"
+                                class="price-tier-values"
+                              >
+                                <span
+                                  v-for="price in tier.upstreamPrices"
+                                  :key="price.label"
+                                  class="price-tier-value"
+                                >
+                                  <em>{{ price.label }}</em>
+                                  <strong>
+                                    {{ priceNumberText(price, row.model, 2) }}
+                                  </strong>
+                                </span>
+                              </div>
+                              <strong v-else class="price-tier-missing">
+                                {{ upstreamPriceSummary(row.model) }}
+                              </strong>
+                            </div>
+                          </div>
+                        </div>
+                      </template>
+                      <template v-else>
+                        <span>
+                          <em>{{ t('llmOps.channelModelDrawer.cost') }}</em>
+                          <strong>{{ compactCostSummary(row) }}</strong>
+                        </span>
+                        <span>
+                          <em>{{ t('llmOps.channelModelDrawer.upstream') }}</em>
+                          <strong>{{ upstreamPriceSummary(row.model) }}</strong>
+                        </span>
+                      </template>
                     </div>
                   </td>
                   <td class="table-cell">
@@ -903,6 +962,7 @@ import { useChannelModelNewDraft } from '@/composables/useChannelModelNewDraft'
 import { useChannelModelPricing } from '@/composables/useChannelModelPricing'
 import { useChannelModelRows } from '@/composables/useChannelModelRows'
 import { useChannelModelSelection } from '@/composables/useChannelModelSelection'
+import { channelPriceTierRows } from '@/utils/channelPriceCatalog'
 import { asArray } from '@/utils/llmOpsPagination'
 
 import CompactSelect from './CompactSelect.vue'
@@ -1027,6 +1087,8 @@ const {
   modelSourceCategory,
   performanceSummaryItems,
   priceText,
+  priceNumberText,
+  providerPriceItemsForModel,
   providerPriceSummary,
   purchaseSourceLabel,
   sortPriceItems,
@@ -1323,6 +1385,25 @@ function snapshotDrafts(source) {
       serializeDraft(draft)
     ])
   )
+}
+
+function priceTierComparisonRows(row) {
+  const tiers = new Map()
+  const append = (items, key) => {
+    channelPriceTierRows(items).forEach((tier) => {
+      const comparison = tiers.get(tier.rangeLabel) || {
+        costPrices: [],
+        rangeLabel: tier.rangeLabel,
+        upstreamPrices: []
+      }
+      comparison[key] = tier.prices
+      tiers.set(tier.rangeLabel, comparison)
+    })
+  }
+
+  append(row?.priceItems || [], 'costPrices')
+  append(providerPriceItemsForModel(row?.model), 'upstreamPrices')
+  return Array.from(tiers.values())
 }
 
 function toggleModelDropdown() {

--- a/frontend/src/components/llm-ops/channelModelDrawer.css
+++ b/frontend/src/components/llm-ops/channelModelDrawer.css
@@ -437,8 +437,8 @@
   @apply min-w-0 space-y-1;
 }
 
-.channel-model-drawer .price-cell p,
-.channel-model-drawer .price-cell span {
+.channel-model-drawer .price-cell > p,
+.channel-model-drawer .price-cell > span {
   @apply grid min-w-0 grid-cols-[2.25rem_minmax(0,1fr)] items-start gap-2 text-xs;
 }
 
@@ -454,8 +454,48 @@
   -webkit-line-clamp: 2;
 }
 
-.channel-model-drawer .price-cell span strong {
+.channel-model-drawer .price-cell > span strong {
   @apply font-medium text-slate-600;
+}
+
+.channel-model-drawer .price-tier-list {
+  @apply grid gap-1.5;
+}
+
+.channel-model-drawer .price-tier {
+  @apply rounded-md border border-slate-100 bg-slate-50 px-2 py-1.5;
+}
+
+.channel-model-drawer .price-tier-range {
+  @apply mb-1 block font-mono text-[11px] font-semibold text-slate-500;
+}
+
+.channel-model-drawer .price-tier-line {
+  @apply grid grid-cols-[2.25rem_minmax(0,1fr)] items-start gap-2 text-xs leading-5;
+}
+
+.channel-model-drawer .price-tier-line > em {
+  @apply not-italic text-slate-400;
+}
+
+.channel-model-drawer .price-tier-values {
+  @apply flex flex-wrap gap-x-2 gap-y-0.5;
+}
+
+.channel-model-drawer .price-tier-value {
+  @apply inline-flex items-baseline gap-1 font-mono text-[11px] text-slate-600;
+}
+
+.channel-model-drawer .price-tier-value em {
+  @apply not-italic text-slate-400;
+}
+
+.channel-model-drawer .price-tier-value strong {
+  @apply font-semibold text-slate-700;
+}
+
+.channel-model-drawer .price-tier-missing {
+  @apply min-w-0 font-medium text-slate-600;
 }
 
 .channel-model-drawer .ability-cell {

--- a/frontend/src/composables/useChannelModelPricing.js
+++ b/frontend/src/composables/useChannelModelPricing.js
@@ -573,6 +573,7 @@ export function useChannelModelPricing({
     modelSourceCategory,
     performanceSummaryItems,
     priceText,
+    priceNumberText,
     providerPriceItemsForModel,
     providerPriceSummary,
     purchaseSourceLabel,

--- a/frontend/src/utils/channelPriceCatalog.js
+++ b/frontend/src/utils/channelPriceCatalog.js
@@ -11,6 +11,34 @@ export function channelPriceSummaryRows(priceItems = []) {
     }))
 }
 
+export function channelPriceTierRows(priceItems = []) {
+  const tiers = new Map()
+
+  priceItems
+    .slice()
+    .sort(channelPriceItemSort)
+    .forEach((item) => {
+      const key = [
+        item.tier_type || 'flat',
+        item.tier_start || '',
+        item.tier_end || ''
+      ].join(':')
+      const tier = tiers.get(key) || {
+        prices: [],
+        rangeLabel: tierRangeLabel(item)
+      }
+
+      tier.prices.push({
+        currency: item.currency,
+        label: priceDimensionLabel(item.dimension),
+        value: item.unit_price
+      })
+      tiers.set(key, tier)
+    })
+
+  return Array.from(tiers.values())
+}
+
 export function channelPriceItemLabel(item = {}) {
   const label = priceDimensionLabel(item.dimension)
   if (item.tier_type !== 'usage_range') return label

--- a/frontend/tests/llmOpsSourcePriceCatalog.test.js
+++ b/frontend/tests/llmOpsSourcePriceCatalog.test.js
@@ -8,7 +8,8 @@ import {
 } from '../src/utils/sourcePriceCatalog.js'
 import {
   channelPriceItemLabel,
-  channelPriceSummaryRows
+  channelPriceSummaryRows,
+  channelPriceTierRows
 } from '../src/utils/channelPriceCatalog.js'
 
 const providerManagementSource = readFileSync(
@@ -33,6 +34,10 @@ const dataComposableSource = readFileSync(
 )
 const channelManagementSource = readFileSync(
   new URL('../src/components/llm-ops/ChannelManagement.vue', import.meta.url),
+  'utf8'
+)
+const channelModelDrawerSource = readFileSync(
+  new URL('../src/components/llm-ops/ChannelModelDrawer.vue', import.meta.url),
   'utf8'
 )
 const llmOpsPageSource = readFileSync(
@@ -260,6 +265,49 @@ test('keeps every channel price tier when summarizing one dimension', () => {
     ]
   )
   assert.equal(channelPriceItemLabel(items[3]), '[32,000, 96,000) Input')
+})
+
+test('groups channel prices by usage tier for side-by-side display', () => {
+  const items = [
+    ['text_input', '3', '0', '32000'],
+    ['text_output', '14', '0', '32000'],
+    ['cache_input', '0.3', '0', '32000'],
+    ['text_input', '4', '32000', null],
+    ['text_output', '16', '32000', null],
+    ['cache_input', '0.4', '32000', null]
+  ].map(([dimension, unit_price, tier_start, tier_end]) => ({
+    dimension,
+    unit_price,
+    currency: 'CNY',
+    tier_type: 'usage_range',
+    tier_start,
+    tier_end
+  }))
+
+  assert.deepEqual(channelPriceTierRows(items), [
+    {
+      prices: [
+        { currency: 'CNY', label: 'Input', value: '3' },
+        { currency: 'CNY', label: 'Output', value: '14' },
+        { currency: 'CNY', label: 'Cache', value: '0.3' }
+      ],
+      rangeLabel: '[0, 32,000)'
+    },
+    {
+      prices: [
+        { currency: 'CNY', label: 'Input', value: '4' },
+        { currency: 'CNY', label: 'Output', value: '16' },
+        { currency: 'CNY', label: 'Cache', value: '0.4' }
+      ],
+      rangeLabel: '[32,000, ∞)'
+    }
+  ])
+})
+
+test('renders configured channel prices as grouped tier comparisons', () => {
+  assert.match(channelModelDrawerSource, /price-tier-list/)
+  assert.match(channelModelDrawerSource, /priceTierComparisonRows\(row\)/)
+  assert.match(channelModelDrawerSource, /price-tier-values/)
 })
 
 test('shows final point values for every resale tier price', () => {


### PR DESCRIPTION
## Summary
- Group channel price items by usage range for readable comparison
- Show cost and upstream Input, Output, and Cache values separately per tier
- Retain the existing compact fallback for models without tiered prices

Closes #281

## Test plan
- [x] `node --test tests/llmOpsSourcePriceCatalog.test.js`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] Scoped ESLint and diff validation