### PR TITLE
feat(llm-ops): version procurement price contracts

### DIFF
--- a/backend/llm_ops/admin.py
+++ b/backend/llm_ops/admin.py
@@ -6,6 +6,7 @@ from .models import (
     ChannelModelPriceHistory,
     ChannelOffering,
     ChannelPriceItem,
+    ChannelPriceVersion,
     CollectedModelPriceHistory,
     CollectedModelPriceSnapshot,
     LLMOpsGlobalConfig,
@@ -285,6 +286,26 @@ class ChannelModelPriceHistoryAdmin(admin.ModelAdmin):
         "model__name",
         "model__code",
         "price_source__name",
+    )
+
+
+@admin.register(ChannelPriceVersion)
+class ChannelPriceVersionAdmin(admin.ModelAdmin):
+    list_display = (
+        "offering",
+        "model",
+        "version",
+        "status",
+        "effective_from",
+        "effective_to",
+        "discount_type",
+        "contract_currency",
+    )
+    list_filter = ("status", "discount_type", "contract_currency")
+    search_fields = (
+        "offering__display_name",
+        "offering__offering_key",
+        "model__name",
     )
 
 

--- a/backend/llm_ops/admin.py
+++ b/backend/llm_ops/admin.py
@@ -4,6 +4,7 @@ from .models import (
     AuditLog,
     ChannelModelPrice,
     ChannelModelPriceHistory,
+    ChannelOffering,
     ChannelPriceItem,
     CollectedModelPriceHistory,
     CollectedModelPriceSnapshot,
@@ -236,6 +237,33 @@ class ChannelModelPriceAdmin(admin.ModelAdmin):
         "model__name",
         "model__code",
         "price_source__name",
+    )
+
+
+@admin.register(ChannelOffering)
+class ChannelOfferingAdmin(admin.ModelAdmin):
+    list_display = (
+        "channel",
+        "meta_model",
+        "offering_key",
+        "display_name",
+        "status",
+        "is_default",
+        "is_sales_enabled",
+        "is_cache_sales_enabled",
+    )
+    list_filter = (
+        "channel",
+        "status",
+        "is_default",
+        "is_sales_enabled",
+        "is_cache_sales_enabled",
+    )
+    search_fields = (
+        "channel__name",
+        "meta_model__name",
+        "offering_key",
+        "display_name",
     )
 
 

--- a/backend/llm_ops/audit.py
+++ b/backend/llm_ops/audit.py
@@ -119,10 +119,48 @@ AUDIT_FIELD_ALLOWLIST: dict[str, tuple[str, ...]] = {
         "latency_ms",
         "notes",
     ),
+    "llm_ops.ChannelOffering": (
+        "channel_id",
+        "meta_model_id",
+        "model_id",
+        "source_offering_id",
+        "offering_key",
+        "display_name",
+        "status",
+        "source_metadata",
+        "is_default",
+        "is_sales_enabled",
+        "is_cache_sales_enabled",
+    ),
+    "llm_ops.ChannelPriceVersion": (
+        "offering_id",
+        "model_id",
+        "meta_model_id",
+        "version",
+        "status",
+        "effective_from",
+        "effective_to",
+        "timezone",
+        "discount_basis",
+        "discount_type",
+        "discount_value",
+        "discount_dimensions",
+        "rounding_mode",
+        "rounding_places",
+        "contract_currency",
+        "contract_exchange_rate",
+        "exchange_rate_effective_from",
+        "exchange_rate_effective_to",
+        "source_evidence",
+        "created_by_id",
+        "updated_by_id",
+    ),
     "llm_ops.ChannelPriceItem": (
         "channel_id",
         "model_id",
         "meta_model_id",
+        "offering_id",
+        "price_version_id",
         "base_price_item_id",
         "source_id",
         "dimension",
@@ -218,6 +256,30 @@ def snapshot_instance(instance: models.Model | None) -> dict[str, Any]:
         except AttributeError:
             continue
         payload[field_name] = serialize_value(value)
+    return payload
+
+
+def snapshot_channel_price_version(instance) -> dict[str, Any]:
+    """Include normalized price rules in a contract version snapshot."""
+    payload = snapshot_instance(instance)
+    payload["price_items"] = [
+        {
+            "dimension": item.dimension,
+            "billing_unit": item.billing_unit,
+            "currency": item.currency,
+            "unit_price": serialize_value(item.unit_price),
+            "tier_type": item.tier_type,
+            "tier_start": serialize_value(item.tier_start),
+            "tier_end": serialize_value(item.tier_end),
+            "spec": item.spec or {},
+            "price_fingerprint": item.price_fingerprint,
+        }
+        for item in instance.price_items.order_by(
+            "dimension",
+            "tier_start",
+            "id",
+        )
+    ]
     return payload
 
 
@@ -335,7 +397,10 @@ def user_agent(request) -> str:
     """Return the user agent with a bounded size."""
     if request is None:
         return ""
-    return (getattr(request, "META", {}).get("HTTP_USER_AGENT", "") or "")[:500]
+    user_agent = (
+        getattr(request, "META", {}).get("HTTP_USER_AGENT", "") or ""
+    )
+    return user_agent[:500]
 
 
 def serialize_value(value):

--- a/backend/llm_ops/collection_services.py
+++ b/backend/llm_ops/collection_services.py
@@ -3357,6 +3357,9 @@ def token_price_item_payloads(
     cache_price = first_decimal_from_row(values, *CACHE_INPUT_PRICE_KEYS)
     input_range = parse_price_range(values.get("input_token_range"))
     output_range = parse_price_range(values.get("output_token_range"))
+    primary_range = (
+        input_range if input_range != (None, None) else output_range
+    )
     if input_price is not None:
         payloads.append(
             price_item_payload(
@@ -3365,8 +3368,8 @@ def token_price_item_payloads(
                 billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
                 unit_price=price_per_million(input_price, item.unit),
                 spec=spec,
-                tier_start=input_range[0],
-                tier_end=input_range[1],
+                tier_start=primary_range[0],
+                tier_end=primary_range[1],
             )
         )
     if output_price is not None:
@@ -3377,8 +3380,8 @@ def token_price_item_payloads(
                 billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
                 unit_price=price_per_million(output_price, item.unit),
                 spec=spec,
-                tier_start=output_range[0],
-                tier_end=output_range[1],
+                tier_start=primary_range[0],
+                tier_end=primary_range[1],
             )
         )
     if cache_price is not None:
@@ -3389,8 +3392,8 @@ def token_price_item_payloads(
                 billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
                 unit_price=price_per_million(cache_price, item.unit),
                 spec=spec,
-                tier_start=input_range[0],
-                tier_end=input_range[1],
+                tier_start=primary_range[0],
+                tier_end=primary_range[1],
             )
         )
     return payloads
@@ -3428,6 +3431,24 @@ def row_price_spec(row) -> dict:
         value = values.get(key) or raw.get(key)
         if value:
             spec[key] = value
+    if values.get("usage_condition_mode") == "multi_metric":
+        usage_conditions = {}
+        for value_key, metric in (
+            ("input_token_range", "input_tokens"),
+            ("output_token_range", "output_tokens"),
+        ):
+            raw_range = values.get(value_key) or raw.get(value_key)
+            if not raw_range:
+                continue
+            start, end = parse_price_range(raw_range)
+            if start is None:
+                continue
+            usage_conditions[metric] = {
+                "start": str(start),
+                "end": str(end) if end is not None else None,
+            }
+        if usage_conditions:
+            spec["usage_conditions"] = usage_conditions
     return spec
 
 

--- a/backend/llm_ops/migrations/0012_channel_offerings.py
+++ b/backend/llm_ops/migrations/0012_channel_offerings.py
@@ -1,0 +1,295 @@
+import django.db.models.deletion
+from django.db import migrations, models
+from django.db.models import Q
+
+
+MIGRATION_MARKER = "0012_channel_offerings"
+
+
+def populate_default_offerings(apps, schema_editor):
+    """Create one default offering for each legacy channel/meta-model pair."""
+    ChannelOffering = apps.get_model("llm_ops", "ChannelOffering")
+    ChannelModelPrice = apps.get_model("llm_ops", "ChannelModelPrice")
+    ChannelModelPriceHistory = apps.get_model(
+        "llm_ops",
+        "ChannelModelPriceHistory",
+    )
+    ChannelPriceItem = apps.get_model("llm_ops", "ChannelPriceItem")
+    MetaModel = apps.get_model("llm_ops", "MetaModel")
+
+    offering_ids = {}
+    price_rows = ChannelModelPrice.objects.all().values(
+        "channel_id",
+        "meta_model_id",
+    ).distinct()
+    for row in price_rows:
+        key = (row["channel_id"], row["meta_model_id"])
+        meta_model = MetaModel.objects.get(pk=row["meta_model_id"])
+        offering, _created = ChannelOffering.objects.get_or_create(
+            channel_id=row["channel_id"],
+            meta_model_id=row["meta_model_id"],
+            is_default=True,
+            defaults={
+                "offering_key": f"default-{row['meta_model_id']}",
+                "display_name": meta_model.name,
+                "source_metadata": {"migration": MIGRATION_MARKER},
+            },
+        )
+        offering_ids[key] = offering.id
+
+    model_groups = (
+        (ChannelModelPrice, "offering_id"),
+        (ChannelModelPriceHistory, "offering_id"),
+        (ChannelPriceItem, "offering_id"),
+    )
+    for model, field_name in model_groups:
+        rows = model.objects.filter(offering_id__isnull=True).values(
+            "channel_id",
+            "meta_model_id",
+        ).distinct()
+        for row in rows:
+            key = (row["channel_id"], row["meta_model_id"])
+            offering_id = offering_ids.get(key)
+            if offering_id is None:
+                meta_model = MetaModel.objects.get(pk=row["meta_model_id"])
+                offering, _created = ChannelOffering.objects.get_or_create(
+                    channel_id=row["channel_id"],
+                    meta_model_id=row["meta_model_id"],
+                    is_default=True,
+                    defaults={
+                        "offering_key": f"default-{row['meta_model_id']}",
+                        "display_name": meta_model.name,
+                        "source_metadata": {
+                            "migration": MIGRATION_MARKER,
+                        },
+                    },
+                )
+                offering_id = offering.id
+                offering_ids[key] = offering_id
+            model.objects.filter(
+                channel_id=row["channel_id"],
+                meta_model_id=row["meta_model_id"],
+                offering_id__isnull=True,
+            ).update(**{field_name: offering_id})
+
+
+def remove_default_offerings(apps, schema_editor):
+    """Detach and remove only offerings created by this migration."""
+    ChannelOffering = apps.get_model("llm_ops", "ChannelOffering")
+    ChannelModelPrice = apps.get_model("llm_ops", "ChannelModelPrice")
+    ChannelModelPriceHistory = apps.get_model(
+        "llm_ops",
+        "ChannelModelPriceHistory",
+    )
+    ChannelPriceItem = apps.get_model("llm_ops", "ChannelPriceItem")
+
+    offerings = ChannelOffering.objects.filter(
+        source_metadata__migration=MIGRATION_MARKER,
+    )
+    offering_ids = list(offerings.values_list("id", flat=True))
+    ChannelModelPrice.objects.filter(offering_id__in=offering_ids).update(
+        offering_id=None
+    )
+    ChannelModelPriceHistory.objects.filter(
+        offering_id__in=offering_ids
+    ).update(offering_id=None)
+    ChannelPriceItem.objects.filter(offering_id__in=offering_ids).update(
+        offering_id=None
+    )
+    offerings.delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("llm_ops", "0011_modelpriceitem_source_current_meta_index"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="ChannelOffering",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("offering_key", models.CharField(max_length=255)),
+                ("display_name", models.CharField(max_length=255)),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("active", "Active"),
+                            ("inactive", "Inactive"),
+                        ],
+                        db_index=True,
+                        default="active",
+                        max_length=20,
+                    ),
+                ),
+                (
+                    "source_metadata",
+                    models.JSONField(blank=True, default=dict),
+                ),
+                (
+                    "is_default",
+                    models.BooleanField(db_index=True, default=False),
+                ),
+                (
+                    "is_sales_enabled",
+                    models.BooleanField(db_index=True, default=False),
+                ),
+                (
+                    "is_cache_sales_enabled",
+                    models.BooleanField(db_index=True, default=False),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "channel",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="offerings",
+                        to="llm_ops.procurementchannel",
+                    ),
+                ),
+                (
+                    "meta_model",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="procurement_offerings",
+                        to="llm_ops.metamodel",
+                    ),
+                ),
+                (
+                    "model",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="procurement_offerings",
+                        to="llm_ops.llmmodel",
+                    ),
+                ),
+                (
+                    "source_offering",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="channel_offerings",
+                        to="llm_ops.sourceskuoffering",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": [
+                    "channel__name",
+                    "meta_model__name",
+                    "display_name",
+                ],
+            },
+        ),
+        migrations.AddConstraint(
+            model_name="channeloffering",
+            constraint=models.UniqueConstraint(
+                fields=("channel", "offering_key"),
+                name="uq_llm_ops_channel_offering_key",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="channeloffering",
+            constraint=models.UniqueConstraint(
+                condition=Q(is_default=True),
+                fields=("channel", "meta_model"),
+                name="uq_llm_ops_default_channel_offering",
+            ),
+        ),
+        migrations.AddField(
+            model_name="channelmodelprice",
+            name="offering",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="model_prices",
+                to="llm_ops.channeloffering",
+            ),
+        ),
+        migrations.AddField(
+            model_name="channelmodelpricehistory",
+            name="offering",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="model_price_history",
+                to="llm_ops.channeloffering",
+            ),
+        ),
+        migrations.AddField(
+            model_name="channelpriceitem",
+            name="offering",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="price_items",
+                to="llm_ops.channeloffering",
+            ),
+        ),
+        migrations.RunPython(
+            populate_default_offerings,
+            remove_default_offerings,
+        ),
+        migrations.RemoveConstraint(
+            model_name="channelmodelprice",
+            name="uq_llm_ops_channel_model_price",
+        ),
+        migrations.AddConstraint(
+            model_name="channelmodelprice",
+            constraint=models.UniqueConstraint(
+                fields=("channel", "model", "offering"),
+                name="uq_llm_ops_channel_model_offering_price",
+            ),
+        ),
+        migrations.RemoveConstraint(
+            model_name="channelpriceitem",
+            name="uq_llm_ops_channel_price_item_fingerprint",
+        ),
+        migrations.AddConstraint(
+            model_name="channelpriceitem",
+            constraint=models.UniqueConstraint(
+                fields=(
+                    "channel",
+                    "model",
+                    "offering",
+                    "dimension",
+                    "billing_unit",
+                    "currency",
+                    "price_fingerprint",
+                ),
+                name="uq_llm_ops_channel_offer_price_item_fp",
+            ),
+        ),
+        migrations.RemoveConstraint(
+            model_name="channelmodelpricehistory",
+            name="uq_llm_ops_channel_price_history_fingerprint",
+        ),
+        migrations.AddConstraint(
+            model_name="channelmodelpricehistory",
+            constraint=models.UniqueConstraint(
+                fields=(
+                    "channel",
+                    "model",
+                    "offering",
+                    "price_fingerprint",
+                ),
+                name="uq_llm_ops_offering_price_history_fingerprint",
+            ),
+        ),
+    ]

--- a/backend/llm_ops/migrations/0013_channel_price_contracts.py
+++ b/backend/llm_ops/migrations/0013_channel_price_contracts.py
@@ -1,0 +1,284 @@
+import django.core.validators
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("llm_ops", "0012_channel_offerings"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="usagereconciliationrecord",
+            name="business_occurred_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="usagereconciliationrecord",
+            name="business_timezone",
+            field=models.CharField(blank=True, default="", max_length=64),
+        ),
+        migrations.AddField(
+            model_name="usagereconciliationrecord",
+            name="exchange_rate_snapshot",
+            field=models.DecimalField(
+                blank=True,
+                decimal_places=8,
+                max_digits=18,
+                null=True,
+            ),
+        ),
+        migrations.AddField(
+            model_name="usagereconciliationrecord",
+            name="exchange_rate_source",
+            field=models.CharField(blank=True, default="", max_length=30),
+        ),
+        migrations.AddField(
+            model_name="usagereconciliationrecord",
+            name="final_price_snapshot",
+            field=models.DecimalField(
+                blank=True,
+                decimal_places=6,
+                max_digits=14,
+                null=True,
+            ),
+        ),
+        migrations.AddField(
+            model_name="usagereconciliationrecord",
+            name="offering",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="reconciliation_records",
+                to="llm_ops.channeloffering",
+            ),
+        ),
+        migrations.AddField(
+            model_name="usagereconciliationrecord",
+            name="price_rule_snapshot",
+            field=models.JSONField(blank=True, default=dict),
+        ),
+        migrations.AddField(
+            model_name="usagereconciliationrecord",
+            name="unit_price_snapshot",
+            field=models.JSONField(blank=True, default=dict),
+        ),
+        migrations.CreateModel(
+            name="ChannelPriceVersion",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("version", models.PositiveIntegerField()),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("draft", "Draft"),
+                            ("scheduled", "Scheduled"),
+                            ("active", "Active"),
+                            ("expired", "Expired"),
+                        ],
+                        db_index=True,
+                        default="draft",
+                        max_length=20,
+                    ),
+                ),
+                (
+                    "effective_from",
+                    models.DateTimeField(
+                        blank=True,
+                        db_index=True,
+                        null=True,
+                    ),
+                ),
+                (
+                    "effective_to",
+                    models.DateTimeField(
+                        blank=True,
+                        db_index=True,
+                        null=True,
+                    ),
+                ),
+                ("timezone", models.CharField(default="UTC", max_length=64)),
+                (
+                    "discount_basis",
+                    models.CharField(
+                        choices=[
+                            ("list_price", "List Price"),
+                            ("contract_price", "Contract Price"),
+                        ],
+                        default="contract_price",
+                        max_length=30,
+                    ),
+                ),
+                (
+                    "discount_type",
+                    models.CharField(
+                        choices=[
+                            ("none", "None"),
+                            ("ratio", "Ratio"),
+                            ("fixed", "Fixed Price"),
+                        ],
+                        default="none",
+                        max_length=20,
+                    ),
+                ),
+                (
+                    "discount_value",
+                    models.DecimalField(
+                        blank=True,
+                        decimal_places=6,
+                        max_digits=14,
+                        null=True,
+                    ),
+                ),
+                (
+                    "rounding_mode",
+                    models.CharField(
+                        choices=[
+                            ("half_up", "Half Up"),
+                            ("up", "Up"),
+                            ("down", "Down"),
+                        ],
+                        default="half_up",
+                        max_length=20,
+                    ),
+                ),
+                (
+                    "rounding_places",
+                    models.PositiveSmallIntegerField(
+                        default=6,
+                        validators=[
+                            django.core.validators.MaxValueValidator(12)
+                        ],
+                    ),
+                ),
+                (
+                    "contract_currency",
+                    models.CharField(blank=True, default="", max_length=10),
+                ),
+                (
+                    "contract_exchange_rate",
+                    models.DecimalField(
+                        blank=True,
+                        decimal_places=8,
+                        max_digits=18,
+                        null=True,
+                    ),
+                ),
+                (
+                    "exchange_rate_effective_from",
+                    models.DateTimeField(blank=True, null=True),
+                ),
+                (
+                    "exchange_rate_effective_to",
+                    models.DateTimeField(blank=True, null=True),
+                ),
+                (
+                    "source_evidence",
+                    models.JSONField(blank=True, default=dict),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="created_channel_price_versions",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "meta_model",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="channel_price_versions",
+                        to="llm_ops.metamodel",
+                    ),
+                ),
+                (
+                    "model",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="channel_price_versions",
+                        to="llm_ops.llmmodel",
+                    ),
+                ),
+                (
+                    "offering",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="price_versions",
+                        to="llm_ops.channeloffering",
+                    ),
+                ),
+                (
+                    "updated_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="updated_channel_price_versions",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["offering", "model", "-version"],
+            },
+        ),
+        migrations.AddField(
+            model_name="channelpriceitem",
+            name="price_version",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="price_items",
+                to="llm_ops.channelpriceversion",
+            ),
+        ),
+        migrations.AddField(
+            model_name="usagereconciliationrecord",
+            name="price_version",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="reconciliation_records",
+                to="llm_ops.channelpriceversion",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="channelpriceversion",
+            index=models.Index(
+                fields=[
+                    "offering",
+                    "model",
+                    "status",
+                    "effective_from",
+                ],
+                name="llmops_price_ver_effective_idx",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="channelpriceversion",
+            constraint=models.UniqueConstraint(
+                fields=("offering", "model", "version"),
+                name="uq_llm_ops_channel_price_version",
+            ),
+        ),
+    ]

--- a/backend/llm_ops/migrations/0014_channel_price_discount_dimensions.py
+++ b/backend/llm_ops/migrations/0014_channel_price_discount_dimensions.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("llm_ops", "0013_channel_price_contracts"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="channelpriceversion",
+            name="discount_dimensions",
+            field=models.JSONField(blank=True, default=list),
+        ),
+    ]

--- a/backend/llm_ops/models.py
+++ b/backend/llm_ops/models.py
@@ -1,3 +1,6 @@
+from decimal import Decimal
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import MaxValueValidator
@@ -1382,6 +1385,216 @@ def _ensure_channel_offering(instance, kwargs):
         kwargs["update_fields"] = list(set(update_fields) | {"offering"})
 
 
+class ChannelPriceVersion(models.Model):
+    """Effective-dated procurement contract price revision."""
+
+    STATUS_DRAFT = "draft"
+    STATUS_SCHEDULED = "scheduled"
+    STATUS_ACTIVE = "active"
+    STATUS_EXPIRED = "expired"
+    STATUS_CHOICES = (
+        (STATUS_DRAFT, "Draft"),
+        (STATUS_SCHEDULED, "Scheduled"),
+        (STATUS_ACTIVE, "Active"),
+        (STATUS_EXPIRED, "Expired"),
+    )
+
+    BASIS_LIST_PRICE = "list_price"
+    BASIS_CONTRACT_PRICE = "contract_price"
+    DISCOUNT_BASIS_CHOICES = (
+        (BASIS_LIST_PRICE, "List Price"),
+        (BASIS_CONTRACT_PRICE, "Contract Price"),
+    )
+
+    DISCOUNT_NONE = "none"
+    DISCOUNT_RATIO = "ratio"
+    DISCOUNT_FIXED = "fixed"
+    DISCOUNT_TYPE_CHOICES = (
+        (DISCOUNT_NONE, "None"),
+        (DISCOUNT_RATIO, "Ratio"),
+        (DISCOUNT_FIXED, "Fixed Price"),
+    )
+
+    ROUND_HALF_UP = "half_up"
+    ROUND_UP = "up"
+    ROUND_DOWN = "down"
+    ROUNDING_MODE_CHOICES = (
+        (ROUND_HALF_UP, "Half Up"),
+        (ROUND_UP, "Up"),
+        (ROUND_DOWN, "Down"),
+    )
+
+    offering = models.ForeignKey(
+        ChannelOffering,
+        related_name="price_versions",
+        on_delete=models.CASCADE,
+    )
+    model = models.ForeignKey(
+        LLMModel,
+        related_name="channel_price_versions",
+        on_delete=models.CASCADE,
+    )
+    meta_model = models.ForeignKey(
+        MetaModel,
+        related_name="channel_price_versions",
+        on_delete=models.CASCADE,
+    )
+    version = models.PositiveIntegerField()
+    status = models.CharField(
+        max_length=20,
+        choices=STATUS_CHOICES,
+        default=STATUS_DRAFT,
+        db_index=True,
+    )
+    effective_from = models.DateTimeField(blank=True, null=True, db_index=True)
+    effective_to = models.DateTimeField(blank=True, null=True, db_index=True)
+    timezone = models.CharField(max_length=64, default="UTC")
+    discount_basis = models.CharField(
+        max_length=30,
+        choices=DISCOUNT_BASIS_CHOICES,
+        default=BASIS_CONTRACT_PRICE,
+    )
+    discount_type = models.CharField(
+        max_length=20,
+        choices=DISCOUNT_TYPE_CHOICES,
+        default=DISCOUNT_NONE,
+    )
+    discount_value = models.DecimalField(
+        max_digits=14,
+        decimal_places=6,
+        blank=True,
+        null=True,
+    )
+    rounding_mode = models.CharField(
+        max_length=20,
+        choices=ROUNDING_MODE_CHOICES,
+        default=ROUND_HALF_UP,
+    )
+    rounding_places = models.PositiveSmallIntegerField(
+        default=6,
+        validators=[MaxValueValidator(12)],
+    )
+    contract_currency = models.CharField(max_length=10, blank=True, default="")
+    contract_exchange_rate = models.DecimalField(
+        max_digits=18,
+        decimal_places=8,
+        blank=True,
+        null=True,
+    )
+    exchange_rate_effective_from = models.DateTimeField(
+        blank=True,
+        null=True,
+    )
+    exchange_rate_effective_to = models.DateTimeField(
+        blank=True,
+        null=True,
+    )
+    source_evidence = models.JSONField(blank=True, default=dict)
+    created_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        related_name="created_channel_price_versions",
+        blank=True,
+        null=True,
+        on_delete=models.SET_NULL,
+    )
+    updated_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        related_name="updated_channel_price_versions",
+        blank=True,
+        null=True,
+        on_delete=models.SET_NULL,
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        ordering = ["offering", "model", "-version"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["offering", "model", "version"],
+                name="uq_llm_ops_channel_price_version",
+            )
+        ]
+        indexes = [
+            models.Index(
+                fields=["offering", "model", "status", "effective_from"],
+                name="llmops_price_ver_effective_idx",
+            )
+        ]
+
+    def __str__(self) -> str:
+        return f"{self.offering} / {self.model.name} / v{self.version}"
+
+    def clean(self):
+        """Validate identity, effective dates, discount, and exchange rate."""
+        super().clean()
+        errors = {}
+        if self.model_id and self.meta_model_id:
+            if self.model.meta_model_id != self.meta_model_id:
+                errors["meta_model"] = "Meta model must match the model."
+        if self.offering_id and self.model_id:
+            if self.offering.meta_model_id != self.model.meta_model_id:
+                errors["offering"] = (
+                    "Offering must belong to the model meta model."
+                )
+        if self.status != self.STATUS_DRAFT and self.effective_from is None:
+            errors["effective_from"] = (
+                "Non-draft versions require an effective start."
+            )
+        if (
+            self.effective_from
+            and self.effective_to
+            and self.effective_to <= self.effective_from
+        ):
+            errors["effective_to"] = (
+                "Effective end must be after effective start."
+            )
+        try:
+            ZoneInfo(self.timezone)
+        except ZoneInfoNotFoundError:
+            errors["timezone"] = "Unknown IANA timezone."
+        if self.discount_type == self.DISCOUNT_RATIO:
+            if self.discount_value is None or not (
+                Decimal("0") <= self.discount_value <= Decimal("1")
+            ):
+                errors["discount_value"] = (
+                    "Ratio discounts must be between 0 and 1."
+                )
+        elif self.discount_type == self.DISCOUNT_FIXED:
+            if self.discount_value is None or self.discount_value < 0:
+                errors["discount_value"] = (
+                    "Fixed prices must be non-negative."
+                )
+        elif self.discount_value is not None:
+            errors["discount_value"] = (
+                "Discount value requires ratio or fixed discount type."
+            )
+        if (
+            self.contract_exchange_rate is not None
+            and self.contract_exchange_rate <= 0
+        ):
+            errors["contract_exchange_rate"] = (
+                "Contract exchange rate must be greater than zero."
+            )
+        if (
+            self.exchange_rate_effective_from
+            and self.exchange_rate_effective_to
+            and self.exchange_rate_effective_to
+            <= self.exchange_rate_effective_from
+        ):
+            errors["exchange_rate_effective_to"] = (
+                "Exchange rate end must be after its start."
+            )
+        if errors:
+            raise ValidationError(errors)
+
+    def save(self, *args, **kwargs):
+        """Keep the canonical model link and validate the contract."""
+        _ensure_meta_model_from_model(self, kwargs)
+        self.full_clean()
+        super().save(*args, **kwargs)
+
+
 class ChannelModelPrice(models.Model):
     """Per-channel listing and price overrides for one model."""
 
@@ -1545,6 +1758,13 @@ class ChannelPriceItem(models.Model):
         blank=True,
         null=True,
         on_delete=models.SET_NULL,
+    )
+    price_version = models.ForeignKey(
+        ChannelPriceVersion,
+        related_name="price_items",
+        blank=True,
+        null=True,
+        on_delete=models.CASCADE,
     )
     dimension = models.CharField(
         max_length=50,
@@ -2592,6 +2812,22 @@ class UsageReconciliationRecord(models.Model):
         related_name="reconciliation_records",
         on_delete=models.CASCADE,
     )
+    offering = models.ForeignKey(
+        ChannelOffering,
+        related_name="reconciliation_records",
+        blank=True,
+        null=True,
+        on_delete=models.SET_NULL,
+    )
+    price_version = models.ForeignKey(
+        ChannelPriceVersion,
+        related_name="reconciliation_records",
+        blank=True,
+        null=True,
+        on_delete=models.SET_NULL,
+    )
+    business_occurred_at = models.DateTimeField(blank=True, null=True)
+    business_timezone = models.CharField(max_length=64, blank=True, default="")
     input_tokens = models.PositiveBigIntegerField(default=0)
     output_tokens = models.PositiveBigIntegerField(default=0)
     cache_input_tokens = models.PositiveBigIntegerField(default=0)
@@ -2625,6 +2861,25 @@ class UsageReconciliationRecord(models.Model):
         choices=STATUS_CHOICES,
         default=STATUS_PERFECT,
         db_index=True,
+    )
+    price_rule_snapshot = models.JSONField(blank=True, default=dict)
+    unit_price_snapshot = models.JSONField(blank=True, default=dict)
+    exchange_rate_snapshot = models.DecimalField(
+        max_digits=18,
+        decimal_places=8,
+        blank=True,
+        null=True,
+    )
+    exchange_rate_source = models.CharField(
+        max_length=30,
+        blank=True,
+        default="",
+    )
+    final_price_snapshot = models.DecimalField(
+        max_digits=14,
+        decimal_places=6,
+        blank=True,
+        null=True,
     )
     notes = models.TextField(blank=True, default="")
     created_at = models.DateTimeField(auto_now_add=True)

--- a/backend/llm_ops/models.py
+++ b/backend/llm_ops/models.py
@@ -1465,6 +1465,7 @@ class ChannelPriceVersion(models.Model):
         blank=True,
         null=True,
     )
+    discount_dimensions = models.JSONField(blank=True, default=list)
     rounding_mode = models.CharField(
         max_length=20,
         choices=ROUNDING_MODE_CHOICES,
@@ -1569,12 +1570,28 @@ class ChannelPriceVersion(models.Model):
             errors["discount_value"] = (
                 "Discount value requires ratio or fixed discount type."
             )
+        valid_dimensions = {
+            value for value, _label in ModelPriceItem.DIMENSION_CHOICES
+        }
+        if not isinstance(self.discount_dimensions, list) or any(
+            value not in valid_dimensions
+            for value in self.discount_dimensions
+        ):
+            errors["discount_dimensions"] = (
+                "Discount dimensions must contain valid price dimensions."
+            )
         if (
             self.contract_exchange_rate is not None
             and self.contract_exchange_rate <= 0
         ):
             errors["contract_exchange_rate"] = (
                 "Contract exchange rate must be greater than zero."
+            )
+        if self.contract_exchange_rate is not None and not (
+            self.contract_currency or ""
+        ).strip():
+            errors["contract_currency"] = (
+                "Contract currency is required for a contract exchange rate."
             )
         if (
             self.exchange_rate_effective_from

--- a/backend/llm_ops/models.py
+++ b/backend/llm_ops/models.py
@@ -1257,6 +1257,131 @@ class ProcurementChannel(models.Model):
         return self.name
 
 
+class ChannelOffering(models.Model):
+    """Contract identity for one upstream procurement offering."""
+
+    STATUS_ACTIVE = "active"
+    STATUS_INACTIVE = "inactive"
+    STATUS_CHOICES = (
+        (STATUS_ACTIVE, "Active"),
+        (STATUS_INACTIVE, "Inactive"),
+    )
+
+    channel = models.ForeignKey(
+        ProcurementChannel,
+        related_name="offerings",
+        on_delete=models.CASCADE,
+    )
+    meta_model = models.ForeignKey(
+        MetaModel,
+        related_name="procurement_offerings",
+        on_delete=models.CASCADE,
+    )
+    model = models.ForeignKey(
+        LLMModel,
+        related_name="procurement_offerings",
+        blank=True,
+        null=True,
+        on_delete=models.SET_NULL,
+    )
+    source_offering = models.ForeignKey(
+        SourceSkuOffering,
+        related_name="channel_offerings",
+        blank=True,
+        null=True,
+        on_delete=models.SET_NULL,
+    )
+    offering_key = models.CharField(max_length=255)
+    display_name = models.CharField(max_length=255)
+    status = models.CharField(
+        max_length=20,
+        choices=STATUS_CHOICES,
+        default=STATUS_ACTIVE,
+        db_index=True,
+    )
+    source_metadata = models.JSONField(blank=True, default=dict)
+    is_default = models.BooleanField(default=False, db_index=True)
+    is_sales_enabled = models.BooleanField(default=False, db_index=True)
+    is_cache_sales_enabled = models.BooleanField(
+        default=False,
+        db_index=True,
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        ordering = ["channel__name", "meta_model__name", "display_name"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["channel", "offering_key"],
+                name="uq_llm_ops_channel_offering_key",
+            ),
+            models.UniqueConstraint(
+                fields=["channel", "meta_model"],
+                condition=models.Q(is_default=True),
+                name="uq_llm_ops_default_channel_offering",
+            ),
+        ]
+
+    def __str__(self) -> str:
+        return f"{self.channel.name} / {self.display_name}"
+
+    def clean(self):
+        """Ensure optional model and source SKU use the same meta model."""
+        super().clean()
+        errors = {}
+        if self.model_id and self.model.meta_model_id != self.meta_model_id:
+            errors["model"] = "Model must belong to the offering meta model."
+        if (
+            self.source_offering_id
+            and self.source_offering.sku.meta_model_id != self.meta_model_id
+        ):
+            errors["source_offering"] = (
+                "Source offering must belong to the offering meta model."
+            )
+        if errors:
+            raise ValidationError(errors)
+
+    def save(self, *args, **kwargs):
+        """Validate offering identity before saving."""
+        self.full_clean()
+        super().save(*args, **kwargs)
+
+
+def _ensure_channel_offering(instance, kwargs):
+    """Attach the legacy default offering and validate explicit offerings."""
+    if not instance.channel_id or not instance.model_id:
+        return
+
+    meta_model_id = instance.model.meta_model_id
+    if instance.offering_id:
+        offering = instance.offering
+        errors = {}
+        if offering.channel_id != instance.channel_id:
+            errors["offering"] = "Offering must belong to the same channel."
+        if offering.meta_model_id != meta_model_id:
+            errors["offering"] = (
+                "Offering must belong to the model meta model."
+            )
+        if errors:
+            raise ValidationError(errors)
+        return
+
+    offering, _created = ChannelOffering.objects.get_or_create(
+        channel_id=instance.channel_id,
+        meta_model_id=meta_model_id,
+        is_default=True,
+        defaults={
+            "offering_key": f"default-{meta_model_id}",
+            "display_name": instance.model.meta_model.name,
+        },
+    )
+    instance.offering = offering
+    update_fields = kwargs.get("update_fields")
+    if update_fields is not None:
+        kwargs["update_fields"] = list(set(update_fields) | {"offering"})
+
+
 class ChannelModelPrice(models.Model):
     """Per-channel listing and price overrides for one model."""
 
@@ -1273,6 +1398,13 @@ class ChannelModelPrice(models.Model):
     meta_model = models.ForeignKey(
         MetaModel,
         related_name="channel_offerings",
+        on_delete=models.CASCADE,
+    )
+    offering = models.ForeignKey(
+        ChannelOffering,
+        related_name="model_prices",
+        blank=True,
+        null=True,
         on_delete=models.CASCADE,
     )
     price_source = models.ForeignKey(
@@ -1338,8 +1470,8 @@ class ChannelModelPrice(models.Model):
         ordering = ["channel__name", "model__name", "id"]
         constraints = [
             models.UniqueConstraint(
-                fields=["channel", "model"],
-                name="uq_llm_ops_channel_model_price",
+                fields=["channel", "model", "offering"],
+                name="uq_llm_ops_channel_model_offering_price",
             )
         ]
 
@@ -1349,6 +1481,7 @@ class ChannelModelPrice(models.Model):
     def save(self, *args, **kwargs):
         """Ensure channel model prices stay linked to canonical models."""
         _ensure_meta_model_from_model(self, kwargs)
+        _ensure_channel_offering(self, kwargs)
         super().save(*args, **kwargs)
 
 
@@ -1390,6 +1523,13 @@ class ChannelPriceItem(models.Model):
     meta_model = models.ForeignKey(
         MetaModel,
         related_name="channel_price_items",
+        on_delete=models.CASCADE,
+    )
+    offering = models.ForeignKey(
+        ChannelOffering,
+        related_name="price_items",
+        blank=True,
+        null=True,
         on_delete=models.CASCADE,
     )
     base_price_item = models.ForeignKey(
@@ -1489,12 +1629,13 @@ class ChannelPriceItem(models.Model):
                 fields=[
                     "channel",
                     "model",
+                    "offering",
                     "dimension",
                     "billing_unit",
                     "currency",
                     "price_fingerprint",
                 ],
-                name="uq_llm_ops_channel_price_item_fingerprint",
+                name="uq_llm_ops_channel_offer_price_item_fp",
             )
         ]
 
@@ -1504,6 +1645,7 @@ class ChannelPriceItem(models.Model):
     def save(self, *args, **kwargs):
         """Ensure channel price items stay linked to canonical models."""
         _ensure_meta_model_from_model(self, kwargs)
+        _ensure_channel_offering(self, kwargs)
         super().save(*args, **kwargs)
 
 
@@ -1523,6 +1665,13 @@ class ChannelModelPriceHistory(models.Model):
     meta_model = models.ForeignKey(
         MetaModel,
         related_name="channel_price_history",
+        on_delete=models.CASCADE,
+    )
+    offering = models.ForeignKey(
+        ChannelOffering,
+        related_name="model_price_history",
+        blank=True,
+        null=True,
         on_delete=models.CASCADE,
     )
     price_source = models.ForeignKey(
@@ -1591,8 +1740,13 @@ class ChannelModelPriceHistory(models.Model):
         ordering = ["-effective_from", "-id"]
         constraints = [
             models.UniqueConstraint(
-                fields=["channel", "model", "price_fingerprint"],
-                name="uq_llm_ops_channel_price_history_fingerprint",
+                fields=[
+                    "channel",
+                    "model",
+                    "offering",
+                    "price_fingerprint",
+                ],
+                name="uq_llm_ops_offering_price_history_fingerprint",
             )
         ]
 
@@ -1602,6 +1756,7 @@ class ChannelModelPriceHistory(models.Model):
     def save(self, *args, **kwargs):
         """Ensure channel price history stays linked to canonical models."""
         _ensure_meta_model_from_model(self, kwargs)
+        _ensure_channel_offering(self, kwargs)
         super().save(*args, **kwargs)
 
 

--- a/backend/llm_ops/price_collectors/parsers/common.py
+++ b/backend/llm_ops/price_collectors/parsers/common.py
@@ -280,6 +280,7 @@ def normalize_text_token_values(row: dict[str, Any]) -> dict[str, str]:
         "region",
         "market",
         "billing_scope",
+        "usage_condition_mode",
     ):
         value = str(row.get(key) or "").strip()
         if value:

--- a/backend/llm_ops/price_collectors/parsers/zhipu.py
+++ b/backend/llm_ops/price_collectors/parsers/zhipu.py
@@ -128,6 +128,8 @@ def fetch_linked_pricing_scripts(url: str, content: str) -> list[str]:
         except requests.RequestException:
             continue
         response.encoding = response.encoding or "utf-8"
+        if str(response.encoding).lower() in {"iso-8859-1", "latin-1"}:
+            response.encoding = "utf-8"
         scripts.append(response.text or "")
     return scripts
 
@@ -381,10 +383,37 @@ def extract_models_from_js_model_lists(content: str) -> list[dict[str, Any]]:
     """Extract model prices from BigModel Vue bundle modelList arrays."""
     models = []
     for fragment in extract_balanced_values(str(content or ""), "modelList"):
-        for item in js_objects_from_array(fragment):
-            model = model_from_js_object(item)
-            if model:
-                models.append(model)
+        models.extend(models_from_js_array(fragment))
+    return models
+
+
+def models_from_js_array(fragment: str) -> list[dict[str, Any]]:
+    """Build models while retaining unnamed continuation price rows."""
+    models = []
+    current = None
+    for item in js_objects_from_array(fragment):
+        model_name = js_string_field(item, "name")
+        if model_name:
+            current = model_from_js_object(item) or None
+            if current is not None:
+                current["price_rows"] = []
+                models.append(current)
+        if current is None:
+            continue
+        current["price_rows"].extend(price_rows_from_js_object(item))
+
+    for model in models:
+        rows = model.get("price_rows") or []
+        if any(row.get("output_token_range") for row in rows):
+            for row in rows:
+                row["usage_condition_mode"] = "multi_metric"
+        has_tiers = len(rows) > 1 or any(
+            row.get("input_token_range")
+            or row.get("output_token_range")
+            for row in rows
+        )
+        if not has_tiers:
+            model.pop("price_rows", None)
     return models
 
 
@@ -407,17 +436,107 @@ def js_objects_from_array(fragment: str) -> list[str]:
 def model_from_js_object(fragment: str) -> dict[str, Any]:
     """Build one model from a BigModel JavaScript pricing row."""
     model_name = js_string_field(fragment, "name")
-    input_prices = js_string_array_field(fragment, "inPrice")
-    output_prices = js_string_array_field(fragment, "outPrice")
-    if not model_name or not input_prices or not output_prices:
+    rows = price_rows_from_js_object(fragment)
+    if not model_name or not rows:
         return {}
-    return model_from_mapping(
+    model = model_from_mapping(
         {
             "model": model_name,
-            "input": input_prices[0],
-            "output": output_prices[0],
+            "input": rows[0]["input_price_per_million"],
+            "output": rows[0]["output_price_per_million"],
         }
     )
+    if not model:
+        return {}
+    return model
+
+
+def price_rows_from_js_object(fragment: str) -> list[dict[str, str]]:
+    """Return every price row and usage condition from one JS object."""
+    input_prices = js_string_array_field(fragment, "inPrice")
+    output_prices = js_string_array_field(fragment, "outPrice")
+    cache_prices = js_string_array_field(fragment, "hit")
+    if not input_prices or not output_prices:
+        return []
+
+    labels = js_string_array_field(fragment, "upDownText")
+    row_count = max(len(input_prices), len(output_prices))
+    rows = []
+    for index in range(row_count):
+        input_price = parse_price(array_value(input_prices, index))
+        output_price = parse_price(array_value(output_prices, index))
+        if input_price is None or output_price is None:
+            continue
+        row = {
+            "input_price_per_million": input_price,
+            "output_price_per_million": output_price,
+        }
+        cache_price = parse_price(array_value(cache_prices, index))
+        if cache_price is not None:
+            row["cache_hit_price_per_million"] = cache_price
+        relevant_labels = labels
+        if row_count > 1 and len(labels) == row_count:
+            relevant_labels = [labels[index]]
+        row.update(usage_ranges_from_labels(relevant_labels))
+        rows.append(row)
+    return rows
+
+
+def array_value(values: list[str], index: int) -> str:
+    """Return an indexed JS array value with a one-value fallback."""
+    if index < len(values):
+        return values[index]
+    if len(values) == 1:
+        return values[0]
+    return ""
+
+
+def usage_ranges_from_labels(labels: list[str]) -> dict[str, str]:
+    """Normalize BigModel context labels to absolute token ranges."""
+    ranges = {}
+    for index, label in enumerate(labels):
+        token_range = token_range_from_label(label)
+        if not token_range:
+            continue
+        normalized = str(label or "").lower()
+        if "输出" in normalized or "output" in normalized:
+            key = "output_token_range"
+        elif "输入" in normalized or "input" in normalized or index == 0:
+            key = "input_token_range"
+        else:
+            key = "output_token_range"
+        ranges[key] = token_range
+    return ranges
+
+
+def token_range_from_label(label: str) -> str:
+    """Parse BigModel's K-token bracket notation into token counts."""
+    match = re.search(r"\[\s*([^\])]+)\)", str(label or ""))
+    if not match:
+        return ""
+    body = match.group(1).strip()
+    if body.endswith("+"):
+        start = token_count_from_k(body[:-1])
+        return f"{start}+" if start is not None else ""
+    parts = [part.strip() for part in body.split(",", 1)]
+    if len(parts) != 2:
+        return ""
+    start = token_count_from_k(parts[0])
+    end = token_count_from_k(parts[1])
+    if start is None or end is None:
+        return ""
+    return f"{start}-{end}"
+
+
+def token_count_from_k(value: str) -> str | None:
+    """Convert one BigModel K-token boundary to an integer token count."""
+    try:
+        amount = Decimal(str(value).strip()) * Decimal("1000")
+    except (InvalidOperation, ValueError):
+        return None
+    if amount < 0 or amount != amount.to_integral_value():
+        return None
+    return format_decimal(amount)
 
 
 def js_string_field(fragment: str, key: str) -> str:

--- a/backend/llm_ops/price_table_validation.py
+++ b/backend/llm_ops/price_table_validation.py
@@ -29,6 +29,7 @@ TIER_CONTRACT_SPEC_KEYS = frozenset(
         "tier_metric",
         "tier_charge_mode",
         "aggregation_period",
+        "usage_conditions",
     }
 )
 SUPPORTED_TIER_DIMENSIONS = frozenset(
@@ -229,6 +230,10 @@ def _validate_usage_range_table(rows: Sequence[Any]) -> None:
             "Usage-range rows must use the request input token contract.",
         )
 
+    if any(spec.get("usage_conditions") for spec in specs):
+        _validate_conditional_usage_table(rows, specs)
+        return
+
     tiers = _sorted_tiers(rows)
     first_start = _decimal(_value(tiers[0], "tier_start"))
     if first_start != Decimal("0"):
@@ -273,6 +278,70 @@ def _validate_usage_range_table(rows: Sequence[Any]) -> None:
             if start > previous_end:
                 _raise(ERROR_GAP, "Tier ranges must not contain gaps.")
         previous_end = end
+
+
+def _validate_conditional_usage_table(
+    rows: Sequence[Any],
+    specs: Sequence[Mapping[str, Any]],
+) -> None:
+    """Validate multi-metric request conditions without flattening them."""
+    seen_conditions = set()
+    allowed_metrics = {"input_tokens", "output_tokens"}
+    for row, spec in zip(rows, specs):
+        conditions = spec.get("usage_conditions")
+        if not isinstance(conditions, Mapping) or not conditions:
+            _raise(
+                ERROR_INVALID_USAGE_RANGE_SPEC,
+                "Conditional price rows require usage_conditions.",
+            )
+        unknown_metrics = set(conditions) - allowed_metrics
+        if unknown_metrics:
+            _raise(
+                ERROR_INVALID_USAGE_RANGE_SPEC,
+                "Usage conditions contain unsupported metrics.",
+            )
+        condition_key = json.dumps(
+            conditions,
+            default=str,
+            sort_keys=True,
+        )
+        if condition_key in seen_conditions:
+            _raise(
+                ERROR_DUPLICATE_RANGE,
+                "Conditional price rules must be unique.",
+            )
+        seen_conditions.add(condition_key)
+        for bounds in conditions.values():
+            if not isinstance(bounds, Mapping):
+                _raise(
+                    ERROR_INVALID_USAGE_RANGE_SPEC,
+                    "Usage condition bounds must be JSON objects.",
+                )
+            start = _decimal(bounds.get("start"))
+            end = _decimal(bounds.get("end"))
+            if start is None or start < Decimal("0"):
+                _raise(
+                    ERROR_INVALID_BOUNDARY,
+                    "Usage condition starts must be non-negative.",
+                )
+            if end is not None and end <= start:
+                _raise(
+                    ERROR_INVALID_BOUNDARY,
+                    "Usage condition ends must be greater than starts.",
+                )
+
+        tier_start = _decimal(_value(row, "tier_start"))
+        tier_end = _decimal(_value(row, "tier_end"))
+        if tier_start is None or tier_start < Decimal("0"):
+            _raise(
+                ERROR_INVALID_BOUNDARY,
+                "Conditional tiers require a non-negative primary start.",
+            )
+        if tier_end is not None and tier_end <= tier_start:
+            _raise(
+                ERROR_INVALID_BOUNDARY,
+                "A conditional tier end must exceed its start.",
+            )
 
 
 def _require_consistent(

--- a/backend/llm_ops/serializers.py
+++ b/backend/llm_ops/serializers.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from datetime import time
 from decimal import Decimal
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
+from django.db import transaction
 from django.utils.text import slugify
 from rest_framework import serializers
 
@@ -21,6 +24,7 @@ from .models import (
     ChannelModelPrice,
     ChannelModelPriceHistory,
     ChannelOffering,
+    ChannelPriceVersion,
     CollectedModelPriceHistory,
     CollectedModelPriceSnapshot,
     LLMOpsGlobalConfig,
@@ -52,8 +56,10 @@ from .services import (
     calculate_channel_model_cost,
     normalize_currency,
     price_role_for_source,
+    resolve_channel_contract_cost,
     stable_fingerprint,
 )
+from .tier_pricing import UsageContext
 from .workflow_config import validate_resale_workflow_config
 
 
@@ -1594,6 +1600,280 @@ class ChannelOfferingSerializer(serializers.ModelSerializer):
         return attrs
 
 
+class ChannelContractPriceItemSerializer(serializers.Serializer):
+    """Nested normalized price rule for one procurement price version."""
+
+    id = serializers.IntegerField(read_only=True)
+    dimension = serializers.ChoiceField(
+        choices=ModelPriceItem.DIMENSION_CHOICES,
+    )
+    billing_unit = serializers.ChoiceField(
+        choices=ModelPriceItem.BILLING_UNIT_CHOICES,
+    )
+    currency = serializers.CharField(max_length=10)
+    unit_price = serializers.DecimalField(max_digits=14, decimal_places=6)
+    tier_type = serializers.ChoiceField(
+        choices=ModelPriceItem.TIER_CHOICES,
+        default=ModelPriceItem.TIER_FLAT,
+    )
+    tier_start = serializers.DecimalField(
+        max_digits=18,
+        decimal_places=6,
+        allow_null=True,
+        required=False,
+    )
+    tier_end = serializers.DecimalField(
+        max_digits=18,
+        decimal_places=6,
+        allow_null=True,
+        required=False,
+    )
+    spec = serializers.JSONField(required=False, default=dict)
+
+    def validate_currency(self, value):
+        return validate_currency_code(value, required=True)
+
+    def validate_unit_price(self, value):
+        if value < 0:
+            raise serializers.ValidationError("unit_price must be >= 0.")
+        return value
+
+    def validate_spec(self, value):
+        windows = (
+            value.get("time_windows") if isinstance(value, dict) else None
+        )
+        if windows is None:
+            return value
+        if not isinstance(windows, list) or not windows:
+            raise serializers.ValidationError(
+                "time_windows must be a non-empty list."
+            )
+        for window in windows:
+            self._validate_time_window(window)
+        return value
+
+    @staticmethod
+    def _validate_time_window(window):
+        if not isinstance(window, dict):
+            raise serializers.ValidationError(
+                "Each time window must be an object."
+            )
+        weekdays = window.get("weekdays")
+        if (
+            not isinstance(weekdays, list)
+            or not weekdays
+            or any(
+                not isinstance(day, int) or day not in range(7)
+                for day in weekdays
+            )
+        ):
+            raise serializers.ValidationError(
+                "weekdays must contain integers from 0 through 6."
+            )
+        try:
+            start = time.fromisoformat(str(window.get("start")))
+            end = time.fromisoformat(str(window.get("end")))
+        except ValueError as exc:
+            raise serializers.ValidationError(
+                "start and end must use HH:MM time format."
+            ) from exc
+        if start == end:
+            raise serializers.ValidationError(
+                "Time window start and end must differ."
+            )
+
+
+class ChannelPriceVersionSerializer(serializers.ModelSerializer):
+    """Create and inspect effective-dated procurement price versions."""
+
+    channel = serializers.IntegerField(
+        source="offering.channel_id",
+        read_only=True,
+    )
+    channel_name = serializers.CharField(
+        source="offering.channel.name",
+        read_only=True,
+    )
+    offering_key = serializers.CharField(
+        source="offering.offering_key",
+        read_only=True,
+    )
+    offering_name = serializers.CharField(
+        source="offering.display_name",
+        read_only=True,
+    )
+    model_name = serializers.CharField(source="model.name", read_only=True)
+    meta_model_name = serializers.CharField(
+        source="meta_model.name",
+        read_only=True,
+    )
+    price_items = ChannelContractPriceItemSerializer(many=True)
+
+    class Meta:
+        model = ChannelPriceVersion
+        fields = "__all__"
+        read_only_fields = (
+            "meta_model",
+            "created_by",
+            "updated_by",
+            "created_at",
+            "updated_at",
+        )
+
+    def validate(self, attrs):
+        offering = attrs.get(
+            "offering",
+            getattr(self.instance, "offering", None),
+        )
+        model = attrs.get("model", getattr(self.instance, "model", None))
+        if (
+            offering
+            and model
+            and offering.meta_model_id != model.meta_model_id
+        ):
+            raise serializers.ValidationError(
+                {"offering": "Offering must belong to the model meta model."}
+            )
+        status_value = attrs.get(
+            "status",
+            getattr(self.instance, "status", ChannelPriceVersion.STATUS_DRAFT),
+        )
+        effective_from = attrs.get(
+            "effective_from",
+            getattr(self.instance, "effective_from", None),
+        )
+        effective_to = attrs.get(
+            "effective_to",
+            getattr(self.instance, "effective_to", None),
+        )
+        if (
+            status_value != ChannelPriceVersion.STATUS_DRAFT
+            and effective_from is None
+        ):
+            raise serializers.ValidationError(
+                {
+                    "effective_from": (
+                        "Non-draft versions require an effective start."
+                    )
+                }
+            )
+        if (
+            effective_from
+            and effective_to
+            and effective_to <= effective_from
+        ):
+            raise serializers.ValidationError(
+                {
+                    "effective_to": (
+                        "Effective end must be after effective start."
+                    )
+                }
+            )
+        discount_type = attrs.get(
+            "discount_type",
+            getattr(
+                self.instance,
+                "discount_type",
+                ChannelPriceVersion.DISCOUNT_NONE,
+            ),
+        )
+        discount_value = attrs.get(
+            "discount_value",
+            getattr(self.instance, "discount_value", None),
+        )
+        if discount_type == ChannelPriceVersion.DISCOUNT_RATIO:
+            if discount_value is None or not (
+                Decimal("0") <= discount_value <= Decimal("1")
+            ):
+                raise serializers.ValidationError(
+                    {
+                        "discount_value": (
+                            "Ratio discounts must be between 0 and 1."
+                        )
+                    }
+                )
+        elif discount_type == ChannelPriceVersion.DISCOUNT_FIXED:
+            if discount_value is None or discount_value < 0:
+                raise serializers.ValidationError(
+                    {"discount_value": "Fixed prices must be non-negative."}
+                )
+        elif discount_value is not None:
+            raise serializers.ValidationError(
+                {
+                    "discount_value": (
+                        "Discount value requires ratio or fixed discount type."
+                    )
+                }
+            )
+        return attrs
+
+    def validate_timezone(self, value):
+        try:
+            ZoneInfo(value)
+        except ZoneInfoNotFoundError as exc:
+            raise serializers.ValidationError(
+                "Unknown IANA timezone."
+            ) from exc
+        return value
+
+    def validate_contract_currency(self, value):
+        return validate_currency_code(value, required=False)
+
+    @transaction.atomic
+    def create(self, validated_data):
+        price_items = validated_data.pop("price_items")
+        model = validated_data["model"]
+        user = self._request_user()
+        version = ChannelPriceVersion.objects.create(
+            **validated_data,
+            meta_model=model.meta_model,
+            created_by=user,
+            updated_by=user,
+        )
+        self._replace_price_items(version, price_items)
+        return version
+
+    @transaction.atomic
+    def update(self, instance, validated_data):
+        price_items = validated_data.pop("price_items", None)
+        validated_data["updated_by"] = self._request_user()
+        version = super().update(instance, validated_data)
+        if price_items is not None:
+            self._replace_price_items(version, price_items)
+        return version
+
+    def _replace_price_items(self, version, price_items):
+        version.price_items.all().delete()
+        for row in price_items:
+            fingerprint = stable_fingerprint(
+                {
+                    "version_id": version.id,
+                    **{
+                        key: str(value)
+                        for key, value in row.items()
+                        if key != "spec"
+                    },
+                    "spec": row.get("spec") or {},
+                }
+            )
+            ChannelPriceItem.objects.create(
+                channel=version.offering.channel,
+                model=version.model,
+                meta_model=version.meta_model,
+                offering=version.offering,
+                price_version=version,
+                price_fingerprint=fingerprint,
+                price_source_type=ChannelPriceItem.SOURCE_MANUAL,
+                **row,
+            )
+
+    def _request_user(self):
+        request = self.context.get("request")
+        if request and request.user.is_authenticated:
+            return request.user
+        return None
+
+
 class ChannelModelPriceHistorySerializer(serializers.ModelSerializer):
     """Serializer for historical channel/model price versions."""
 
@@ -2078,6 +2358,16 @@ class UsageReconciliationRecordSerializer(serializers.ModelSerializer):
         source="model.provider.name",
         read_only=True,
     )
+    offering_key = serializers.CharField(
+        source="offering.offering_key",
+        read_only=True,
+        allow_null=True,
+    )
+    offering_name = serializers.CharField(
+        source="offering.display_name",
+        read_only=True,
+        allow_null=True,
+    )
     expected_amount = serializers.DecimalField(
         max_digits=14,
         decimal_places=6,
@@ -2103,6 +2393,7 @@ class UsageReconciliationRecordSerializer(serializers.ModelSerializer):
         fields = "__all__"
         extra_kwargs = {
             "meta_model": {"required": False},
+            "price_version": {"required": False},
         }
         read_only_fields = (
             "created_at",
@@ -2111,7 +2402,34 @@ class UsageReconciliationRecordSerializer(serializers.ModelSerializer):
             "discrepancy",
             "discrepancy_percent",
             "status",
+            "price_version",
+            "price_rule_snapshot",
+            "unit_price_snapshot",
+            "exchange_rate_snapshot",
+            "exchange_rate_source",
+            "final_price_snapshot",
         )
+
+    def validate(self, attrs):
+        channel = attrs.get("channel", getattr(self.instance, "channel", None))
+        model = attrs.get("model", getattr(self.instance, "model", None))
+        offering = attrs.get(
+            "offering",
+            getattr(self.instance, "offering", None),
+        )
+        if offering and channel and offering.channel_id != channel.id:
+            raise serializers.ValidationError(
+                {"offering": "Offering must belong to the same channel."}
+            )
+        if (
+            offering
+            and model
+            and offering.meta_model_id != model.meta_model_id
+        ):
+            raise serializers.ValidationError(
+                {"offering": "Offering must belong to the model meta model."}
+            )
+        return attrs
 
     def _apply_calculation(self, attrs):
         channel = attrs.get("channel")
@@ -2120,9 +2438,7 @@ class UsageReconciliationRecordSerializer(serializers.ModelSerializer):
             return attrs
         attrs["meta_model"] = model.meta_model
 
-        expected = calculate_channel_model_cost(
-            channel,
-            model,
+        usage = UsageContext(
             input_tokens=attrs.get("input_tokens") or 0,
             output_tokens=attrs.get("output_tokens") or 0,
             cache_input_tokens=attrs.get("cache_input_tokens") or 0,
@@ -2130,8 +2446,57 @@ class UsageReconciliationRecordSerializer(serializers.ModelSerializer):
             audio_output_seconds=attrs.get("audio_output_seconds") or 0,
             video_input_seconds=attrs.get("video_input_seconds") or 0,
             video_output_seconds=attrs.get("video_output_seconds") or 0,
-            video_resolution=attrs.get("video_resolution") or "",
+            occurred_at=attrs.get("business_occurred_at"),
+            timezone=attrs.get("business_timezone") or "UTC",
         )
+        resolution = resolve_channel_contract_cost(
+            channel,
+            model,
+            usage=usage,
+            offering=attrs.get("offering"),
+        )
+        if resolution is not None:
+            expected = resolution.total
+            attrs["offering"] = resolution.offering
+            attrs["price_version"] = resolution.price_version
+            attrs["price_rule_snapshot"] = {
+                "price_version": resolution.price_version.version,
+                "discount_basis": (
+                    resolution.price_version.discount_basis
+                ),
+                "discount_type": resolution.price_version.discount_type,
+                "discount_value": (
+                    str(resolution.price_version.discount_value)
+                    if resolution.price_version.discount_value is not None
+                    else None
+                ),
+                "rounding_mode": resolution.price_version.rounding_mode,
+                "rounding_places": resolution.price_version.rounding_places,
+                "rules": resolution.price_rules,
+            }
+            attrs["unit_price_snapshot"] = resolution.unit_prices
+            attrs["exchange_rate_snapshot"] = resolution.exchange_rate
+            attrs["exchange_rate_source"] = (
+                resolution.exchange_rate_source
+            )
+            attrs["final_price_snapshot"] = expected
+        else:
+            expected = calculate_channel_model_cost(
+                channel,
+                model,
+                input_tokens=usage.input_tokens,
+                output_tokens=usage.output_tokens,
+                cache_input_tokens=usage.cache_input_tokens,
+                audio_input_seconds=usage.audio_input_seconds,
+                audio_output_seconds=usage.audio_output_seconds,
+                video_input_seconds=usage.video_input_seconds,
+                video_output_seconds=usage.video_output_seconds,
+                video_resolution=attrs.get("video_resolution") or "",
+                offering=attrs.get("offering"),
+                occurred_at=usage.occurred_at,
+                business_timezone=usage.timezone,
+            )
+            attrs["final_price_snapshot"] = expected
         charged = attrs.get("charged_amount") or Decimal("0")
         discrepancy = expected - charged
         discrepancy_percent = Decimal("0")

--- a/backend/llm_ops/serializers.py
+++ b/backend/llm_ops/serializers.py
@@ -1573,6 +1573,7 @@ class ChannelOfferingSerializer(serializers.ModelSerializer):
         model = ChannelOffering
         fields = "__all__"
         read_only_fields = ("created_at", "updated_at")
+        validators = []
 
     def validate(self, attrs):
         meta_model = attrs.get(
@@ -1584,6 +1585,18 @@ class ChannelOfferingSerializer(serializers.ModelSerializer):
             "source_offering",
             getattr(self.instance, "source_offering", None),
         )
+        channel = attrs.get(
+            "channel",
+            getattr(self.instance, "channel", None),
+        )
+        offering_key = attrs.get(
+            "offering_key",
+            getattr(self.instance, "offering_key", ""),
+        )
+        is_default = attrs.get(
+            "is_default",
+            getattr(self.instance, "is_default", False),
+        )
         errors = {}
         if model and meta_model and model.meta_model_id != meta_model.id:
             errors["model"] = "Model must belong to the offering meta model."
@@ -1594,6 +1607,29 @@ class ChannelOfferingSerializer(serializers.ModelSerializer):
         ):
             errors["source_offering"] = (
                 "Source offering must belong to the offering meta model."
+            )
+        queryset = ChannelOffering.objects.all()
+        if self.instance is not None:
+            queryset = queryset.exclude(pk=self.instance.pk)
+        if channel and offering_key and queryset.filter(
+            channel=channel,
+            offering_key=offering_key,
+        ).exists():
+            errors["offering_key"] = (
+                "Offering key must be unique within the channel."
+            )
+        if (
+            is_default
+            and channel
+            and meta_model
+            and queryset.filter(
+                channel=channel,
+                meta_model=meta_model,
+                is_default=True,
+            ).exists()
+        ):
+            errors["is_default"] = (
+                "Only one default offering is allowed per channel and model."
             )
         if errors:
             raise serializers.ValidationError(errors)
@@ -1721,6 +1757,7 @@ class ChannelPriceVersionSerializer(serializers.ModelSerializer):
         )
 
     def validate(self, attrs):
+        self._validate_immutable_version(attrs)
         offering = attrs.get(
             "offering",
             getattr(self.instance, "offering", None),
@@ -1805,7 +1842,64 @@ class ChannelPriceVersionSerializer(serializers.ModelSerializer):
                     )
                 }
             )
+        dimensions = attrs.get(
+            "discount_dimensions",
+            getattr(self.instance, "discount_dimensions", []),
+        )
+        valid_dimensions = {
+            value for value, _label in ModelPriceItem.DIMENSION_CHOICES
+        }
+        if not isinstance(dimensions, list) or any(
+            value not in valid_dimensions for value in dimensions
+        ):
+            raise serializers.ValidationError(
+                {
+                    "discount_dimensions": (
+                        "Discount dimensions must contain valid price "
+                        "dimensions."
+                    )
+                }
+            )
+        contract_currency = attrs.get(
+            "contract_currency",
+            getattr(self.instance, "contract_currency", ""),
+        )
+        contract_rate = attrs.get(
+            "contract_exchange_rate",
+            getattr(self.instance, "contract_exchange_rate", None),
+        )
+        if contract_rate is not None and not contract_currency:
+            raise serializers.ValidationError(
+                {
+                    "contract_currency": (
+                        "Contract currency is required for a contract "
+                        "exchange rate."
+                    )
+                }
+            )
         return attrs
+
+    def _validate_immutable_version(self, attrs):
+        instance = self.instance
+        if instance is None or instance.status == instance.STATUS_DRAFT:
+            return
+        immutable_fields = set(attrs) - {"status"}
+        if immutable_fields:
+            raise serializers.ValidationError(
+                {
+                    field: "Published price versions are immutable."
+                    for field in sorted(immutable_fields)
+                }
+            )
+        if "status" not in attrs:
+            return
+        allowed_statuses = {instance.status, instance.STATUS_EXPIRED}
+        if instance.status == instance.STATUS_SCHEDULED:
+            allowed_statuses.add(instance.STATUS_ACTIVE)
+        if attrs["status"] not in allowed_statuses:
+            raise serializers.ValidationError(
+                {"status": "Invalid published version status transition."}
+            )
 
     def validate_timezone(self, value):
         try:
@@ -1984,6 +2078,18 @@ class ChannelPriceItemSerializer(serializers.ModelSerializer):
         return value
 
     def validate(self, attrs):
+        version = attrs.get(
+            "price_version",
+            getattr(self.instance, "price_version", None),
+        )
+        if version is not None and version.status != version.STATUS_DRAFT:
+            raise serializers.ValidationError(
+                {
+                    "price_version": (
+                        "Published price version items are immutable."
+                    )
+                }
+            )
         rows = channel_price_table_rows(attrs, instance=self.instance)
         validate_serializer_price_table(rows)
         return attrs
@@ -2436,6 +2542,17 @@ class UsageReconciliationRecordSerializer(serializers.ModelSerializer):
             )
         return attrs
 
+    def validate_business_timezone(self, value):
+        if not value:
+            return value
+        try:
+            ZoneInfo(value)
+        except ZoneInfoNotFoundError as exc:
+            raise serializers.ValidationError(
+                "Unknown IANA timezone."
+            ) from exc
+        return value
+
     def _apply_calculation(self, attrs):
         channel = attrs.get("channel")
         model = attrs.get("model")
@@ -2474,6 +2591,9 @@ class UsageReconciliationRecordSerializer(serializers.ModelSerializer):
                     str(resolution.price_version.discount_value)
                     if resolution.price_version.discount_value is not None
                     else None
+                ),
+                "discount_dimensions": (
+                    resolution.price_version.discount_dimensions
                 ),
                 "rounding_mode": resolution.price_version.rounding_mode,
                 "rounding_places": resolution.price_version.rounding_places,

--- a/backend/llm_ops/serializers.py
+++ b/backend/llm_ops/serializers.py
@@ -2368,6 +2368,11 @@ class UsageReconciliationRecordSerializer(serializers.ModelSerializer):
         read_only=True,
         allow_null=True,
     )
+    price_version_number = serializers.IntegerField(
+        source="price_version.version",
+        read_only=True,
+        allow_null=True,
+    )
     expected_amount = serializers.DecimalField(
         max_digits=14,
         decimal_places=6,

--- a/backend/llm_ops/serializers.py
+++ b/backend/llm_ops/serializers.py
@@ -20,6 +20,7 @@ from .models import (
     AuditLog,
     ChannelModelPrice,
     ChannelModelPriceHistory,
+    ChannelOffering,
     CollectedModelPriceHistory,
     CollectedModelPriceSnapshot,
     LLMOpsGlobalConfig,
@@ -1438,6 +1439,14 @@ class ChannelModelPriceSerializer(serializers.ModelSerializer):
         read_only=True,
         allow_null=True,
     )
+    offering_key = serializers.CharField(
+        source="offering.offering_key",
+        read_only=True,
+    )
+    offering_name = serializers.CharField(
+        source="offering.display_name",
+        read_only=True,
+    )
 
     class Meta:
         model = ChannelModelPrice
@@ -1445,7 +1454,9 @@ class ChannelModelPriceSerializer(serializers.ModelSerializer):
         read_only_fields = ("created_at", "updated_at")
         extra_kwargs = {
             "meta_model": {"required": False},
+            "offering": {"required": False, "allow_null": True},
         }
+        validators = []
 
     def validate(self, attrs):
         if "currency" in attrs:
@@ -1467,6 +1478,53 @@ class ChannelModelPriceSerializer(serializers.ModelSerializer):
             "custom_video_output_price_per_second",
         )
         validate_non_negative_prices(attrs, price_fields)
+        channel = attrs.get("channel", getattr(self.instance, "channel", None))
+        model = attrs.get("model", getattr(self.instance, "model", None))
+        offering = attrs.get(
+            "offering",
+            getattr(self.instance, "offering", None),
+        )
+        if offering and channel and offering.channel_id != channel.id:
+            raise serializers.ValidationError(
+                {"offering": "Offering must belong to the same channel."}
+            )
+        if (
+            offering
+            and model
+            and offering.meta_model_id != model.meta_model_id
+        ):
+            raise serializers.ValidationError(
+                {
+                    "offering": (
+                        "Offering must belong to the model meta model."
+                    )
+                }
+            )
+        if channel and model:
+            unique_offering = offering
+            if unique_offering is None:
+                unique_offering = ChannelOffering.objects.filter(
+                    channel=channel,
+                    meta_model=model.meta_model,
+                    is_default=True,
+                ).first()
+            if unique_offering is not None:
+                duplicate = ChannelModelPrice.objects.filter(
+                    channel=channel,
+                    model=model,
+                    offering=unique_offering,
+                )
+                if self.instance is not None:
+                    duplicate = duplicate.exclude(pk=self.instance.pk)
+                if duplicate.exists():
+                    raise serializers.ValidationError(
+                        {
+                            "offering": (
+                                "This model price already exists for the "
+                                "offering."
+                            )
+                        }
+                    )
         return attrs
 
     def create(self, validated_data):
@@ -1477,6 +1535,63 @@ class ChannelModelPriceSerializer(serializers.ModelSerializer):
         model = validated_data.get("model", instance.model)
         validated_data["meta_model"] = model.meta_model
         return super().update(instance, validated_data)
+
+
+class ChannelOfferingSerializer(serializers.ModelSerializer):
+    """Serializer for independently managed procurement offerings."""
+
+    channel_name = serializers.CharField(
+        source="channel.name",
+        read_only=True,
+    )
+    meta_model_name = serializers.CharField(
+        source="meta_model.name",
+        read_only=True,
+    )
+    meta_model_code = serializers.CharField(
+        source="meta_model.code",
+        read_only=True,
+    )
+    model_name = serializers.CharField(
+        source="model.name",
+        read_only=True,
+        allow_null=True,
+    )
+    source_offering_name = serializers.CharField(
+        source="source_offering.exposed_model_name",
+        read_only=True,
+        allow_null=True,
+    )
+
+    class Meta:
+        model = ChannelOffering
+        fields = "__all__"
+        read_only_fields = ("created_at", "updated_at")
+
+    def validate(self, attrs):
+        meta_model = attrs.get(
+            "meta_model",
+            getattr(self.instance, "meta_model", None),
+        )
+        model = attrs.get("model", getattr(self.instance, "model", None))
+        source_offering = attrs.get(
+            "source_offering",
+            getattr(self.instance, "source_offering", None),
+        )
+        errors = {}
+        if model and meta_model and model.meta_model_id != meta_model.id:
+            errors["model"] = "Model must belong to the offering meta model."
+        if (
+            source_offering
+            and meta_model
+            and source_offering.sku.meta_model_id != meta_model.id
+        ):
+            errors["source_offering"] = (
+                "Source offering must belong to the offering meta model."
+            )
+        if errors:
+            raise serializers.ValidationError(errors)
+        return attrs
 
 
 class ChannelModelPriceHistorySerializer(serializers.ModelSerializer):
@@ -1504,6 +1619,14 @@ class ChannelModelPriceHistorySerializer(serializers.ModelSerializer):
         source="price_source.name",
         read_only=True,
         allow_null=True,
+    )
+    offering_key = serializers.CharField(
+        source="offering.offering_key",
+        read_only=True,
+    )
+    offering_name = serializers.CharField(
+        source="offering.display_name",
+        read_only=True,
     )
 
     class Meta:
@@ -1548,13 +1671,23 @@ class ChannelPriceItemSerializer(serializers.ModelSerializer):
         read_only=True,
         allow_null=True,
     )
+    offering_key = serializers.CharField(
+        source="offering.offering_key",
+        read_only=True,
+    )
+    offering_name = serializers.CharField(
+        source="offering.display_name",
+        read_only=True,
+    )
 
     class Meta:
         model = ChannelPriceItem
         fields = "__all__"
         extra_kwargs = {
             "meta_model": {"required": False},
+            "offering": {"required": False, "allow_null": True},
         }
+        validators = []
         read_only_fields = (
             "effective_from",
             "effective_to",

--- a/backend/llm_ops/services.py
+++ b/backend/llm_ops/services.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import timedelta
-from decimal import Decimal
+from datetime import datetime, timedelta
+from decimal import Decimal, ROUND_DOWN, ROUND_HALF_UP, ROUND_UP
 import hashlib
 import json
+import logging
 import re
 
 from cloud_billing.dashboard import _build_exchange_rate_info
@@ -20,7 +21,9 @@ from .meta_model_lookup import (
 from .models import (
     ChannelModelPrice,
     ChannelModelPriceHistory,
+    ChannelOffering,
     ChannelPriceItem,
+    ChannelPriceVersion,
     LLMModel,
     LLMProvider,
     MetaModel,
@@ -55,6 +58,7 @@ from .tier_pricing import (
 ZERO = Decimal("0")
 ONE = Decimal("1")
 SUPPORTED_DISPLAY_CURRENCIES = {"USD", "CNY"}
+logger = logging.getLogger(__name__)
 MANUAL_MODEL_PRICE_FIELDS = {
     "input_price_per_million": (
         ModelPriceItem.DIMENSION_TEXT_INPUT,
@@ -115,6 +119,19 @@ class CurrencyConversionContext:
     rate_source_label: str
     rate_source_url: str
     rate_collected_at: str
+
+
+@dataclass(frozen=True)
+class ChannelCostResolution:
+    """Auditable result of resolving one procurement contract price."""
+
+    total: Decimal
+    offering: ChannelOffering
+    price_version: ChannelPriceVersion
+    unit_prices: dict[str, str]
+    price_rules: list[dict]
+    exchange_rate: Decimal
+    exchange_rate_source: str
 
 
 class TieredPriceScheduleRequired(ValueError):
@@ -1722,6 +1739,200 @@ def calculate_usage_cost(
     ).quantize(Decimal("0.000001"))
 
 
+def resolve_channel_contract_cost(
+    channel: ProcurementChannel,
+    model: LLMModel,
+    *,
+    usage: UsageContext,
+    offering: ChannelOffering | None = None,
+) -> ChannelCostResolution | None:
+    """Resolve the effective offering version with auditable price details."""
+    if offering is None:
+        offering = ChannelOffering.objects.filter(
+            channel=channel,
+            meta_model=model.meta_model,
+            is_default=True,
+        ).first()
+    if offering is None:
+        return None
+    if offering.channel_id != channel.id:
+        raise ValueError("Offering must belong to the selected channel.")
+    if offering.meta_model_id != model.meta_model_id:
+        raise ValueError("Offering must belong to the model meta model.")
+
+    business_time = usage.occurred_at or timezone.now()
+    versions = (
+        ChannelPriceVersion.objects.filter(
+            offering=offering,
+            model=model,
+            status__in=(
+                ChannelPriceVersion.STATUS_ACTIVE,
+                ChannelPriceVersion.STATUS_SCHEDULED,
+            ),
+            effective_from__lte=business_time,
+        )
+        .filter(
+            Q(effective_to__isnull=True)
+            | Q(effective_to__gt=business_time)
+        )
+        .prefetch_related("price_items")
+        .order_by("-version", "-id")
+    )
+    resolutions = []
+    for version in versions:
+        resolution = _resolve_channel_price_version_cost(
+            version,
+            usage=usage,
+            business_time=business_time,
+        )
+        if resolution is not None:
+            resolutions.append(resolution)
+    if not resolutions:
+        return None
+    if len(resolutions) > 1:
+        logger.warning(
+            "Multiple channel price versions matched offering=%s model=%s; "
+            "using conservative highest resolved cost.",
+            offering.id,
+            model.id,
+        )
+    return max(resolutions, key=lambda item: item.total)
+
+
+def _resolve_channel_price_version_cost(
+    version: ChannelPriceVersion,
+    *,
+    usage: UsageContext,
+    business_time: datetime,
+) -> ChannelCostResolution | None:
+    """Apply rules, discount, rounding, and exchange to one version."""
+    items = list(version.price_items.all())
+    if not items:
+        return None
+    exchange_rate, exchange_source = _version_exchange_rate(
+        version,
+        items=items,
+        business_time=business_time,
+    )
+    rounding = {
+        ChannelPriceVersion.ROUND_HALF_UP: ROUND_HALF_UP,
+        ChannelPriceVersion.ROUND_UP: ROUND_UP,
+        ChannelPriceVersion.ROUND_DOWN: ROUND_DOWN,
+    }[version.rounding_mode]
+    quantum = Decimal("1").scaleb(-version.rounding_places)
+    tiers = []
+    rules = []
+    for item in items:
+        price = item.unit_price
+        if version.discount_type == ChannelPriceVersion.DISCOUNT_RATIO:
+            price *= version.discount_value or ZERO
+        elif version.discount_type == ChannelPriceVersion.DISCOUNT_FIXED:
+            price = version.discount_value or ZERO
+        price = (price * exchange_rate).quantize(quantum, rounding=rounding)
+        spec = {
+            **dict(item.spec or {}),
+            "timezone": version.timezone,
+        }
+        tiers.append(
+            PriceTier(
+                dimension=item.dimension,
+                billing_unit=item.billing_unit,
+                currency=version.contract_currency or item.currency,
+                unit_price=price,
+                tier_type=item.tier_type,
+                tier_start=item.tier_start,
+                tier_end=item.tier_end,
+                spec=spec,
+            )
+        )
+        rules.append(
+            {
+                "price_item_id": item.id,
+                "dimension": item.dimension,
+                "billing_unit": item.billing_unit,
+                "source_currency": item.currency,
+                "source_unit_price": str(item.unit_price),
+                "resolved_unit_price": str(price),
+                "tier_type": item.tier_type,
+                "tier_start": (
+                    str(item.tier_start)
+                    if item.tier_start is not None
+                    else None
+                ),
+                "tier_end": (
+                    str(item.tier_end) if item.tier_end is not None else None
+                ),
+                "spec": spec,
+            }
+        )
+    schedule = PriceSchedule(tiers=tuple(tiers))
+    total = calculate_price_schedule_usage_cost(schedule, usage)
+    unit_prices = resolve_usage_unit_prices(schedule, usage)
+    return ChannelCostResolution(
+        total=total,
+        offering=version.offering,
+        price_version=version,
+        unit_prices={
+            ModelPriceItem.DIMENSION_TEXT_INPUT: decimal_to_string(
+                unit_prices.input_per_million
+            ),
+            ModelPriceItem.DIMENSION_TEXT_OUTPUT: decimal_to_string(
+                unit_prices.output_per_million
+            ),
+            ModelPriceItem.DIMENSION_CACHE_INPUT: decimal_to_string(
+                unit_prices.cache_input_per_million
+            ),
+            ModelPriceItem.DIMENSION_IMAGE_OUTPUT: decimal_to_string(
+                unit_prices.image_output_per_image
+            ),
+            ModelPriceItem.DIMENSION_AUDIO_INPUT: decimal_to_string(
+                unit_prices.audio_input_per_second
+            ),
+            ModelPriceItem.DIMENSION_AUDIO_OUTPUT: decimal_to_string(
+                unit_prices.audio_output_per_second
+            ),
+            ModelPriceItem.DIMENSION_VIDEO_INPUT: decimal_to_string(
+                unit_prices.video_input_per_second
+            ),
+            ModelPriceItem.DIMENSION_VIDEO_OUTPUT: decimal_to_string(
+                unit_prices.video_output_per_second
+            ),
+        },
+        price_rules=rules,
+        exchange_rate=exchange_rate,
+        exchange_rate_source=exchange_source,
+    )
+
+
+def _version_exchange_rate(
+    version: ChannelPriceVersion,
+    *,
+    items: list[ChannelPriceItem],
+    business_time: datetime,
+) -> tuple[Decimal, str]:
+    """Prefer an effective contract rate, then the platform default rate."""
+    rate = version.contract_exchange_rate
+    starts = version.exchange_rate_effective_from
+    ends = version.exchange_rate_effective_to
+    if (
+        rate is not None
+        and (starts is None or starts <= business_time)
+        and (ends is None or business_time < ends)
+    ):
+        return rate, "contract"
+
+    source_currency = normalize_currency(items[0].currency)
+    target_currency = normalize_currency(version.contract_currency)
+    if not target_currency or source_currency == target_currency:
+        return ONE, "platform_default"
+    context = build_currency_conversion_context(target_currency)
+    if source_currency == "USD" and target_currency == "CNY":
+        return context.usd_to_cny_rate, "platform_default"
+    if source_currency == "CNY" and target_currency == "USD":
+        return ONE / context.usd_to_cny_rate, "platform_default"
+    return ONE, "platform_default"
+
+
 def calculate_channel_model_cost(
     channel: ProcurementChannel,
     model: LLMModel,
@@ -1734,8 +1945,30 @@ def calculate_channel_model_cost(
     video_input_seconds: Decimal | int | str = 0,
     video_output_seconds: Decimal | int | str = 0,
     video_resolution: str = "",
+    offering: ChannelOffering | None = None,
+    occurred_at: datetime | None = None,
+    business_timezone: str = "UTC",
 ) -> Decimal:
     """Resolve channel prices and calculate expected usage cost."""
+    usage = UsageContext(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_input_tokens=cache_input_tokens,
+        audio_input_seconds=audio_input_seconds,
+        audio_output_seconds=audio_output_seconds,
+        video_input_seconds=video_input_seconds,
+        video_output_seconds=video_output_seconds,
+        occurred_at=occurred_at,
+        timezone=business_timezone,
+    )
+    contract = resolve_channel_contract_cost(
+        channel,
+        model,
+        usage=usage,
+        offering=offering,
+    )
+    if contract is not None:
+        return contract.total
     schedule = resolve_channel_price_schedule(
         channel,
         model,
@@ -1743,15 +1976,7 @@ def calculate_channel_model_cost(
     )
     return calculate_price_schedule_usage_cost(
         schedule,
-        UsageContext(
-            input_tokens=input_tokens,
-            output_tokens=output_tokens,
-            cache_input_tokens=cache_input_tokens,
-            audio_input_seconds=audio_input_seconds,
-            audio_output_seconds=audio_output_seconds,
-            video_input_seconds=video_input_seconds,
-            video_output_seconds=video_output_seconds,
-        ),
+        usage,
     )
 
 

--- a/backend/llm_ops/services.py
+++ b/backend/llm_ops/services.py
@@ -1814,6 +1814,7 @@ def record_channel_model_price_history(
     existing = ChannelModelPriceHistory.objects.filter(
         channel=price.channel,
         model=price.model,
+        offering=price.offering,
         price_fingerprint=fingerprint,
     ).first()
     if existing:
@@ -1823,6 +1824,7 @@ def record_channel_model_price_history(
     ChannelModelPriceHistory.objects.filter(
         channel=price.channel,
         model=price.model,
+        offering=price.offering,
         is_current=True,
     ).update(
         is_current=False,
@@ -1832,6 +1834,7 @@ def record_channel_model_price_history(
         channel=price.channel,
         model=price.model,
         meta_model=price.meta_model,
+        offering=price.offering,
         price_source=price.price_source,
         is_listed=price.is_listed,
         settlement_ratio=price.settlement_ratio,
@@ -1862,6 +1865,7 @@ def sync_channel_price_items(
     ChannelPriceItem.objects.filter(
         channel=price.channel,
         model=price.model,
+        offering=price.offering,
         is_current=True,
     ).update(is_current=False, effective_to=now)
 
@@ -1871,6 +1875,7 @@ def sync_channel_price_items(
             {
                 "channel_id": price.channel_id,
                 "model_id": price.model_id,
+                "offering_id": price.offering_id,
                 "dimension": payload["dimension"],
                 "billing_unit": payload["billing_unit"],
                 "currency": payload["currency"],
@@ -1887,6 +1892,7 @@ def sync_channel_price_items(
         item, _ = ChannelPriceItem.objects.update_or_create(
             channel=price.channel,
             model=price.model,
+            offering=price.offering,
             dimension=payload["dimension"],
             billing_unit=payload["billing_unit"],
             currency=payload["currency"],

--- a/backend/llm_ops/services.py
+++ b/backend/llm_ops/services.py
@@ -1824,9 +1824,19 @@ def _resolve_channel_price_version_cost(
     rules = []
     for item in items:
         price = item.unit_price
-        if version.discount_type == ChannelPriceVersion.DISCOUNT_RATIO:
+        discount_applies = (
+            not version.discount_dimensions
+            or item.dimension in version.discount_dimensions
+        )
+        if (
+            discount_applies
+            and version.discount_type == ChannelPriceVersion.DISCOUNT_RATIO
+        ):
             price *= version.discount_value or ZERO
-        elif version.discount_type == ChannelPriceVersion.DISCOUNT_FIXED:
+        elif (
+            discount_applies
+            and version.discount_type == ChannelPriceVersion.DISCOUNT_FIXED
+        ):
             price = version.discount_value or ZERO
         price = (price * exchange_rate).quantize(quantum, rounding=rounding)
         spec = {
@@ -1969,9 +1979,17 @@ def calculate_channel_model_cost(
     )
     if contract is not None:
         return contract.total
+    override = None
+    if offering is not None:
+        override = ChannelModelPrice.objects.filter(
+            channel=channel,
+            model=model,
+            offering=offering,
+        ).first()
     schedule = resolve_channel_price_schedule(
         channel,
         model,
+        override=override,
         video_resolution=video_resolution,
     )
     return calculate_price_schedule_usage_cost(

--- a/backend/llm_ops/tests/test_channel_offerings.py
+++ b/backend/llm_ops/tests/test_channel_offerings.py
@@ -1,0 +1,133 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from llm_ops.models import (
+    ChannelModelPrice,
+    ChannelOffering,
+    LLMModel,
+    LLMProvider,
+    MetaModel,
+    ProcurementChannel,
+)
+
+
+class ChannelOfferingAPITests(TestCase):
+    """Protect procurement offering identity and legacy API behavior."""
+
+    def setUp(self):
+        self.client = APIClient()
+        user = get_user_model().objects.create_user(
+            username="offering-ops",
+            password="secret",
+            is_staff=True,
+        )
+        self.client.force_authenticate(user)
+        self.provider = LLMProvider.objects.create(
+            name="OpenAI",
+            code="openai-offering-tests",
+        )
+        self.meta_model = MetaModel.objects.create(
+            name="GPT-5",
+            code="gpt-5-offering-tests",
+        )
+        self.model = LLMModel.objects.create(
+            provider=self.provider,
+            meta_model=self.meta_model,
+            name="GPT-5",
+            code="gpt-5-offering-tests",
+        )
+        self.channel = ProcurementChannel.objects.create(
+            name="Supplier",
+            code="supplier-offering-tests",
+        )
+
+    def test_same_channel_and_model_accept_two_procurement_offerings(self):
+        first = self._create_offering("sku-primary", "Primary SKU")
+        second = self._create_offering("sku-backup", "Backup SKU")
+
+        for offering in (first, second):
+            response = self.client.post(
+                reverse("channel-model-price-list"),
+                {
+                    "channel": self.channel.id,
+                    "model": self.model.id,
+                    "offering": offering.id,
+                    "custom_input_price_per_million": "2.5",
+                },
+                format="json",
+            )
+            self.assertEqual(response.status_code, 201, response.data)
+
+        self.assertEqual(ChannelModelPrice.objects.count(), 2)
+        self.assertEqual(
+            set(
+                ChannelModelPrice.objects.values_list(
+                    "offering__offering_key",
+                    flat=True,
+                )
+            ),
+            {"sku-primary", "sku-backup"},
+        )
+
+    def test_legacy_price_payload_creates_and_returns_default_offering(self):
+        response = self.client.post(
+            reverse("channel-model-price-list"),
+            {
+                "channel": self.channel.id,
+                "model": self.model.id,
+                "custom_input_price_per_million": "2.5",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 201, response.data)
+        price = ChannelModelPrice.objects.get()
+        self.assertIsNotNone(price.offering_id)
+        self.assertEqual(response.data["offering"], price.offering_id)
+        self.assertEqual(
+            response.data["offering_key"],
+            price.offering.offering_key,
+        )
+        self.assertTrue(price.offering.is_default)
+
+    def test_price_rejects_offering_from_another_meta_model(self):
+        other_meta_model = MetaModel.objects.create(
+            name="Claude",
+            code="claude-offering-tests",
+        )
+        offering = ChannelOffering.objects.create(
+            channel=self.channel,
+            meta_model=other_meta_model,
+            offering_key="claude-sku",
+            display_name="Claude SKU",
+        )
+
+        response = self.client.post(
+            reverse("channel-model-price-list"),
+            {
+                "channel": self.channel.id,
+                "model": self.model.id,
+                "offering": offering.id,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("offering", response.data)
+
+    def _create_offering(self, key, name):
+        response = self.client.post(
+            reverse("channel-offering-list"),
+            {
+                "channel": self.channel.id,
+                "meta_model": self.meta_model.id,
+                "model": self.model.id,
+                "offering_key": key,
+                "display_name": name,
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+        return ChannelOffering.objects.get(pk=response.data["id"])

--- a/backend/llm_ops/tests/test_channel_offerings.py
+++ b/backend/llm_ops/tests/test_channel_offerings.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
@@ -116,6 +118,43 @@ class ChannelOfferingAPITests(TestCase):
 
         self.assertEqual(response.status_code, 400)
         self.assertIn("offering", response.data)
+
+    def test_legacy_bulk_upsert_updates_only_the_default_offering(self):
+        default_price = ChannelModelPrice.objects.create(
+            channel=self.channel,
+            model=self.model,
+            settlement_ratio="0.9",
+        )
+        custom_offering = self._create_offering(
+            "sku-secondary",
+            "Secondary SKU",
+        )
+        custom_price = ChannelModelPrice.objects.create(
+            channel=self.channel,
+            model=self.model,
+            offering=custom_offering,
+            settlement_ratio="0.7",
+        )
+
+        response = self.client.post(
+            reverse("channel-model-price-bulk-upsert"),
+            {
+                "items": [
+                    {
+                        "channel": self.channel.id,
+                        "model": self.model.id,
+                        "settlement_ratio": "0.5",
+                    }
+                ]
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200, response.data)
+        default_price.refresh_from_db()
+        custom_price.refresh_from_db()
+        self.assertEqual(default_price.settlement_ratio, Decimal("0.5"))
+        self.assertEqual(custom_price.settlement_ratio, Decimal("0.7"))
 
     def _create_offering(self, key, name):
         response = self.client.post(

--- a/backend/llm_ops/tests/test_channel_price_contracts.py
+++ b/backend/llm_ops/tests/test_channel_price_contracts.py
@@ -1,0 +1,291 @@
+from datetime import datetime, timedelta, timezone as dt_timezone
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from llm_ops.models import (
+    ChannelOffering,
+    ChannelPriceItem,
+    ChannelPriceVersion,
+    LLMModel,
+    LLMProvider,
+    MetaModel,
+    ModelPriceItem,
+    ProcurementChannel,
+    UsageReconciliationRecord,
+)
+from llm_ops.services import calculate_channel_model_cost
+
+
+class ChannelPriceContractTests(TestCase):
+    """Exercise version, time, discount, exchange, and snapshot contracts."""
+
+    def setUp(self):
+        self.client = APIClient()
+        user = get_user_model().objects.create_user(
+            username="contract-ops",
+            password="secret",
+            is_staff=True,
+        )
+        self.client.force_authenticate(user)
+        provider = LLMProvider.objects.create(
+            name="OpenAI",
+            code="openai-contract-tests",
+        )
+        meta_model = MetaModel.objects.create(
+            name="GPT-5 Contract",
+            code="gpt-5-contract-tests",
+        )
+        self.model = LLMModel.objects.create(
+            provider=provider,
+            meta_model=meta_model,
+            name="GPT-5 Contract",
+            code="gpt-5-contract-tests",
+        )
+        self.channel = ProcurementChannel.objects.create(
+            name="Contract Supplier",
+            code="contract-supplier-tests",
+        )
+        self.offering = ChannelOffering.objects.create(
+            channel=self.channel,
+            meta_model=meta_model,
+            model=self.model,
+            offering_key="contract-sku",
+            display_name="Contract SKU",
+        )
+
+    def test_future_version_resolves_only_after_effective_time(self):
+        now = timezone.now().replace(microsecond=0)
+        current = self._create_version(
+            version=1,
+            effective_from=now - timedelta(days=1),
+            effective_to=now + timedelta(hours=1),
+            unit_price="1",
+        )
+        future = self._create_version(
+            version=2,
+            status=ChannelPriceVersion.STATUS_SCHEDULED,
+            effective_from=now + timedelta(hours=1),
+            unit_price="2",
+        )
+
+        before = calculate_channel_model_cost(
+            self.channel,
+            self.model,
+            offering=self.offering,
+            occurred_at=now,
+            input_tokens=1_000_000,
+        )
+        after = calculate_channel_model_cost(
+            self.channel,
+            self.model,
+            offering=self.offering,
+            occurred_at=now + timedelta(hours=2),
+            input_tokens=1_000_000,
+        )
+
+        self.assertEqual(before, Decimal("1.000000"))
+        self.assertEqual(after, Decimal("2.000000"))
+        self.assertEqual(current.price_items.count(), 1)
+        self.assertEqual(future.price_items.count(), 1)
+
+    def test_time_windows_support_timezone_and_cross_midnight(self):
+        occurred_at = datetime(
+            2026,
+            8,
+            18,
+            13,
+            0,
+            tzinfo=dt_timezone.utc,
+        )
+        self._create_version(
+            version=1,
+            effective_from=occurred_at - timedelta(days=1),
+            unit_price="1",
+            timezone_name="Asia/Shanghai",
+            price_items=[
+                self._price_item(
+                    "1",
+                    start="08:00",
+                    end="20:00",
+                ),
+                self._price_item(
+                    "3",
+                    start="20:00",
+                    end="08:00",
+                ),
+            ],
+        )
+
+        night_cost = calculate_channel_model_cost(
+            self.channel,
+            self.model,
+            offering=self.offering,
+            occurred_at=occurred_at,
+            input_tokens=1_000_000,
+        )
+        day_cost = calculate_channel_model_cost(
+            self.channel,
+            self.model,
+            offering=self.offering,
+            occurred_at=occurred_at - timedelta(hours=12),
+            input_tokens=1_000_000,
+        )
+        with self.assertLogs("llm_ops.tier_pricing", level="WARNING"):
+            missing_time_cost = calculate_channel_model_cost(
+                self.channel,
+                self.model,
+                offering=self.offering,
+                input_tokens=1_000_000,
+            )
+
+        self.assertEqual(night_cost, Decimal("3.000000"))
+        self.assertEqual(day_cost, Decimal("1.000000"))
+        self.assertEqual(missing_time_cost, Decimal("3.000000"))
+
+    def test_discount_and_contract_exchange_rate_are_applied(self):
+        now = timezone.now()
+        self._create_version(
+            version=1,
+            effective_from=now - timedelta(hours=1),
+            unit_price="10",
+            discount_type=ChannelPriceVersion.DISCOUNT_RATIO,
+            discount_value="0.8",
+            contract_currency="CNY",
+            contract_exchange_rate="7",
+            exchange_rate_effective_from=now - timedelta(days=1),
+            exchange_rate_effective_to=now + timedelta(days=1),
+        )
+
+        cost = calculate_channel_model_cost(
+            self.channel,
+            self.model,
+            offering=self.offering,
+            occurred_at=now,
+            input_tokens=1_000_000,
+        )
+
+        self.assertEqual(cost, Decimal("56.000000"))
+
+    def test_overlapping_versions_fall_back_to_highest_cost_with_warning(self):
+        now = timezone.now()
+        self._create_version(
+            version=1,
+            effective_from=now - timedelta(hours=1),
+            unit_price="1",
+        )
+        self._create_version(
+            version=2,
+            effective_from=now - timedelta(minutes=30),
+            unit_price="3",
+        )
+
+        with self.assertLogs("llm_ops.services", level="WARNING"):
+            cost = calculate_channel_model_cost(
+                self.channel,
+                self.model,
+                offering=self.offering,
+                occurred_at=now,
+                input_tokens=1_000_000,
+            )
+
+        self.assertEqual(cost, Decimal("3.000000"))
+
+    def test_reconciliation_persists_resolution_snapshot(self):
+        now = timezone.now()
+        version = self._create_version(
+            version=1,
+            effective_from=now - timedelta(hours=1),
+            unit_price="2",
+            contract_exchange_rate="7",
+            contract_currency="CNY",
+        )
+
+        response = self.client.post(
+            reverse("reconciliation-record-list"),
+            {
+                "date": now.date().isoformat(),
+                "business_occurred_at": now.isoformat(),
+                "business_timezone": "Asia/Shanghai",
+                "channel": self.channel.id,
+                "model": self.model.id,
+                "offering": self.offering.id,
+                "input_tokens": 1_000_000,
+                "charged_amount": "14",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 201, response.data)
+        record = UsageReconciliationRecord.objects.get()
+        self.assertEqual(record.price_version, version)
+        self.assertEqual(record.exchange_rate_snapshot, Decimal("7"))
+        self.assertEqual(record.exchange_rate_source, "contract")
+        self.assertEqual(record.final_price_snapshot, Decimal("14"))
+        self.assertEqual(
+            record.unit_price_snapshot["text_input"],
+            "14.000000",
+        )
+
+        item = ChannelPriceItem.objects.get(price_version=version)
+        item.unit_price = Decimal("99")
+        item.save(update_fields=["unit_price"])
+        record.refresh_from_db()
+        self.assertEqual(record.final_price_snapshot, Decimal("14"))
+
+    def _create_version(
+        self,
+        *,
+        version,
+        effective_from,
+        unit_price=None,
+        price_items=None,
+        status=ChannelPriceVersion.STATUS_ACTIVE,
+        effective_to=None,
+        timezone_name="UTC",
+        **extra,
+    ):
+        items = price_items or [self._price_item(unit_price)]
+        payload = {
+            "offering": self.offering.id,
+            "model": self.model.id,
+            "version": version,
+            "status": status,
+            "effective_from": effective_from.isoformat(),
+            "effective_to": (
+                effective_to.isoformat() if effective_to else None
+            ),
+            "timezone": timezone_name,
+            "price_items": items,
+            **extra,
+        }
+        response = self.client.post(
+            reverse("channel-price-version-list"),
+            payload,
+            format="json",
+        )
+        self.assertEqual(response.status_code, 201, response.data)
+        return ChannelPriceVersion.objects.get(pk=response.data["id"])
+
+    def _price_item(self, unit_price, *, start=None, end=None):
+        spec = {}
+        if start and end:
+            spec["time_windows"] = [
+                {
+                    "weekdays": list(range(7)),
+                    "start": start,
+                    "end": end,
+                }
+            ]
+        return {
+            "dimension": ModelPriceItem.DIMENSION_TEXT_INPUT,
+            "billing_unit": ModelPriceItem.UNIT_PER_1M_TOKENS,
+            "currency": "USD",
+            "unit_price": unit_price,
+            "tier_type": ModelPriceItem.TIER_FLAT,
+            "spec": spec,
+        }

--- a/backend/llm_ops/tests/test_channel_price_contracts.py
+++ b/backend/llm_ops/tests/test_channel_price_contracts.py
@@ -8,6 +8,8 @@ from django.utils import timezone
 from rest_framework.test import APIClient
 
 from llm_ops.models import (
+    AuditLog,
+    ChannelModelPrice,
     ChannelOffering,
     ChannelPriceItem,
     ChannelPriceVersion,
@@ -195,6 +197,183 @@ class ChannelPriceContractTests(TestCase):
 
         self.assertEqual(cost, Decimal("3.000000"))
 
+    def test_effective_price_filter_excludes_future_version_items(self):
+        now = timezone.now()
+        current = self._create_version(
+            version=1,
+            effective_from=now - timedelta(hours=1),
+            effective_to=now + timedelta(hours=1),
+            unit_price="1",
+        )
+        future = self._create_version(
+            version=2,
+            status=ChannelPriceVersion.STATUS_SCHEDULED,
+            effective_from=now + timedelta(hours=1),
+            unit_price="2",
+        )
+        legacy_current = self._legacy_price_item(
+            price_fingerprint="legacy-current",
+            is_current=True,
+        )
+        legacy_stale = self._legacy_price_item(
+            price_fingerprint="legacy-stale",
+            is_current=False,
+        )
+
+        response = self.client.get(
+            reverse("channel-price-item-list"),
+            {"is_effective": "true"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        item_ids = {item["id"] for item in response.data["results"]}
+        self.assertIn(current.price_items.get().id, item_ids)
+        self.assertNotIn(future.price_items.get().id, item_ids)
+        self.assertIn(legacy_current.id, item_ids)
+        self.assertNotIn(legacy_stale.id, item_ids)
+
+    def test_discount_can_target_selected_price_dimensions(self):
+        now = timezone.now()
+        self._create_version(
+            version=1,
+            effective_from=now - timedelta(hours=1),
+            discount_type=ChannelPriceVersion.DISCOUNT_RATIO,
+            discount_value="0.5",
+            discount_dimensions=[ModelPriceItem.DIMENSION_TEXT_INPUT],
+            price_items=[
+                self._price_item("10"),
+                {
+                    **self._price_item("10"),
+                    "dimension": ModelPriceItem.DIMENSION_TEXT_OUTPUT,
+                },
+            ],
+        )
+
+        cost = calculate_channel_model_cost(
+            self.channel,
+            self.model,
+            offering=self.offering,
+            occurred_at=now,
+            input_tokens=1_000_000,
+            output_tokens=1_000_000,
+        )
+
+        self.assertEqual(cost, Decimal("15.000000"))
+
+    def test_active_version_price_items_are_immutable_through_api(self):
+        version = self._create_version(
+            version=1,
+            effective_from=timezone.now() - timedelta(hours=1),
+            unit_price="1",
+        )
+
+        response = self.client.patch(
+            reverse("channel-price-version-detail", args=[version.id]),
+            {"price_items": [self._price_item("99")]},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(version.price_items.get().unit_price, Decimal("1"))
+
+        item = version.price_items.get()
+        item_update = self.client.patch(
+            reverse("channel-price-item-detail", args=[item.id]),
+            {"unit_price": "98"},
+            format="json",
+        )
+        item_delete = self.client.delete(
+            reverse("channel-price-item-detail", args=[item.id]),
+        )
+        version_delete = self.client.delete(
+            reverse("channel-price-version-detail", args=[version.id]),
+        )
+
+        self.assertEqual(item_update.status_code, 400)
+        self.assertEqual(item_delete.status_code, 400)
+        self.assertEqual(version_delete.status_code, 400)
+        self.assertTrue(ChannelPriceVersion.objects.filter(pk=version.id))
+        item.refresh_from_db()
+        self.assertEqual(item.unit_price, Decimal("1"))
+
+    def test_draft_version_audit_keeps_nested_price_rule_changes(self):
+        version = self._create_version(
+            version=1,
+            status=ChannelPriceVersion.STATUS_DRAFT,
+            effective_from=timezone.now() + timedelta(days=1),
+            unit_price="1",
+        )
+
+        response = self.client.patch(
+            reverse("channel-price-version-detail", args=[version.id]),
+            {
+                "price_items": [self._price_item("2")],
+                "source_evidence": {"contract": "renewal"},
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200, response.data)
+        audit = AuditLog.objects.get(
+            target_type="llm_ops.ChannelPriceVersion",
+            target_id=str(version.id),
+            action=AuditLog.ACTION_UPDATE,
+        )
+        self.assertEqual(
+            audit.before["price_items"][0]["unit_price"],
+            "1.000000",
+        )
+        self.assertEqual(
+            audit.after["price_items"][0]["unit_price"],
+            "2.000000",
+        )
+        self.assertEqual(
+            audit.after["source_evidence"],
+            {"contract": "renewal"},
+        )
+
+    def test_legacy_cost_resolution_honors_explicit_offering(self):
+        first = ChannelOffering.objects.create(
+            channel=self.channel,
+            meta_model=self.model.meta_model,
+            offering_key="legacy-first",
+            display_name="Legacy First",
+        )
+        second = ChannelOffering.objects.create(
+            channel=self.channel,
+            meta_model=self.model.meta_model,
+            offering_key="legacy-second",
+            display_name="Legacy Second",
+        )
+        ChannelModelPrice.objects.create(
+            channel=self.channel,
+            model=self.model,
+            offering=first,
+            custom_input_price_per_million="1",
+        )
+        ChannelModelPrice.objects.create(
+            channel=self.channel,
+            model=self.model,
+            offering=second,
+            custom_input_price_per_million="4",
+        )
+
+        first_cost = calculate_channel_model_cost(
+            self.channel,
+            self.model,
+            offering=first,
+            input_tokens=1_000_000,
+        )
+        second_cost = calculate_channel_model_cost(
+            self.channel,
+            self.model,
+            offering=second,
+            input_tokens=1_000_000,
+        )
+
+        self.assertEqual(first_cost, Decimal("1.000000"))
+        self.assertEqual(second_cost, Decimal("4.000000"))
+
     def test_reconciliation_persists_resolution_snapshot(self):
         now = timezone.now()
         version = self._create_version(
@@ -289,3 +468,17 @@ class ChannelPriceContractTests(TestCase):
             "tier_type": ModelPriceItem.TIER_FLAT,
             "spec": spec,
         }
+
+    def _legacy_price_item(self, *, price_fingerprint, is_current):
+        return ChannelPriceItem.objects.create(
+            channel=self.channel,
+            model=self.model,
+            meta_model=self.model.meta_model,
+            offering=self.offering,
+            dimension=ModelPriceItem.DIMENSION_TEXT_INPUT,
+            billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
+            currency="USD",
+            unit_price="1",
+            price_fingerprint=price_fingerprint,
+            is_current=is_current,
+        )

--- a/backend/llm_ops/tests/test_tier_pricing.py
+++ b/backend/llm_ops/tests/test_tier_pricing.py
@@ -285,6 +285,95 @@ class TieredPricingKernelTests(SimpleTestCase):
                 usage=Decimal("10_000_000"),
             )
 
+    def test_resolves_multi_metric_glm_price_conditions(self):
+        def tier(dimension, price, start, end, conditions):
+            return PriceTier(
+                dimension=dimension,
+                billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
+                currency="CNY",
+                unit_price=Decimal(price),
+                tier_type=ModelPriceItem.TIER_USAGE_RANGE,
+                tier_start=Decimal(start),
+                tier_end=Decimal(end) if end is not None else None,
+                spec={
+                    **usage_range_spec(),
+                    "usage_conditions": conditions,
+                },
+            )
+
+        rules = (
+            (
+                "2",
+                "8",
+                "0",
+                "32000",
+                {
+                    "input_tokens": {"start": "0", "end": "32000"},
+                    "output_tokens": {"start": "0", "end": "200"},
+                },
+            ),
+            (
+                "3",
+                "14",
+                "0",
+                "32000",
+                {
+                    "input_tokens": {"start": "0", "end": "32000"},
+                    "output_tokens": {"start": "200", "end": None},
+                },
+            ),
+            (
+                "4",
+                "16",
+                "32000",
+                "200000",
+                {
+                    "input_tokens": {"start": "32000", "end": "200000"},
+                },
+            ),
+        )
+        tiers = []
+        for input_price, output_price, start, end, conditions in rules:
+            tiers.extend(
+                [
+                    tier(
+                        ModelPriceItem.DIMENSION_TEXT_INPUT,
+                        input_price,
+                        start,
+                        end,
+                        conditions,
+                    ),
+                    tier(
+                        ModelPriceItem.DIMENSION_TEXT_OUTPUT,
+                        output_price,
+                        start,
+                        end,
+                        conditions,
+                    ),
+                ]
+            )
+        schedule = PriceSchedule(tiers=tuple(tiers))
+
+        short_output = resolve_usage_unit_prices(
+            schedule,
+            UsageContext(input_tokens=10_000, output_tokens=100),
+        )
+        long_output = resolve_usage_unit_prices(
+            schedule,
+            UsageContext(input_tokens=10_000, output_tokens=300),
+        )
+        long_input = resolve_usage_unit_prices(
+            schedule,
+            UsageContext(input_tokens=50_000, output_tokens=100),
+        )
+
+        self.assertEqual(short_output.input_per_million, Decimal("2"))
+        self.assertEqual(short_output.output_per_million, Decimal("8"))
+        self.assertEqual(long_output.input_per_million, Decimal("3"))
+        self.assertEqual(long_output.output_per_million, Decimal("14"))
+        self.assertEqual(long_input.input_per_million, Decimal("4"))
+        self.assertEqual(long_input.output_per_million, Decimal("16"))
+
     def test_derive_resale_pricing_format_classifies_flat_schedule(self):
         schedule = PriceSchedule(
             tiers=(

--- a/backend/llm_ops/tests/test_tier_pricing.py
+++ b/backend/llm_ops/tests/test_tier_pricing.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from decimal import Decimal
 
 from django.test import SimpleTestCase
@@ -430,6 +431,76 @@ class TieredPricingKernelTests(SimpleTestCase):
         )
 
         self.assertEqual(derive_resale_pricing_format(schedule), "mixed")
+
+    def test_conditional_fallback_considers_unconditional_highest_price(self):
+        schedule = PriceSchedule(
+            tiers=(
+                self._flat_tier(
+                    "2",
+                    {
+                        "time_windows": [
+                            {
+                                "weekdays": list(range(7)),
+                                "start": "08:00",
+                                "end": "20:00",
+                            }
+                        ]
+                    },
+                ),
+                self._flat_tier("5", {}),
+            )
+        )
+
+        with self.assertLogs("llm_ops.tier_pricing", level="WARNING"):
+            prices = resolve_usage_unit_prices(schedule, UsageContext())
+
+        self.assertEqual(prices.input_per_million, Decimal("5"))
+
+    def test_overlapping_time_rules_warn_and_choose_highest_price(self):
+        window = {
+            "time_windows": [
+                {
+                    "weekdays": list(range(7)),
+                    "start": "08:00",
+                    "end": "20:00",
+                }
+            ],
+            "timezone": "UTC",
+        }
+        schedule = PriceSchedule(
+            tiers=(
+                self._flat_tier("1", window),
+                self._flat_tier("3", window),
+            )
+        )
+        usage = UsageContext(
+            input_tokens=1_000_000,
+            occurred_at=datetime(
+                2026,
+                8,
+                18,
+                12,
+                tzinfo=timezone.utc,
+            ),
+        )
+
+        with self.assertLogs("llm_ops.tier_pricing", level="WARNING"):
+            prices = resolve_usage_unit_prices(schedule, usage)
+
+        self.assertEqual(prices.input_per_million, Decimal("3"))
+
+    @staticmethod
+    def _flat_tier(unit_price, spec):
+        return PriceTier(
+            dimension=ModelPriceItem.DIMENSION_TEXT_INPUT,
+            billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
+            currency="USD",
+            unit_price=Decimal(unit_price),
+            tier_type=ModelPriceItem.TIER_FLAT,
+            tier_start=None,
+            tier_end=None,
+            spec=spec,
+        )
 
     @staticmethod
     def _tier(

--- a/backend/llm_ops/tests/test_zhipu_price_collector.py
+++ b/backend/llm_ops/tests/test_zhipu_price_collector.py
@@ -1,10 +1,22 @@
 import json
+from decimal import Decimal
 from unittest.mock import Mock, patch
 
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TestCase
 
+from llm_ops.collection_services import (
+    sync_model_price_items,
+    upsert_collected_offering,
+)
+from llm_ops.models import (
+    LLMProvider,
+    MetaModel,
+    ModelPriceItem,
+    PriceCollectionSource,
+)
 from llm_ops.price_collectors import collect_vendor_price_catalog
 from llm_ops.price_collectors.parsers.zhipu import extract_models
+from llm_ops.skill_runner import standard_catalog_to_collected_catalog
 
 
 ZHIPU_PRICING_JSON = json.dumps(
@@ -60,17 +72,44 @@ newModel:{model:[{
   unit2:"百万tokens",
   modelList:[
     {
-      name:"GLM-5.2",
-      upDownText:["1M"],
-      inPrice:["8元"],
-      outPrice:["28元"],
-      hit:["2元"]
+      name:"GLM-5.1",
+      rowspan:2,
+      upDownText:["输入长度 [0, 32)"],
+      inPrice:["6元"],
+      outPrice:["24元"],
+      hit:["1.3元"]
     },
     {
       name:"",
       upDownText:["输入长度 [32+)"],
       inPrice:["8元"],
-      outPrice:["28元"]
+      outPrice:["28元"],
+      hit:["2元"]
+    },
+    {
+      name:"GLM-4.7",
+      rowspan:3,
+      upDownText:["输入长度 [0, 32)", "输出长度 [0, 0.2)"],
+      inPrice:["2元"],
+      outPrice:["8元"]
+    },
+    {
+      name:"",
+      upDownText:["输入长度 [0, 32)", "输出长度 [0.2+)"],
+      inPrice:["3元"],
+      outPrice:["14元"]
+    },
+    {
+      name:"",
+      upDownText:["输入长度 [32, 200)"],
+      inPrice:["4元"],
+      outPrice:["16元"]
+    },
+    {
+      name:"GLM-4.7-Flash",
+      upDownText:["200K"],
+      inPrice:["免费"],
+      outPrice:["免费"]
     }
   ]
 }]}
@@ -118,10 +157,82 @@ class ZhipuPriceCatalogCollectorTests(SimpleTestCase):
     def test_extract_models_from_bigmodel_bundle_model_list(self):
         models = extract_models(ZHIPU_BUNDLE_MODEL_LIST)
 
-        self.assertEqual(len(models), 1)
-        self.assertEqual(models[0]["model_id"], "glm-5.2")
-        self.assertEqual(models[0]["input_price_per_million"], "8")
-        self.assertEqual(models[0]["output_price_per_million"], "28")
+        self.assertEqual(
+            [model["model_id"] for model in models],
+            ["glm-4.7", "glm-5.1"],
+        )
+        glm_51 = next(
+            model for model in models if model["model_id"] == "glm-5.1"
+        )
+        self.assertEqual(
+            glm_51["price_rows"],
+            [
+                {
+                    "input_price_per_million": "6",
+                    "output_price_per_million": "24",
+                    "cache_hit_price_per_million": "1.3",
+                    "input_token_range": "0-32000",
+                },
+                {
+                    "input_price_per_million": "8",
+                    "output_price_per_million": "28",
+                    "cache_hit_price_per_million": "2",
+                    "input_token_range": "32000+",
+                },
+            ],
+        )
+        glm_47 = next(
+            model for model in models if model["model_id"] == "glm-4.7"
+        )
+        self.assertEqual(
+            glm_47["price_rows"],
+            [
+                {
+                    "input_price_per_million": "2",
+                    "output_price_per_million": "8",
+                    "input_token_range": "0-32000",
+                    "output_token_range": "0-200",
+                    "usage_condition_mode": "multi_metric",
+                },
+                {
+                    "input_price_per_million": "3",
+                    "output_price_per_million": "14",
+                    "input_token_range": "0-32000",
+                    "output_token_range": "200+",
+                    "usage_condition_mode": "multi_metric",
+                },
+                {
+                    "input_price_per_million": "4",
+                    "output_price_per_million": "16",
+                    "input_token_range": "32000-200000",
+                    "usage_condition_mode": "multi_metric",
+                },
+            ],
+        )
+
+    def test_catalog_preserves_bigmodel_usage_conditions(self):
+        payload = collect_vendor_price_catalog(
+            "zhipu",
+            {
+                "raw_html": ZHIPU_BUNDLE_MODEL_LIST,
+                "provider_name": "智谱",
+                "model_codes": ["glm-4.7"],
+            },
+        )
+
+        rows = payload["models"][0]["price_rows"]
+
+        self.assertEqual(len(rows), 3)
+        self.assertEqual(
+            rows[0]["values"],
+            {
+                "input_price": "2",
+                "output_price": "8",
+                "input_token_range": "0-32000",
+                "output_token_range": "0-200",
+                "usage_condition_mode": "multi_metric",
+            },
+        )
 
     def test_js_shell_without_model_prices_returns_empty_catalog(self):
         payload = collect_vendor_price_catalog(
@@ -155,8 +266,8 @@ class ZhipuPriceCatalogCollectorTests(SimpleTestCase):
             {"source_url": "https://bigmodel.cn/pricing"},
         )
 
-        self.assertEqual(payload["total_models"], 1)
-        self.assertEqual(payload["models"][0]["model_id"], "glm-5.2")
+        self.assertEqual(payload["total_models"], 2)
+        self.assertEqual(payload["models"][0]["model_id"], "glm-4.7")
         requested_urls = [call.args[0] for call in mocked_get.call_args_list]
         self.assertEqual(
             requested_urls,
@@ -185,3 +296,89 @@ class ZhipuPriceCatalogCollectorTests(SimpleTestCase):
         self.assertEqual(payload["provider"]["currency"], "CNY")
         self.assertEqual(payload["total_models"], 1)
         self.assertEqual(payload["models"][0]["model_id"], "glm-4.7")
+
+
+class ZhipuPriceCatalogPersistenceTests(TestCase):
+    def test_glm_conditions_persist_idempotently_with_source_evidence(self):
+        provider = LLMProvider.objects.create(name="智谱", code="zhipu")
+        source = PriceCollectionSource.objects.create(
+            name="智谱官方",
+            slug="zhipu-official",
+            provider=provider,
+            source_category=(
+                PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
+            ),
+            endpoint_url="https://bigmodel.cn/pricing",
+            currency="CNY",
+            is_enabled=True,
+            updates_model_prices=True,
+        )
+        meta_model = MetaModel.objects.create(
+            code="glm-4.7",
+            name="GLM-4.7",
+            owner_code="zhipu",
+            owner_name="智谱",
+        )
+        payload = collect_vendor_price_catalog(
+            "zhipu",
+            {
+                "raw_html": ZHIPU_BUNDLE_MODEL_LIST,
+                "source_url": source.endpoint_url,
+                "provider_name": provider.name,
+                "model_codes": [meta_model.code],
+            },
+        )
+        item = standard_catalog_to_collected_catalog(payload).models[0]
+        offering, _ = upsert_collected_offering(
+            item,
+            source=source,
+            source_url=source.endpoint_url,
+            meta_model=meta_model,
+        )
+
+        first_items = sync_model_price_items(
+            item,
+            source=source,
+            offering=offering,
+            source_url=source.endpoint_url,
+        )
+        second_items = sync_model_price_items(
+            item,
+            source=source,
+            offering=offering,
+            source_url=source.endpoint_url,
+        )
+
+        input_items = [
+            price_item
+            for price_item in first_items
+            if price_item.dimension == ModelPriceItem.DIMENSION_TEXT_INPUT
+        ]
+        output_items = [
+            price_item
+            for price_item in first_items
+            if price_item.dimension == ModelPriceItem.DIMENSION_TEXT_OUTPUT
+        ]
+        self.assertEqual(len(input_items), 3)
+        self.assertEqual(len(output_items), 3)
+        self.assertEqual(
+            {price_item.id for price_item in first_items},
+            {price_item.id for price_item in second_items},
+        )
+        first_rule = next(
+            price_item
+            for price_item in input_items
+            if price_item.unit_price == Decimal("2")
+        )
+        self.assertEqual(
+            first_rule.spec["usage_conditions"],
+            {
+                "input_tokens": {"start": "0", "end": "32000"},
+                "output_tokens": {"start": "0", "end": "200"},
+            },
+        )
+        self.assertEqual(
+            first_rule.raw_payload["values"]["input_token_range"],
+            "0-32000",
+        )
+        self.assertEqual(first_rule.currency, "CNY")

--- a/backend/llm_ops/tier_pricing.py
+++ b/backend/llm_ops/tier_pricing.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from datetime import datetime, time, timezone as dt_timezone
 from decimal import Decimal
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from .models import ModelPriceItem
 from .price_table_validation import (
@@ -87,6 +89,8 @@ class UsageContext:
     audio_output_seconds: Decimal | int | str = ZERO
     video_input_seconds: Decimal | int | str = ZERO
     video_output_seconds: Decimal | int | str = ZERO
+    occurred_at: datetime | None = None
+    timezone: str = "UTC"
 
 
 @dataclass(frozen=True)
@@ -209,16 +213,15 @@ def resolve_usage_price_tier(
     if not tiers:
         raise ValueError(f"No price tier exists for {dimension}.")
     conditional_tiers = tuple(
-        tier for tier in tiers if tier.spec.get("usage_conditions")
+        tier
+        for tier in tiers
+        if tier.spec.get("usage_conditions") or tier.spec.get("time_windows")
     )
     if conditional_tiers:
         matches = tuple(
             tier
             for tier in conditional_tiers
-            if _usage_matches_conditions(
-                usage,
-                tier.spec.get("usage_conditions"),
-            )
+            if _usage_matches_tier(usage, tier)
         )
         if matches:
             return max(matches, key=lambda tier: tier.unit_price)
@@ -264,6 +267,62 @@ def _usage_matches_conditions(
         if value < start or (end is not None and value >= end):
             return False
     return True
+
+
+def _usage_matches_tier(usage: UsageContext, tier: PriceTier) -> bool:
+    """Match all quantity and local-time conditions on a price rule."""
+    conditions = tier.spec.get("usage_conditions")
+    if conditions and not _usage_matches_conditions(usage, conditions):
+        return False
+    windows = tier.spec.get("time_windows")
+    if windows and not _usage_matches_time_windows(
+        usage,
+        windows,
+        timezone_name=str(tier.spec.get("timezone") or usage.timezone),
+    ):
+        return False
+    return True
+
+
+def _usage_matches_time_windows(
+    usage: UsageContext,
+    windows: object,
+    *,
+    timezone_name: str,
+) -> bool:
+    """Match weekday/time windows, including intervals crossing midnight."""
+    if usage.occurred_at is None or not isinstance(windows, list):
+        return False
+    occurred_at = usage.occurred_at
+    if occurred_at.tzinfo is None:
+        occurred_at = occurred_at.replace(tzinfo=dt_timezone.utc)
+    try:
+        local_time = occurred_at.astimezone(ZoneInfo(timezone_name))
+    except ZoneInfoNotFoundError:
+        return False
+
+    for window in windows:
+        if not isinstance(window, dict):
+            continue
+        try:
+            start = time.fromisoformat(str(window.get("start")))
+            end = time.fromisoformat(str(window.get("end")))
+            weekdays = {int(day) for day in window.get("weekdays", [])}
+        except (TypeError, ValueError):
+            continue
+        current_time = local_time.timetz().replace(tzinfo=None)
+        weekday = local_time.weekday()
+        if start < end:
+            if weekday in weekdays and start <= current_time < end:
+                return True
+            continue
+        if start > end:
+            if current_time >= start and weekday in weekdays:
+                return True
+            previous_weekday = (weekday - 1) % 7
+            if current_time < end and previous_weekday in weekdays:
+                return True
+    return False
 
 
 def resolve_usage_unit_prices(

--- a/backend/llm_ops/tier_pricing.py
+++ b/backend/llm_ops/tier_pricing.py
@@ -218,14 +218,31 @@ def resolve_usage_price_tier(
         if tier.spec.get("usage_conditions") or tier.spec.get("time_windows")
     )
     if conditional_tiers:
-        matches = tuple(
+        conditional_matches = tuple(
             tier
             for tier in conditional_tiers
             if _usage_matches_tier(usage, tier)
         )
+        matches = tuple(
+            tier
+            for tier in tiers
+            if _usage_matches_tier(usage, tier)
+        )
         if matches:
+            if len(matches) > 1:
+                logger.warning(
+                    "Multiple conditional price rules matched "
+                    "dimension=%s; using conservative highest unit price.",
+                    dimension,
+                )
+            elif not conditional_matches:
+                logger.warning(
+                    "No conditional price rule matched dimension=%s; "
+                    "using the unconditional unit price.",
+                    dimension,
+                )
             return max(matches, key=lambda tier: tier.unit_price)
-        fallback = max(conditional_tiers, key=lambda tier: tier.unit_price)
+        fallback = max(tiers, key=lambda tier: tier.unit_price)
         logger.warning(
             "No conditional price rule matched dimension=%s; "
             "using conservative highest unit price.",

--- a/backend/llm_ops/tier_pricing.py
+++ b/backend/llm_ops/tier_pricing.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from decimal import Decimal
 
@@ -14,6 +15,8 @@ from .price_table_validation import (
 ZERO = Decimal("0")
 ONE = Decimal("1")
 SIX_PLACES = Decimal("0.000001")
+
+logger = logging.getLogger(__name__)
 
 
 class TieredPriceNotSupportedError(ValueError):
@@ -205,6 +208,27 @@ def resolve_usage_price_tier(
     tiers = schedule.for_dimension(dimension)
     if not tiers:
         raise ValueError(f"No price tier exists for {dimension}.")
+    conditional_tiers = tuple(
+        tier for tier in tiers if tier.spec.get("usage_conditions")
+    )
+    if conditional_tiers:
+        matches = tuple(
+            tier
+            for tier in conditional_tiers
+            if _usage_matches_conditions(
+                usage,
+                tier.spec.get("usage_conditions"),
+            )
+        )
+        if matches:
+            return max(matches, key=lambda tier: tier.unit_price)
+        fallback = max(conditional_tiers, key=lambda tier: tier.unit_price)
+        logger.warning(
+            "No conditional price rule matched dimension=%s; "
+            "using conservative highest unit price.",
+            dimension,
+        )
+        return fallback
     metric_value = ZERO
     if any(tier.tier_type != ModelPriceItem.TIER_FLAT for tier in tiers):
         metric_value = _decimal_or_zero(usage.input_tokens)
@@ -217,6 +241,29 @@ def resolve_usage_price_tier(
     except PriceTierNotFoundError:
         # Usage above the highest defined tier bills at the top tier rate.
         return tiers[-1]
+
+
+def _usage_matches_conditions(
+    usage: UsageContext,
+    conditions: object,
+) -> bool:
+    """Return whether all normalized request conditions match usage."""
+    if not isinstance(conditions, dict) or not conditions:
+        return False
+    usage_values = {
+        "input_tokens": _decimal_or_zero(usage.input_tokens),
+        "output_tokens": _decimal_or_zero(usage.output_tokens),
+    }
+    for metric, bounds in conditions.items():
+        if metric not in usage_values or not isinstance(bounds, dict):
+            return False
+        start = _decimal_or_zero(bounds.get("start"))
+        end_value = bounds.get("end")
+        end = None if end_value is None else _decimal_or_zero(end_value)
+        value = usage_values[metric]
+        if value < start or (end is not None and value >= end):
+            return False
+    return True
 
 
 def resolve_usage_unit_prices(

--- a/backend/llm_ops/urls.py
+++ b/backend/llm_ops/urls.py
@@ -5,6 +5,7 @@ from .views import (
     AuditLogViewSet,
     ChannelModelPriceHistoryViewSet,
     ChannelModelPriceViewSet,
+    ChannelOfferingViewSet,
     ChannelPriceItemViewSet,
     CollectedModelPriceHistoryViewSet,
     CollectedModelPriceSnapshotViewSet,
@@ -58,6 +59,11 @@ router.register(
     basename="model-price-item",
 )
 router.register(r"channels", ProcurementChannelViewSet, basename="channel")
+router.register(
+    r"channel-offerings",
+    ChannelOfferingViewSet,
+    basename="channel-offering",
+)
 router.register(
     r"channel-model-prices",
     ChannelModelPriceViewSet,

--- a/backend/llm_ops/urls.py
+++ b/backend/llm_ops/urls.py
@@ -7,6 +7,7 @@ from .views import (
     ChannelModelPriceViewSet,
     ChannelOfferingViewSet,
     ChannelPriceItemViewSet,
+    ChannelPriceVersionViewSet,
     CollectedModelPriceHistoryViewSet,
     CollectedModelPriceSnapshotViewSet,
     LLMOpsGlobalConfigAPIView,
@@ -63,6 +64,11 @@ router.register(
     r"channel-offerings",
     ChannelOfferingViewSet,
     basename="channel-offering",
+)
+router.register(
+    r"channel-price-versions",
+    ChannelPriceVersionViewSet,
+    basename="channel-price-version",
 )
 router.register(
     r"channel-model-prices",

--- a/backend/llm_ops/views.py
+++ b/backend/llm_ops/views.py
@@ -52,6 +52,7 @@ from .models import (
     AuditLog,
     ChannelModelPrice,
     ChannelModelPriceHistory,
+    ChannelOffering,
     ChannelPriceItem,
     CollectedModelPriceHistory,
     CollectedModelPriceSnapshot,
@@ -75,6 +76,7 @@ from .serializers import (
     AuditLogSerializer,
     ChannelModelPriceHistorySerializer,
     ChannelModelPriceSerializer,
+    ChannelOfferingSerializer,
     ChannelPriceItemSerializer,
     CollectedModelPriceHistorySerializer,
     CollectedModelPriceSnapshotSerializer,
@@ -1525,17 +1527,21 @@ class ChannelModelPriceViewSet(
             "meta_model",
             "model",
             "model__provider",
+            "offering",
             "price_source",
         )
         channel = self.request.query_params.get("channel")
         meta_model = self.request.query_params.get("meta_model")
         model = self.request.query_params.get("model")
+        offering = self.request.query_params.get("offering")
         if channel:
             queryset = queryset.filter(channel_id=channel)
         if meta_model:
             queryset = queryset.filter(meta_model_id=meta_model)
         if model:
             queryset = queryset.filter(model_id=model)
+        if offering:
+            queryset = queryset.filter(offering_id=offering)
         return queryset.order_by("channel__name", "model__name", "id")
 
     def perform_create(self, serializer):
@@ -1623,14 +1629,28 @@ class ChannelModelPriceViewSet(
                 )
                 serializer.is_valid(raise_exception=True)
                 data = serializer.validated_data
+                offering = data.get("offering")
+                if offering is None:
+                    offering, _created = ChannelOffering.objects.get_or_create(
+                        channel=data["channel"],
+                        meta_model=data["model"].meta_model,
+                        is_default=True,
+                        defaults={
+                            "offering_key": (
+                                f"default-{data['model'].meta_model_id}"
+                            ),
+                            "display_name": data["model"].meta_model.name,
+                        },
+                    )
                 lookup = {
                     "channel": data["channel"],
                     "model": data["model"],
+                    "offering": offering,
                 }
                 defaults = {
                     key: value
                     for key, value in data.items()
-                    if key not in {"channel", "model"}
+                    if key not in {"channel", "model", "offering"}
                 }
                 defaults["meta_model"] = data["model"].meta_model
                 price, created = ChannelModelPrice.objects.update_or_create(
@@ -1712,11 +1732,13 @@ class ChannelModelPriceHistoryViewSet(
             "meta_model",
             "model",
             "model__provider",
+            "offering",
             "price_source",
         )
         channel = self.request.query_params.get("channel")
         meta_model = self.request.query_params.get("meta_model")
         model = self.request.query_params.get("model")
+        offering = self.request.query_params.get("offering")
         is_current = self.request.query_params.get("is_current")
         if channel:
             queryset = queryset.filter(channel_id=channel)
@@ -1724,9 +1746,53 @@ class ChannelModelPriceHistoryViewSet(
             queryset = queryset.filter(meta_model_id=meta_model)
         if model:
             queryset = queryset.filter(model_id=model)
+        if offering:
+            queryset = queryset.filter(offering_id=offering)
         if is_current in {"true", "false"}:
             queryset = queryset.filter(is_current=is_current == "true")
         return queryset.order_by("-effective_from", "-id")
+
+
+class ChannelOfferingViewSet(
+    AuditModelViewSetMixin,
+    LLMOpsPermissionMixin,
+    viewsets.ModelViewSet,
+):
+    """CRUD API for procurement offering identities and sales controls."""
+
+    audit_category = AuditLog.CATEGORY_CONFIGURATION
+    serializer_class = ChannelOfferingSerializer
+
+    def get_queryset(self):
+        queryset = ChannelOffering.objects.select_related(
+            "channel",
+            "meta_model",
+            "model",
+            "source_offering",
+            "source_offering__sku",
+        )
+        channel = self.request.query_params.get("channel")
+        meta_model = self.request.query_params.get("meta_model")
+        status_value = self.request.query_params.get("status")
+        is_sales_enabled = self.request.query_params.get(
+            "is_sales_enabled"
+        )
+        if channel:
+            queryset = queryset.filter(channel_id=channel)
+        if meta_model:
+            queryset = queryset.filter(meta_model_id=meta_model)
+        if status_value:
+            queryset = queryset.filter(status=status_value)
+        if is_sales_enabled in {"true", "false"}:
+            queryset = queryset.filter(
+                is_sales_enabled=is_sales_enabled == "true"
+            )
+        return queryset.order_by(
+            "channel__name",
+            "meta_model__name",
+            "display_name",
+            "id",
+        )
 
 
 class ChannelPriceItemViewSet(
@@ -1745,12 +1811,14 @@ class ChannelPriceItemViewSet(
             "meta_model",
             "model",
             "model__provider",
+            "offering",
             "base_price_item",
             "source",
         )
         channel = self.request.query_params.get("channel")
         meta_model = self.request.query_params.get("meta_model")
         model = self.request.query_params.get("model")
+        offering = self.request.query_params.get("offering")
         dimension = self.request.query_params.get("dimension")
         is_current = self.request.query_params.get("is_current")
         if channel:
@@ -1759,6 +1827,8 @@ class ChannelPriceItemViewSet(
             queryset = queryset.filter(meta_model_id=meta_model)
         if model:
             queryset = queryset.filter(model_id=model)
+        if offering:
+            queryset = queryset.filter(offering_id=offering)
         if dimension:
             queryset = queryset.filter(dimension=dimension)
         if is_current in {"true", "false"}:

--- a/backend/llm_ops/views.py
+++ b/backend/llm_ops/views.py
@@ -28,7 +28,11 @@ from rest_framework.views import APIView
 
 from accounts.permissions import HasRequiredFeature
 
-from .audit import record_audit_log, snapshot_instance
+from .audit import (
+    record_audit_log,
+    snapshot_channel_price_version,
+    snapshot_instance,
+)
 from .collection_services import (
     SUPPORTED_OFFICIAL_PRICE_SYNC_PROVIDER_CODES,
     ensure_supported_official_provider_source,
@@ -209,6 +213,10 @@ class AuditModelViewSetMixin:
 
     audit_category = None
 
+    def get_audit_snapshot(self, instance):
+        """Return the safe audit snapshot for one model instance."""
+        return snapshot_instance(instance)
+
     def perform_create(self, serializer):
         instance = serializer.save()
         record_audit_log(
@@ -217,13 +225,13 @@ class AuditModelViewSetMixin:
             category=self.audit_category,
             target=instance,
             summary=f"Created {instance}",
-            after=snapshot_instance(instance),
+            after=self.get_audit_snapshot(instance),
         )
 
     def perform_update(self, serializer):
-        before = snapshot_instance(serializer.instance)
+        before = self.get_audit_snapshot(serializer.instance)
         instance = serializer.save()
-        after = snapshot_instance(instance)
+        after = self.get_audit_snapshot(instance)
         record_audit_log(
             request=self.request,
             action=AuditLog.ACTION_UPDATE,
@@ -235,7 +243,7 @@ class AuditModelViewSetMixin:
         )
 
     def perform_destroy(self, instance):
-        before = snapshot_instance(instance)
+        before = self.get_audit_snapshot(instance)
         target_repr = str(instance)
         record_audit_log(
             request=self.request,
@@ -1615,14 +1623,21 @@ class ChannelModelPriceViewSet(
         prices = []
         with transaction.atomic():
             for item in items:
-                existing = (
-                    ChannelModelPrice.objects.select_for_update()
-                    .filter(
+                existing_queryset = (
+                    ChannelModelPrice.objects.select_for_update().filter(
                         channel_id=item.get("channel"),
                         model_id=item.get("model"),
                     )
-                    .first()
                 )
+                if item.get("offering") is not None:
+                    existing_queryset = existing_queryset.filter(
+                        offering_id=item.get("offering")
+                    )
+                else:
+                    existing_queryset = existing_queryset.filter(
+                        offering__is_default=True
+                    )
+                existing = existing_queryset.first()
                 before = snapshot_instance(existing)
                 serializer = self.get_serializer(
                     existing,
@@ -1807,6 +1822,17 @@ class ChannelPriceVersionViewSet(
     audit_category = AuditLog.CATEGORY_PRICING
     serializer_class = ChannelPriceVersionSerializer
 
+    def get_audit_snapshot(self, instance):
+        """Capture contract fields and nested normalized price rules."""
+        return snapshot_channel_price_version(instance)
+
+    def perform_destroy(self, instance):
+        if instance.status != ChannelPriceVersion.STATUS_DRAFT:
+            raise ValidationError(
+                "Published price versions are immutable."
+            )
+        super().perform_destroy(instance)
+
     def get_queryset(self):
         queryset = ChannelPriceVersion.objects.select_related(
             "offering",
@@ -1867,6 +1893,7 @@ class ChannelPriceItemViewSet(
         price_version = self.request.query_params.get("price_version")
         dimension = self.request.query_params.get("dimension")
         is_current = self.request.query_params.get("is_current")
+        is_effective = self.request.query_params.get("is_effective")
         if channel:
             queryset = queryset.filter(channel_id=channel)
         if meta_model:
@@ -1881,6 +1908,24 @@ class ChannelPriceItemViewSet(
             queryset = queryset.filter(dimension=dimension)
         if is_current in {"true", "false"}:
             queryset = queryset.filter(is_current=is_current == "true")
+        if is_effective == "true":
+            now = timezone.now()
+            queryset = queryset.filter(
+                Q(price_version__isnull=False) | Q(is_current=True)
+            ).filter(
+                Q(price_version__isnull=True)
+                | Q(
+                    price_version__status__in=(
+                        ChannelPriceVersion.STATUS_ACTIVE,
+                        ChannelPriceVersion.STATUS_SCHEDULED,
+                    ),
+                    price_version__effective_from__lte=now,
+                )
+            ).filter(
+                Q(price_version__isnull=True)
+                | Q(price_version__effective_to__isnull=True)
+                | Q(price_version__effective_to__gt=now)
+            )
         return queryset.order_by(
             "channel__name",
             "model__name",
@@ -1888,6 +1933,17 @@ class ChannelPriceItemViewSet(
             "tier_start",
             "id",
         )
+
+    def perform_destroy(self, instance):
+        if (
+            instance.price_version_id
+            and instance.price_version.status
+            != ChannelPriceVersion.STATUS_DRAFT
+        ):
+            raise ValidationError(
+                "Published price version items are immutable."
+            )
+        super().perform_destroy(instance)
 
 
 class ResalePlatformViewSet(

--- a/backend/llm_ops/views.py
+++ b/backend/llm_ops/views.py
@@ -54,6 +54,7 @@ from .models import (
     ChannelModelPriceHistory,
     ChannelOffering,
     ChannelPriceItem,
+    ChannelPriceVersion,
     CollectedModelPriceHistory,
     CollectedModelPriceSnapshot,
     LLMModel,
@@ -78,6 +79,7 @@ from .serializers import (
     ChannelModelPriceSerializer,
     ChannelOfferingSerializer,
     ChannelPriceItemSerializer,
+    ChannelPriceVersionSerializer,
     CollectedModelPriceHistorySerializer,
     CollectedModelPriceSnapshotSerializer,
     LLMModelSerializer,
@@ -1795,6 +1797,48 @@ class ChannelOfferingViewSet(
         )
 
 
+class ChannelPriceVersionViewSet(
+    AuditModelViewSetMixin,
+    LLMOpsPermissionMixin,
+    viewsets.ModelViewSet,
+):
+    """CRUD API for effective-dated procurement price contracts."""
+
+    audit_category = AuditLog.CATEGORY_PRICING
+    serializer_class = ChannelPriceVersionSerializer
+
+    def get_queryset(self):
+        queryset = ChannelPriceVersion.objects.select_related(
+            "offering",
+            "offering__channel",
+            "meta_model",
+            "model",
+            "created_by",
+            "updated_by",
+        ).prefetch_related("price_items")
+        channel = self.request.query_params.get("channel")
+        offering = self.request.query_params.get("offering")
+        meta_model = self.request.query_params.get("meta_model")
+        model = self.request.query_params.get("model")
+        status_value = self.request.query_params.get("status")
+        if channel:
+            queryset = queryset.filter(offering__channel_id=channel)
+        if offering:
+            queryset = queryset.filter(offering_id=offering)
+        if meta_model:
+            queryset = queryset.filter(meta_model_id=meta_model)
+        if model:
+            queryset = queryset.filter(model_id=model)
+        if status_value:
+            queryset = queryset.filter(status=status_value)
+        return queryset.order_by(
+            "offering__channel__name",
+            "offering__display_name",
+            "model__name",
+            "-version",
+        )
+
+
 class ChannelPriceItemViewSet(
     AuditModelViewSetMixin,
     LLMOpsPermissionMixin,
@@ -1812,6 +1856,7 @@ class ChannelPriceItemViewSet(
             "model",
             "model__provider",
             "offering",
+            "price_version",
             "base_price_item",
             "source",
         )
@@ -1819,6 +1864,7 @@ class ChannelPriceItemViewSet(
         meta_model = self.request.query_params.get("meta_model")
         model = self.request.query_params.get("model")
         offering = self.request.query_params.get("offering")
+        price_version = self.request.query_params.get("price_version")
         dimension = self.request.query_params.get("dimension")
         is_current = self.request.query_params.get("is_current")
         if channel:
@@ -1829,6 +1875,8 @@ class ChannelPriceItemViewSet(
             queryset = queryset.filter(model_id=model)
         if offering:
             queryset = queryset.filter(offering_id=offering)
+        if price_version:
+            queryset = queryset.filter(price_version_id=price_version)
         if dimension:
             queryset = queryset.filter(dimension=dimension)
         if is_current in {"true", "false"}:
@@ -2843,9 +2891,13 @@ class UsageReconciliationRecordViewSet(
             "channel",
             "model",
             "model__provider",
+            "offering",
+            "price_version",
         )
         channel = self.request.query_params.get("channel")
         model = self.request.query_params.get("model")
+        offering = self.request.query_params.get("offering")
+        price_version = self.request.query_params.get("price_version")
         status_value = self.request.query_params.get("status")
         date_from = self.request.query_params.get("date_from")
         date_to = self.request.query_params.get("date_to")
@@ -2854,6 +2906,10 @@ class UsageReconciliationRecordViewSet(
             queryset = queryset.filter(channel_id=channel)
         if model:
             queryset = queryset.filter(model_id=model)
+        if offering:
+            queryset = queryset.filter(offering_id=offering)
+        if price_version:
+            queryset = queryset.filter(price_version_id=price_version)
         if status_value:
             queryset = queryset.filter(status=status_value)
         if date_from:

--- a/frontend/src/api/llmOps.js
+++ b/frontend/src/api/llmOps.js
@@ -183,6 +183,37 @@ export const llmOpsApi = {
     return apiClient.delete(`${base}/channels/${id}/`)
   },
 
+  listChannelOfferings(params) {
+    return apiClient.get(`${base}/channel-offerings/`, paramsOrEmpty(params))
+  },
+
+  createChannelOffering(payload) {
+    return apiClient.post(`${base}/channel-offerings/`, payload)
+  },
+
+  updateChannelOffering(id, payload) {
+    return apiClient.patch(`${base}/channel-offerings/${id}/`, payload)
+  },
+
+  deleteChannelOffering(id) {
+    return apiClient.delete(`${base}/channel-offerings/${id}/`)
+  },
+
+  listChannelPriceVersions(params) {
+    return apiClient.get(
+      `${base}/channel-price-versions/`,
+      paramsOrEmpty(params)
+    )
+  },
+
+  createChannelPriceVersion(payload) {
+    return apiClient.post(`${base}/channel-price-versions/`, payload)
+  },
+
+  updateChannelPriceVersion(id, payload) {
+    return apiClient.patch(`${base}/channel-price-versions/${id}/`, payload)
+  },
+
   listChannelModelPrices(params) {
     return apiClient.get(`${base}/channel-model-prices/`, paramsOrEmpty(params))
   },

--- a/frontend/src/components/llm-ops/ModelWorkbenchPanel.vue
+++ b/frontend/src/components/llm-ops/ModelWorkbenchPanel.vue
@@ -92,6 +92,135 @@
         </div>
       </div>
 
+      <div class="panel overflow-hidden p-0">
+        <div class="table-toolbar">
+          <div>
+            <h3 class="panel-title">
+              {{ t('llmOps.modelWorkbenchPanel.contractRelations.title') }}
+            </h3>
+            <p class="mt-1 text-xs text-slate-500">
+              {{
+                t('llmOps.modelWorkbenchPanel.contractRelations.description')
+              }}
+            </p>
+          </div>
+        </div>
+        <div class="overflow-x-auto">
+          <table class="data-table">
+            <thead>
+              <tr>
+                <th class="table-head">
+                  {{ t('llmOps.modelWorkbenchPanel.columns.channel') }}
+                </th>
+                <th class="table-head">
+                  {{
+                    t('llmOps.modelWorkbenchPanel.contractRelations.offering')
+                  }}
+                </th>
+                <th class="table-head">
+                  {{ t('llmOps.modelWorkbenchPanel.contractRelations.sales') }}
+                </th>
+                <th class="table-head">
+                  {{
+                    t('llmOps.modelWorkbenchPanel.contractRelations.current')
+                  }}
+                </th>
+                <th class="table-head">
+                  {{ t('llmOps.modelWorkbenchPanel.contractRelations.future') }}
+                </th>
+                <th class="table-head">
+                  {{ t('llmOps.modelWorkbenchPanel.contractRelations.rules') }}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="offering in selectedOfferings" :key="offering.id">
+                <td class="table-cell">
+                  {{ offering.channel_name || channelName(offering.channel) }}
+                </td>
+                <td class="table-cell">
+                  <div class="font-medium text-slate-800">
+                    {{ offering.display_name }}
+                  </div>
+                  <div class="font-mono text-[11px] text-slate-500">
+                    {{ offering.offering_key }}
+                  </div>
+                </td>
+                <td class="table-cell">
+                  <div class="flex flex-col gap-2 text-xs">
+                    <label
+                      class="inline-flex items-center gap-2"
+                      :title="
+                        t(
+                          'llmOps.modelWorkbenchPanel.contractRelations.salesTip'
+                        )
+                      "
+                    >
+                      <input
+                        type="checkbox"
+                        :checked="offering.is_sales_enabled"
+                        :disabled="updatingOfferingId === offering.id"
+                        @change="
+                          toggleOffering(
+                            offering,
+                            'is_sales_enabled',
+                            $event.target.checked
+                          )
+                        "
+                      />
+                      {{
+                        t('llmOps.modelWorkbenchPanel.contractRelations.direct')
+                      }}
+                    </label>
+                    <label
+                      class="inline-flex items-center gap-2"
+                      :title="
+                        t(
+                          'llmOps.modelWorkbenchPanel.contractRelations.cacheTip'
+                        )
+                      "
+                    >
+                      <input
+                        type="checkbox"
+                        :checked="offering.is_cache_sales_enabled"
+                        :disabled="updatingOfferingId === offering.id"
+                        @change="
+                          toggleOffering(
+                            offering,
+                            'is_cache_sales_enabled',
+                            $event.target.checked
+                          )
+                        "
+                      />
+                      {{
+                        t('llmOps.modelWorkbenchPanel.contractRelations.cache')
+                      }}
+                    </label>
+                  </div>
+                </td>
+                <td class="table-cell text-xs">
+                  {{ versionSummary(currentVersionFor(offering.id)) }}
+                </td>
+                <td class="table-cell text-xs">
+                  {{ versionSummary(futureVersionFor(offering.id)) }}
+                </td>
+                <td
+                  class="table-cell max-w-md text-xs"
+                  :title="ruleSummary(currentVersionFor(offering.id))"
+                >
+                  {{ ruleSummary(currentVersionFor(offering.id)) }}
+                </td>
+              </tr>
+              <tr v-if="!selectedOfferings.length">
+                <td class="table-cell text-slate-500" colspan="6">
+                  {{ t('llmOps.modelWorkbenchPanel.contractRelations.empty') }}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
       <div class="grid gap-4 xl:grid-cols-2">
         <div class="panel overflow-hidden p-0">
           <div class="table-toolbar">
@@ -157,6 +286,14 @@
 import { computed, defineComponent, h, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import { llmOpsApi } from '@/api/llmOps'
+import { useToast } from '@/composables/useToast'
+import {
+  currentContractVersion,
+  futureContractVersion,
+  offeringsForModel
+} from '@/utils/channelContractRelations'
+import { userFacingApiError } from '@/utils/llmOpsErrors'
 import CompactSelect from './CompactSelect.vue'
 
 const MiniTable = defineComponent({
@@ -218,16 +355,21 @@ const props = defineProps({
   summary: { type: Object, default: () => ({}) },
   models: { type: Array, default: () => [] },
   channels: { type: Array, default: () => [] },
+  channelOfferings: { type: Array, default: () => [] },
   priceItems: { type: Array, default: () => [] },
   channelPriceItems: { type: Array, default: () => [] },
+  channelPriceVersions: { type: Array, default: () => [] },
   focusModelId: { type: [Number, String], default: null },
   listings: { type: Array, default: () => [] },
   records: { type: Array, default: () => [] }
 })
 
+const emit = defineEmits(['refresh'])
 const { t } = useI18n()
+const { showError, showSuccess } = useToast()
 const catalogScope = ref('all')
 const selectedModelId = ref('')
+const updatingOfferingId = ref(null)
 
 const catalogScopeOptions = computed(() => [
   {
@@ -252,6 +394,7 @@ const officialColumns = computed(() => [
 
 const channelColumns = computed(() => [
   t('llmOps.modelWorkbenchPanel.columns.channel'),
+  t('llmOps.modelWorkbenchPanel.columns.offering'),
   t('llmOps.modelWorkbenchPanel.columns.dimension'),
   t('llmOps.modelWorkbenchPanel.columns.price')
 ])
@@ -265,6 +408,8 @@ const listingColumns = computed(() => [
 const reconciliationColumns = computed(() => [
   t('llmOps.modelWorkbenchPanel.columns.date'),
   t('llmOps.modelWorkbenchPanel.columns.channel'),
+  t('llmOps.modelWorkbenchPanel.columns.offering'),
+  t('llmOps.modelWorkbenchPanel.columns.version'),
   t('llmOps.modelWorkbenchPanel.columns.variance')
 ])
 
@@ -345,6 +490,21 @@ const anomalyRecords = computed(() =>
   modelRecords.value.filter((record) => record.status !== 'perfect')
 )
 
+const selectedVersions = computed(() =>
+  props.channelPriceVersions.filter(
+    (version) => String(version.model) === String(selectedModelId.value)
+  )
+)
+
+const selectedOfferings = computed(() => {
+  return offeringsForModel({
+    offerings: props.channelOfferings,
+    versions: selectedVersions.value,
+    priceItems: props.channelPriceItems,
+    modelId: selectedModelId.value
+  })
+})
+
 const officialRows = computed(() =>
   props.priceItems
     .filter((item) => String(item.model) === String(selectedModelId.value))
@@ -362,6 +522,7 @@ const channelRows = computed(() =>
     .slice(0, 12)
     .map((item) => [
       item.channel_name || channelName(item.channel),
+      item.offering_name || item.offering_key || '-',
       dimensionLabel(item.dimension),
       money(item.unit_price, item.currency)
     ])
@@ -386,6 +547,8 @@ const reconciliationRows = computed(() =>
     .map((record) => [
       record.date,
       record.channel_name || channelName(record.channel),
+      record.offering_name || record.offering_key || '-',
+      record.price_version_number ? `v${record.price_version_number}` : '-',
       `${money(record.discrepancy, '')} · ${record.status}`
     ])
 )
@@ -395,6 +558,63 @@ function channelName(channelId) {
     props.channels.find((channel) => String(channel.id) === String(channelId))
       ?.name || '-'
   )
+}
+
+function currentVersionFor(offeringId) {
+  return currentContractVersion(selectedVersions.value, offeringId)
+}
+
+function futureVersionFor(offeringId) {
+  return futureContractVersion(selectedVersions.value, offeringId)
+}
+
+function versionSummary(version) {
+  if (!version) return '-'
+  const effective = version.effective_from
+    ? new Date(version.effective_from).toLocaleString()
+    : '-'
+  return `v${version.version} · ${version.status} · ${effective}`
+}
+
+function ruleSummary(version) {
+  if (!version) return '-'
+  const prices = (version.price_items || []).map((item) => {
+    const windows = item.spec?.time_windows || []
+    const windowLabel = windows.length
+      ? windows.map((window) => `${window.start}-${window.end}`).join(', ')
+      : t('llmOps.modelWorkbenchPanel.contractRelations.allTime')
+    return `${dimensionLabel(item.dimension)} ${item.unit_price} ${
+      item.currency
+    } · ${windowLabel}`
+  })
+  const discount =
+    version.discount_type === 'none'
+      ? ''
+      : ` · ${version.discount_basis}/${version.discount_type} ${
+          version.discount_value
+        }`
+  const exchange = version.contract_exchange_rate
+    ? ` · FX ${version.contract_exchange_rate} (${version.contract_currency})`
+    : ''
+  return `${prices.join(' | ')}${discount}${exchange}`
+}
+
+async function toggleOffering(offering, field, value) {
+  updatingOfferingId.value = offering.id
+  try {
+    await llmOpsApi.updateChannelOffering(offering.id, { [field]: value })
+    showSuccess(t('llmOps.modelWorkbenchPanel.contractRelations.updated'))
+    emit('refresh')
+  } catch (error) {
+    showError(
+      userFacingApiError(
+        error,
+        t('llmOps.modelWorkbenchPanel.contractRelations.updateFailed')
+      )
+    )
+  } finally {
+    updatingOfferingId.value = null
+  }
 }
 
 function channelDisplayName(value) {

--- a/frontend/src/composables/useChannelModelSelection.js
+++ b/frontend/src/composables/useChannelModelSelection.js
@@ -95,7 +95,6 @@ export function useChannelModelSelection({
 
   const availableModelOptions = computed(() => {
     const keyword = normalizeSearch(modelSearch.value)
-    const limit = keyword ? 80 : 24
     return availableModelGroups.value
       .map((option) => {
         const haystack = modelOptionSearchText(option)
@@ -107,7 +106,6 @@ export function useChannelModelSelection({
       .filter((item) => item.score > 0)
       .sort((left, right) => right.score - left.score)
       .map((item) => item.option)
-      .slice(0, limit)
   })
 
   const selectedModelOptions = computed(() =>

--- a/frontend/src/composables/useLLMOpsData.js
+++ b/frontend/src/composables/useLLMOpsData.js
@@ -36,8 +36,10 @@ export function useLLMOpsData() {
   const metaModels = ref([])
   const models = ref([])
   const channels = ref([])
+  const channelOfferings = ref([])
   const channelPrices = ref([])
   const channelPriceItems = ref([])
+  const channelPriceVersions = ref([])
   const channelPriceHistory = ref([])
   const modelPriceItems = ref([])
   const resalePlatforms = ref([])
@@ -164,14 +166,18 @@ export function useLLMOpsData() {
   }
 
   async function refreshChannelPricingData() {
-    const [prices, items] = await Promise.all([
+    const [offerings, prices, items, versions] = await Promise.all([
+      fetchList(llmOpsApi.listChannelOfferings),
       fetchList(llmOpsApi.listChannelModelPrices),
       fetchList(llmOpsApi.listChannelPriceItems, {
         is_current: 'true'
-      })
+      }),
+      fetchList(llmOpsApi.listChannelPriceVersions)
     ])
+    channelOfferings.value = asArray(offerings)
     channelPrices.value = asArray(prices)
     channelPriceItems.value = asArray(items)
+    channelPriceVersions.value = asArray(versions)
   }
 
   async function refreshModelPriceItems() {
@@ -217,7 +223,9 @@ export function useLLMOpsData() {
         if (group === 'channelPricing') {
           return (
             !asArray(channelPrices.value).length ||
-            !asArray(channelPriceItems.value).length
+            !asArray(channelPriceItems.value).length ||
+            !asArray(channelOfferings.value).length ||
+            !asArray(channelPriceVersions.value).length
           )
         }
         return !asArray(groupValues[group]?.value).length
@@ -241,7 +249,9 @@ export function useLLMOpsData() {
         if (group === 'channelPricing') {
           return (
             !asArray(channelPrices.value).length ||
-            !asArray(channelPriceItems.value).length
+            !asArray(channelPriceItems.value).length ||
+            !asArray(channelOfferings.value).length ||
+            !asArray(channelPriceVersions.value).length
           )
         }
         return !asArray(groupValues[group]?.value).length
@@ -415,9 +425,11 @@ export function useLLMOpsData() {
   }
 
   return {
+    channelOfferings,
     channelPriceHistory,
     channelPriceItems,
     channelPrices,
+    channelPriceVersions,
     channels,
     collectionRuns,
     displayCurrency,

--- a/frontend/src/composables/useLLMOpsData.js
+++ b/frontend/src/composables/useLLMOpsData.js
@@ -170,7 +170,7 @@ export function useLLMOpsData() {
       fetchList(llmOpsApi.listChannelOfferings),
       fetchList(llmOpsApi.listChannelModelPrices),
       fetchList(llmOpsApi.listChannelPriceItems, {
-        is_current: 'true'
+        is_effective: 'true'
       }),
       fetchList(llmOpsApi.listChannelPriceVersions)
     ])

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1508,14 +1508,33 @@
     },
     "modelWorkbenchPanel": {
       "channelPrices": "Channel procurement prices",
+      "contractRelations": {
+        "allTime": "All time",
+        "cache": "Cache sales",
+        "cacheTip": "Controls whether cached-token pricing may be sold; cost data remains available when disabled.",
+        "current": "Current contract",
+        "description": "Meta model → channel → offering → current and future contract rules. Sales controls do not remove procurement cost data.",
+        "direct": "Direct sales",
+        "empty": "No procurement offering is linked to this model yet.",
+        "future": "Future contract",
+        "offering": "Offering / upstream SKU",
+        "rules": "Price rules",
+        "sales": "Sales availability",
+        "salesTip": "Controls sales availability independently from internal cost collection and comparison.",
+        "title": "Procurement contract relationships",
+        "updateFailed": "Failed to update offering sales availability.",
+        "updated": "Offering sales availability updated."
+      },
       "columns": {
         "channel": "Channel",
         "date": "Date",
         "dimension": "Dimension",
+        "offering": "Offering",
         "platform": "Platform",
         "price": "Price",
         "source": "Source",
         "status": "Status",
+        "version": "Price version",
         "variance": "Variance"
       },
       "dimension": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1518,14 +1518,33 @@
     },
     "modelWorkbenchPanel": {
       "channelPrices": "渠道采购价",
+      "contractRelations": {
+        "allTime": "全时段",
+        "cache": "缓存销售",
+        "cacheTip": "控制缓存 Token 价格是否可销售；关闭后仍保留成本数据。",
+        "current": "当前合同",
+        "description": "元模型 → 渠道 → 货源 → 当前及未来合同规则。销售开关不会删除采购成本数据。",
+        "direct": "直接销售",
+        "empty": "当前模型尚未关联采购货源。",
+        "future": "未来合同",
+        "offering": "货源 / 上游 SKU",
+        "rules": "价格规则",
+        "sales": "销售可用性",
+        "salesTip": "销售可用性独立于内部成本采集和比价。",
+        "title": "采购价格合同关系",
+        "updateFailed": "更新货源销售可用性失败。",
+        "updated": "货源销售可用性已更新。"
+      },
       "columns": {
         "channel": "渠道",
         "date": "日期",
         "dimension": "维度",
+        "offering": "货源",
         "platform": "平台",
         "price": "价格",
         "source": "来源",
         "status": "状态",
+        "version": "价格版本",
         "variance": "差异"
       },
       "dimension": {

--- a/frontend/src/pages/LLMOps.vue
+++ b/frontend/src/pages/LLMOps.vue
@@ -173,10 +173,13 @@
               :summary="summary"
               :models="models"
               :channels="channels"
+              :channel-offerings="channelOfferings"
               :price-items="modelPriceItems"
               :channel-price-items="channelPriceItems"
+              :channel-price-versions="channelPriceVersions"
               :listings="listings"
               :records="records"
+              @refresh="refreshAll(activeSection)"
             />
 
             <ListingRiskPanel
@@ -399,9 +402,11 @@ const {
 } = useLLMOpsNavigation()
 
 const {
+  channelOfferings,
   channelPriceHistory,
   channelPriceItems,
   channelPrices,
+  channelPriceVersions,
   channels,
   collectionRuns,
   displayCurrency,

--- a/frontend/src/utils/channelContractRelations.js
+++ b/frontend/src/utils/channelContractRelations.js
@@ -1,0 +1,56 @@
+export function offeringsForModel({
+  offerings,
+  versions,
+  priceItems,
+  modelId
+}) {
+  const relatedIds = new Set(
+    versions
+      .filter((version) => sameId(version.model, modelId))
+      .map((version) => String(version.offering))
+  )
+  priceItems
+    .filter((item) => sameId(item.model, modelId))
+    .forEach((item) => {
+      if (item.offering) relatedIds.add(String(item.offering))
+    })
+  return offerings.filter(
+    (offering) =>
+      sameId(offering.model, modelId) || relatedIds.has(String(offering.id))
+  )
+}
+
+export function currentContractVersion(versions, offeringId, now = Date.now()) {
+  return versions
+    .filter((version) => {
+      if (!sameId(version.offering, offeringId)) return false
+      if (!['active', 'scheduled'].includes(version.status)) return false
+      const start = version.effective_from
+        ? new Date(version.effective_from).getTime()
+        : Number.POSITIVE_INFINITY
+      const end = version.effective_to
+        ? new Date(version.effective_to).getTime()
+        : Number.POSITIVE_INFINITY
+      return start <= now && now < end
+    })
+    .sort((left, right) => Number(right.version) - Number(left.version))[0]
+}
+
+export function futureContractVersion(versions, offeringId, now = Date.now()) {
+  return versions
+    .filter(
+      (version) =>
+        sameId(version.offering, offeringId) &&
+        version.effective_from &&
+        new Date(version.effective_from).getTime() > now
+    )
+    .sort(
+      (left, right) =>
+        new Date(left.effective_from).getTime() -
+        new Date(right.effective_from).getTime()
+    )[0]
+}
+
+function sameId(left, right) {
+  return String(left) === String(right)
+}

--- a/frontend/tests/llmOpsChannelContractRelations.test.js
+++ b/frontend/tests/llmOpsChannelContractRelations.test.js
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  currentContractVersion,
+  futureContractVersion,
+  offeringsForModel
+} from '../src/utils/channelContractRelations.js'
+
+test('relation overview keeps every offering linked through versions or prices', () => {
+  const result = offeringsForModel({
+    offerings: [
+      { id: 1, model: 10 },
+      { id: 2, model: null },
+      { id: 3, model: 20 }
+    ],
+    versions: [{ offering: 2, model: 10 }],
+    priceItems: [],
+    modelId: 10
+  })
+
+  assert.deepEqual(
+    result.map((offering) => offering.id),
+    [1, 2]
+  )
+})
+
+test('current and future contracts use business effective boundaries', () => {
+  const now = new Date('2026-08-18T00:00:00Z').getTime()
+  const versions = [
+    {
+      offering: 1,
+      version: 1,
+      status: 'active',
+      effective_from: '2026-08-17T00:00:00Z',
+      effective_to: '2026-08-19T00:00:00Z'
+    },
+    {
+      offering: 1,
+      version: 2,
+      status: 'scheduled',
+      effective_from: '2026-08-19T00:00:00Z',
+      effective_to: null
+    }
+  ]
+
+  assert.equal(currentContractVersion(versions, 1, now).version, 1)
+  assert.equal(futureContractVersion(versions, 1, now).version, 2)
+})

--- a/frontend/tests/llmOpsChannelModelSelection.test.js
+++ b/frontend/tests/llmOpsChannelModelSelection.test.js
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { ref } from 'vue'
+
+import { useChannelModelSelection } from '../src/composables/useChannelModelSelection.js'
+
+function buildSelection(modelCount = 30) {
+  const models = Array.from({ length: modelCount }, (_, index) => {
+    const number = index + 1
+    return {
+      id: number,
+      code: `provider-model-${number}`,
+      name: `Provider Model ${number}`,
+      meta_model: {
+        code: `model-${number}`,
+        name: `Model ${number}`,
+        owner_code: 'vendor',
+        owner_name: 'Vendor'
+      }
+    }
+  })
+  const modelSearch = ref('')
+  const selection = useChannelModelSelection({
+    baseAvailableModels: ref(models),
+    fuzzyScore: (haystack, keyword) =>
+      haystack.toLowerCase().includes(keyword) ? 1 : 0,
+    metaModelDisplayName: (metaModel) => metaModel.name,
+    metaModelForSourceModel: (model) => model.meta_model,
+    metaModelIdentityKey: (metaModel) => metaModel.code,
+    metaModelVendorKey: (group) => group.ownerCode,
+    metaModelVendorName: (group) => group.ownerName,
+    modalityLabel: (value) => value,
+    modelOptionSearchText: (group) => `${group.code} ${group.name}`,
+    modelSearch,
+    modelSourceCategory: () => 'supplier',
+    normalizeSearch: (value) =>
+      String(value || '')
+        .trim()
+        .toLowerCase(),
+    providerModelDescription: () => '',
+    providerPriceSummary: () => [],
+    purchaseSourceLabel: (model) => model.name,
+    selectedModelKeys: ref(new Set()),
+    selectedProviderByModelKey: ref({}),
+    selectedVendorKey: ref(''),
+    sourceCategoryBadge: () => '',
+    t: (key) => key
+  })
+  return { modelSearch, selection }
+}
+
+test('keeps every addable model reachable when more than 24 exist', () => {
+  const { selection } = buildSelection()
+
+  assert.equal(selection.availableModelCount.value, 30)
+  assert.equal(selection.availableModelOptions.value.length, 30)
+})
+
+test('searches models after the former first-page cutoff', () => {
+  const { modelSearch, selection } = buildSelection()
+
+  modelSearch.value = 'model-30'
+
+  assert.deepEqual(
+    selection.availableModelOptions.value.map((model) => model.code),
+    ['model-30']
+  )
+})


### PR DESCRIPTION
## Summary
- Preserve all conditional GLM input/output price tiers and keep repeated collection idempotent.
- Keep every addable channel model reachable through browsing, search, and bulk selection.
- Introduce procurement offering identities so one channel and meta model can maintain independent upstream SKUs, prices, sales controls, and cache-sales controls.
- Add immutable effective-dated price versions with quantity/time rules, timezone handling, targeted discounts, rounding, contract exchange rates, conservative fallback warnings, and auditable before/after snapshots.
- Persist reconciliation snapshots and expose the meta-model → channel → offering → current/future contract relationship in the bilingual operations workbench.
- Preserve the latest main-branch transaction locking while matching legacy bulk upserts to the correct default offering.

Closes #292

## Test plan
- [x] 231 related Django tests pass in the PostgreSQL development container
- [x] 135 frontend unit tests pass
- [x] Targeted ESLint passes
- [x] Vue typecheck passes
- [x] Production frontend build passes
- [x] Django migration drift check and Python compileall pass
- [x] ego-browser task space 71 verifies current/future contracts, time rules, discounts, exchange rates, bilingual copy, and sales-control updates