### PR TITLE
feat(accounts): add self-serve user display name

### DIFF
--- a/backend/accounts/admin.py
+++ b/backend/accounts/admin.py
@@ -33,6 +33,7 @@ class ProfileAdmin(admin.ModelAdmin):
         'language',
         'timezone',
         'nickname',
+        'display_name',
     ]
     list_filter = [
         'registration_completed',
@@ -42,7 +43,8 @@ class ProfileAdmin(admin.ModelAdmin):
     search_fields = [
         'user__username',
         'user__email',
-        'nickname'
+        'nickname',
+        'display_name'
     ]
     readonly_fields = [
         'registration_token',
@@ -62,6 +64,7 @@ class ProfileAdmin(admin.ModelAdmin):
         ('Profile Information', {
             'fields': (
                 'nickname',
+                'display_name',
                 'avatar_url',
                 'bio',
                 'language',

--- a/backend/accounts/migrations/0008_profile_display_name.py
+++ b/backend/accounts/migrations/0008_profile_display_name.py
@@ -1,0 +1,23 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounts', '0007_role_profile_preferred_platform'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='profile',
+            name='display_name',
+            field=models.CharField(
+                blank=True,
+                help_text=(
+                    'User-chosen display name shown across platforms. '
+                    'Falls back to first/last name or username when empty.'
+                ),
+                max_length=120,
+            ),
+        ),
+    ]

--- a/backend/accounts/models.py
+++ b/backend/accounts/models.py
@@ -133,6 +133,15 @@ class Profile(models.Model):
         help_text="User nickname."
     )
 
+    display_name = models.CharField(
+        max_length=120,
+        blank=True,
+        help_text=(
+            "User-chosen display name shown across platforms. "
+            "Falls back to first/last name or username when empty."
+        ),
+    )
+
     avatar_url = models.URLField(
         blank=True,
         help_text="URL link to the user's avatar."

--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -422,13 +422,14 @@ class UserDetailsSerializer(serializers.ModelSerializer):
     Also includes authentication method information and password change
     capability.
     """
-    display_name = serializers.SerializerMethodField(
-        read_only=True,
+    display_name = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        max_length=Profile._meta.get_field('display_name').max_length,
         help_text=_(
-            "User-friendly display name, prioritizing "
-            "first_name + last_name from OAuth providers, "
-            "falling back to username"
-        )
+            "User-chosen display name. When empty the resolved name "
+            "falls back to first_name + last_name, then username."
+        ),
     )
 
     virtual_email = serializers.SerializerMethodField(
@@ -496,30 +497,10 @@ class UserDetailsSerializer(serializers.ModelSerializer):
             'virtual_email',
             'profile',
             'auth_info',
-            'display_name',
             'is_staff',
             'roles',
             'access_profile',
         ]
-
-    def get_display_name(self, obj):
-        """
-        Get user-friendly display name.
-
-        Priority order:
-        1. first_name + last_name (from OAuth providers like Google)
-        2. first_name only (if last_name is empty)
-        3. username (fallback)
-
-        This provides a more friendly name display for OAuth users
-        who typically have proper first_name and last_name from their provider.
-        """
-        if obj.first_name and obj.last_name:
-            return f"{obj.first_name} {obj.last_name}".strip()
-        elif obj.first_name:
-            return obj.first_name.strip()
-        else:
-            return obj.username
 
     def get_virtual_email(self, obj):
         """
@@ -545,6 +526,7 @@ class UserDetailsSerializer(serializers.ModelSerializer):
                 'language': profile.language,
                 'timezone': profile.timezone,
                 'nickname': profile.nickname,
+                'display_name': profile.display_name,
                 'avatar_url': profile.avatar_url
             }
         except Profile.DoesNotExist:
@@ -606,6 +588,12 @@ class UserDetailsSerializer(serializers.ModelSerializer):
 
         return auth_info
 
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        profile = getattr(instance, 'profile', None)
+        data['display_name'] = profile.display_name if profile else ''
+        return data
+
     def get_roles(self, obj):
         """Serialize effective roles for the current user."""
         effective_roles = get_effective_roles(obj)
@@ -630,19 +618,27 @@ class UserDetailsSerializer(serializers.ModelSerializer):
 
     def update(self, instance, validated_data):
         """
-        Update user instance and profile language/timezone if provided.
+        Update user instance and profile fields if provided.
         """
+        display_name = validated_data.pop('display_name', None)
         profile_language = validated_data.pop('profile_language', None)
         profile_timezone = validated_data.pop('profile_timezone', None)
 
         # Update user fields
         instance = super().update(instance, validated_data)
 
-        # Update profile language and/or timezone if provided
-        if profile_language is not None or profile_timezone is not None:
+        # Update profile fields if provided
+        if (
+            display_name is not None
+            or profile_language is not None
+            or profile_timezone is not None
+        ):
             try:
                 profile = instance.profile
                 update_fields = []
+                if display_name is not None:
+                    profile.display_name = display_name.strip()
+                    update_fields.append('display_name')
                 if profile_language is not None:
                     normalized_lang = normalize_language_code(
                         profile_language
@@ -670,6 +666,11 @@ class UserDetailsSerializer(serializers.ModelSerializer):
                 )
                 Profile.objects.create(
                     user=instance,
+                    display_name=(
+                        display_name.strip()
+                        if display_name is not None
+                        else ''
+                    ),
                     language=default_lang,
                     timezone=default_tz
                 )

--- a/frontend/src/components/settings/DisplayNameCard.vue
+++ b/frontend/src/components/settings/DisplayNameCard.vue
@@ -1,0 +1,126 @@
+<template>
+  <div class="bg-white rounded border border-gray-200 shadow-sm">
+    <div class="px-4 py-3 border-b border-gray-200 bg-gray-50">
+      <div class="flex items-center gap-2 text-gray-800">
+        <svg
+          class="w-4 h-4 flex-none"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+          />
+        </svg>
+        <h3 class="text-sm font-semibold">
+          {{ t('settings.displayNameCard.title') }}
+        </h3>
+      </div>
+    </div>
+    <div class="p-4">
+      <p class="text-xs text-gray-600 mb-4">
+        {{ t('settings.displayNameCard.desc') }}
+      </p>
+      <form @submit.prevent="handleSave" class="space-y-4">
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-3 items-start">
+          <div class="md:col-span-1">
+            <label
+              for="displayName"
+              class="block text-sm font-medium text-gray-700 mb-1"
+            >
+              {{ t('settings.displayNameCard.label') }}
+            </label>
+          </div>
+          <div class="md:col-span-2">
+            <input
+              id="displayName"
+              v-model="form.display_name"
+              type="text"
+              maxlength="120"
+              :placeholder="t('settings.displayNameCard.placeholder')"
+              class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500 text-sm"
+            />
+          </div>
+        </div>
+
+        <div class="flex justify-end">
+          <BaseButton
+            type="submit"
+            variant="primary"
+            size="sm"
+            :loading="saving"
+          >
+            {{ t('settings.saveSettings') }}
+          </BaseButton>
+        </div>
+      </form>
+      <p
+        v-if="saveMessage"
+        class="mt-2 text-sm"
+        :class="
+          saveMessageType === 'success' ? 'text-green-600' : 'text-red-600'
+        "
+      >
+        {{ saveMessage }}
+      </p>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { reactive, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useUserStore } from '@/store/user'
+import BaseButton from '@/components/ui/BaseButton.vue'
+
+const { t } = useI18n()
+const userStore = useUserStore()
+
+const saving = ref(false)
+const saveMessage = ref('')
+const saveMessageType = ref('success')
+
+const form = reactive({
+  display_name: ''
+})
+
+function syncFromProfile() {
+  const userInfo = userStore.userInfo
+  if (userInfo) {
+    form.display_name = userInfo.display_name || ''
+  }
+}
+
+watch(
+  () => userStore.userInfo,
+  (userInfo) => {
+    if (userInfo) syncFromProfile()
+  },
+  { deep: true }
+)
+
+syncFromProfile()
+
+async function handleSave() {
+  saving.value = true
+  saveMessage.value = ''
+  try {
+    await userStore.updateProfile({
+      display_name: form.display_name.trim()
+    })
+    saveMessage.value = t('settings.displayNameCard.saved')
+    saveMessageType.value = 'success'
+    setTimeout(() => {
+      saveMessage.value = ''
+    }, 3000)
+  } catch (err) {
+    saveMessage.value = t('settings.displayNameCard.error')
+    saveMessageType.value = 'error'
+  } finally {
+    saving.value = false
+  }
+}
+</script>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -304,6 +304,14 @@
     "saveSettings": "Save Settings",
     "settingsSaved": "Settings saved successfully",
     "settingsError": "Failed to save settings",
+    "displayNameCard": {
+      "title": "Display Name",
+      "desc": "Sets the name shown across platforms (including quotations). When empty, it falls back to the user's name or username.",
+      "label": "Display Name",
+      "placeholder": "Enter display name",
+      "saved": "Display name saved successfully",
+      "error": "Failed to save. Please try again."
+    },
     "scene": "Scene",
     "sceneDesc": "Select the scene mode used by AI when processing chats. Different scenes use different processing methods and prompt templates.",
     "preferenceChangeWarning": "Note: Changing this setting will affect the output language for AI summaries, tags, and metadata in future chat processing. Scene switching affects AI processing methods and prompt templates. The new setting will take effect on the next chat processed.",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -255,6 +255,14 @@
     "saveSettings": "Guardar configuración",
     "settingsSaved": "Configuración guardada exitosamente",
     "settingsError": "Error al guardar configuración",
+    "displayNameCard": {
+      "title": "Nombre para mostrar",
+      "desc": "Define el nombre que se muestra en todas las plataformas (incluidas las cotizaciones). Si está vacío, se usará el nombre o el nombre de usuario.",
+      "label": "Nombre para mostrar",
+      "placeholder": "Introduzca el nombre para mostrar",
+      "saved": "Nombre para mostrar guardado correctamente",
+      "error": "Error al guardar. Inténtelo de nuevo."
+    },
     "scene": "Escena",
     "sceneDesc": "Seleccione el modo de escena utilizado por la IA al procesar correos. Diferentes escenas utilizan diferentes métodos de procesamiento y plantillas de indicaciones.",
     "preferenceChangeWarning": "Nota: Cambiar esta configuración afectará el idioma de salida para resúmenes, etiquetas y metadatos de la IA en el procesamiento futuro de correos. Cambiar la escena afecta los métodos de procesamiento de la IA y las plantillas de indicaciones. La nueva configuración tendrá efecto en el próximo correo procesado.",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -314,6 +314,14 @@
     "saveSettings": "保存设置",
     "settingsSaved": "设置保存成功",
     "settingsError": "保存设置失败",
+    "displayNameCard": {
+      "title": "显示名称",
+      "desc": "设置在所有平台（含报价单）中展示的名称。留空时自动回退为姓名或用户名。",
+      "label": "显示名称",
+      "placeholder": "请输入显示名称",
+      "saved": "显示名称保存成功",
+      "error": "保存失败，请重试"
+    },
     "scene": "场景",
     "sceneDesc": "选择AI处理对话时使用的场景模式，不同场景使用不同的处理方式和提示词模板。",
     "preferenceChangeWarning": "提示：更改此设置将影响后续对话处理时的智能总结、标签和元数据的输出语言。场景切换会影响AI的处理方式和提示词模板。新设置将在下次处理对话时生效。",

--- a/frontend/src/modules/quotation/stores/auth.ts
+++ b/frontend/src/modules/quotation/stores/auth.ts
@@ -27,7 +27,14 @@ function mapDevMindUser(user: any): AppUser | null {
   const lastName = user.last_name || ''
   const fullName = `${firstName} ${lastName}`.trim()
   return {
-    name: profile.nickname || fullName || user.username || user.email || 'DevMind User',
+    name:
+      user.display_name ||
+      profile.display_name ||
+      profile.nickname ||
+      fullName ||
+      user.username ||
+      user.email ||
+      'DevMind User',
     title: profile.bio || '',
     email: user.email || user.username || '',
     role: roleLabelFromDevMind(user),

--- a/frontend/src/pages/settings/Profile.vue
+++ b/frontend/src/pages/settings/Profile.vue
@@ -19,6 +19,9 @@
         <!-- User Profile Section -->
         <UserProfileSection />
 
+        <!-- Display Name Card -->
+        <DisplayNameCard />
+
         <!-- Basic Information Card -->
         <BasicInfoCard />
 
@@ -36,6 +39,7 @@ import { useUserStore } from '@/store/user'
 import AppLayout from '@/components/layout/AppLayout.vue'
 import BaseLoading from '@/components/ui/BaseLoading.vue'
 import UserProfileSection from '@/components/settings/UserProfileSection.vue'
+import DisplayNameCard from '@/components/settings/DisplayNameCard.vue'
 import BasicInfoCard from '@/components/settings/BasicInfoCard.vue'
 import ChangePasswordCard from '@/components/settings/ChangePasswordCard.vue'
 


### PR DESCRIPTION
## Summary
- Add `Profile.display_name` (migration 0008), editable by the user via PATCH `/v1/auth/user` through `UserDetailsSerializer`; Profile is auto-created when missing.
- Expose the value in the user/profile payload and in the accounts admin.
- Quotation platform: the quote's order user now prefers `display_name` (falls back to nickname → first/last name → username/email).
- New editable "Display Name" card on the settings Profile page, with zh-CN / en / es i18n.

## Test plan
- [x] `makemigrations --check` clean; migration applied to dev DB
- [x] accounts tests pass (16 passed; 3 pre-existing failures unrelated)
- [x] Serializer verified: write / read / clear display_name, Profile auto-create
- [x] `npm run typecheck` passes