### PR TITLE
fix(hyperbdr): repair legacy migration ordering

### DIFF
--- a/backend/hyperbdr_dashboard/migrations/0002_remove_host_and_unused_fields.py
+++ b/backend/hyperbdr_dashboard/migrations/0002_remove_host_and_unused_fields.py
@@ -10,13 +10,8 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RemoveField(
-            model_name='host',
-            name='data_source',
-        ),
-        migrations.RemoveField(
-            model_name='host',
-            name='tenant',
+        migrations.DeleteModel(
+            name='Host',
         ),
         migrations.RemoveConstraint(
             model_name='license',
@@ -65,8 +60,5 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name='tenant',
             constraint=models.UniqueConstraint(fields=('data_source', 'source_tenant_id'), name='hyperbdr_dash_tenant_src_uniq'),
-        ),
-        migrations.DeleteModel(
-            name='Host',
         ),
     ]


### PR DESCRIPTION
## Summary

- Repair the legacy HyperBDR migration ordering.
- Keep the existing migration chain executable when the quotation-platform changes are integrated.

## Details

### HyperBDR migration ordering

- Correct the historical migration dependency so Django can resolve the migration graph in the expected order.
- Remove the obsolete dependency relationship without changing runtime business behavior.
- Keep this maintenance fix isolated from the quotation permission implementation.

## Merge and conflict status

- Latest origin/main is included through commit f4cc626.
- This PR contains only the HyperBDR migration-ordering fix.
- The branch was merged with the latest main without conflicts.
- This PR is targeted to main.

## Test plan

- [x] Migration dependency and ordering reviewed.
- [x] Exactly one database migration script is included in this commit.
- [x] git diff --check passed.

Made with [Orca](https://github.com/stablyai/orca) 🐋
