### PR TITLE
fix(quotation): remove embedded imported documents panel

### DIFF
--- a/frontend/scripts/quotation-document-parsing.test.mjs
+++ b/frontend/scripts/quotation-document-parsing.test.mjs
@@ -65,13 +65,12 @@ test('archive sync imports Excel and PDF files into normal quotations', () => {
   assert.doesNotMatch(importedDocumentsPage, /confirmDocumentParseResult/)
 })
 
-test('imported document controls stay mounted while their panel is hidden', () => {
-  assert.match(
+test('imported document controls are not mounted in the quotation list', () => {
+  assert.doesNotMatch(quotationListPage, /<ImportedDocumentsPage/)
+  assert.doesNotMatch(
     quotationListPage,
-    /<ImportedDocumentsPage\s+embedded/,
+    /handleImportedQuotationCreated|handleImportedQuotationLifecycleChanged/,
   )
-  assert.match(quotationListPage, /@quotation-created="handleImportedQuotationCreated"/)
-  assert.doesNotMatch(quotationListPage, /v-if="false"/)
 })
 
 test('imported documents page keeps only fallback parse states in the list', () => {
@@ -115,9 +114,9 @@ test('imported documents expose archive and recovery controls', () => {
   assert.match(importedDocumentsPage, /DialogPanel/)
   assert.match(documentsApi, /assets_affected/)
   assert.match(importedDocumentsPage, /quotationLifecycleChanged/)
-  assert.match(
+  assert.doesNotMatch(
     quotationListPage,
-    /@quotation-lifecycle-changed="handleImportedQuotationLifecycleChanged"/,
+    /handleImportedQuotationLifecycleChanged/,
   )
 })
 

--- a/frontend/scripts/quotation-feishu-oauth-return.test.mjs
+++ b/frontend/scripts/quotation-feishu-oauth-return.test.mjs
@@ -82,8 +82,8 @@ test('Imported files browser exposes lifecycle controls in its visible panels', 
 
 test('imported Feishu files live under the Quotes page', () => {
   assert.match(quotationApp, /QuotationList/)
-  assert.match(quotationApp, /ImportedDocumentsPage/)
-  assert.match(quotationApp, /embedded/)
+  assert.doesNotMatch(quotationApp, /ImportedDocumentsPage/)
+  assert.doesNotMatch(quotationApp, /handleImportedQuotation/)
   assert.doesNotMatch(quotationApp, /quoteListPanel/)
   assert.doesNotMatch(quotationApp, /tabImports/)
   assert.doesNotMatch(quotationApp, /setQuoteListPanel/)

--- a/frontend/src/modules/quotation/App.vue
+++ b/frontend/src/modules/quotation/App.vue
@@ -30,7 +30,6 @@ import QuotationList from './components/QuotationList.vue'
 import QuotationCreate from './components/QuotationCreate.vue'
 import QuotationDetails from './components/QuotationDetails.vue'
 import QuotationDetailsDrawer from './components/QuotationDetailsDrawer.vue'
-import ImportedDocumentsPage from './components/ImportedDocumentsPage.vue'
 import AuditLogPage from './components/AuditLogPage.vue'
 import ViewPermissionPage from './components/ViewPermissionPage.vue'
 import ProductServiceManager from './components/ProductServiceManager.vue'
@@ -721,17 +720,6 @@ async function handleFeishuUploadDone(_id: string) {
   await refreshQuotations()
 }
 
-async function handleImportedQuotationCreated(id: string) {
-  await refreshQuotations()
-  await loadQuotationFormContext()
-  selectedQuotationId.value = id
-}
-
-async function handleImportedQuotationLifecycleChanged() {
-  await refreshQuotations()
-  await loadQuotationFormContext()
-}
-
 async function handleRefreshCustomers() {
   await loadQuotationFormContext()
 }
@@ -1161,12 +1149,6 @@ function reloadPage() {
             @query-change="handleQuotationListQueryChange"
           />
 
-          <ImportedDocumentsPage
-            embedded
-            @toast="triggerToast"
-            @quotation-created="handleImportedQuotationCreated"
-            @quotation-lifecycle-changed="handleImportedQuotationLifecycleChanged"
-          />
         </div>
 
         <QuotationCreate


### PR DESCRIPTION
## Summary

- Remove the embedded imported-document panel from the Quote Desk quotation list.
- Prevent the Feishu sync status card, archive file browser, and imported-document filters from appearing below the quotation table.
- Preserve the existing quotation list, Feishu upload, manual sync, document download, parsing APIs, and backend synchronization jobs.
- Keep the `/quotation/imports` redirect for backward compatibility.
- Add regression assertions to prevent the removed panel from being mounted again.

## Test plan

- [x] `npm run test:quotation`: 116 tests passed
- [x] `npm run test:unit`: 135 tests passed
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `git diff --check`
- [x] Ego Lite: quotation list renders normally without the removed panel
- [x] Ego Lite: pagination from page 1 to page 2 and back works normally
- [x] Ego Lite: existing `Sync from Feishu` control remains available

## Scope note

- No backend code, database schema, synchronization task, or shared document API was removed.
- The existing imported-document component remains unused so the current change does not affect other document-related functionality.