### PR TITLE
fix(quotation): refresh expired platform tokens

### DIFF
--- a/frontend/scripts/quotation-platform-auth-refresh.test.mjs
+++ b/frontend/scripts/quotation-platform-auth-refresh.test.mjs
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const client = readFileSync(
+  new URL('../src/modules/quotation/api/client.ts', import.meta.url),
+  'utf8'
+)
+
+test('Quote Desk refreshes the platform token after a 401 response', () => {
+  assert.match(client, /REFRESH_TOKEN_KEY = ['"]refresh_token['"]/
+  )
+  assert.match(client, /\/v1\/auth\/token\/refresh/)
+  assert.match(client, /response\.status === 401/)
+  assert.match(client, /Authorization.*newAccessToken/)
+})
+
+test('Quote Desk clears platform auth when refresh cannot recover the session', () => {
+  assert.match(client, /localStorage\.removeItem\(REFRESH_TOKEN_KEY\)/)
+  assert.match(client, /window\.location\.href = ['"]\/login['"]/
+  )
+})

--- a/frontend/src/modules/quotation/api/client.ts
+++ b/frontend/src/modules/quotation/api/client.ts
@@ -1,5 +1,8 @@
 const TOKEN_KEY = 'access_token'
 const LEGACY_TOKEN_KEY = 'qmp_access_token'
+const REFRESH_TOKEN_KEY = 'refresh_token'
+
+let refreshPromise: Promise<string> | null = null
 
 export function getAccessToken(): string | null {
   return localStorage.getItem(TOKEN_KEY) || localStorage.getItem(LEGACY_TOKEN_KEY)
@@ -14,6 +17,11 @@ export function clearAccessToken(): void {
   localStorage.removeItem(LEGACY_TOKEN_KEY)
 }
 
+function clearPlatformAuth(): void {
+  clearAccessToken()
+  localStorage.removeItem(REFRESH_TOKEN_KEY)
+}
+
 export function getApiBaseUrl(): string {
   const rawBase = (import.meta.env.VITE_API_BASE_URL as string | undefined)?.trim()
   const origin =
@@ -21,6 +29,16 @@ export function getApiBaseUrl(): string {
       ? rawBase.replace(/\/api(?:\/v\d+)?\/?$/, '').replace(/\/$/, '')
       : window.location.origin
   return `${origin}/api/v1/quotation`
+}
+
+function getPlatformApiBaseUrl(): string {
+  return getApiBaseUrl().replace(/\/api\/v1\/quotation$/, '')
+}
+
+function redirectToLogin(): void {
+  if (window.location.pathname !== '/login') {
+    window.location.href = '/login'
+  }
 }
 
 export class ApiError extends Error {
@@ -60,9 +78,69 @@ function extractDetail(payload: unknown, fallback: string): string {
   return typeof detail === 'string' ? detail : fallback
 }
 
+async function refreshAccessToken(): Promise<string> {
+  const refreshToken = localStorage.getItem(REFRESH_TOKEN_KEY)
+  if (!refreshToken) {
+    clearPlatformAuth()
+    redirectToLogin()
+    throw new ApiError('Authentication required', 401)
+  }
+
+  if (!refreshPromise) {
+    refreshPromise = (async () => {
+      const response = await fetch(
+        `${getPlatformApiBaseUrl()}/api/v1/auth/token/refresh`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ refresh: refreshToken }),
+        },
+      )
+
+      let payload: unknown
+      try {
+        payload = await response.json()
+      } catch {
+        payload = undefined
+      }
+
+      if (!response.ok) {
+        if (response.status === 400 || response.status === 401) {
+          clearPlatformAuth()
+          redirectToLogin()
+          throw new ApiError('Authentication required', response.status)
+        }
+        throw new ApiError(
+          'Authentication service unavailable',
+          response.status,
+        )
+      }
+
+      const data = unwrapResponse<{ access?: string }>(payload)
+      if (!data?.access) {
+        clearPlatformAuth()
+        redirectToLogin()
+        throw new ApiError('Authentication required', 401)
+      }
+
+      setAccessToken(data.access)
+      return data.access
+    })().finally(() => {
+      refreshPromise = null
+    })
+  }
+
+  return refreshPromise
+}
+
+function isLoginRequest(path: string): boolean {
+  return path === '/auth/login'
+}
+
 export async function apiRequest<T>(
   path: string,
   options: RequestInit = {},
+  allowRefresh = true,
 ): Promise<T> {
   const headers = new Headers(options.headers || {})
   if (!headers.has('Content-Type') && !(options.body instanceof FormData)) {
@@ -78,6 +156,16 @@ export async function apiRequest<T>(
     ...options,
     headers,
   })
+
+  if (response.status === 401 && allowRefresh && !isLoginRequest(path)) {
+    const newAccessToken = await refreshAccessToken()
+    const retryHeaders = new Headers(options.headers || {})
+    if (!retryHeaders.has('Content-Type') && !(options.body instanceof FormData)) {
+      retryHeaders.set('Content-Type', 'application/json')
+    }
+    retryHeaders.set('Authorization', `Bearer ${newAccessToken}`)
+    return apiRequest(path, { ...options, headers: retryHeaders }, false)
+  }
 
   if (response.status === 204) {
     if (!response.ok) {


### PR DESCRIPTION
## Summary
- refresh expired DevMind access tokens before retrying Quote Desk requests
- serialize concurrent token refresh requests to avoid duplicate refreshes
- clear platform authentication and redirect to login when refresh fails
- keep Feishu token handling and quotation business logic unchanged

## Test plan
- [x] Quote Desk tests: 116 passed
- [x] Platform authentication regression tests: 2 passed
- [x] Vue typecheck passed
- [x] Production frontend build passed
- [x] git diff --check passed
- [x] Ego Lite: invalid access token + valid refresh token recovered automatically
- [x] Ego Lite: invalid access and refresh tokens redirected to /login
- [x] No JWT raw error displayed after either authentication failure path

## Integration note
- This PR is independent of PR #306.
- No backend, Feishu token, quotation data, or permission logic was changed.
- The unrelated existing worktree change in backend/cloud_billing/periodic_tasks.py is not included.