### PR TITLE
fix(quotation): align numbering and draft revisions

### DIFF
--- a/backend/quotation/serializers.py
+++ b/backend/quotation/serializers.py
@@ -759,6 +759,11 @@ class QuotationSerializer(serializers.ModelSerializer):
 
 
 class QuotationCreateSerializer(serializers.Serializer):
+    numbering_mode = serializers.ChoiceField(
+        choices=("auto", "custom"),
+        required=False,
+        default="custom",
+    )
     quote_no = serializers.CharField(
         max_length=Quotation._meta.get_field("quote_no").max_length,
     )

--- a/backend/quotation/services/quotation_service.py
+++ b/backend/quotation/services/quotation_service.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 from decimal import ROUND_HALF_UP, Decimal
 from typing import Any, Iterable
 
@@ -210,6 +212,26 @@ def build_quotation(
             extended_price=item.get("extended_price") or 0,
         )
     return quotation
+
+
+def get_next_auto_quote_number(product_line: str, quote_date) -> str:
+    """Return the next globally unique number for a product line and date."""
+    base = (
+        f"{str(product_line or 'BDR').strip()}"
+        f"{quote_date.day:02d}{quote_date.month:02d}"
+        f"{quote_date.year % 100:02d}"
+    )
+    existing = set(
+        Quotation.objects.filter(
+            quote_no__regex=rf"^{re.escape(base)}(?:\.[0-9]+)?$",
+        ).values_list("quote_no", flat=True)
+    )
+    if base not in existing:
+        return base
+    suffix = 1
+    while f"{base}.{suffix}" in existing:
+        suffix += 1
+    return f"{base}.{suffix}"
 
 
 def replace_items(

--- a/backend/quotation/test_hardening.py
+++ b/backend/quotation/test_hardening.py
@@ -84,6 +84,34 @@ class QuotationBoundaryTests(TestCase):
         assert Decimal(response.data["vat_amount"]) == Decimal("18.00")
         assert Decimal(response.data["grand_total"]) == Decimal("198.00")
 
+    def test_auto_numbering_uses_quotes_created_by_other_users(self):
+        first_payload = quote_payload("ignored-by-auto-numbering")
+        first_payload["numbering_mode"] = "auto"
+        first = self.api.post(
+            "/api/v1/quotation/quotations",
+            first_payload,
+            format="json",
+        )
+        self.assertEqual(first.status_code, 201, first.data)
+        self.assertEqual(first.data["quote_no"], "BDR150726")
+
+        other = User.objects.create_user(
+            username="qa-hardening-other",
+            email="other@example.com",
+            password="password",
+        )
+        other_api = APIClient()
+        other_api.force_authenticate(user=other)
+        second_payload = quote_payload("also-ignored-by-auto-numbering")
+        second_payload["numbering_mode"] = "auto"
+        second = other_api.post(
+            "/api/v1/quotation/quotations",
+            second_payload,
+            format="json",
+        )
+        self.assertEqual(second.status_code, 201, second.data)
+        self.assertEqual(second.data["quote_no"], "BDR150726.1")
+
     def test_rejects_invalid_quantity_discount_price_and_vat_boundaries(self):
         invalid_values = [
             ("qty", "0", "10.00"),

--- a/backend/quotation/tests.py
+++ b/backend/quotation/tests.py
@@ -159,6 +159,44 @@ class QuotationVersionHistoryTests(TestCase):
         assert response.data["versions"] == []
         assert response.data["status"] == "generated"
 
+    def test_editing_draft_keeps_quote_number_and_has_no_version(self):
+        user = User.objects.create_user(
+            username="alice-draft-edit",
+            email="alice.chen@oneprocloud.com",
+            password="password",
+        )
+        quotation = build_quotation(
+            data=self._base_quote_data("BDR240826"),
+            items_data=[],
+        )
+        api = APIClient()
+        api.force_authenticate(user=user)
+        response = api.put(
+            f"/api/v1/quotation/quotations/{quotation.id}",
+            {
+                "quote_no": "BDR240826",
+                "status": "draft",
+                "project_name": "Edited draft",
+                "payment_terms": quotation.payment_terms,
+                "quote_date": str(quotation.quote_date),
+                "expire_date": str(quotation.expire_date),
+                "issuer_contact_name": quotation.issuer_contact_name,
+                "issuer_contact_email": quotation.issuer_contact_email,
+                "client_company": quotation.client_company,
+                "contact_person": quotation.contact_person,
+                "email": quotation.email,
+                "items": [],
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200
+        assert response.data["quote_no"] == "BDR240826"
+        assert response.data["versions"] == []
+        quotation.refresh_from_db()
+        assert quotation.quote_no == "BDR240826"
+        assert quotation.version_current == 0
+
     def test_generate_after_edit_does_not_duplicate_same_snapshot(self):
         user = User.objects.create_user(
             username="alice-generate-dedupe",

--- a/backend/quotation/views/quotations.py
+++ b/backend/quotation/views/quotations.py
@@ -49,6 +49,7 @@ from quotation.services.quotation_service import (
     build_quotation,
     calculate_totals,
     create_version_snapshot,
+    get_next_auto_quote_number,
     replace_items,
 )
 
@@ -257,12 +258,24 @@ class QuotationListCreateView(APIView):
         ser.is_valid(raise_exception=True)
         data = ser.validated_data
         data["created_by_email"] = user_display_email(request.user)
+        numbering_mode = data.pop("numbering_mode", "custom")
         items = data.pop("items", [])
-        try:
-            with transaction.atomic():
-                quotation = build_quotation(data=data, items_data=items)
-        except IntegrityError:
-            return Response({"detail": "quote_no already exists"}, status=409)
+        for attempt in range(3):
+            try:
+                with transaction.atomic():
+                    if numbering_mode == "auto":
+                        data["quote_no"] = get_next_auto_quote_number(
+                            data["product_line"],
+                            data["quote_date"],
+                        )
+                    quotation = build_quotation(data=data, items_data=items)
+                break
+            except IntegrityError:
+                if numbering_mode != "auto" or attempt == 2:
+                    return Response(
+                        {"detail": "quote_no already exists"},
+                        status=409,
+                    )
         quotation = Quotation.objects.prefetch_related(
             "items", "documents__replicas", "versions"
         ).get(pk=quotation.pk)
@@ -403,7 +416,32 @@ class QuotationDetailView(APIView):
                 items_changed = "items" in data
                 quotation.save()
                 skip_version = bool(data.get("skip_version"))
-                if not skip_version and (status_changed or items_changed):
+                draft_edit = (
+                    previous_status == QuoteStatus.DRAFT
+                    and quotation.status == QuoteStatus.DRAFT
+                )
+                revision_statuses = {
+                    QuoteStatus.UPLOADED,
+                    QuoteStatus.SENT,
+                    QuoteStatus.ACCEPTED,
+                    QuoteStatus.REJECTED,
+                    QuoteStatus.EXPIRED,
+                    QuoteStatus.CANCELLED,
+                }
+                if (
+                    not skip_version
+                    and not draft_edit
+                    and (
+                        (
+                            previous_status in revision_statuses
+                            and (status_changed or items_changed)
+                        )
+                        or (
+                            status_changed
+                            and quotation.status != QuoteStatus.DRAFT
+                        )
+                    )
+                ):
                     default_notes = (
                         f"Updated status to {data['status']}"
                         if status_changed

--- a/frontend/src/modules/quotation/App.vue
+++ b/frontend/src/modules/quotation/App.vue
@@ -666,10 +666,18 @@ async function handleSaveQuotation(newQuote: Quotation) {
     const wasCreate = !editingQuoteId.value
     const exists = Boolean(editingQuoteId.value)
     const willGenerate = ownedQuote.status === 'Generated'
+    const usesQuoteRevisions = [
+      'Uploaded',
+      'Sent',
+      'Accepted',
+      'Rejected',
+      'Expired',
+      'Cancelled',
+    ].includes(ownedQuote.status)
     let saved = exists
       ? await updateQuotationApi(ownedQuote, {
           notes: t('quotation.app.versionNotesEditQuote'),
-          skipVersion: willGenerate,
+          skipVersion: !usesQuoteRevisions,
         })
       : await createQuotationApi(ownedQuote)
 

--- a/frontend/src/modules/quotation/api/quotations.ts
+++ b/frontend/src/modules/quotation/api/quotations.ts
@@ -635,7 +635,10 @@ export async function getQuotationFormContext(
 export async function createQuotation(quote: Quotation): Promise<Quotation> {
   const created = await apiRequest<ApiQuotation>('/quotations', {
     method: 'POST',
-    body: JSON.stringify(mapQuotationToCreatePayload(quote)),
+    body: JSON.stringify({
+      ...mapQuotationToCreatePayload(quote),
+      numbering_mode: quote.quoteNoMode || 'custom',
+    }),
   });
   return mapApiQuotation(created);
 }

--- a/frontend/src/modules/quotation/components/QuotationCreate.vue
+++ b/frontend/src/modules/quotation/components/QuotationCreate.vue
@@ -248,12 +248,25 @@ const existingQuoteNumbers = computed(() =>
     : props.quotations.map((quote) => quote.quoteNo),
 )
 const quoteNoIsUnique = computed(() =>
-  isQuotationNumberUnique(quoteNo.value, props.quotations, props.editingQuote?.id),
+  quoteNoMode.value === 'auto'
+    || isQuotationNumberUnique(
+      quoteNo.value,
+      props.quotations,
+      props.editingQuote?.id,
+    ),
 )
 const draftSubmittedQuoteNo = computed(() =>
   props.editingQuote && quoteNoMode.value !== 'custom'
     ? props.editingQuote.quoteNo
     : quoteNo.value,
+)
+
+const editingQuoteUsesRevisions = computed(() =>
+  Boolean(
+    props.editingQuote &&
+      ['Uploaded', 'Sent', 'Accepted', 'Rejected', 'Expired', 'Cancelled']
+        .includes(props.editingQuote.status),
+  ),
 )
 
 const customerHistory = computed(() => buildCustomerHistory(historySourceQuotations.value))
@@ -302,8 +315,12 @@ const productLineSelectOptions = computed(() => [
 ])
 
 function regenerateQuoteNo(line = productLine.value, date = quoteDate.value) {
-  if (props.editingQuote) {
+  if (props.editingQuote && editingQuoteUsesRevisions.value) {
     quoteNo.value = getNextRevisionQuoteNumber(props.editingQuote.quoteNo, existingQuoteNumbers.value)
+    return
+  }
+  if (props.editingQuote) {
+    quoteNo.value = props.editingQuote.quoteNo
     return
   }
   quoteNo.value = getNextAutoQuoteNumber(line, dateFromInput(date), existingQuoteNumbers.value)
@@ -506,7 +523,9 @@ function loadEditingQuoteIntoForm(editingQuote: Quotation) {
   productLine.value =
     editingQuote.productLine ||
     inferProductLineFromQuoteNumber(editingQuote.quoteNo, props.productLineOptions)
-  quoteNo.value = getNextRevisionQuoteNumber(editingQuote.quoteNo, existingQuoteNumbers.value)
+  quoteNo.value = editingQuoteUsesRevisions.value
+    ? getNextRevisionQuoteNumber(editingQuote.quoteNo, existingQuoteNumbers.value)
+    : editingQuote.quoteNo
   projectName.value = editingQuote.projectName
   clientCompany.value = editingQuote.clientCompany
   contactPerson.value = editingQuote.contactPerson
@@ -659,6 +678,14 @@ function applyCreateDraft(draft: CreateQuoteDraft) {
     Array.isArray(draft.items) && draft.items.length > 0
       ? JSON.parse(JSON.stringify(draft.items))
       : items.value
+  if (quoteNoMode.value === 'auto') {
+    quoteNo.value = getNextAutoQuoteNumber(
+      productLine.value,
+      dateFromInput(quoteDate.value),
+      existingQuoteNumbers.value,
+    )
+    preferDraftQuoteNo.value = false
+  }
   window.setTimeout(() => {
     applyingCreateDraft.value = false
   }, 0)
@@ -952,6 +979,7 @@ function validateForm(status: 'Draft' | 'Generated') {
   }
   if (
     targetQuoteNo.trim() &&
+    quoteNoMode.value === 'custom' &&
     !isQuotationNumberUnique(targetQuoteNo, props.quotations, props.editingQuote?.id)
   ) {
     tempErrors.quoteNo = t('quotation.pages.create.errors.quoteNoDuplicate')
@@ -1035,6 +1063,7 @@ function handleSubmit(status: 'Draft' | 'Generated') {
   const newQuote: Quotation = {
     id: props.editingQuote ? props.editingQuote.id : `quote-${Date.now()}`,
     quoteNo: status === 'Draft' ? draftSubmittedQuoteNo.value : quoteNo.value,
+    quoteNoMode: quoteNoMode.value,
     productLine: productLine.value,
     productLineName: selectedProductLineOption.value?.label || '',
     projectName: projectName.value,
@@ -1180,7 +1209,7 @@ const itemErrorEntries = computed(() =>
                 <span class="text-xs font-bold text-dm-text-tertiary">
                   {{ t('quotation.pages.create.numberingSettings') }}
                 </span>
-                <span v-if="editingQuote" class="text-xs font-semibold text-dm-primary">
+                <span v-if="editingQuoteUsesRevisions" class="text-xs font-semibold text-dm-primary">
                   {{ t('quotation.pages.create.revisionAutoSuffix') }}
                 </span>
               </div>
@@ -1195,7 +1224,7 @@ const itemErrorEntries = computed(() =>
                       test-id="quote-product-line-select"
                       class-name="min-w-0 flex-1"
                       :model-value="productLine"
-                      :disabled="!!editingQuote && quoteNoMode === 'auto'"
+                      :disabled="editingQuoteUsesRevisions && quoteNoMode === 'auto'"
                       :options="productLineSelectOptions"
                       panel-class-name="qmp-dropdown-panel--product-line"
                       @update:model-value="onProductLineSelect"

--- a/frontend/src/modules/quotation/types.ts
+++ b/frontend/src/modules/quotation/types.ts
@@ -73,6 +73,7 @@ export interface QuoteVersion {
 export interface Quotation {
   id: string;
   quoteNo: string;
+  quoteNoMode?: 'auto' | 'custom';
   sourceType?: 'manual' | 'document_import';
   sourceDocumentType?: 'excel' | 'pdf';
   sourceDocument?: {


### PR DESCRIPTION
## Summary

- Generate quotation numbers on the backend across all users, using `.1`, `.2`, and later suffixes for same-day same-product quotes.
- Keep draft quotation numbers unchanged when a draft is edited or saved again.
- Start quotation revision numbering with `_R1` only after the quotation has entered the Feishu-uploaded lifecycle.
- Prevent draft edits from creating quotation version snapshots while preserving snapshots for formal status transitions and revisions.
- Add backend regression coverage for cross-user numbering and draft editing behavior.

## Test plan

- [x] Backend quotation tests: 41 passed
- [x] Frontend Quote Desk tests: 122 passed
- [x] Frontend unit tests: 156 passed
- [x] Vue TypeScript check passed
- [x] Vite production build passed
- [x] Python compilation passed
- [x] `git diff --check` passed
- [x] Ego Lite: same-day same-product numbering verified as `BDR240826`, `BDR240826.1`, and `BDR240826.2`
- [x] Ego Lite: draft edit preserved `BDR240826.2` without `_R1`

## Scope note

- No database schema changes or migrations.
- A test draft was created locally during browser verification and can be deleted from the quotation list.
- Feishu upload was not executed because the test user had no authorized upload directory.

## Integration note

- Branch is based on the latest `main`.
- This PR is intentionally non-Draft.