### PR TITLE
feat(quotation): remember contact title and persist line item additions

### DIFF
--- a/frontend/src/modules/quotation/App.vue
+++ b/frontend/src/modules/quotation/App.vue
@@ -66,6 +66,7 @@ import {
 } from './api/quotations'
 import { useAuthStore } from './stores/auth'
 import { useQuotationI18n } from './composables/useQuotationI18n'
+import { saveContactTitle } from './utils/contactTitleStorage'
 
 const auth = useAuthStore()
 const { t, quoteStatusLabel } = useQuotationI18n()
@@ -705,6 +706,8 @@ async function handleSaveQuotation(newQuote: Quotation) {
     if (wasCreate) {
       clearCreateQuoteDraft(auth.currentUser.email)
     }
+
+    saveContactTitle(auth.currentUser.email, ownedQuote.issuerContactTitle)
 
     if (willGenerate) {
       saved = await generateQuotationApi(saved.id, auth.currentUser.email)

--- a/frontend/src/modules/quotation/components/QuotationCreate.vue
+++ b/frontend/src/modules/quotation/components/QuotationCreate.vue
@@ -86,6 +86,7 @@ import {
   getBillingEmailOptions,
 } from '../utils/customerHistory'
 import { clearCurrentUserSignature, rememberUserSignature } from '../utils/signatureStorage'
+import { getSavedContactTitle } from '../utils/contactTitleStorage'
 import {
   loadCreateQuoteDraft,
   saveCreateQuoteDraft,
@@ -149,6 +150,10 @@ function getDefaultExpireDate(date = new Date()) {
   return formatDateInput(new Date(date.getTime() + 30 * 24 * 60 * 60 * 1000))
 }
 
+function getDefaultIssuerContactTitle() {
+  return getSavedContactTitle(props.currentUser?.email) || props.currentUser?.title || ''
+}
+
 const quoteNo = ref('')
 const quoteNoMode = ref<'auto' | 'custom'>('auto')
 const productLine = ref<QuoteProductLine>('BDR')
@@ -177,7 +182,7 @@ const remarksDisclaimer = ref('')
 const issuerCompanyName = ref(DEFAULT_ISSUER_COMPANY_NAME)
 const issuerContactName = ref(props.currentUser?.name ?? '')
 const issuerContactEmail = ref(props.currentUser?.email ?? '')
-const issuerContactTitle = ref(props.currentUser?.title ?? '')
+const issuerContactTitle = ref(getDefaultIssuerContactTitle())
 const issuerSignature = ref('')
 const previewWidthPercent = ref(DEFAULT_PREVIEW_WIDTH_PERCENT)
 const isAddingProductLine = ref(false)
@@ -590,7 +595,7 @@ function resetCreateForm() {
   issuerCompanyName.value = DEFAULT_ISSUER_COMPANY_NAME
   issuerContactName.value = props.currentUser?.name ?? ''
   issuerContactEmail.value = props.currentUser?.email ?? ''
-  issuerContactTitle.value = props.currentUser?.title ?? ''
+  issuerContactTitle.value = getDefaultIssuerContactTitle()
   issuerSignature.value = ''
   items.value = [
     {
@@ -672,7 +677,7 @@ function applyCreateDraft(draft: CreateQuoteDraft) {
   issuerContactEmail.value =
     draft.issuerContactEmail || props.currentUser?.email || ''
   issuerContactTitle.value =
-    draft.issuerContactTitle || props.currentUser?.title || ''
+    draft.issuerContactTitle || getDefaultIssuerContactTitle()
   issuerSignature.value = draft.issuerSignature || ''
   items.value =
     Array.isArray(draft.items) && draft.items.length > 0
@@ -1709,14 +1714,6 @@ const itemErrorEntries = computed(() =>
                 <Layers class="h-4 w-4 text-dm-text-tertiary" />
                 <h3 class="text-sm font-bold text-dm-text">{{ t('quotation.pages.create.step4Title') }}</h3>
               </div>
-              <button
-                type="button"
-                class="flex cursor-pointer items-center gap-1 rounded-md border border-dashed border-blue-400 px-2.5 py-1.5 text-sm font-semibold text-dm-primary transition duration-150 hover:bg-dm-primary-bg/50"
-                @click="handleAddLineItem"
-              >
-                <Plus class="h-3.5 w-3.5" />
-                {{ t('quotation.actions.addLineItem') }}
-              </button>
             </div>
 
             <div
@@ -1892,6 +1889,17 @@ const itemErrorEntries = computed(() =>
                   </div>
                 </div>
               </div>
+            </div>
+
+            <div class="border-t border-dm-border-light pt-3">
+              <button
+                type="button"
+                class="flex w-full cursor-pointer items-center justify-center gap-1.5 rounded-lg border border-dashed border-blue-200 bg-blue-50/40 px-4 py-2.5 text-sm font-semibold text-dm-primary transition duration-150 hover:border-blue-300 hover:bg-blue-50"
+                @click="handleAddLineItem"
+              >
+                <Plus class="h-4 w-4" />
+                {{ t('quotation.actions.addLineItem') }}
+              </button>
             </div>
           </div>
         </div>

--- a/frontend/src/modules/quotation/utils/contactTitleStorage.ts
+++ b/frontend/src/modules/quotation/utils/contactTitleStorage.ts
@@ -1,0 +1,31 @@
+const CONTACT_TITLE_STORAGE_PREFIX = 'qmp_user_contact_title_'
+
+function storageKey(email: string): string {
+  return `${CONTACT_TITLE_STORAGE_PREFIX}${email.trim().toLowerCase()}`
+}
+
+export function getSavedContactTitle(email?: string | null): string {
+  if (!email || typeof window === 'undefined') return ''
+
+  try {
+    return localStorage.getItem(storageKey(email))?.trim() || ''
+  } catch {
+    return ''
+  }
+}
+
+export function saveContactTitle(
+  email: string | null | undefined,
+  title: string | null | undefined,
+): void {
+  if (!email || typeof window === 'undefined') return
+
+  const normalizedTitle = title?.trim() || ''
+  if (!normalizedTitle) return
+
+  try {
+    localStorage.setItem(storageKey(email), normalizedTitle)
+  } catch {
+    // Ignore storage failures and keep quotation saving successful.
+  }
+}

--- a/frontend/src/modules/quotation/utils/createDraftStorage.ts
+++ b/frontend/src/modules/quotation/utils/createDraftStorage.ts
@@ -62,7 +62,10 @@ export function isCreateQuoteDraftMeaningful(
   ) {
     return true;
   }
-  return (draft.items || []).some(
+  const items = draft.items || [];
+  if (items.length > 1) return true;
+
+  return items.some(
     (item) =>
       Boolean(item.description?.trim() || item.name?.trim() || item.itemId?.trim()) ||
       Number(item.listPrice) > 0 ||


### PR DESCRIPTION
## Summary

- Remember the latest saved Contact Title per user and prefill it for new quotations.
- Keep the add-line-item action at the bottom of Step 4 for easier repeated use.
- Preserve an added blank line item across refresh by treating multiple draft rows as meaningful.

## Verification

- `npm run test:quotation` — 123 passed.
- `npm run test:unit` — 152 passed; 2 environment dependency failures because `vue` and `@intlify/message-compiler` are unavailable in this checkout.
- `npm run typecheck` — unavailable because `vue-tsc` is not installed.
- `npm run build` — unavailable because `vite` is not installed.
- `git diff --check` — passed.

No issue is linked to this standalone UX fix.