### PR TITLE
Fix LLM Ops console pricing and status consistency

### DIFF
--- a/backend/llm_ops/assistant_tools.py
+++ b/backend/llm_ops/assistant_tools.py
@@ -39,6 +39,7 @@ DEFAULT_LIMIT = 30
 MAX_LIMIT = 100
 DEFAULT_INPUT_TOKENS = 10_000_000
 DEFAULT_OUTPUT_TOKENS = 15_000_000
+SOURCE_HEALTH_STALE_HOURS = 7 * 24
 
 DECISION_STATUSES = {
     "all",
@@ -937,7 +938,7 @@ def query_source_health(arguments: dict[str, Any]) -> dict[str, Any]:
         raise ValueError("invalid source health status")
     stale_hours = _bounded_int(
         arguments.get("stale_hours"),
-        48,
+        SOURCE_HEALTH_STALE_HOURS,
         1,
         8760,
         "stale_hours",

--- a/backend/llm_ops/collection_services.py
+++ b/backend/llm_ops/collection_services.py
@@ -330,6 +330,7 @@ def sync_yunce_model_prices(
     base_url = resolve_collection_base_url(source=source, base_url=base_url)
     run = PriceCollectionRun.objects.create(source=source)
     active_offering_ids: set[int] = set()
+    changed_price_item_ids: set[int] = set()
     stats = {
         "models": 0,
         "created": 0,
@@ -373,11 +374,14 @@ def sync_yunce_model_prices(
                     run=run,
                     offering=offering,
                 )
-                sync_model_price_items(
+                price_items = sync_model_price_items(
                     item,
                     source=source,
                     offering=offering,
                     source_url=catalog.source_url,
+                )
+                changed_price_item_ids.update(
+                    price_item.id for price_item in price_items
                 )
                 active_offering_ids.add(offering.id)
                 stats["models"] += 1
@@ -388,6 +392,16 @@ def sync_yunce_model_prices(
                 source=source,
                 active_offering_ids=active_offering_ids,
             )
+            changed_price_item_ids.update(stale_stats["price_item_ids"])
+            channel_sync = sync_dependent_channel_price_items_for_price_items(
+                ModelPriceItem.objects.filter(id__in=changed_price_item_ids),
+            )
+            stats["channel_model_prices_synced"] = channel_sync[
+                "channel_model_prices"
+            ]
+            stats["channel_price_items_synced"] = channel_sync[
+                "channel_price_items"
+            ]
             source.last_collected_at = timezone.now()
             source.save(update_fields=["last_collected_at", "updated_at"])
             run.status = PriceCollectionRun.STATUS_SUCCEEDED
@@ -409,6 +423,12 @@ def sync_yunce_model_prices(
                 ),
                 "closed_stale_price_items": stale_stats["price_items"],
                 "closed_stale_history": stale_stats["history"],
+                "channel_model_prices_synced": channel_sync[
+                    "channel_model_prices"
+                ],
+                "channel_price_items_synced": channel_sync[
+                    "channel_price_items"
+                ],
             }
             run.save()
         return stats
@@ -448,6 +468,7 @@ def sync_vendor_price_source_catalog(
     )
     run = PriceCollectionRun.objects.create(source=source)
     active_offering_ids: set[int] = set()
+    changed_price_item_ids: set[int] = set()
     stats = {
         "models": 0,
         "created": 0,
@@ -505,11 +526,14 @@ def sync_vendor_price_source_catalog(
                     run=run,
                     offering=offering,
                 )
-                sync_model_price_items(
+                price_items = sync_model_price_items(
                     item,
                     source=source,
                     offering=offering,
                     source_url=catalog.source_url,
+                )
+                changed_price_item_ids.update(
+                    price_item.id for price_item in price_items
                 )
                 active_offering_ids.add(offering.id)
                 stats["models"] += 1
@@ -520,6 +544,16 @@ def sync_vendor_price_source_catalog(
                 source=source,
                 active_offering_ids=active_offering_ids,
             )
+            changed_price_item_ids.update(stale_stats["price_item_ids"])
+            channel_sync = sync_dependent_channel_price_items_for_price_items(
+                ModelPriceItem.objects.filter(id__in=changed_price_item_ids),
+            )
+            stats["channel_model_prices_synced"] = channel_sync[
+                "channel_model_prices"
+            ]
+            stats["channel_price_items_synced"] = channel_sync[
+                "channel_price_items"
+            ]
             source.last_collected_at = timezone.now()
             source.save(update_fields=["last_collected_at", "updated_at"])
             run.status = PriceCollectionRun.STATUS_SUCCEEDED
@@ -540,6 +574,12 @@ def sync_vendor_price_source_catalog(
                 ),
                 "closed_stale_price_items": stale_stats["price_items"],
                 "closed_stale_history": stale_stats["history"],
+                "channel_model_prices_synced": channel_sync[
+                    "channel_model_prices"
+                ],
+                "channel_price_items_synced": channel_sync[
+                    "channel_price_items"
+                ],
             }
             run.save()
         return stats

--- a/backend/llm_ops/tests/test_assistant_tools.py
+++ b/backend/llm_ops/tests/test_assistant_tools.py
@@ -224,6 +224,28 @@ class LLMOpsAssistantToolTests(TestCase):
         self.assertEqual(row["health_status"], "failed")
         self.assertEqual(row["latest_error"], "upstream timeout")
 
+    def test_source_health_uses_same_seven_day_freshness_window_as_console(
+        self,
+    ):
+        source = PriceCollectionSource.objects.create(
+            name="Manual Source",
+            slug="manual-source",
+            last_collected_at=timezone.now() - timedelta(days=3),
+        )
+
+        result = execute_llm_ops_tool(
+            "llm_ops_query_source_health",
+            {"status": "all"},
+        )
+
+        row = next(
+            item
+            for item in result["result"]["rows"]
+            if item["source_id"] == source.id
+        )
+        self.assertEqual(result["result"]["stale_hours"], 7 * 24)
+        self.assertEqual(row["health_status"], "healthy")
+
     def test_price_change_query_ranks_largest_change_first(self):
         now = timezone.now()
         for index, price in enumerate(("1", "3")):

--- a/backend/llm_ops/tests/test_source_collectors.py
+++ b/backend/llm_ops/tests/test_source_collectors.py
@@ -13,6 +13,8 @@ from llm_ops.collection_services import (
 from llm_ops.collectors import CollectedModelPricing, NormalizedPriceRow
 from llm_ops.global_config import price_sync_source_queryset
 from llm_ops.models import (
+    ChannelModelPrice,
+    ChannelPriceItem,
     CollectedModelPriceHistory,
     LLMProvider,
     MetaModel,
@@ -20,8 +22,10 @@ from llm_ops.models import (
     ModelSku,
     PriceCollectionRun,
     PriceCollectionSource,
+    ProcurementChannel,
     SourceSkuOffering,
 )
+from llm_ops.services import sync_channel_price_items
 from llm_ops.source_collectors import (
     collect_price_source,
     get_price_source_collector,
@@ -645,6 +649,94 @@ class PriceCollectionSkuPersistenceTests(TestCase):
         self.assertEqual(input_item.offering, offering)
         self.assertEqual(input_item.model.sku, sku)
         self.assertEqual(input_item.unit_price, Decimal("1.000000"))
+
+    def test_auto_source_sync_refreshes_dependent_channel_price_items(self):
+        first = self.collected_item()
+        catalog = mock.Mock(
+            models=[first],
+            source_url=self.source.endpoint_url,
+            total_models=1,
+        )
+        standard_catalog = {
+            "schema_version": "llm_ops.model_price_catalog.v1",
+            "source_type": "provider_adapter",
+            "models": [{}],
+            "raw_payload": {},
+        }
+        with (
+            mock.patch(
+                "llm_ops.collection_services.collect_vendor_price_catalog",
+                return_value=standard_catalog,
+            ),
+            mock.patch(
+                "llm_ops.collection_services."
+                "standard_catalog_to_collected_catalog",
+                return_value=catalog,
+            ),
+        ):
+            sync_vendor_price_source_catalog(
+                provider_code="deepseek",
+                source=self.source,
+                verify_source=False,
+            )
+
+        model = ModelPriceItem.objects.get(
+            source=self.source,
+            dimension=ModelPriceItem.DIMENSION_TEXT_INPUT,
+            is_current=True,
+        ).model
+        channel = ProcurementChannel.objects.create(
+            name="DeepSeek Official",
+            code="deepseek-official-channel",
+            currency="CNY",
+        )
+        channel_price = ChannelModelPrice.objects.create(
+            channel=channel,
+            model=model,
+            price_source=self.source,
+            is_listed=True,
+        )
+        sync_channel_price_items(channel_price)
+
+        refreshed = self.collected_item()
+        refreshed.price_rows[0].values["input_price"] = "4.5"
+        refreshed.price_rows[0].values["output_price"] = "13.5"
+        refreshed_catalog = mock.Mock(
+            models=[refreshed],
+            source_url=self.source.endpoint_url,
+            total_models=1,
+        )
+        with (
+            mock.patch(
+                "llm_ops.collection_services.collect_vendor_price_catalog",
+                return_value=standard_catalog,
+            ),
+            mock.patch(
+                "llm_ops.collection_services."
+                "standard_catalog_to_collected_catalog",
+                return_value=refreshed_catalog,
+            ),
+        ):
+            result = sync_vendor_price_source_catalog(
+                provider_code="deepseek",
+                source=self.source,
+                verify_source=False,
+            )
+
+        current_items = ChannelPriceItem.objects.filter(
+            channel=channel,
+            model=model,
+            is_current=True,
+        )
+        input_item = current_items.get(
+            dimension=ModelPriceItem.DIMENSION_TEXT_INPUT,
+        )
+        output_item = current_items.get(
+            dimension=ModelPriceItem.DIMENSION_TEXT_OUTPUT,
+        )
+        self.assertEqual(input_item.unit_price, Decimal("4.500000"))
+        self.assertEqual(output_item.unit_price, Decimal("13.500000"))
+        self.assertEqual(result["channel_model_prices_synced"], 1)
 
     def test_siliconflow_mixed_flat_tiered_rows_persist_as_tiers(self):
         from llm_ops.price_collectors.parsers import siliconflow

--- a/frontend/src/components/llm-ops/CollectionHealthPanel.vue
+++ b/frontend/src/components/llm-ops/CollectionHealthPanel.vue
@@ -66,7 +66,7 @@
                 </span>
               </td>
               <td class="table-cell text-right font-mono">
-                {{ row.successRate }}%
+                {{ row.successRate === null ? '-' : `${row.successRate}%` }}
               </td>
               <td class="table-cell text-right font-mono">
                 {{ row.consecutiveFailures }}
@@ -117,6 +117,7 @@ const sourceRows = computed(() =>
         .sort((left, right) => runTime(right) - runTime(left))
       const succeeded = runs.filter((run) => run.status === 'succeeded').length
       const latestRun = runs[0] || null
+      const latestStatus = latestRun?.status || source.latest_run_status || ''
       const lastCollectedAt =
         source.last_collected_at ||
         latestRun?.finished_at ||
@@ -128,12 +129,12 @@ const sourceRows = computed(() =>
         enabled: source.is_enabled !== false,
         stale,
         failures,
-        latestStatus: latestRun?.status || ''
+        latestStatus
       })
       return {
         ...source,
-        latestStatus: latestRun?.status || '',
-        successRate: percentage(succeeded, runs.length),
+        latestStatus,
+        successRate: runs.length ? percentage(succeeded, runs.length) : null,
         consecutiveFailures: failures,
         lastCollectedAt,
         healthLabel: health.label,

--- a/frontend/src/components/llm-ops/GlobalConfigPanel.vue
+++ b/frontend/src/components/llm-ops/GlobalConfigPanel.vue
@@ -97,7 +97,7 @@
               v-if="metaSchedule.mode === 'custom'"
               type="button"
               class="schedule-reset-button"
-              @click="resetScheduleEditor(metaSchedule, [2])"
+              @click="resetScheduleEditor(metaSchedule, [2], 35)"
             >
               {{ t('llmOps.globalConfigPanel.schedule.reselect') }}
             </button>
@@ -109,7 +109,11 @@
             <div class="schedule-hour-selector">
               <span>{{ t('llmOps.globalConfigPanel.schedule.hours') }}</span>
               <small>
-                {{ t('llmOps.globalConfigPanel.schedule.fixedMinute') }}
+                {{
+                  t('llmOps.globalConfigPanel.schedule.fixedMinute', {
+                    minute: minuteLabel(metaSchedule.minute)
+                  })
+                }}
               </small>
             </div>
             <div class="schedule-hour-list">
@@ -184,7 +188,7 @@
               v-if="priceSchedule.mode === 'custom'"
               type="button"
               class="schedule-reset-button"
-              @click="resetScheduleEditor(priceSchedule, [1, 7, 13, 19])"
+              @click="resetScheduleEditor(priceSchedule, [1, 7, 13, 19], 15)"
             >
               {{ t('llmOps.globalConfigPanel.schedule.reselect') }}
             </button>
@@ -199,7 +203,11 @@
             <div class="schedule-hour-selector">
               <span>{{ t('llmOps.globalConfigPanel.schedule.hours') }}</span>
               <small>
-                {{ t('llmOps.globalConfigPanel.schedule.fixedMinute') }}
+                {{
+                  t('llmOps.globalConfigPanel.schedule.fixedMinute', {
+                    minute: minuteLabel(priceSchedule.minute)
+                  })
+                }}
               </small>
             </div>
             <div class="schedule-hour-list">
@@ -442,7 +450,6 @@ const sourceMode = ref('all')
 
 const metaSchedule = reactive(createScheduleEditor())
 const priceSchedule = reactive(createScheduleEditor())
-const FIXED_SCHEDULE_MINUTE = 5
 
 const form = reactive({
   meta_model_sync_enabled: true,
@@ -720,10 +727,10 @@ function applySchedule(target, nextSchedule) {
   target.touched = nextSchedule.touched
 }
 
-function resetScheduleEditor(target, hours) {
+function resetScheduleEditor(target, hours, minute) {
   applySchedule(target, {
     hours,
-    minute: FIXED_SCHEDULE_MINUTE,
+    minute,
     mode: 'hours',
     originalCron: '',
     touched: true
@@ -732,13 +739,12 @@ function resetScheduleEditor(target, hours) {
 
 function markScheduleTouched(schedule) {
   schedule.touched = true
-  schedule.minute = FIXED_SCHEDULE_MINUTE
 }
 
 function availableHourOptions(schedule, index) {
   const currentHour = schedule.hours[index]
   const usedHours = new Set(schedule.hours)
-  const minute = schedule.touched ? FIXED_SCHEDULE_MINUTE : schedule.minute
+  const minute = schedule.minute
   return hourOptions
     .filter((hour) => hour.value === currentHour || !usedHours.has(hour.value))
     .map((hour) => ({
@@ -788,7 +794,7 @@ function scheduleToCron(schedule) {
   const hours = Array.from(new Set(schedule.hours))
     .sort((left, right) => left - right)
     .join(',')
-  return `${FIXED_SCHEDULE_MINUTE} ${hours} * * *`
+  return `${schedule.minute} ${hours} * * *`
 }
 
 function scheduleSummary(schedule) {
@@ -796,7 +802,7 @@ function scheduleSummary(schedule) {
     return t('llmOps.globalConfigPanel.schedule.custom')
   }
 
-  const minute = schedule.touched ? FIXED_SCHEDULE_MINUTE : schedule.minute
+  const minute = schedule.minute
   const times = Array.from(new Set(schedule.hours))
     .sort((left, right) => left - right)
     .map((hour) => timeLabel(hour, minute))

--- a/frontend/src/components/llm-ops/MetaModelManagement.vue
+++ b/frontend/src/components/llm-ops/MetaModelManagement.vue
@@ -215,8 +215,7 @@
               <p class="drawer-result-note">
                 {{
                   t('llmOps.metaModelManagement.summary.modelResult', {
-                    total: drawerTotal,
-                    active: selectedVendorActiveCount
+                    total: drawerTotal
                   })
                 }}
               </p>
@@ -546,12 +545,6 @@ const metricCards = computed(() => {
       hint: t('llmOps.metaModelManagement.metrics.status.hint')
     }
   ]
-})
-
-const selectedVendorActiveCount = computed(() => {
-  if (statusFilter.value === 'active') return drawerTotal.value
-  if (statusFilter.value) return 0
-  return Number(selectedVendorRow.value?.active_model_count || 0)
 })
 
 const syncActionLabel = computed(() =>

--- a/frontend/src/components/llm-ops/PriceChangePanel.vue
+++ b/frontend/src/components/llm-ops/PriceChangePanel.vue
@@ -24,6 +24,7 @@
           class-name="w-36"
           size="sm"
         />
+        <p class="text-xs text-slate-500">{{ rangeSummary }}</p>
       </div>
       <div class="overflow-x-auto">
         <table class="data-table">
@@ -33,13 +34,19 @@
                 {{ t('llmOps.priceChangePanel.columns.object') }}
               </th>
               <th class="table-head">
-                {{ t('llmOps.priceChangePanel.columns.type') }}
+                {{ t('llmOps.priceChangePanel.columns.dimension') }}
+              </th>
+              <th class="table-head">
+                {{ t('llmOps.priceChangePanel.columns.source') }}
               </th>
               <th class="table-head text-right">
-                {{ t('llmOps.priceChangePanel.columns.input') }}
+                {{ t('llmOps.priceChangePanel.columns.previous') }}
               </th>
               <th class="table-head text-right">
-                {{ t('llmOps.priceChangePanel.columns.output') }}
+                {{ t('llmOps.priceChangePanel.columns.current') }}
+              </th>
+              <th class="table-head text-right">
+                {{ t('llmOps.priceChangePanel.columns.change') }}
               </th>
               <th class="table-head">
                 {{ t('llmOps.priceChangePanel.columns.currency') }}
@@ -56,21 +63,28 @@
                 <p class="mt-1 text-xs text-slate-500">{{ row.context }}</p>
               </td>
               <td class="table-cell">
+                {{ dimensionLabel(row.dimension) }}
+              </td>
+              <td class="table-cell">
+                <p>{{ row.source || '-' }}</p>
                 <span :class="['status-pill', row.tone]">
                   {{ row.type_label }}
                 </span>
               </td>
               <td class="table-cell text-right font-mono">
-                {{ money(row.input, row.currency) }}
+                {{ money(row.previous, row.currency) }}
               </td>
               <td class="table-cell text-right font-mono">
-                {{ money(row.output, row.currency) }}
+                {{ money(row.current, row.currency) }}
+              </td>
+              <td class="table-cell text-right font-mono">
+                {{ deltaText(row) }}
               </td>
               <td class="table-cell">{{ row.currency || '-' }}</td>
               <td class="table-cell">{{ formatDateTime(row.time) }}</td>
             </tr>
             <tr v-if="!filteredRows.length">
-              <td class="table-cell text-slate-500" colspan="6">
+              <td class="table-cell text-slate-500" colspan="8">
                 {{ t('llmOps.priceChangePanel.empty') }}
               </td>
             </tr>
@@ -86,6 +100,10 @@ import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import CompactSelect from './CompactSelect.vue'
+import {
+  buildPriceChangeRows,
+  priceChangeDelta
+} from '@/utils/llmOpsPriceChanges'
 
 const props = defineProps({
   channelHistory: { type: Array, default: () => [] },
@@ -96,6 +114,7 @@ const props = defineProps({
 
 const { t } = useI18n()
 const typeFilter = ref('all')
+const MAX_VISIBLE_ROWS = 120
 const typeFilterOptions = computed(() => [
   { label: t('llmOps.priceChangePanel.filters.all'), value: 'all' },
   { label: t('llmOps.priceChangePanel.types.channel'), value: 'channel' },
@@ -104,49 +123,23 @@ const typeFilterOptions = computed(() => [
 ])
 
 const changeRows = computed(() => {
-  const channelRows = props.channelHistory.map((item) => ({
-    key: `channel-${item.id}`,
-    type: 'channel',
-    modelId: item.model,
-    type_label: t('llmOps.priceChangePanel.types.channel'),
-    tone: 'info',
+  return buildPriceChangeRows({
+    channelHistory: props.channelHistory,
+    listingHistory: props.listingHistory,
+    priceItems: props.priceItems
+  }).map((row) => ({
+    ...row,
     name:
-      item.model_name ||
-      t('llmOps.priceChangePanel.fallback.model', { id: item.model }),
-    context:
-      item.channel_name ||
-      t('llmOps.priceChangePanel.fallback.channel', { id: item.channel }),
-    input: item.input_price_per_million,
-    output: item.output_price_per_million,
-    currency: item.currency,
-    time: item.effective_from || item.created_at
+      row.name ||
+      t('llmOps.priceChangePanel.fallback.model', { id: row.modelId }),
+    type_label: t(`llmOps.priceChangePanel.types.${row.type}`),
+    tone: { channel: 'info', listing: 'warn', official: 'success' }[
+      row.type
+    ]
   }))
-  const listingRows = props.listingHistory.map((item) => ({
-    key: `listing-${item.id}`,
-    type: 'listing',
-    modelId: item.model,
-    type_label: t('llmOps.priceChangePanel.types.listing'),
-    tone: 'warn',
-    name:
-      item.model_name ||
-      t('llmOps.priceChangePanel.fallback.model', { id: item.model }),
-    context:
-      item.platform_name ||
-      t('llmOps.priceChangePanel.fallback.platform', {
-        id: item.platform
-      }),
-    input: item.retail_input_price_per_million,
-    output: item.retail_output_price_per_million,
-    currency: item.currency,
-    time: item.effective_from || item.created_at
-  }))
-  const officialRows = recentOfficialRows()
-  return [...channelRows, ...listingRows, ...officialRows].sort(
-    (left, right) => new Date(right.time || 0) - new Date(left.time || 0)
-  )
 })
 
-const filteredRows = computed(() => {
+const allFilteredRows = computed(() => {
   let rows = changeRows.value
   if (props.focusModelId) {
     rows = rows.filter(
@@ -156,8 +149,21 @@ const filteredRows = computed(() => {
   if (typeFilter.value !== 'all') {
     rows = rows.filter((row) => row.type === typeFilter.value)
   }
-  return rows.slice(0, 120)
+  return rows
 })
+
+const filteredRows = computed(() =>
+  allFilteredRows.value.slice(0, MAX_VISIBLE_ROWS)
+)
+
+const rangeSummary = computed(() =>
+  t('llmOps.priceChangePanel.rangeSummary', {
+    channel: props.channelHistory.length,
+    listing: props.listingHistory.length,
+    shown: filteredRows.value.length,
+    total: allFilteredRows.value.length
+  })
+)
 
 const metrics = computed(() => [
   {
@@ -177,24 +183,6 @@ const metrics = computed(() => [
   }
 ])
 
-function recentOfficialRows() {
-  return props.priceItems.map((item) => ({
-    key: `official-${item.id}`,
-    type: 'official',
-    modelId: item.model,
-    type_label: t('llmOps.priceChangePanel.types.official'),
-    tone: 'success',
-    name:
-      item.model_name ||
-      t('llmOps.priceChangePanel.fallback.model', { id: item.model }),
-    context: dimensionLabel(item.dimension),
-    input: item.dimension === 'text_input' ? item.unit_price : null,
-    output: item.dimension === 'text_output' ? item.unit_price : null,
-    currency: item.currency,
-    time: item.effective_from || item.updated_at || item.created_at
-  }))
-}
-
 function dimensionLabel(value) {
   return (
     {
@@ -208,6 +196,15 @@ function dimensionLabel(value) {
       video_output: t('llmOps.priceChangePanel.dimension.videoOutput')
     }[value] || value
   )
+}
+
+function deltaText(row) {
+  const delta = priceChangeDelta(row)
+  if (delta === null) return '-'
+  const previous = Number(row.previous)
+  const percent = previous ? ` (${((delta / previous) * 100).toFixed(2)}%)` : ''
+  const sign = delta > 0 ? '+' : ''
+  return `${sign}${delta.toFixed(6)}${percent}`
 }
 
 function money(value, currency) {

--- a/frontend/src/components/llm-ops/PriceSourceModal.vue
+++ b/frontend/src/components/llm-ops/PriceSourceModal.vue
@@ -88,7 +88,14 @@
               <span class="field-label">
                 {{ t('llmOps.priceSourceModal.fields.autoSyncSource') }}
               </span>
+              <input
+                v-if="isEditing"
+                class="field"
+                :value="editingSyncSourceLabel"
+                disabled
+              />
               <CompactSelect
+                v-else
                 v-model="selectedAutoSyncSourceCode"
                 :disabled="
                   !shouldCreateAutoSyncPreset ||
@@ -348,10 +355,18 @@ const autoSyncSourceStatus = computed(() => {
 })
 
 const autoSyncSourceHelpText = computed(() => {
+  if (isEditing.value) {
+    return t('llmOps.priceSourceModal.autoSyncPreset.existingSource')
+  }
   if (!shouldCreateAutoSyncPreset.value) {
     return t('llmOps.priceSourceModal.autoSyncPreset.manualMode')
   }
   return autoSyncSourceStatus.value
+})
+
+const editingSyncSourceLabel = computed(() => {
+  const source = props.source || {}
+  return [source.provider_name, source.name].filter(Boolean).join(' · ') || '-'
 })
 
 const saveDisabled = computed(

--- a/frontend/src/composables/useAgioneListingDisplay.js
+++ b/frontend/src/composables/useAgioneListingDisplay.js
@@ -55,6 +55,17 @@ export function useAgioneListingDisplay({
   const listingKpis = computed(() => {
     const visibleRows = visibleListingRows.value
     const listedRows = visibleRows.filter((row) => row.is_listed)
+    const workflowModelIds = new Set(
+      visibleRows.map((row) => String(row.model?.id || ''))
+    )
+    const workflowCandidates = (props.summary?.procurement || []).filter(
+      (row) =>
+        (row.options || []).length > 0 &&
+        !workflowModelIds.has(String(row.model_id || ''))
+    )
+    const candidateModels = new Set(
+      workflowCandidates.map((row) => String(row.model_id))
+    ).size
     const rowMargins = listedRows
       .map((row) => listingUnifiedMarginRate(row))
       .filter((value) => value !== null)
@@ -68,20 +79,20 @@ export function useAgioneListingDisplay({
       : null
     return [
       {
-        label: t('llmOps.listingBoard.kpis.availableModels.label'),
+        label: t('llmOps.listingBoard.kpis.workflowModels.label'),
         value: visibleRows.length,
-        hint: t('llmOps.listingBoard.kpis.availableModels.hint', {
+        hint: t('llmOps.listingBoard.kpis.workflowModels.hint', {
           count: unlistedCount(visibleRows, listedRows)
         }),
-        delta: t('llmOps.listingBoard.kpis.availableModels.delta'),
+        delta: t('llmOps.listingBoard.kpis.workflowModels.delta'),
         deltaTone: 'text-slate-400'
       },
       {
-        label: t('llmOps.listingBoard.kpis.platforms.label'),
-        value: props.platformCount,
-        hint: t('llmOps.listingBoard.kpis.platforms.hint'),
-        delta: t('llmOps.listingBoard.kpis.platforms.delta'),
-        deltaTone: 'text-slate-400'
+        label: t('llmOps.listingBoard.kpis.candidateModels.label'),
+        value: candidateModels,
+        hint: t('llmOps.listingBoard.kpis.candidateModels.hint'),
+        delta: t('llmOps.listingBoard.kpis.candidateModels.delta'),
+        deltaTone: candidateModels ? 'text-amber-600' : 'text-slate-400'
       },
       {
         label: t('llmOps.listingBoard.kpis.listed.label'),
@@ -94,10 +105,10 @@ export function useAgioneListingDisplay({
         deltaTone: listedRows.length > 0 ? 'text-emerald-600' : 'text-amber-600'
       },
       {
-        label: t('llmOps.listingBoard.kpis.unlisted.label'),
+        label: t('llmOps.listingBoard.kpis.workflowUnlisted.label'),
         value: visibleRows.length - listedRows.length,
-        hint: t('llmOps.listingBoard.kpis.unlisted.hint'),
-        delta: t('llmOps.listingBoard.kpis.unlisted.delta'),
+        hint: t('llmOps.listingBoard.kpis.workflowUnlisted.hint'),
+        delta: t('llmOps.listingBoard.kpis.workflowUnlisted.delta'),
         deltaTone: 'text-amber-600'
       },
       {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -800,6 +800,9 @@
       "subtitle": "A dedicated view for pricing, channels, resale, and reconciliation",
       "navigationLabel": "LLM Operations navigation"
     },
+    "loading": {
+      "section": "Loading data required for “{section}”…"
+    },
     "toolbar": {
       "displayCurrency": "Display currency",
       "resalePlatform": "Resale platform",
@@ -1658,8 +1661,13 @@
     },
     "priceChangePanel": {
       "columns": {
+        "change": "Delta",
+        "current": "New / current",
         "currency": "Currency",
+        "dimension": "Dimension",
         "object": "Object",
+        "previous": "Previous",
+        "source": "Source",
         "time": "Time",
         "type": "Type",
         "input": "Input",
@@ -1676,6 +1684,7 @@
         "videoOutput": "Video output"
       },
       "empty": "No price change records yet.",
+      "rangeSummary": "Loaded the latest {channel} channel and {listing} listing versions; showing {shown}/{total} dimension records",
       "fallback": {
         "channel": "Channel {id}",
         "model": "Model {id}",
@@ -2005,9 +2014,9 @@
       "schedule": {
         "addHour": "Add run hour",
         "custom": "Custom schedule",
-        "customDescription": "The current schedule is outside the visual editor range. Saving other settings keeps it unchanged. Reselect run hours to switch it to minute 05.",
+        "customDescription": "The current schedule is outside the visual editor range. Saving other settings keeps it unchanged. Reselect run hours to adjust it.",
         "emptyHours": "Select at least one run time",
-        "fixedMinute": "After changes, runs at minute 05 in each selected hour.",
+        "fixedMinute": "Runs at minute {minute} in each selected hour.",
         "hours": "Run hours",
         "optionDescription": "Runs daily at {time}",
         "removeHour": "Remove run hour",
@@ -2188,7 +2197,7 @@
         "unknown": "Unknown"
       },
       "summary": {
-        "modelResult": "{total} meta models · {active} active",
+        "modelResult": "{total} meta models",
         "vendors": "Providers"
       },
       "table": {
@@ -2566,6 +2575,7 @@
       },
       "autoSyncPreset": {
         "empty": "No auto-sync sources are available to add.",
+        "existingSource": "Editing keeps the current sync source. Create a new price source to switch it.",
         "exists": "This sync source has already been added.",
         "existsBadge": "Added",
         "loading": "Loading sync sources.",
@@ -2994,15 +3004,15 @@
         "confirmOffline": "Batch confirm offline"
       },
       "kpis": {
-        "availableModels": {
-          "label": "Listable models",
-          "hint": "{count} unlisted",
-          "delta": "This period"
+        "workflowModels": {
+          "label": "Workflow models",
+          "hint": "{count} are not online yet",
+          "delta": "Current platform"
         },
-        "platforms": {
-          "label": "Resale platforms",
-          "hint": "Visible resale platform total",
-          "delta": "Stable"
+        "candidateModels": {
+          "label": "Awaiting workflow",
+          "hint": "Has procurement supply; use New listing to enter the workflow",
+          "delta": "Candidates"
         },
         "listed": {
           "label": "Listed",
@@ -3010,9 +3020,9 @@
           "activeDelta": "+ publishing",
           "pendingDelta": "Pending"
         },
-        "unlisted": {
-          "label": "Unlisted",
-          "hint": "Can be handled from the workspace",
+        "workflowUnlisted": {
+          "label": "Workflow not online",
+          "hint": "Already in this platform workflow but not online",
           "delta": "Needs action"
         },
         "averageMargin": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -808,6 +808,9 @@
       "subtitle": "价格、渠道、转售与对账的独立运营视图",
       "navigationLabel": "大模型运营管理导航"
     },
+    "loading": {
+      "section": "正在加载「{section}」所需数据…"
+    },
     "toolbar": {
       "displayCurrency": "显示货币",
       "resalePlatform": "挂售平台",
@@ -1666,8 +1669,13 @@
     },
     "priceChangePanel": {
       "columns": {
+        "change": "差额",
+        "current": "新值 / 当前值",
         "currency": "币种",
+        "dimension": "计价维度",
         "object": "对象",
+        "previous": "旧值",
+        "source": "来源",
         "time": "时间",
         "type": "类型",
         "input": "输入",
@@ -1684,6 +1692,7 @@
         "videoOutput": "视频输出"
       },
       "empty": "暂无价格变化记录。",
+      "rangeSummary": "已载入渠道最近 {channel} 个、挂售最近 {listing} 个价格版本；显示 {shown}/{total} 个维度记录",
       "fallback": {
         "channel": "渠道 {id}",
         "model": "模型 {id}",
@@ -2013,9 +2022,9 @@
       "schedule": {
         "addHour": "添加执行小时",
         "custom": "自定义周期",
-        "customDescription": "当前周期超出可视化编辑范围，保存其它配置时会保留原周期；如需调整，请重新选择执行小时，之后统一在 05 分执行。",
+        "customDescription": "当前周期超出可视化编辑范围，保存其它配置时会保留原周期；如需调整，请重新选择执行小时。",
         "emptyHours": "请选择至少一个执行时间",
-        "fixedMinute": "修改后统一在所选小时的 05 分执行。",
+        "fixedMinute": "在所选小时的 {minute} 分执行。",
         "hours": "执行小时",
         "optionDescription": "每天 {time} 执行",
         "removeHour": "删除执行小时",
@@ -2196,7 +2205,7 @@
         "unknown": "未知"
       },
       "summary": {
-        "modelResult": "{total} 个元模型 · {active} 个可用",
+        "modelResult": "{total} 个元模型",
         "vendors": "厂商"
       },
       "table": {
@@ -2574,6 +2583,7 @@
       },
       "autoSyncPreset": {
         "empty": "暂无可添加的自动同步来源。",
+        "existingSource": "编辑时保留当前同步来源；如需更换，请新建价格源。",
         "exists": "当前同步来源已经添加。",
         "existsBadge": "已添加",
         "loading": "正在加载同步来源。",
@@ -3002,15 +3012,15 @@
         "confirmOffline": "批量确认下架"
       },
       "kpis": {
-        "availableModels": {
-          "label": "可挂售模型",
-          "hint": "{count} 个未上架",
-          "delta": "本周期"
+        "workflowModels": {
+          "label": "流程内模型",
+          "hint": "其中 {count} 个尚未上线",
+          "delta": "当前平台"
         },
-        "platforms": {
-          "label": "挂售平台",
-          "hint": "可见挂售平台汇总",
-          "delta": "稳定"
+        "candidateModels": {
+          "label": "待进入流程",
+          "hint": "已有采购供应，需通过“新建上架”进入流程",
+          "delta": "候选模型"
         },
         "listed": {
           "label": "已上架",
@@ -3018,9 +3028,9 @@
           "activeDelta": "+ 上架中",
           "pendingDelta": "待上架"
         },
-        "unlisted": {
-          "label": "未上架",
-          "hint": "可在工作台一键处理",
+        "workflowUnlisted": {
+          "label": "流程内未上线",
+          "hint": "已进入当前平台流程但尚未在线",
           "delta": "需处理"
         },
         "averageMargin": {

--- a/frontend/src/pages/LLMOps.vue
+++ b/frontend/src/pages/LLMOps.vue
@@ -37,7 +37,30 @@
             @refresh="handleRefreshAll"
           />
 
-          <BaseLoading v-if="loading" class="py-20" />
+          <div
+            v-if="loading"
+            class="llm-ops-loading-skeleton px-5 py-6 lg:px-7"
+            role="status"
+            aria-live="polite"
+          >
+            <div class="mb-4 flex items-center gap-3 text-sm text-slate-600">
+              <span
+                class="h-4 w-4 animate-spin rounded-full border-2 border-slate-300 border-t-indigo-600"
+                aria-hidden="true"
+              />
+              <span>{{ loadingSectionLabel }}</span>
+            </div>
+            <div class="grid animate-pulse gap-4 md:grid-cols-3">
+              <div
+                v-for="index in 3"
+                :key="index"
+                class="h-28 rounded-xl border border-slate-200 bg-white"
+              />
+            </div>
+            <div
+              class="mt-4 h-72 animate-pulse rounded-xl border border-slate-200 bg-white"
+            />
+          </div>
           <LLMOpsErrorState
             v-else-if="pageError"
             class="my-6"
@@ -515,6 +538,11 @@ const mobileNavigationOpen = ref(false)
 let desktopMediaQuery = null
 const inlineWorkspaceKey = computed(
   () => `inline-${resaleWorkspaceFocusModelId.value || 'new'}`
+)
+const loadingSectionLabel = computed(() =>
+  t('llmOps.loading.section', {
+    section: activeNav.value?.label || t('llmOps.shell.title')
+  })
 )
 
 const inlineCanPublish = computed(() => {

--- a/frontend/src/utils/llmOpsPriceChanges.js
+++ b/frontend/src/utils/llmOpsPriceChanges.js
@@ -1,0 +1,119 @@
+const channelDimensions = [
+  ['text_input', 'input_price_per_million'],
+  ['text_output', 'output_price_per_million'],
+  ['image_output', 'image_output_price_per_image'],
+  ['audio_input', 'audio_input_price_per_second'],
+  ['audio_output', 'audio_output_price_per_second'],
+  ['video_input', 'video_input_price_per_second'],
+  ['video_output', 'video_output_price_per_second']
+]
+
+const listingDimensions = [
+  ['text_input', 'retail_input_price_per_million'],
+  ['text_output', 'retail_output_price_per_million'],
+  ['cache_input', 'retail_cache_input_price_per_million'],
+  ['image_output', 'retail_image_output_price_per_image'],
+  ['audio_input', 'retail_audio_input_price_per_second'],
+  ['audio_output', 'retail_audio_output_price_per_second'],
+  ['video_input', 'retail_video_input_price_per_second'],
+  ['video_output', 'retail_video_output_price_per_second']
+]
+
+export function buildPriceChangeRows({
+  channelHistory = [],
+  listingHistory = [],
+  priceItems = []
+} = {}) {
+  const rows = [
+    ...historyRows(channelHistory, {
+      type: 'channel',
+      dimensions: channelDimensions,
+      groupKey: (item) =>
+        [item.channel, item.model, item.offering || 'default'].join(':'),
+      context: (item) => item.offering_name || item.channel_name || '',
+      source: (item) => item.price_source_name || item.channel_name || ''
+    }),
+    ...historyRows(listingHistory, {
+      type: 'listing',
+      dimensions: listingDimensions,
+      groupKey: (item) =>
+        [item.platform, item.model, item.channel || 'automatic'].join(':'),
+      context: (item) => item.channel_name || item.platform_name || '',
+      source: (item) => item.platform_name || ''
+    }),
+    ...priceItems.map((item) => ({
+      key: `official-${item.id}-${item.dimension}`,
+      type: 'official',
+      modelId: item.model,
+      name: item.model_name || item.meta_model_name || '',
+      context: item.offering_exposed_model_name || item.sku_display_name || '',
+      source: item.source_name || item.provider_name || '',
+      dimension: item.dimension,
+      previous: null,
+      current: item.unit_price,
+      currency: item.currency,
+      time: item.effective_from || item.updated_at || item.created_at
+    }))
+  ]
+  return rows.sort(
+    (left, right) => new Date(right.time || 0) - new Date(left.time || 0)
+  )
+}
+
+export function priceChangeDelta(row) {
+  const previous = numericValue(row?.previous)
+  const current = numericValue(row?.current)
+  if (previous === null || current === null) return null
+  return current - previous
+}
+
+function historyRows(items, config) {
+  const groups = new Map()
+  items.forEach((item) => {
+    const key = config.groupKey(item)
+    const versions = groups.get(key) || []
+    versions.push(item)
+    groups.set(key, versions)
+  })
+
+  const rows = []
+  groups.forEach((versions) => {
+    versions.sort(
+      (left, right) => historyTime(right) - historyTime(left)
+    )
+    versions.forEach((item, index) => {
+      const previous = versions[index + 1] || null
+      config.dimensions.forEach(([dimension, field]) => {
+        if (!hasValue(item[field])) return
+        rows.push({
+          key: `${config.type}-${item.id}-${dimension}`,
+          type: config.type,
+          modelId: item.model,
+          name: item.model_name || item.meta_model_name || '',
+          context: config.context(item),
+          source: config.source(item),
+          dimension,
+          previous: previous?.[field] ?? null,
+          current: item[field],
+          currency: item.currency,
+          time: item.effective_from || item.created_at
+        })
+      })
+    })
+  })
+  return rows
+}
+
+function historyTime(item) {
+  return new Date(item?.effective_from || item?.created_at || 0).getTime()
+}
+
+function hasValue(value) {
+  return value !== null && value !== undefined && value !== ''
+}
+
+function numericValue(value) {
+  if (!hasValue(value)) return null
+  const number = Number(value)
+  return Number.isFinite(number) ? number : null
+}

--- a/frontend/tests/llmOpsConsoleConsistency.test.js
+++ b/frontend/tests/llmOpsConsoleConsistency.test.js
@@ -1,0 +1,142 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+import {
+  buildPriceChangeRows,
+  priceChangeDelta
+} from '../src/utils/llmOpsPriceChanges.js'
+
+function source(path) {
+  return readFileSync(new URL(path, import.meta.url), 'utf8')
+}
+
+const listingDisplaySource = source(
+  '../src/composables/useAgioneListingDisplay.js'
+)
+const globalConfigSource = source(
+  '../src/components/llm-ops/GlobalConfigPanel.vue'
+)
+const metaModelSource = source(
+  '../src/components/llm-ops/MetaModelManagement.vue'
+)
+const priceSourceModalSource = source(
+  '../src/components/llm-ops/PriceSourceModal.vue'
+)
+const healthSource = source(
+  '../src/components/llm-ops/CollectionHealthPanel.vue'
+)
+const pageSource = source('../src/pages/LLMOps.vue')
+
+test('builds distinguishable price changes for every pricing dimension', () => {
+  const rows = buildPriceChangeRows({
+    channelHistory: [
+      {
+        id: 2,
+        channel: 3,
+        channel_name: 'Channel A',
+        model: 7,
+        offering: 9,
+        price_source_name: 'Supplier A',
+        currency: 'CNY',
+        input_price_per_million: '2',
+        effective_from: '2026-08-21T02:00:00Z'
+      },
+      {
+        id: 1,
+        channel: 3,
+        channel_name: 'Channel A',
+        model: 7,
+        offering: 9,
+        price_source_name: 'Supplier A',
+        currency: 'CNY',
+        input_price_per_million: '1',
+        effective_from: '2026-08-20T02:00:00Z'
+      }
+    ],
+    listingHistory: [
+      {
+        id: 4,
+        platform: 6,
+        platform_name: 'Platform A',
+        model: 7,
+        channel: 3,
+        channel_name: 'Channel A',
+        currency: 'CNY',
+        retail_cache_input_price_per_million: '0.8',
+        effective_from: '2026-08-21T02:30:00Z'
+      },
+      {
+        id: 3,
+        platform: 6,
+        platform_name: 'Platform A',
+        model: 7,
+        channel: 3,
+        channel_name: 'Channel A',
+        currency: 'CNY',
+        retail_cache_input_price_per_million: '0.5',
+        effective_from: '2026-08-20T02:30:00Z'
+      }
+    ],
+    priceItems: [
+      {
+        id: 5,
+        model: 7,
+        model_name: 'Model A',
+        source_name: 'Official A',
+        dimension: 'cache_input',
+        currency: 'CNY',
+        unit_price: '0.2',
+        effective_from: '2026-08-21T03:00:00Z'
+      }
+    ]
+  })
+
+  const channel = rows.find(
+    (row) => row.type === 'channel' && row.dimension === 'text_input'
+  )
+  const official = rows.find((row) => row.type === 'official')
+  const listing = rows.find(
+    (row) => row.type === 'listing' && row.dimension === 'cache_input'
+  )
+  assert.equal(channel.previous, '1')
+  assert.equal(channel.current, '2')
+  assert.equal(channel.source, 'Supplier A')
+  assert.equal(priceChangeDelta(channel), 1)
+  assert.equal(official.dimension, 'cache_input')
+  assert.equal(official.current, '0.2')
+  assert.equal(official.source, 'Official A')
+  assert.equal(listing.previous, '0.5')
+  assert.equal(listing.current, '0.8')
+  assert.ok(Math.abs(priceChangeDelta(listing) - 0.3) < Number.EPSILON * 2)
+})
+
+test('labels listing KPIs as workflow scope and counts supply candidates', () => {
+  assert.match(listingDisplaySource, /workflowCandidates/)
+  assert.match(listingDisplaySource, /candidateModels/)
+})
+
+test('uses each parsed cron minute in schedule help and future edits', () => {
+  assert.doesNotMatch(globalConfigSource, /FIXED_SCHEDULE_MINUTE/)
+  assert.match(globalConfigSource, /schedule\.minute/)
+})
+
+test('does not combine filtered model totals with vendor-wide active totals', () => {
+  assert.doesNotMatch(metaModelSource, /selectedVendorActiveCount/)
+  assert.match(metaModelSource, /modelResult[\s\S]*?total: drawerTotal/)
+})
+
+test('shows the current sync source while an automatic source is edited', () => {
+  assert.match(priceSourceModalSource, /editingSyncSourceLabel/)
+  assert.match(priceSourceModalSource, /v-if="isEditing"/)
+})
+
+test('falls back to source latest status when recent runs are truncated', () => {
+  assert.match(healthSource, /source\.latest_run_status/)
+  assert.match(healthSource, /successRate === null/)
+})
+
+test('renders contextual loading skeletons for slow section data', () => {
+  assert.match(pageSource, /llm-ops-loading-skeleton/)
+  assert.match(pageSource, /loadingSectionLabel/)
+})

--- a/frontend/tests/llmOpsOperationEntry.test.js
+++ b/frontend/tests/llmOpsOperationEntry.test.js
@@ -83,7 +83,9 @@ test('applies assistant model targets to model-scoped LLM Ops sections', () => {
   assert.match(priceChangeSource, /focusModelId:/)
   assert.ok(
     priceChangeSource.indexOf('if (props.focusModelId)') <
-      priceChangeSource.indexOf('return rows.slice(0, 120)')
+      priceChangeSource.indexOf(
+        'allFilteredRows.value.slice(0, MAX_VISIBLE_ROWS)'
+      )
   )
   assert.doesNotMatch(priceChangeSource, /priceItems\.slice\(0, 80\)/)
   assert.match(


### PR DESCRIPTION
## Summary
- refresh dependent channel price items after automatic vendor and Yunce price collection
- expose dimension-level price history with source, previous/current value, and delta
- align listing KPIs, health freshness, cron minutes, filtered counts, automatic source edit state, and loading feedback
- add backend and frontend regression coverage for the corrected semantics

Closes #316

## Test plan
- [x] `.venv/bin/pytest -q backend/llm_ops/tests/test_source_collectors.py backend/llm_ops/tests/test_assistant_tools.py backend/llm_ops/tests/test_services.py backend/llm_ops/tests/test_views.py` (185 passed)
- [x] `npm run test:unit` (156 passed)
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `git diff --check`
- [x] ego-browser task space 9 verified the affected production baseline flows