### PR TITLE
fix(quotation): refresh dates when editing quotes

### DIFF
--- a/frontend/src/modules/quotation/components/QuotationCreate.vue
+++ b/frontend/src/modules/quotation/components/QuotationCreate.vue
@@ -145,9 +145,8 @@ function formatDateInput(date: Date) {
   return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
 }
 
-function getDefaultExpireDate() {
-  const today = new Date()
-  return formatDateInput(new Date(today.getTime() + 30 * 24 * 60 * 60 * 1000))
+function getDefaultExpireDate(date = new Date()) {
+  return formatDateInput(new Date(date.getTime() + 30 * 24 * 60 * 60 * 1000))
 }
 
 const quoteNo = ref('')
@@ -546,8 +545,9 @@ function loadEditingQuoteIntoForm(editingQuote: Quotation) {
     loadedPaymentTermOption === 'Others' ? editingQuote.paymentTerms || '' : ''
   vatRateInput.value = formatVatRateForInput(editingQuote.vatRate)
   taxLabel.value = resolveTaxLabel(editingQuote.taxLabel)
-  quoteDate.value = editingQuote.quoteDate || formatDateInput(new Date())
-  expireDate.value = editingQuote.expireDate || getDefaultExpireDate()
+  const todayInput = formatDateInput(new Date())
+  quoteDate.value = todayInput
+  expireDate.value = getDefaultExpireDate(dateFromInput(todayInput))
   remarksDisclaimer.value = editingQuote.remarksDisclaimer ?? ''
   issuerCompanyName.value = editingQuote.issuerCompanyName ?? DEFAULT_ISSUER_COMPANY_NAME
   issuerContactName.value =
@@ -585,7 +585,7 @@ function resetCreateForm() {
   vatRateInput.value = ''
   taxLabel.value = DEFAULT_TAX_LABEL
   quoteDate.value = todayInput
-  expireDate.value = getDefaultExpireDate()
+  expireDate.value = getDefaultExpireDate(dateFromInput(todayInput))
   remarksDisclaimer.value = ''
   issuerCompanyName.value = DEFAULT_ISSUER_COMPANY_NAME
   issuerContactName.value = props.currentUser?.name ?? ''
@@ -766,6 +766,14 @@ watch(
     )
   },
 )
+
+watch(quoteDate, (nextDate, previousDate) => {
+  if (!previousDate || nextDate === previousDate) return
+  if (expireDate.value !== getDefaultExpireDate(dateFromInput(previousDate))) {
+    return
+  }
+  expireDate.value = getDefaultExpireDate(dateFromInput(nextDate))
+})
 
 watch(
   [


### PR DESCRIPTION
## Summary

- Refresh the quotation date to the current date when opening an existing quote for editing.
- Default the quotation validity date to 30 days after the current quotation date.
- Keep the validity date synchronized when the quotation date changes, unless the user has manually changed the validity date.

## Test plan

- [x] Frontend Quote Desk tests: 122 passed
- [x] Frontend unit tests: 156 passed
- [x] Vue TypeScript check passed
- [x] Vite production build passed
- [x] `git diff --check` passed
- [x] Ego Lite: editing an old quote refreshed the date to 2026-08-25 and validity to 2026-09-24
- [x] Ego Lite: changing the quote date refreshed the default validity date by 30 days
- [x] Ego Lite: manually changing validity preserved the custom date after changing the quote date

## Scope note

- Changes are limited to quotation edit-form date and validity behavior.
- No database schema changes or migrations.
- Existing manually selected validity dates are preserved.

## Integration note

- Branch is based on the latest `main`.
- No merge conflicts with the current open quotation copy PR (#323).
- This PR is intentionally non-Draft.