### PR TITLE
fix(layout): hide workspace sidebar on settings pages

### DIFF
--- a/frontend/src/components/layout/AppHeader.vue
+++ b/frontend/src/components/layout/AppHeader.vue
@@ -237,7 +237,6 @@ import { useUserStore } from '@/store/user'
 import LanguageSwitcher from '@/components/ui/LanguageSwitcher.vue'
 import PlatformSwitcher from '@/components/layout/PlatformSwitcher.vue'
 import { appVersion } from '@/config/version'
-import { getCurrentPlatformKey } from '@/utils/platformAccess'
 
 defineProps({
   showMenuButton: {
@@ -259,17 +258,7 @@ const copied = ref(false)
 const displayVersion = computed(() => {
   return appVersion.startsWith('v') ? appVersion : `v${appVersion}`
 })
-const settingsRoute = computed(() => {
-  if (getCurrentPlatformKey(route.path) === 'operations_console') {
-    return {
-      name: 'SettingsProfile',
-      query: {
-        from_platform: 'operations_console'
-      }
-    }
-  }
-  return { name: 'SettingsProfile' }
-})
+const settingsRoute = computed(() => ({ name: 'SettingsProfile' }))
 
 const pageTitle = computed(() => {
   const routeNames = {

--- a/frontend/src/components/layout/AppLayout.vue
+++ b/frontend/src/components/layout/AppLayout.vue
@@ -72,10 +72,7 @@ const contentKey = computed(() =>
   route.path.startsWith('/quotation') ? 'quotation' : route.path
 )
 const resolvedShowSidebar = computed(() => {
-  if (
-    route.path.startsWith('/settings') &&
-    route.query.from_platform === 'operations_console'
-  ) {
+  if (route.path.startsWith('/settings')) {
     return false
   }
   return props.showSidebar


### PR DESCRIPTION
## Summary
- Settings pages (`/settings/*`) now always render full-width without the workspace sidebar; previously the sidebar appeared unless the page was opened with `from_platform=operations_console`.
- Removed the now-dead `from_platform` query param and unused `getCurrentPlatformKey` import from `AppHeader`.

## Test plan
- [x] `npm run typecheck` passes
- [x] Manual: open user settings from workspace → no sidebar
- [x] Other pages (`/cloud-billing/settings`, etc.) unaffected