### PR TITLE
fix: honor Alibaba billing client timeout

### DIFF
--- a/backend/cloud_billing/clouds/alibaba_provider.py
+++ b/backend/cloud_billing/clouds/alibaba_provider.py
@@ -143,6 +143,8 @@ class AlibabaCloud(BaseCloudProvider):
         config = Config(
             access_key_id=self.config.api_key,
             access_key_secret=self.config.api_secret,
+            connect_timeout=self.config.timeout,
+            read_timeout=self.config.timeout,
             endpoint=endpoint,
         )
         return Client(config)

--- a/backend/cloud_billing/clouds/alibaba_provider.py
+++ b/backend/cloud_billing/clouds/alibaba_provider.py
@@ -140,11 +140,12 @@ class AlibabaCloud(BaseCloudProvider):
 
     def _build_client(self, endpoint: str) -> Client:
         """Build a BSS client for the given endpoint."""
+        timeout_ms = self.config.timeout * 1000
         config = Config(
             access_key_id=self.config.api_key,
             access_key_secret=self.config.api_secret,
-            connect_timeout=self.config.timeout,
-            read_timeout=self.config.timeout,
+            connect_timeout=timeout_ms,
+            read_timeout=timeout_ms,
             endpoint=endpoint,
         )
         return Client(config)

--- a/backend/cloud_billing/tests/test_alibaba_provider.py
+++ b/backend/cloud_billing/tests/test_alibaba_provider.py
@@ -39,6 +39,20 @@ class TestAlibabaCloud:
         result = provider._extract_cash_balance(response)
         assert result == 100.50
 
+    def test_build_client_uses_configured_timeout(self):
+        """Alibaba SDK client should honor the configured request timeout."""
+        provider = self._make_provider()
+        provider.config.timeout = 45
+
+        with patch(
+            "cloud_billing.clouds.alibaba_provider.Client"
+        ) as client_class:
+            provider._build_client("business.aliyuncs.com")
+
+        sdk_config = client_class.call_args.args[0]
+        assert sdk_config.connect_timeout == 45
+        assert sdk_config.read_timeout == 45
+
     def test_extract_cash_balance_returns_cash_plus_credit(self):
         """Balance should be cash + credit for international accounts."""
         provider = self._make_provider()

--- a/backend/cloud_billing/tests/test_alibaba_provider.py
+++ b/backend/cloud_billing/tests/test_alibaba_provider.py
@@ -50,8 +50,8 @@ class TestAlibabaCloud:
             provider._build_client("business.aliyuncs.com")
 
         sdk_config = client_class.call_args.args[0]
-        assert sdk_config.connect_timeout == 45
-        assert sdk_config.read_timeout == 45
+        assert sdk_config.connect_timeout == 45_000
+        assert sdk_config.read_timeout == 45_000
 
     def test_extract_cash_balance_returns_cash_plus_credit(self):
         """Balance should be cash + credit for international accounts."""


### PR DESCRIPTION
## Summary

- Convert AlibabaConfig timeout values from seconds to milliseconds at the Tea SDK boundary.
- Apply the configured timeout to both connection and read operations.
- Correct the regression test so 45 seconds must produce 45,000 milliseconds.

Closes #267

Sentry: TOWER-18

## Verification

Passed:
- Alibaba provider tests: 16 passed
- Ruff E4, E7, E9, and F checks on both changed files
- TDD reproduction: the corrected timeout assertion failed before the implementation and passed afterward
- Git diff check

Repository baseline:
- Targeted Mypy still reports three existing diagnostics on unchanged lines in alibaba_provider.py.
- No deployment was performed. Keep Sentry unresolved until production verification.