### PR TITLE
fix(quotation): keep quote number unchanged when saving draft

### DIFF
--- a/frontend/src/modules/quotation/components/QuotationCreate.vue
+++ b/frontend/src/modules/quotation/components/QuotationCreate.vue
@@ -244,6 +244,11 @@ const existingQuoteNumbers = computed(() => props.quotations.map((quote) => quot
 const quoteNoIsUnique = computed(() =>
   isQuotationNumberUnique(quoteNo.value, props.quotations, props.editingQuote?.id),
 )
+const draftSubmittedQuoteNo = computed(() =>
+  props.editingQuote && quoteNoMode.value !== 'custom'
+    ? props.editingQuote.quoteNo
+    : quoteNo.value,
+)
 
 const customerHistory = computed(() => buildCustomerHistory(historySourceQuotations.value))
 const customerCompanyOptions = computed(() => getCompanyOptions(customerHistory.value))
@@ -932,12 +937,17 @@ const previewQuote = computed<Quotation>(() => ({
   createdAt: props.editingQuote ? props.editingQuote.createdAt : `${quoteDate.value} 00:00:00`,
 }))
 
-function validateForm() {
+function validateForm(status: 'Draft' | 'Generated') {
   const tempErrors: Record<string, string> = {}
-  if (!quoteNo.value.trim()) {
+  const targetQuoteNo =
+    status === 'Draft' ? draftSubmittedQuoteNo.value : quoteNo.value
+  if (!targetQuoteNo.trim()) {
     tempErrors.quoteNo = t('quotation.pages.create.errors.quoteNoRequired')
   }
-  if (quoteNo.value.trim() && !quoteNoIsUnique.value) {
+  if (
+    targetQuoteNo.trim() &&
+    !isQuotationNumberUnique(targetQuoteNo, props.quotations, props.editingQuote?.id)
+  ) {
     tempErrors.quoteNo = t('quotation.pages.create.errors.quoteNoDuplicate')
   }
   if (!paymentTerms.value.trim()) {
@@ -1000,7 +1010,7 @@ function validateForm() {
 }
 
 function handleSubmit(status: 'Draft' | 'Generated') {
-  const validationErrors = validateForm()
+  const validationErrors = validateForm(status)
   if (Object.keys(validationErrors).length > 0) {
     const firstErrorMsg =
       Object.values(validationErrors)[0] ||
@@ -1018,7 +1028,7 @@ function handleSubmit(status: 'Draft' | 'Generated') {
 
   const newQuote: Quotation = {
     id: props.editingQuote ? props.editingQuote.id : `quote-${Date.now()}`,
-    quoteNo: quoteNo.value,
+    quoteNo: status === 'Draft' ? draftSubmittedQuoteNo.value : quoteNo.value,
     productLine: productLine.value,
     productLineName: selectedProductLineOption.value?.label || '',
     projectName: projectName.value,


### PR DESCRIPTION
## Summary
- Editing a draft pre-filled a revision number (`_R1`/`_R2`) into the form and Save-as-Draft persisted it, so the quote number changed on every draft save.
- Draft saves now reuse the existing quote number (unless the user switches to custom numbering); Generate still assigns the revision suffix.
- Validation now checks the number actually submitted for draft saves.

## Test plan
- [x] `npm run typecheck` passes
- [x] Manual: edit a draft, Save as Draft → quote number unchanged
- [x] Manual: edit a quote, Generate → revision suffix still applied