### PR TITLE
fix: stabilize LLM Ops platform context and pricing

### DIFF
--- a/backend/llm_ops/assistant/capability.py
+++ b/backend/llm_ops/assistant/capability.py
@@ -15,6 +15,8 @@ from llm_ops.assistant_tools import (
 
 INSTRUCTIONS = """
 你是大模型运营助手。
+如果页面上下文提供了当前挂售平台，所有涉及挂售、收益或未上架状态的
+查询都必须使用该平台；回答中明确写出平台名称，不得默认改用 Agione。
 回答必须先区分运营模型和市场参考模型：
 - operational 表示已有渠道配置或当前平台挂售意图，
   可以进入运营待办。
@@ -42,7 +44,11 @@ llm_ops_get_operation_entry，在回答中给出其返回的控制台链接。
 """
 
 
-def _execute_tool(name, _context, arguments):
+def _execute_tool(name, context, arguments):
+    page_context = context.page_context or {}
+    page_platform_id = page_context.get("resale_platform_id")
+    if str(page_platform_id).isdigit():
+        arguments = {**arguments, "platform_id": int(page_platform_id)}
     return execute_llm_ops_tool(name, arguments)
 
 

--- a/backend/llm_ops/collectors/official.py
+++ b/backend/llm_ops/collectors/official.py
@@ -1295,6 +1295,10 @@ def extract_token_prices(
     if table_prices is not None:
         return table_prices
 
+    labeled_prices = extract_labeled_token_prices(text, currency)
+    if labeled_prices is not None:
+        return labeled_prices
+
     input_price = extract_labeled_price(
         text,
         labels=("input", "prompt", "输入", "输入价格"),
@@ -1312,6 +1316,7 @@ def extract_token_prices(
             "cache hit",
             "cache read",
             "cached input",
+            "context caching",
             "缓存命中",
         ),
         currency=currency,
@@ -1325,17 +1330,118 @@ def extract_token_prices(
     return None
 
 
+def extract_labeled_token_prices(
+    text: str,
+    currency: str,
+) -> tuple[Decimal, Decimal, Decimal | None] | None:
+    """Extract token prices from explicit input/output column labels."""
+    input_price = extract_labeled_price(
+        text,
+        labels=("input", "prompt", "输入", "输入价格"),
+        currency=currency,
+    )
+    output_price = extract_labeled_price(
+        text,
+        labels=("output", "completion", "输出", "输出价格"),
+        currency=currency,
+    )
+    if input_price is None or output_price is None:
+        return None
+    cache_price = extract_labeled_price(
+        text,
+        labels=(
+            "cache hits",
+            "cache hit",
+            "cache read",
+            "cached input",
+            "context caching",
+            "缓存命中",
+        ),
+        currency=currency,
+    )
+    return input_price, output_price, cache_price
+
+
 def extract_ordered_token_prices(
     text: str,
     currency: str,
 ) -> tuple[Decimal, Decimal, Decimal | None] | None:
     """Extract token prices from table rows with known column order."""
+    row_prices = extract_labeled_table_row_prices(text, currency)
+    if row_prices is not None:
+        return row_prices
+
     prices = extract_money_values(text, currency)
     if len(prices) >= 5 and has_cache_hit_header(text):
         return prices[0], prices[4], prices[3]
     if len(prices) >= 5 and has_anthropic_cache_write_shape(prices):
         return prices[0], prices[4], prices[3]
     return None
+
+
+def extract_labeled_table_row_prices(
+    text: str,
+    currency: str,
+) -> tuple[Decimal, Decimal, Decimal | None] | None:
+    """Extract token prices from rows labeled input and output."""
+    if "|" not in text:
+        return None
+
+    input_values = _table_row_money_values(
+        text,
+        labels=("input", "prompt", "输入"),
+        currency=currency,
+    )
+    output_values = _table_row_money_values(
+        text,
+        labels=("output", "completion", "输出"),
+        currency=currency,
+    )
+    if not input_values or not output_values:
+        return None
+
+    cache_price = None
+    if has_cache_hit_header(text):
+        if len(input_values) >= 3:
+            cache_price = input_values[2]
+        else:
+            cache_values = _table_row_money_values(
+                text,
+                labels=(
+                    "cache hits",
+                    "cache hit",
+                    "cache read",
+                    "cached input",
+                    "context caching",
+                    "缓存命中",
+                ),
+                currency=currency,
+            )
+            if cache_values:
+                cache_price = cache_values[0]
+    return input_values[0], output_values[0], cache_price
+
+
+def _table_row_money_values(
+    text: str,
+    *,
+    labels: tuple[str, ...],
+    currency: str,
+) -> list[Decimal]:
+    """Return amounts from the first table row matching one of the labels."""
+    for line in text.splitlines():
+        normalized = line.lower()
+        for label in labels:
+            match = re.search(
+                rf"(?<![a-z]){re.escape(label)}(?![a-z])",
+                normalized,
+            )
+            if not match:
+                continue
+            values = extract_money_values(line[match.end():], currency)
+            if values:
+                return values
+    return []
 
 
 def has_cache_hit_header(text: str) -> bool:
@@ -1346,6 +1452,7 @@ def has_cache_hit_header(text: str) -> bool:
         or "cache hit" in normalized
         or "cache read" in normalized
         or "cached input" in normalized
+        or "context caching" in normalized
     )
 
 
@@ -1479,6 +1586,7 @@ def normalize_source_text(content: str) -> str:
     text = html.unescape(str(content or ""))
     text = re.sub(r"<script\b[^>]*>.*?</script>", " ", text, flags=re.I | re.S)
     text = re.sub(r"<style\b[^>]*>.*?</style>", " ", text, flags=re.I | re.S)
+    text = re.sub(r">\s+<", "><", text)
     text = re.sub(r"</tr\s*>", "\n", text, flags=re.I)
     text = re.sub(r"</t[dh]\s*>", " | ", text, flags=re.I)
     text = re.sub(r"<[^>]+>", " ", text)

--- a/backend/llm_ops/tests/test_assistant_tools.py
+++ b/backend/llm_ops/tests/test_assistant_tools.py
@@ -6,6 +6,7 @@ from django.test import TestCase
 from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 
+from ai_assistant.contracts import ToolExecutionContext
 from ai_assistant.provider import AssistantCapabilityProvider
 from llm_ops.assistant import assistant_provider, get_assistant_capability
 from llm_ops.assistant_tools import execute_llm_ops_tool
@@ -19,6 +20,7 @@ from llm_ops.models import (
     PriceCollectionRun,
     PriceCollectionSource,
     ProcurementChannel,
+    ResalePlatform,
 )
 
 
@@ -113,6 +115,42 @@ class LLMOpsAssistantToolTests(TestCase):
         self.assertEqual(overview["operational_models"], 1)
         self.assertEqual(overview["market_reference_models"], 1)
         self.assertEqual(overview["decision_counts"]["no_supply"], 1)
+
+    def test_capability_uses_current_page_platform_for_queries(self):
+        platform = ResalePlatform.objects.create(
+            name="Secondary Platform",
+            code="secondary-platform",
+            platform_type=ResalePlatform.PLATFORM_TYPE_INTERNAL,
+            currency="CNY",
+            is_active=True,
+        )
+        other_platform = ResalePlatform.objects.create(
+            name="Other Platform",
+            code="other-platform",
+            platform_type=ResalePlatform.PLATFORM_TYPE_INTERNAL,
+            currency="CNY",
+            is_active=True,
+        )
+        tool = next(
+            tool
+            for tool in get_assistant_capability().tools
+            if tool.name == "llm_ops_get_overview"
+        )
+
+        result = tool.handler(
+            ToolExecutionContext(
+                user_id=None,
+                app_key="llm_ops",
+                conversation_id="test",
+                page_context={"resale_platform_id": str(platform.id)},
+            ),
+            {"platform_id": other_platform.id},
+        )
+
+        self.assertEqual(
+            result["result"]["platform"]["platform_id"],
+            platform.id,
+        )
 
     def test_decision_query_never_returns_market_reference_as_no_supply(self):
         result = execute_llm_ops_tool(

--- a/backend/llm_ops/tests/test_official_collector.py
+++ b/backend/llm_ops/tests/test_official_collector.py
@@ -18,6 +18,8 @@ from llm_ops.collection_services import (
 from llm_ops.collectors.official import (
     OFFICIAL_PROVIDER_CONFIGS,
     collect_official_pricing_catalog,
+    extract_token_prices,
+    normalize_source_text,
 )
 from llm_ops.constants import canonical_meta_model_identity
 from llm_ops.models import (
@@ -51,6 +53,91 @@ class MockPricingResponse:
     def raise_for_status(self):
         if self.status_code >= 400:
             raise RuntimeError(f"HTTP {self.status_code}")
+
+
+class OfficialTokenPriceExtractionTests(TestCase):
+    def test_labeled_columns_keep_google_output_separate_from_cache(self):
+        prices = extract_token_prices(
+            "Input tokens $1.25; Output tokens $10.00; "
+            "Cached input tokens $0.13",
+            "USD",
+        )
+
+        self.assertEqual(
+            prices,
+            (Decimal("1.25"), Decimal("10.00"), Decimal("0.13")),
+        )
+
+    def test_google_table_rows_keep_first_cache_tier(self):
+        prices = extract_token_prices(
+            normalize_source_text(
+                """
+                <table>
+                  <tr>
+                    <th>Model</th>
+                    <th>Type</th>
+                    <th>Price (/1M tokens)</th>
+                    <th>Price (/1M tokens) &gt; 200K</th>
+                    <th>Price (/1M Context caching)</th>
+                    <th>Price (/1M Context caching) &gt; 200K</th>
+                  </tr>
+                  <tr>
+                    <td>Gemini 2.5 Pro</td>
+                    <td>Input (text, image, video, audio)</td>
+                    <td>$1.25</td>
+                    <td>$2.50</td>
+                    <td>$0.13</td>
+                    <td>$0.25</td>
+                  </tr>
+                  <tr>
+                    <td>Output (text)</td>
+                    <td>$10.00</td>
+                    <td>$15.00</td>
+                  </tr>
+                </table>
+                """
+            ),
+            "USD",
+        )
+
+        self.assertEqual(
+            prices,
+            (Decimal("1.25"), Decimal("10.00"), Decimal("0.13")),
+        )
+
+    def test_google_table_rows_read_standalone_context_caching_price(self):
+        prices = extract_token_prices(
+            normalize_source_text(
+                """
+                <table>
+                  <tr>
+                    <th>Model</th>
+                    <th>Type</th>
+                    <th>Price (/1M tokens)</th>
+                  </tr>
+                  <tr>
+                    <td>Gemini 2.5 Pro</td>
+                    <td>Input (text)</td>
+                    <td>$1.25</td>
+                  </tr>
+                  <tr>
+                    <td>Output (text)</td>
+                    <td>$10.00</td>
+                  </tr>
+                  <tr>
+                    <td>Context caching</td>
+                    <td>$0.13</td>
+                  </tr>
+                </table>
+                """
+            ),
+            "USD",
+        )
+
+        self.assertEqual(
+            prices,
+            (Decimal("1.25"), Decimal("10.00"), Decimal("0.13")),
+        )
 
 
 class OfficialCollectionSyncTests(TestCase):

--- a/frontend/src/components/layout/AppSidebar.vue
+++ b/frontend/src/components/layout/AppSidebar.vue
@@ -159,6 +159,36 @@
           <span v-if="isMobile || !collapsed">{{ t('dashboard.title') }}</span>
         </router-link>
 
+        <router-link
+          v-if="userStore.userHasFeature('llm_ops')"
+          to="/llm-ops"
+          class="nav-item"
+          :class="[
+            isActive('/llm-ops') ? 'nav-item-active' : '',
+            collapsed && !isMobile ? 'nav-item-collapsed' : ''
+          ]"
+          @click="isMobile && $emit('close')"
+          @mouseenter="preloadRoute('/llm-ops')"
+          :title="collapsed && !isMobile ? t('platforms.llmOps') : undefined"
+        >
+          <svg
+            class="w-5 h-5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M9 3h6m-7 4h8m-9 4h10m-9 4h8m-9 4h6"
+            />
+          </svg>
+          <span v-if="isMobile || !collapsed">
+            {{ t('platforms.llmOps') }}
+          </span>
+        </router-link>
+
         <!-- Cloud Billing Menu with Submenu -->
         <div
           v-if="userStore.userHasFeature('operations_console')"

--- a/frontend/src/components/llm-ops/LLMOpsHeader.vue
+++ b/frontend/src/components/llm-ops/LLMOpsHeader.vue
@@ -209,7 +209,14 @@ const selectedResalePlatformIdModel = computed({
 })
 
 const showPlatformControl = computed(() =>
-  ['monitor', 'reseller'].includes(props.activeSection)
+  [
+    'channelMatrix',
+    'listingRisk',
+    'modelWorkbench',
+    'monitor',
+    'priceChanges',
+    'reseller'
+  ].includes(props.activeSection)
 )
 const showPlatformActions = computed(() => props.activeSection === 'reseller')
 const toolbar = computed(() => toolbarForSection(props.activeSection))

--- a/frontend/src/composables/useGlobalAssistant.js
+++ b/frontend/src/composables/useGlobalAssistant.js
@@ -120,7 +120,7 @@ export function useGlobalAssistant() {
         conversationId,
         {
           message,
-          page_context: { app_key: appKey }
+          page_context: pageContextFor(appKey)
         },
         {
           onProgress(event) {
@@ -176,6 +176,16 @@ export function useGlobalAssistant() {
       loading.value = false
       if (version === activationVersion) await loadHistory(version)
     }
+  }
+
+  function pageContextFor(appKey) {
+    const pageContext = { app_key: appKey }
+    if (appKey !== 'llm_ops' || typeof localStorage === 'undefined') {
+      return pageContext
+    }
+    const platformId = localStorage.getItem('llm_ops_resale_platform')
+    if (platformId) pageContext.resale_platform_id = platformId
+    return pageContext
   }
 
   function askQuestion(question) {

--- a/frontend/src/composables/useLLMOpsData.js
+++ b/frontend/src/composables/useLLMOpsData.js
@@ -29,6 +29,9 @@ export function useLLMOpsData() {
   const loading = ref(false)
   const pageError = ref('')
   const loadedSections = new Set()
+  let resaleListingsRequestId = 0
+  let priceHistoryRequestId = 0
+  let summaryRequestId = 0
 
   const sources = ref([])
   const collectionRuns = ref([])
@@ -103,8 +106,13 @@ export function useLLMOpsData() {
 
   async function refreshSectionData(section, options = {}) {
     const groups = dataGroupsForSection(section)
+    if (groups.includes('platforms')) {
+      await loadDataGroup('platforms', section, options)
+    }
     await Promise.all(
-      groups.map((group) => loadDataGroup(group, section, options))
+      groups
+        .filter((group) => group !== 'platforms')
+        .map((group) => loadDataGroup(group, section, options))
     )
   }
 
@@ -137,6 +145,7 @@ export function useLLMOpsData() {
       resalePlatforms.value = asArray(
         await fetchList(llmOpsApi.listResalePlatforms)
       )
+      ensureSelectedResalePlatform()
       await loadResaleWorkflowConfig()
       return
     }
@@ -190,22 +199,36 @@ export function useLLMOpsData() {
   async function refreshResaleListings(
     platformId = selectedResalePlatformId.value
   ) {
+    const requestId = ++resaleListingsRequestId
     const params = platformId ? { platform: platformId } : {}
-    listings.value = asArray(
+    const nextListings = asArray(
       await fetchList(llmOpsApi.listResaleListings, params)
     )
+    if (
+      requestId !== resaleListingsRequestId ||
+      String(platformId || '') !== String(selectedResalePlatformId.value || '')
+    ) {
+      return
+    }
+    listings.value = nextListings
   }
 
   async function refreshResalePlatformSelection(section) {
     const platformSections = [
+      'channelMatrix',
       'listingRisk',
       'modelWorkbench',
       'monitor',
+      'priceChanges',
       'reseller'
     ]
     platformSections.forEach((sectionKey) => loadedSections.delete(sectionKey))
     if (section === 'monitor') {
       await refreshSummary('monitor')
+      return
+    }
+    if (section === 'priceChanges') {
+      await refreshPriceHistoryData()
       return
     }
     await Promise.all([refreshResaleListings(), refreshSummary()])
@@ -270,8 +293,13 @@ export function useLLMOpsData() {
   }
 
   async function refreshPriceHistoryData(modelId = null) {
+    const requestId = ++priceHistoryRequestId
     const model = Number(modelId)
     const modelFilter = Number.isInteger(model) && model > 0 ? { model } : {}
+    const platformFilter = selectedResalePlatformId.value
+      ? { platform: selectedResalePlatformId.value }
+      : {}
+    const platformId = selectedResalePlatformId.value
     const [channelHistoryData, listingHistoryData] = await Promise.all([
       fetchFirstPage(llmOpsApi.listChannelModelPriceHistory, {
         ...modelFilter,
@@ -279,9 +307,16 @@ export function useLLMOpsData() {
       }),
       fetchFirstPage(llmOpsApi.listResaleListingPriceHistory, {
         ...modelFilter,
+        ...platformFilter,
         page_size: PRICE_HISTORY_PAGE_SIZE
       })
     ])
+    if (
+      requestId !== priceHistoryRequestId ||
+      String(platformId || '') !== String(selectedResalePlatformId.value || '')
+    ) {
+      return
+    }
     channelPriceHistory.value = asArray(channelHistoryData)
     listingPriceHistory.value = asArray(listingHistoryData)
   }
@@ -365,19 +400,11 @@ export function useLLMOpsData() {
 
   async function refreshPlatformData() {
     try {
-      const [platformData, listingData, summaryRes] = await Promise.all([
-        fetchList(llmOpsApi.listResalePlatforms),
-        fetchList(
-          llmOpsApi.listResaleListings,
-          selectedResalePlatformId.value
-            ? { platform: selectedResalePlatformId.value }
-            : {}
-        ),
-        llmOpsApi.getSummary(summaryParams())
-      ])
-      resalePlatforms.value = asArray(platformData)
-      listings.value = asArray(listingData)
-      summary.value = normalizeSummary(extract(summaryRes))
+      resalePlatforms.value = asArray(
+        await fetchList(llmOpsApi.listResalePlatforms)
+      )
+      ensureSelectedResalePlatform()
+      await Promise.all([refreshResaleListings(), refreshSummary()])
       await loadResaleWorkflowConfig()
     } catch (error) {
       showError(errorMessage(error, t('llmOps.dataErrors.refreshPlatforms')))
@@ -402,7 +429,15 @@ export function useLLMOpsData() {
   }
 
   async function refreshSummary(scope = 'full') {
+    const requestId = ++summaryRequestId
+    const platformId = selectedResalePlatformId.value
     const summaryRes = await llmOpsApi.getSummary(summaryParams(scope))
+    if (
+      requestId !== summaryRequestId ||
+      String(platformId || '') !== String(selectedResalePlatformId.value || '')
+    ) {
+      return
+    }
     summary.value = normalizeSummary(extract(summaryRes))
   }
 
@@ -418,6 +453,24 @@ export function useLLMOpsData() {
       resale_platform: selectedResalePlatformId.value || '',
       scope
     }
+  }
+
+  function ensureSelectedResalePlatform() {
+    const platforms = asArray(resalePlatforms.value).filter(
+      (platform) => platform.is_active !== false
+    )
+    if (!platforms.length) {
+      selectedResalePlatformId.value = ''
+      return
+    }
+    const exists = platforms.some(
+      (platform) =>
+        String(platform.id) === String(selectedResalePlatformId.value || '')
+    )
+    if (exists) return
+    const fallback =
+      platforms.find((platform) => platform.code === 'agione') || platforms[0]
+    selectedResalePlatformId.value = String(fallback.id)
   }
 
   function invalidateSectionCache() {

--- a/frontend/src/composables/useLLMOpsResalePublishing.js
+++ b/frontend/src/composables/useLLMOpsResalePublishing.js
@@ -83,9 +83,14 @@ export function useLLMOpsResalePublishing({
     }
     loadResaleWorkflowConfig(platformId)
     if (
-      !['listingRisk', 'modelWorkbench', 'monitor', 'reseller'].includes(
-        activeSection.value
-      )
+      ![
+        'channelMatrix',
+        'listingRisk',
+        'modelWorkbench',
+        'monitor',
+        'priceChanges',
+        'reseller'
+      ].includes(activeSection.value)
     ) {
       return
     }
@@ -99,10 +104,7 @@ export function useLLMOpsResalePublishing({
   watch(
     activeResalePlatforms,
     (platforms) => {
-      if (!platforms.length) {
-        selectedResalePlatformId.value = ''
-        return
-      }
+      if (!platforms.length) return
       const exists = platforms.some(
         (platform) =>
           String(platform.id) === String(selectedResalePlatformId.value)

--- a/frontend/src/utils/llmOpsSectionData.js
+++ b/frontend/src/utils/llmOpsSectionData.js
@@ -1,12 +1,13 @@
 const SECTION_DATA_GROUPS = {
   audit: ['channels'],
-  channelMatrix: ['channels', 'channelPricing', 'summary'],
+  channelMatrix: ['platforms', 'channels', 'channelPricing', 'summary'],
   channels: ['channels'],
   collectionHealth: ['sources', 'runs'],
   globalConfig: ['sources'],
-  listingRisk: ['summary'],
+  listingRisk: ['platforms', 'summary'],
   metaModels: ['providers'],
   modelWorkbench: [
+    'platforms',
     'models',
     'channels',
     'modelPrices',
@@ -16,7 +17,7 @@ const SECTION_DATA_GROUPS = {
     'summary'
   ],
   monitor: ['platforms', 'summary'],
-  priceChanges: ['modelPrices', 'priceHistory'],
+  priceChanges: ['platforms', 'modelPrices', 'priceHistory'],
   providers: ['sources', 'runs', 'providers'],
   reconciler: ['channels', 'models', 'records'],
   reseller: ['platforms', 'providers', 'models', 'listings', 'summary'],

--- a/frontend/tests/appSidebar.test.js
+++ b/frontend/tests/appSidebar.test.js
@@ -15,3 +15,8 @@ test('keeps Data Ops available without showing it in the app sidebar', () => {
   assert.doesNotMatch(sidebarSource, /to="\/data-ops"/)
   assert.match(routerSource, /path:\s*'\/data-ops'/)
 })
+
+test('shows LLM Ops in the workspace sidebar when authorized', () => {
+  assert.match(sidebarSource, /userHasFeature\('llm_ops'\)/)
+  assert.match(sidebarSource, /to="\/llm-ops"/)
+})

--- a/frontend/tests/llmOpsChannelPriceMatrix.test.js
+++ b/frontend/tests/llmOpsChannelPriceMatrix.test.js
@@ -112,6 +112,7 @@ test('calculates savings against the currently listed channel', () => {
 
 test('loads contract pricing data only when the matrix is opened', () => {
   assert.deepEqual(dataGroupsForSection('channelMatrix'), [
+    'platforms',
     'channels',
     'channelPricing',
     'summary'

--- a/frontend/tests/llmOpsResilience.test.js
+++ b/frontend/tests/llmOpsResilience.test.js
@@ -25,6 +25,10 @@ const llmOpsPageSource = readFileSync(
   new URL('../src/pages/LLMOps.vue', import.meta.url),
   'utf8'
 )
+const llmOpsHeaderSource = readFileSync(
+  new URL('../src/components/llm-ops/LLMOpsHeader.vue', import.meta.url),
+  'utf8'
+)
 const modelWorkbenchSource = readFileSync(
   new URL('../src/components/llm-ops/ModelWorkbenchPanel.vue', import.meta.url),
   'utf8'
@@ -55,6 +59,10 @@ const reconciliationSource = readFileSync(
 )
 const resalePublishingSource = readFileSync(
   new URL('../src/composables/useLLMOpsResalePublishing.js', import.meta.url),
+  'utf8'
+)
+const llmOpsDataSource = readFileSync(
+  new URL('../src/composables/useLLMOpsData.js', import.meta.url),
   'utf8'
 )
 const resaleWorkspaceSource = readFileSync(
@@ -218,13 +226,37 @@ test('uses a recognizable create icon in the reconciliation action', () => {
 })
 
 test('refreshes platform-bound data in every platform-aware section', () => {
+  const platformSections = [
+    'channelMatrix',
+    'listingRisk',
+    'modelWorkbench',
+    'monitor',
+    'priceChanges',
+    'reseller'
+  ]
+
+  platformSections.forEach((section) => {
+    assert.ok(dataGroupsForSection(section).includes('platforms'))
+    assert.match(llmOpsHeaderSource, new RegExp(`'${section}'`))
+  })
   assert.match(
     resalePublishingSource,
-    /'listingRisk',[\s\S]*'modelWorkbench',[\s\S]*'monitor',[\s\S]*'reseller'/
+    /'channelMatrix',[\s\S]*'listingRisk',[\s\S]*'modelWorkbench',[\s\S]*'monitor',[\s\S]*'priceChanges',[\s\S]*'reseller'/
   )
   assert.match(
     resalePublishingSource,
     /refreshResalePlatformSelection\(activeSection\.value\)/
+  )
+})
+
+test('keeps the persisted platform until platform options have loaded', () => {
+  assert.match(
+    resalePublishingSource,
+    /if \(!platforms\.length\) return/
+  )
+  assert.match(
+    llmOpsDataSource,
+    /const selectedResalePlatformId = ref\([\s\S]*readStorage\('llm_ops_resale_platform'\)/
   )
 })
 


### PR DESCRIPTION
## Summary

- Scope all platform-aware LLM Ops sections, assistant queries, and async refresh results to the selected resale platform.
- Improve official token-price extraction for labeled Input/Output and Context caching table layouts.
- Add the authorized LLM Ops entry to the main sidebar and cover the behavior with backend and frontend regression tests.

Closes #314

## Test plan

- [x] Backend targeted tests: 4 passed
- [x] Frontend targeted unit tests: 32 passed
- [x] Frontend production build
- [x] Python compile checks
- [x] Flake8 on changed backend files
- [x] git diff --check
- [ ] Full backend target files: blocked locally because Redis host redis:6379 is unavailable
- [ ] Black check: reports three touched backend files would be reformatted; formatting was left unchanged to avoid unrelated diff expansion

The PR is intentionally left open for review; auto-merge is not enabled.