### PR TITLE
Improve LLM Ops overview and meta-model price coverage

### DIFF
--- a/backend/llm_ops/serializers.py
+++ b/backend/llm_ops/serializers.py
@@ -644,6 +644,18 @@ class MetaModelSerializer(serializers.ModelSerializer):
         read_only=True,
         required=False,
     )
+    current_price_source_count = serializers.IntegerField(
+        read_only=True,
+        required=False,
+    )
+    current_price_item_count = serializers.IntegerField(
+        read_only=True,
+        required=False,
+    )
+    current_priced_sku_count = serializers.IntegerField(
+        read_only=True,
+        required=False,
+    )
     release_date = serializers.SerializerMethodField()
 
     class Meta:

--- a/backend/llm_ops/tests/test_views.py
+++ b/backend/llm_ops/tests/test_views.py
@@ -4163,6 +4163,75 @@ class LLMOpsViewTests(TestCase):
         self.assertIn("decision_status", diagnostic)
         self.assertIn("yield_metrics", diagnostic)
 
+    def test_summary_monitor_scope_returns_platform_overview_metrics(self):
+        provider = LLMProvider.objects.create(
+            name="Overview Provider",
+            code="overview-provider",
+        )
+        model = LLMModel.objects.create(
+            provider=provider,
+            name="Overview Model",
+            code="overview-model",
+            input_price_per_million="10",
+            output_price_per_million="20",
+        )
+        channel = ProcurementChannel.objects.create(
+            name="Overview Channel",
+            code="overview-channel",
+        )
+        source = PriceCollectionSource.objects.create(
+            name="Overview Source",
+            slug="overview-source",
+            is_enabled=True,
+        )
+        platform = ResalePlatform.objects.create(
+            code="overview-platform",
+            name="Overview Platform",
+            fee_rate="0.05",
+            service_fee_rate="0.02",
+            tax_rate="0.06",
+            settlement_rate="0.95",
+            yield_warning="0.15",
+        )
+        ChannelModelPrice.objects.create(
+            channel=channel,
+            model=model,
+            price_source=source,
+            is_listed=True,
+            custom_input_price_per_million="10",
+            custom_output_price_per_million="20",
+        )
+        self._create_online_listing(
+            platform=platform,
+            model=model,
+            channel=channel,
+            retail_input_price_per_million="20",
+            retail_output_price_per_million="40",
+        )
+
+        response = self.client.get(
+            reverse("llm-ops-summary"),
+            {"resale_platform": platform.id, "scope": "monitor"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        overview = response.data["agione"]["overview"]
+        self.assertEqual(overview["meta_models"], 1)
+        self.assertEqual(overview["enabled_price_sources"], 1)
+        self.assertEqual(overview["active_channels"], 1)
+        self.assertEqual(overview["active_listings"], 1)
+        self.assertEqual(overview["risk_points"], 1)
+        self.assertAlmostEqual(overview["overall_yield"], 0.395)
+        self.assertEqual(overview["active_model_skus"], 1)
+        self.assertEqual(overview["operational_models"], 1)
+        self.assertEqual(overview["channel_coverage_rate"], 1.0)
+        self.assertEqual(overview["listing_coverage_rate"], 1.0)
+        self.assertEqual(overview["unlisted_models"], 0)
+        self.assertAlmostEqual(overview["median_yield"], 0.395)
+        self.assertEqual(overview["unresolved_yield_models"], 0)
+        self.assertEqual(overview["healthy_price_sources"], 0)
+        self.assertEqual(overview["price_source_health_rate"], 0.0)
+
     def test_summary_separates_market_reference_from_operational_models(self):
         provider = LLMProvider.objects.create(
             name="Reference Provider",

--- a/backend/llm_ops/views.py
+++ b/backend/llm_ops/views.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import timedelta
 from decimal import Decimal
 
 import requests
@@ -1109,6 +1110,21 @@ class MetaModelViewSet(
         queryset = (
             MetaModel.objects.annotate(
                 provider_price_count=Count("provider_prices"),
+                current_price_source_count=Count(
+                    "price_items__source_id",
+                    distinct=True,
+                    filter=Q(price_items__is_current=True),
+                ),
+                current_price_item_count=Count(
+                    "price_items",
+                    distinct=True,
+                    filter=Q(price_items__is_current=True),
+                ),
+                current_priced_sku_count=Count(
+                    "price_items__sku_id",
+                    distinct=True,
+                    filter=Q(price_items__is_current=True),
+                ),
             )
             .exclude(
                 owner_code__in=SUPPLIER_SOURCE_OWNER_ALIASES.keys(),
@@ -4715,6 +4731,70 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
             monitor_diagnostics = [
                 _monitor_diagnostic_payload(item) for item in diagnostics
             ]
+            operational_diagnostics = [
+                item
+                for item in diagnostics
+                if item["operation_scope"] == OPERATION_SCOPE_OPERATIONAL
+            ]
+            yield_values = [
+                Decimal(str(value))
+                for item in operational_diagnostics
+                for value in (
+                    item["yield_metrics"]["input_yield"],
+                    item["yield_metrics"]["output_yield"],
+                )
+                if value is not None
+            ]
+            overall_yield = (
+                sum(yield_values) / len(yield_values)
+                if yield_values
+                else None
+            )
+            sorted_yields = sorted(yield_values)
+            midpoint = len(sorted_yields) // 2
+            median_yield = None
+            if sorted_yields:
+                median_yield = sorted_yields[midpoint]
+                if len(sorted_yields) % 2 == 0:
+                    median_yield = (
+                        sorted_yields[midpoint - 1] + median_yield
+                    ) / Decimal("2")
+            enabled_price_sources = list(
+                PriceCollectionSource.objects.filter(is_enabled=True)
+                .exclude(
+                    source_type=PriceCollectionSource.SOURCE_TYPE_AGIONE,
+                )
+                .only("id", "last_collected_at")
+            )
+            healthy_price_sources = sum(
+                1
+                for source in enabled_price_sources
+                if (
+                    source.last_collected_at
+                    and source.last_collected_at
+                    >= timezone.now() - timedelta(days=7)
+                )
+            )
+            operational_model_count = len(operational_diagnostics)
+            models_with_channel = sum(
+                1
+                for item in operational_diagnostics
+                if item["coverage_count"] > 0
+            )
+            listed_models = sum(
+                1
+                for item in operational_diagnostics
+                if item["current_listing"]
+                and item["current_listing"]["is_listed"]
+            )
+            unresolved_yield_models = sum(
+                1
+                for item in operational_diagnostics
+                if (
+                    item["yield_metrics"]["input_yield"] is None
+                    and item["yield_metrics"]["output_yield"] is None
+                )
+            )
             return Response(
                 {
                     "scope": "monitor",
@@ -4726,6 +4806,52 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
                         "platform_name": (
                             selected_platform.name if selected_platform else ""
                         ),
+                        "overview": {
+                            "active_model_skus": len(models),
+                            "meta_models": MetaModel.objects.filter(
+                                status=MetaModel.STATUS_ACTIVE,
+                            ).count(),
+                            "enabled_price_sources": len(
+                                enabled_price_sources,
+                            ),
+                            "active_channels": len(channels),
+                            "active_listings": len(active_listings),
+                            "operational_models": operational_model_count,
+                            "channel_coverage_rate": _as_optional_float(
+                                Decimal(models_with_channel)
+                                / operational_model_count
+                                if operational_model_count
+                                else None,
+                            ),
+                            "listing_coverage_rate": _as_optional_float(
+                                Decimal(listed_models)
+                                / operational_model_count
+                                if operational_model_count
+                                else None,
+                            ),
+                            "unlisted_models": (
+                                operational_model_count - listed_models
+                            ),
+                            "overall_yield": _as_optional_float(
+                                overall_yield,
+                            ),
+                            "median_yield": _as_optional_float(median_yield),
+                            "unresolved_yield_models": (
+                                unresolved_yield_models
+                            ),
+                            "healthy_price_sources": healthy_price_sources,
+                            "price_source_health_rate": _as_optional_float(
+                                Decimal(healthy_price_sources)
+                                / len(enabled_price_sources)
+                                if enabled_price_sources
+                                else None,
+                            ),
+                            "risk_points": sum(
+                                1
+                                for item in operational_diagnostics
+                                if item["decision_priority"] < 8
+                            ),
+                        },
                         "diagnostics": monitor_diagnostics,
                     },
                 }

--- a/frontend/src/components/llm-ops/LLMOpsMonitorDashboard.vue
+++ b/frontend/src/components/llm-ops/LLMOpsMonitorDashboard.vue
@@ -1,31 +1,110 @@
 <template>
   <section class="space-y-4">
-    <div
-      class="queue-summary-grid"
-      :aria-label="t('llmOps.overview.queueSummaryLabel')"
-    >
-      <button
-        v-for="item in kpiCards"
-        :key="item.key"
-        type="button"
-        :aria-pressed="simulationStatus === item.filter"
-        :class="[
-          'queue-summary-card',
-          item.tone,
-          { 'is-active': simulationStatus === item.filter }
-        ]"
-        @click="simulationStatusModel = item.filter"
-      >
-        <span class="queue-summary-label">{{ item.label }}</span>
-        <strong class="queue-summary-value">{{ item.value }}</strong>
-      </button>
+    <div class="overview-intro">
+      <div>
+        <p class="overview-kicker">{{ t('llmOps.overview.kicker') }}</p>
+        <h2 class="overview-title">{{ t('llmOps.overview.title') }}</h2>
+        <p class="overview-subtitle">{{ t('llmOps.overview.subtitle') }}</p>
+      </div>
+      <span class="overview-live-dot">{{ t('llmOps.overview.live') }}</span>
+      <div class="overview-key-metrics">
+        <button
+          v-for="item in headlineKpiCards"
+          :key="item.key"
+          type="button"
+          :class="['headline-metric', item.tone]"
+          @click="handleKpiClick(item)"
+        >
+          <strong>{{ item.value }}</strong>
+          <span>{{ item.label }}</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="overview-insight-grid">
+      <section class="insight-panel">
+        <div class="insight-heading">
+          <div>
+            <p class="insight-eyebrow">{{ t('llmOps.overview.insights.healthEyebrow') }}</p>
+            <h3>{{ t('llmOps.overview.insights.healthTitle') }}</h3>
+          </div>
+          <span class="insight-value">{{ healthScore }}%</span>
+        </div>
+        <div class="health-track"><span :style="{ width: `${healthScore}%` }" /></div>
+        <div class="health-legend">
+          <span><i class="legend-dot success" />{{ t('llmOps.overview.insights.covered') }} {{ coveredCount }}</span>
+          <span><i class="legend-dot warn" />{{ t('llmOps.overview.insights.unlisted') }} {{ unlistedCount }}</span>
+          <span><i class="legend-dot danger" />{{ t('llmOps.overview.insights.risk') }} {{ riskCount }}</span>
+        </div>
+      </section>
+
+      <section class="insight-panel">
+        <div class="insight-heading">
+          <div>
+            <p class="insight-eyebrow">{{ t('llmOps.overview.insights.channelEyebrow') }}</p>
+            <h3>{{ t('llmOps.overview.insights.channelTitle') }}</h3>
+          </div>
+          <button class="insight-link" type="button" @click="emit('navigateToSection', 'channelMatrix')">
+            {{ t('llmOps.overview.insights.viewDetails') }}
+          </button>
+        </div>
+        <div v-if="channelBreakdown.length" class="channel-breakdown">
+          <div v-for="item in channelBreakdown" :key="item.name" class="channel-row">
+            <span>{{ item.name }}</span><strong>{{ item.count }}</strong>
+            <span class="channel-bar"><i :style="{ width: `${item.percent}%` }" /></span>
+          </div>
+        </div>
+        <p v-else class="insight-empty">{{ t('llmOps.overview.insights.noChannelData') }}</p>
+      </section>
+    </div>
+
+    <div class="overview-density-grid">
+      <section class="density-panel">
+        <div class="density-heading">
+          <div>
+            <p class="insight-eyebrow">{{ t('llmOps.overview.insights.structureEyebrow') }}</p>
+            <h3>{{ t('llmOps.overview.insights.structureTitle') }}</h3>
+          </div>
+        </div>
+        <div class="structure-grid">
+          <div v-for="item in structureStats" :key="item.label" class="structure-item">
+            <span>{{ item.label }}</span>
+            <strong>{{ item.value }}</strong>
+            <small>{{ item.hint }}</small>
+          </div>
+        </div>
+      </section>
+
+      <section class="density-panel">
+        <div class="density-heading">
+          <div>
+            <p class="insight-eyebrow">{{ t('llmOps.overview.insights.riskEyebrow') }}</p>
+            <h3>{{ t('llmOps.overview.insights.riskTitle') }}</h3>
+          </div>
+          <span class="risk-total">{{ riskCount }}</span>
+        </div>
+        <div class="risk-breakdown">
+          <button v-for="item in riskBreakdown" :key="item.key" type="button" class="risk-row" @click="simulationStatusModel = item.filter">
+            <span class="risk-mark" :class="item.tone" />
+            <span>{{ item.label }}</span>
+            <strong>{{ item.count }}</strong>
+          </button>
+        </div>
+      </section>
     </div>
 
     <div class="panel overflow-hidden p-0">
       <div class="table-toolbar gap-3">
-        <h3 class="panel-title">
-          {{ t('llmOps.overview.decisionTable.title') }}
-        </h3>
+        <div>
+          <h3 class="panel-title">
+            {{ t('llmOps.overview.decisionTable.title') }}
+          </h3>
+          <p class="yield-tip">
+            <strong>{{ t('llmOps.overview.yieldTip.label') }}</strong>
+            {{ t('llmOps.overview.yieldTip.formula') }}
+            <span>{{ t('llmOps.overview.yieldTip.requirement') }}</span>
+          </p>
+        </div>
         <div
           class="decision-filter-group"
           :aria-label="t('llmOps.overview.filters.label')"
@@ -63,8 +142,8 @@
               <th class="table-head">
                 {{ t('llmOps.overview.columns.yield') }}
               </th>
-              <th class="table-head">
-                {{ t('llmOps.overview.columns.decision') }}
+              <th class="table-head min-w-72">
+                {{ t('llmOps.overview.columns.recommendation') }}
               </th>
               <th class="table-head">
                 {{ t('llmOps.overview.columns.lastUpdate') }}
@@ -113,10 +192,19 @@
               <td class="table-cell min-w-36">
                 <PricePair :rows="yieldRows(row)" />
               </td>
-              <td class="table-cell min-w-52">
-                <span :class="['status-pill', row.status_tone]">
-                  {{ statusTitle(row) }}
-                </span>
+              <td class="table-cell min-w-72">
+                <div class="decision-advice">
+                  <div class="decision-advice-head">
+                    <span :class="['status-pill', row.status_tone]">
+                      {{ statusTitle(row) }}
+                    </span>
+                    <span class="decision-priority">
+                      {{ decisionPriorityLabel(row) }}
+                    </span>
+                  </div>
+                  <p class="decision-reason">{{ decisionReason(row) }}</p>
+                  <p class="decision-impact">{{ decisionImpact(row) }}</p>
+                </div>
                 <button
                   type="button"
                   class="decision-action-button"
@@ -188,11 +276,58 @@ const props = defineProps({
 
 const emit = defineEmits([
   'navigateToSection',
-  'navigateToWorkspace',
   'update:simulationStatus'
 ])
 
 const { t } = useI18n()
+
+const headlineKpiKeys = new Set([
+  'active_model_skus',
+  'channel_coverage_rate',
+  'listing_coverage_rate',
+  'overall_yield',
+  'risk_points'
+])
+
+const headlineKpiCards = computed(() =>
+  props.kpiCards.filter((item) => headlineKpiKeys.has(item.key))
+)
+
+const coveredCount = computed(() => props.monitorTableRows.filter((row) => Number(row.coverage_count || 0) > 0).length)
+const unlistedCount = computed(() => props.monitorTableRows.filter((row) => !row.current_listing?.is_listed).length)
+const riskCount = computed(() => props.monitorTableRows.filter((row) => Number(row.decision_priority ?? 8) < 8).length)
+const healthScore = computed(() => {
+  const total = props.monitorTableRows.length
+  if (!total) return 0
+  return Math.round((coveredCount.value / total) * 100)
+})
+const channelBreakdown = computed(() => {
+  const counts = new Map()
+  props.monitorTableRows.forEach((row) => {
+    const name = row.recommended_channel?.channel_name || t('llmOps.overview.insights.unassigned')
+    counts.set(name, (counts.get(name) || 0) + 1)
+  })
+  const max = Math.max(...counts.values(), 1)
+  return [...counts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 4).map(([name, count]) => ({ name, count, percent: Math.round((count / max) * 100) }))
+})
+
+const structureStats = computed(() => [
+  { label: t('llmOps.overview.insights.models'), value: props.monitorTableRows.length, hint: t('llmOps.overview.insights.modelsHint') },
+  { label: t('llmOps.overview.insights.providers'), value: new Set(props.monitorTableRows.map((row) => row.provider_name).filter(Boolean)).size, hint: t('llmOps.overview.insights.providersHint') },
+  { label: t('llmOps.overview.insights.channels'), value: new Set(props.monitorTableRows.map((row) => row.recommended_channel?.channel_name).filter(Boolean)).size, hint: t('llmOps.overview.insights.channelsHint') },
+  { label: t('llmOps.overview.insights.listed'), value: props.monitorTableRows.filter((row) => row.current_listing?.is_listed).length, hint: t('llmOps.overview.insights.listedHint') }
+])
+
+const riskBreakdown = computed(() => {
+  const rows = props.monitorTableRows
+  const count = (predicate) => rows.filter(predicate).length
+  return [
+    { key: 'unlisted', label: t('llmOps.overview.kpi.unlistedModels.label'), count: count((row) => !row.current_listing?.is_listed), filter: 'unlisted', tone: 'warn' },
+    { key: 'yield', label: t('llmOps.overview.kpi.unresolvedYieldModels.label'), count: count((row) => row.input_yield == null && row.output_yield == null), filter: 'priority', tone: 'info' },
+    { key: 'channel', label: t('llmOps.overview.kpi.missingChannel.label'), count: count((row) => Number(row.coverage_count || 0) === 0), filter: 'no_supply', tone: 'danger' },
+    { key: 'decision', label: t('llmOps.overview.kpi.needsAction.label'), count: count((row) => Number(row.decision_priority ?? 8) < 8), filter: 'priority', tone: 'danger' }
+  ]
+})
 
 const simulationStatusModel = computed({
   get: () => props.simulationStatus,
@@ -216,19 +351,18 @@ function handleRowClick(row) {
     })
     return
   }
-  if (!isOperationalRow(row)) {
-    emit('navigateToSection', {
-      modelId: row.model_id,
-      section: 'modelWorkbench'
-    })
+  emit('navigateToSection', {
+    modelId: row.model_id,
+    section: 'modelWorkbench'
+  })
+}
+
+function handleKpiClick(item) {
+  if (item.section) {
+    emit('navigateToSection', item.section)
     return
   }
-  emit('navigateToWorkspace', {
-    autoListing: Boolean(
-      row.current_listing?.is_listed && row.current_listing.channel_id === null
-    ),
-    modelId: row.model_id
-  })
+  if (item.filter) simulationStatusModel.value = item.filter
 }
 
 function handleDataEvent(type) {
@@ -265,6 +399,23 @@ function percent(value) {
 function statusTitle(row) {
   const key = `llmOps.decision.status.${row.decision_status || 'ready'}`
   return t(key)
+}
+
+function decisionPriorityLabel(row) {
+  const priority = Number(row.decision_priority ?? 8)
+  if (priority <= 2) return t('llmOps.overview.priority.urgent')
+  if (priority <= 5) return t('llmOps.overview.priority.attention')
+  return t('llmOps.overview.priority.normal')
+}
+
+function decisionReason(row) {
+  return t(`llmOps.overview.advice.${row.decision_status || 'ready'}.reason`, {
+    channels: Number(row.coverage_count || 0)
+  })
+}
+
+function decisionImpact(row) {
+  return t(`llmOps.overview.advice.${row.decision_status || 'ready'}.impact`)
 }
 
 function rowAriaLabel(row) {
@@ -424,33 +575,120 @@ function relativeTime(value) {
 </script>
 
 <style scoped>
-.queue-summary-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.75rem;
-}
-.queue-summary-card {
+.overview-intro {
+  position: relative;
+  overflow: hidden;
   display: flex;
-  min-height: 8.75rem;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 1rem;
+  border: 1px solid #dbeafe;
+  border-radius: 1.5rem;
+  background: radial-gradient(circle at 0% 0%, rgba(16,185,129,.15), transparent 38%), radial-gradient(circle at 100% 100%, rgba(14,165,233,.13), transparent 42%), linear-gradient(135deg, rgba(255,255,255,.98), rgba(248,250,252,.98));
+  box-shadow: 0 24px 60px -42px rgba(15,23,42,.45);
+  padding: 1.5rem 1.75rem;
+}
+.overview-key-metrics {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  width: min(100%, 48rem);
+  margin-left: auto;
+  border-left: 1px solid #dbeafe;
+}
+.headline-metric {
+  min-width: 0;
+  padding: .2rem .85rem;
+  border-right: 1px solid #dbeafe;
+  color: var(--ui-text-secondary);
+  text-align: left;
+}
+.headline-metric strong { display: block; color: var(--ui-text-primary); font-size: 1.45rem; letter-spacing: -.04em; }
+.headline-metric span { display: block; margin-top: .2rem; font-size: .68rem; line-height: 1.25; }
+.headline-metric.warn strong { color: #b45309; }
+.headline-metric.danger strong { color: #dc2626; }
+.overview-kicker {
+  color: #059669;
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+.overview-title {
+  margin-top: 0.2rem;
+  color: var(--ui-text-primary);
+  font-size: 1.8rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+}
+.overview-subtitle {
+  margin-top: 0.25rem;
+  color: var(--ui-text-secondary);
+  font-size: 0.82rem;
+}
+.overview-live-dot {
+  border: 1px solid #a7f3d0;
+  border-radius: 999px;
+  background: #ecfdf5;
+  color: #047857;
+  font-size: 0.68rem;
+  font-weight: 700;
+  padding: 0.35rem 0.65rem;
+  text-transform: uppercase;
+}
+.overview-insight-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+.insight-panel {
   border: 1px solid var(--ui-border-default);
-  border-left: 0.2rem solid var(--ui-color-primary);
   border-radius: var(--ui-radius-card);
   background: var(--ui-bg-card);
-  padding: var(--ui-space-card);
-  color: var(--ui-text-primary);
-  text-align: left;
-  transition:
-    border-color 0.16s ease,
-    background 0.16s ease;
+  padding: 1rem 1.1rem;
 }
+.insight-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 1rem; }
+.insight-eyebrow { color: var(--ui-text-muted); font-size: 0.67rem; font-weight: 800; letter-spacing: 0.1em; text-transform: uppercase; }
+.insight-heading h3 { margin-top: 0.2rem; color: var(--ui-text-primary); font-size: 0.95rem; font-weight: 700; }
+.insight-value { color: var(--ui-color-primary); font-size: 1.45rem; font-weight: 750; }
+.health-track { height: 0.45rem; margin-top: 1rem; overflow: hidden; border-radius: 999px; background: var(--ui-bg-muted); }
+.health-track span { display: block; height: 100%; border-radius: inherit; background: var(--ui-color-success); }
+.health-legend { display: flex; flex-wrap: wrap; gap: 0.8rem; margin-top: 0.8rem; color: var(--ui-text-secondary); font-size: 0.72rem; }
+.legend-dot { display: inline-block; width: 0.45rem; height: 0.45rem; margin-right: 0.3rem; border-radius: 50%; }
+.legend-dot.success { background: var(--ui-color-success); }
+.legend-dot.warn { background: var(--ui-color-warning); }
+.legend-dot.danger { background: var(--ui-color-destructive); }
+.insight-link { color: var(--ui-color-primary); font-size: 0.72rem; font-weight: 700; }
+.insight-link:hover { text-decoration: underline; }
+.channel-breakdown { display: grid; gap: 0.65rem; margin-top: 1rem; }
+.channel-row { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 0.5rem; color: var(--ui-text-secondary); font-size: 0.75rem; }
+.channel-row strong { color: var(--ui-text-primary); }
+.channel-bar { grid-column: 1 / -1; height: 0.28rem; overflow: hidden; border-radius: 999px; background: var(--ui-bg-muted); }
+.channel-bar i { display: block; height: 100%; border-radius: inherit; background: var(--ui-color-primary); }
+.insight-empty { margin-top: 1rem; color: var(--ui-text-muted); font-size: 0.78rem; }
+.overview-density-grid { display: grid; grid-template-columns: 1.2fr .8fr; gap: .75rem; }
+.density-panel { border: 1px solid #e5e7eb; border-radius: 1.15rem; background: #fff; padding: 1.1rem 1.2rem; box-shadow: 0 12px 28px -24px rgba(15,23,42,.45); }
+.density-heading { display: flex; align-items: flex-start; justify-content: space-between; }
+.density-heading h3 { margin-top: .2rem; color: var(--ui-text-primary); font-size: .95rem; font-weight: 700; }
+.structure-grid { display: grid; grid-template-columns: repeat(4, minmax(0,1fr)); gap: .6rem; margin-top: 1rem; }
+.structure-item { border-left: 2px solid #d1fae5; padding-left: .7rem; }
+.structure-item span, .structure-item small { display: block; color: var(--ui-text-muted); font-size: .7rem; }
+.structure-item strong { display: block; margin: .25rem 0; color: var(--ui-text-primary); font-size: 1.45rem; }
+.risk-total { color: #dc2626; font-size: 1.45rem; font-weight: 750; }
+.risk-breakdown { display: grid; gap: .25rem; margin-top: .75rem; }
+.risk-row { display: grid; grid-template-columns: auto 1fr auto; align-items: center; gap: .6rem; border-radius: .55rem; padding: .5rem .35rem; color: var(--ui-text-secondary); font-size: .78rem; text-align: left; }
+.risk-row:hover { background: #f8fafc; }
+.risk-row strong { color: var(--ui-text-primary); }
+.risk-mark { width: .5rem; height: .5rem; border-radius: 50%; background: #94a3b8; }
+.risk-mark.warn { background: #f59e0b; }
+.risk-mark.danger { background: #ef4444; }
+.risk-mark.info { background: #38bdf8; }
 .queue-summary-card:hover,
 .queue-summary-card:focus-visible,
 .queue-summary-card.is-active {
-  border-color: var(--ui-color-primary);
-  background: var(--ui-color-primary-subtle);
+  border-color: #bae6fd;
+  background: #f8fafc;
+  box-shadow: 0 18px 34px -24px rgba(15,23,42,.5);
+  transform: translateY(-2px);
   outline: none;
 }
 .queue-summary-card.danger {
@@ -479,6 +717,15 @@ function relativeTime(value) {
   border-radius: 0.5rem;
   background: var(--ui-bg-card);
 }
+.yield-tip {
+  max-width: 48rem;
+  margin-top: .35rem;
+  color: var(--ui-text-secondary);
+  font-size: .72rem;
+  line-height: 1.5;
+}
+.yield-tip strong { color: var(--ui-text-primary); }
+.yield-tip span { color: var(--ui-text-muted); }
 .decision-filter-button {
   min-height: 2rem;
   padding: 0.35rem 0.75rem;
@@ -551,6 +798,11 @@ function relativeTime(value) {
   font-weight: 600;
   text-align: left;
 }
+.decision-advice { display: grid; gap: .35rem; }
+.decision-advice-head { display: flex; align-items: center; gap: .5rem; }
+.decision-priority { color: var(--ui-text-muted); font-size: .68rem; font-weight: 650; }
+.decision-reason { color: var(--ui-text-primary); font-size: .78rem; font-weight: 600; line-height: 1.4; }
+.decision-impact { color: var(--ui-text-secondary); font-size: .72rem; line-height: 1.4; }
 .decision-action-button:hover,
 .decision-action-button:focus-visible {
   text-decoration: underline;
@@ -584,8 +836,12 @@ function relativeTime(value) {
   color: var(--ui-text-muted);
 }
 @media (min-width: 768px) {
-  .queue-summary-grid {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-  }
+}
+@media (max-width: 767px) {
+  .overview-insight-grid, .overview-density-grid { grid-template-columns: 1fr; }
+  .structure-grid { grid-template-columns: repeat(2, minmax(0,1fr)); }
+  .overview-intro { flex-direction: column; }
+  .overview-key-metrics { width: 100%; margin: .5rem 0 0; border-top: 1px solid #dbeafe; border-left: 0; }
+  .headline-metric { padding: .7rem .45rem 0; }
 }
 </style>

--- a/frontend/src/components/llm-ops/MetaModelManagement.vue
+++ b/frontend/src/components/llm-ops/MetaModelManagement.vue
@@ -230,6 +230,7 @@
                   <col class="capability-col" />
                   <col class="context-col" />
                   <col class="release-col" />
+                  <col class="price-source-col" />
                   <col class="status-col" />
                 </colgroup>
                 <thead>
@@ -247,17 +248,21 @@
                       {{ t('llmOps.metaModelManagement.table.releaseDate') }}
                     </th>
                     <th class="table-head">
+                      {{ t('llmOps.metaModelManagement.table.priceSources') }}
+                    </th>
+                    <th class="table-head">
                       {{ t('llmOps.metaModelManagement.table.status') }}
                     </th>
                   </tr>
                 </thead>
                 <tbody>
                   <tr v-if="drawerLoading">
-                    <td class="table-cell text-slate-500" colspan="5">
+                    <td class="table-cell text-slate-500" colspan="6">
                       {{ t('common.loading') }}
                     </td>
                   </tr>
-                  <tr v-for="item in paginatedVendorMetaRows" :key="item.id">
+                  <template v-for="item in paginatedVendorMetaRows" :key="item.id">
+                  <tr>
                     <td class="table-cell">
                       <div
                         class="meta-model-main"
@@ -334,6 +339,19 @@
                       </p>
                     </td>
                     <td class="table-cell">
+                      <button
+                        type="button"
+                        class="price-source-count"
+                        :title="t('llmOps.metaModelManagement.priceSources.hint')"
+                        @click="toggleMetaModelPrices(item)"
+                      >
+                        {{ t('llmOps.metaModelManagement.priceSources.coverage', {
+                          sources: item.current_price_source_count || 0,
+                          skus: item.current_priced_sku_count || 0
+                        }) }}
+                      </button>
+                    </td>
+                    <td class="table-cell">
                       <div class="meta-model-status">
                         <span :class="['status-pill', statusTone(item.status)]">
                           {{ statusLabel(item.status) }}
@@ -341,8 +359,40 @@
                       </div>
                     </td>
                   </tr>
+                  <tr v-if="expandedMetaModelId === item.id" class="price-detail-row">
+                    <td class="table-cell" colspan="6">
+                      <p v-if="expandedPricesLoading" class="text-xs text-slate-500">{{ t('common.loading') }}</p>
+                      <div v-else-if="priceSourceGroups.length" class="price-source-groups">
+                        <div class="price-coverage-intro">
+                          <span>{{ t('llmOps.metaModelManagement.priceSources.coveragePath') }}</span>
+                          <strong>{{ compactMetaModelName(item) }}</strong>
+                        </div>
+                        <section v-for="group in priceSourceGroups" :key="group.name" class="price-source-group">
+                          <div class="price-source-group-head">
+                            <div>
+                              <p class="price-source-label">{{ t('llmOps.metaModelManagement.priceSources.sourceLabel') }}</p>
+                              <strong>{{ group.name }}</strong>
+                            </div>
+                            <span>{{ t('llmOps.metaModelManagement.priceSources.sourceSummary', { skus: group.skus.length }) }}</span>
+                          </div>
+                          <div class="price-detail-list">
+                            <article v-for="sku in group.skus" :key="sku.key" class="price-sku-card">
+                              <strong>{{ sku.name }}</strong>
+                              <div class="price-token-list">
+                                <span v-for="price in sku.prices" :key="price.label" class="price-token">
+                                  <b>{{ price.label }}</b>{{ price.value }}
+                                </span>
+                              </div>
+                            </article>
+                          </div>
+                        </section>
+                      </div>
+                      <p v-else class="text-xs text-slate-500">{{ t('llmOps.metaModelManagement.priceSources.empty') }}</p>
+                    </td>
+                  </tr>
+                  </template>
                   <tr v-if="!drawerLoading && !vendorMetaRows.length">
-                    <td class="table-cell text-slate-500" colspan="5">
+                    <td class="table-cell text-slate-500" colspan="6">
                       {{ t('llmOps.metaModelManagement.empty.models') }}
                     </td>
                   </tr>
@@ -437,7 +487,56 @@ const ownerRows = ref([])
 const drawerRows = ref([])
 const drawerTotal = ref(0)
 const drawerLoading = ref(false)
+const expandedMetaModelId = ref(null)
+const expandedPrices = ref([])
+const expandedPricesLoading = ref(false)
 const ownerSummaryLoading = ref(false)
+
+const priceSourceGroups = computed(() => {
+  const groups = new Map()
+  expandedPrices.value.forEach((price) => {
+    const name = price.source_name || t('llmOps.metaModelManagement.priceSources.unknown')
+    const group = groups.get(name) || { name, items: [], skuMap: new Map() }
+    group.items.push(price)
+    const skuName = price.sku_display_name || price.model_name || price.sku_code || t('llmOps.metaModelManagement.priceSources.unknownSku')
+    const sku = group.skuMap.get(skuName) || { key: skuName, name: skuName, dimensions: new Map() }
+    const dimension = price.dimension || ''
+    if (!sku.dimensions.has(dimension)) sku.dimensions.set(dimension, price)
+    group.skuMap.set(skuName, sku)
+    groups.set(name, group)
+  })
+  return [...groups.values()].map((group) => ({
+    name: group.name,
+    items: group.items,
+    skus: [...group.skuMap.values()].map((sku) => ({
+      key: sku.key,
+      name: sku.name,
+      prices: [...sku.dimensions.values()]
+        .slice(0, 3)
+        .map((price) => ({
+          label: priceDimensionLabel(price.dimension),
+          value: `${price.currency} ${formatPrice(price.unit_price)}`
+        }))
+    }))
+  }))
+})
+
+function priceDimensionLabel(value) {
+  const labels = {
+    text_input: t('llmOps.metaModelManagement.priceSources.input'),
+    text_output: t('llmOps.metaModelManagement.priceSources.output'),
+    cache_input: t('llmOps.metaModelManagement.priceSources.cache')
+  }
+  return labels[value] || value
+}
+
+function formatPrice(value) {
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric)) return '-'
+  return new Intl.NumberFormat(undefined, {
+    maximumFractionDigits: 4
+  }).format(numeric)
+}
 
 const statusOptions = computed(() => [
   {
@@ -644,6 +743,29 @@ async function fetchVendorMetaModels() {
     )
   } finally {
     drawerLoading.value = false
+  }
+}
+
+async function toggleMetaModelPrices(item) {
+  if (expandedMetaModelId.value === item.id) {
+    expandedMetaModelId.value = null
+    expandedPrices.value = []
+    return
+  }
+  expandedMetaModelId.value = item.id
+  expandedPrices.value = []
+  expandedPricesLoading.value = true
+  try {
+    const response = await llmOpsApi.listModelPriceItems({
+      meta_model: item.id,
+      is_current: true,
+      page_size: 100
+    })
+    expandedPrices.value = paginationResults(paginationPayload(response))
+  } catch (error) {
+    showError(errorMessage(error, t('llmOps.metaModelManagement.errors.loadDetails')))
+  } finally {
+    expandedPricesLoading.value = false
   }
 }
 

--- a/frontend/src/components/llm-ops/metaModelManagement.css
+++ b/frontend/src/components/llm-ops/metaModelManagement.css
@@ -173,11 +173,11 @@
 }
 
 .meta-model-management .meta-model-table .model-col {
-  width: 26%;
+  width: 24%;
 }
 
 .meta-model-management .meta-model-table .capability-col {
-  width: 32%;
+  width: 26%;
 }
 
 .meta-model-management .meta-model-table .context-col {
@@ -185,11 +185,17 @@
 }
 
 .meta-model-management .meta-model-table .release-col {
+  width: 12%;
+}
+
+.meta-model-management .meta-model-table .price-source-col {
   width: 14%;
+  min-width: 9rem;
 }
 
 .meta-model-management .meta-model-table .status-col {
   width: 10%;
+  min-width: 5.5rem;
 }
 
 .meta-model-management .control-field {
@@ -363,6 +369,74 @@
 
 .meta-model-management .meta-model-status {
   @apply mx-auto flex min-w-0 justify-center;
+}
+
+.meta-model-management .price-source-count {
+  @apply mx-auto block rounded-lg border border-indigo-100 bg-indigo-50/60 px-2.5 py-1.5 text-center text-xs font-semibold text-indigo-700 transition hover:border-indigo-200 hover:bg-indigo-100 hover:underline;
+}
+
+.meta-model-management .price-detail-row > td {
+  @apply border-t-0 bg-slate-50 px-5 py-5;
+}
+
+.meta-model-management .price-detail-list {
+  @apply grid gap-3 p-3 text-xs text-slate-600;
+}
+
+.meta-model-management .price-source-groups {
+  @apply grid gap-3;
+}
+
+.meta-model-management .price-coverage-intro {
+  @apply flex flex-wrap items-center gap-2 rounded-lg border border-indigo-100 bg-indigo-50/50 px-3 py-2 text-xs text-indigo-700;
+}
+
+.meta-model-management .price-coverage-intro strong {
+  @apply font-semibold text-indigo-900;
+}
+
+.meta-model-management .price-source-group {
+  @apply overflow-hidden rounded-xl border border-slate-200 bg-white;
+}
+
+.meta-model-management .price-source-group-head {
+  @apply flex items-center justify-between gap-3 border-b border-slate-100 bg-slate-50 px-4 py-3 text-xs;
+}
+
+.meta-model-management .price-source-group-head strong {
+  @apply text-sm text-slate-800;
+}
+
+.meta-model-management .price-source-group-head span {
+  @apply text-slate-500;
+}
+
+.meta-model-management .price-source-label {
+  @apply mb-0.5 text-[10px] font-semibold uppercase tracking-wider text-slate-400;
+}
+
+.meta-model-management .price-sku-card {
+  @apply grid gap-2 rounded-lg border border-slate-200 bg-white px-3 py-3 shadow-sm;
+}
+
+.meta-model-management .price-sku-card > strong {
+  @apply truncate text-sm font-semibold text-slate-800;
+}
+
+.meta-model-management .price-token-list {
+  @apply flex flex-wrap gap-1.5;
+}
+
+.meta-model-management .price-token {
+  @apply inline-flex items-center gap-1 rounded-md bg-slate-100 px-2 py-1 font-mono text-[11px] text-slate-600;
+}
+
+.meta-model-management .price-token b {
+  @apply font-sans font-semibold text-slate-500;
+}
+
+@media (max-width: 640px) {
+  .meta-model-management .price-source-group-head { @apply items-start; }
 }
 
 .meta-model-management .status-pill {

--- a/frontend/src/composables/useLLMOpsMonitor.js
+++ b/frontend/src/composables/useLLMOpsMonitor.js
@@ -56,7 +56,108 @@ export function useLLMOpsMonitor({ summary }) {
 
   const kpiCards = computed(() => {
     const counts = summarizeMonitorRows(enrichedProcurementRows.value)
+    const overview = summary.value.agione?.overview || {}
     return [
+      {
+        key: 'active_model_skus',
+        label: t('llmOps.overview.kpi.activeModelSkus.label'),
+        value: Number(overview.active_model_skus || 0),
+        section: 'modelWorkbench',
+        tone: 'info'
+      },
+      {
+        key: 'operational_models',
+        label: t('llmOps.overview.kpi.operationalModels.label'),
+        value: Number(overview.operational_models || 0),
+        filter: 'operational',
+        tone: 'info'
+      },
+      {
+        key: 'channel_coverage_rate',
+        label: t('llmOps.overview.kpi.channelCoverageRate.label'),
+        value: formatPercent(overview.channel_coverage_rate),
+        section: 'channelMatrix',
+        tone: rateTone(overview.channel_coverage_rate)
+      },
+      {
+        key: 'listing_coverage_rate',
+        label: t('llmOps.overview.kpi.listingCoverageRate.label'),
+        value: formatPercent(overview.listing_coverage_rate),
+        section: 'listingRisk',
+        tone: rateTone(overview.listing_coverage_rate)
+      },
+      {
+        key: 'unlisted_models',
+        label: t('llmOps.overview.kpi.unlistedModels.label'),
+        value: Number(overview.unlisted_models || 0),
+        filter: 'unlisted',
+        tone: Number(overview.unlisted_models || 0) ? 'warn' : 'success'
+      },
+      {
+        key: 'meta_models',
+        label: t('llmOps.overview.kpi.metaModels.label'),
+        value: Number(overview.meta_models || 0),
+        section: 'metaModels',
+        tone: 'info'
+      },
+      {
+        key: 'price_sources',
+        label: t('llmOps.overview.kpi.priceSources.label'),
+        value: Number(overview.enabled_price_sources || 0),
+        section: 'providers',
+        tone: 'info'
+      },
+      {
+        key: 'channels',
+        label: t('llmOps.overview.kpi.channels.label'),
+        value: Number(overview.active_channels || 0),
+        section: 'channels',
+        tone: 'info'
+      },
+      {
+        key: 'listings',
+        label: t('llmOps.overview.kpi.activeListings.label'),
+        value: Number(overview.active_listings || 0),
+        section: 'listingRisk',
+        tone: 'success'
+      },
+      {
+        key: 'overall_yield',
+        label: t('llmOps.overview.kpi.overallYield.label'),
+        value: formatPercent(overview.overall_yield),
+        section: 'listingRisk',
+        tone: overview.overall_yield === null ? 'info' : 'success'
+      },
+      {
+        key: 'median_yield',
+        label: t('llmOps.overview.kpi.medianYield.label'),
+        value: formatPercent(overview.median_yield),
+        section: 'listingRisk',
+        tone: overview.median_yield === null ? 'info' : 'success'
+      },
+      {
+        key: 'unresolved_yield_models',
+        label: t('llmOps.overview.kpi.unresolvedYieldModels.label'),
+        value: Number(overview.unresolved_yield_models || 0),
+        filter: 'priority',
+        tone: Number(overview.unresolved_yield_models || 0)
+          ? 'warn'
+          : 'success'
+      },
+      {
+        key: 'price_source_health_rate',
+        label: t('llmOps.overview.kpi.priceSourceHealthRate.label'),
+        value: formatPercent(overview.price_source_health_rate),
+        section: 'collectionHealth',
+        tone: rateTone(overview.price_source_health_rate)
+      },
+      {
+        key: 'risk_points',
+        label: t('llmOps.overview.kpi.riskPoints.label'),
+        value: Number(overview.risk_points || 0),
+        filter: 'priority',
+        tone: Number(overview.risk_points || 0) ? 'danger' : 'success'
+      },
       {
         key: 'needs_action',
         label: t('llmOps.overview.kpi.needsAction.label'),
@@ -135,6 +236,18 @@ export function useLLMOpsMonitor({ summary }) {
     simulationStatus,
     simulationStatusOptions
   }
+}
+
+function formatPercent(value) {
+  if (value === null || value === undefined || value === '') return '-'
+  const numericValue = Number(value)
+  if (!Number.isFinite(numericValue)) return '-'
+  return `${(numericValue * 100).toFixed(1)}%`
+}
+
+function rateTone(value) {
+  if (value === null || value === undefined || value === '') return 'info'
+  return Number(value) < 1 ? 'warn' : 'success'
 }
 
 function monitorModelSubtitle(row) {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1594,6 +1594,9 @@
         "operational": "Operational models"
       },
       "kpi": {
+        "activeModelSkus": {
+          "label": "Active model SKUs"
+        },
         "channelCoverage": "Channel coverage",
         "channelCoverageHint": "Available procurement channel count",
         "listingLinks": "Listing links",
@@ -2250,6 +2253,19 @@
         "previous": "Previous",
         "summary": "{total} meta models, page {current} / {pages}"
       },
+      "priceSources": {
+        "coverage": "{sources} sources · {skus} SKUs covered",
+        "hint": "SKU quotes are aggregated by price source. Billing dimensions and usage tiers are summarized within each SKU.",
+        "empty": "No current prices for this meta model.",
+        "unknown": "Unnamed source",
+        "unknownSku": "Unnamed SKU",
+        "sourceSummary": "{skus} SKUs covered",
+        "coveragePath": "Price coverage: Meta model → Source → SKU quotes",
+        "sourceLabel": "Price source",
+        "input": "Input",
+        "output": "Output",
+        "cache": "Cache"
+      },
       "status": {
         "active": "Active",
         "deprecated": "Deprecated",
@@ -2266,6 +2282,7 @@
         "metaModel": "Meta model",
         "metaModels": "Meta models",
         "releaseDate": "Release date",
+        "priceSources": "Price sources",
         "status": "Status",
         "vendor": "Provider"
       }
@@ -3462,7 +3479,53 @@
       }
     },
     "overview": {
+      "kicker": "Platform pulse",
+      "title": "LLM operations at a glance",
+      "subtitle": "A live view of model supply, distribution, margin, and operational risk.",
+      "live": "Live",
       "kpi": {
+        "activeModelSkus": {
+          "label": "Active model SKUs"
+        },
+        "activeListings": {
+          "label": "Active listings"
+        },
+        "channels": {
+          "label": "Active channels"
+        },
+        "channelCoverageRate": {
+          "label": "Channel coverage"
+        },
+        "listingCoverageRate": {
+          "label": "Listing coverage"
+        },
+        "medianYield": {
+          "label": "Median yield"
+        },
+        "metaModels": {
+          "label": "Meta models"
+        },
+        "overallYield": {
+          "label": "Overall yield"
+        },
+        "operationalModels": {
+          "label": "Operational models"
+        },
+        "priceSources": {
+          "label": "Enabled price sources"
+        },
+        "priceSourceHealthRate": {
+          "label": "Price-source health"
+        },
+        "riskPoints": {
+          "label": "Operational risk points"
+        },
+        "unlistedModels": {
+          "label": "Unlisted models"
+        },
+        "unresolvedYieldModels": {
+          "label": "Yield unavailable"
+        },
         "needsAction": {
           "label": "Needs action"
         },
@@ -3485,7 +3548,29 @@
         "lastUpdate": "Last update",
         "model": "Model",
         "procurement": "Procurement",
-        "yield": "Yield"
+        "yield": "Yield",
+        "recommendation": "Operational recommendation"
+      },
+      "priority": {
+        "urgent": "Act now",
+        "attention": "Needs review",
+        "normal": "Monitor"
+      },
+      "yieldTip": {
+        "label": "Yield formula: ",
+        "formula": "(retail price × (1 − platform fee − service fee − tax) − procurement cost × settlement rate) ÷ retail price.",
+        "requirement": "Yield is withheld when tax, settlement rate, procurement cost, or retail price is missing."
+      },
+      "advice": {
+        "no_supply": { "reason": "No usable procurement channel is configured.", "impact": "This model cannot be sold or cost-compared reliably." },
+        "currency_unresolved": { "reason": "The channel price needs a currency conversion rate.", "impact": "Margin and lowest-cost comparison remain unreliable." },
+        "platform_fee_unresolved": { "reason": "Platform fee rules are incomplete.", "impact": "A reliable yield cannot be calculated before listing decisions." },
+        "low_yield": { "reason": "Current listing yield is below the configured warning threshold.", "impact": "This listing may reduce margin; review price or procurement channel." },
+        "not_lowest_channel": { "reason": "The listing is not using the lowest available procurement channel.", "impact": "Switching the supply route may improve margin without changing the sale price." },
+        "unlisted": { "reason": "A procurement path is ready, but no active listing exists.", "impact": "This model is not currently available for sales." },
+        "single_channel": { "reason": "Only {channels} procurement channel is available.", "impact": "Supply continuity is exposed if this channel becomes unavailable." },
+        "ready": { "reason": "Coverage, listing, and yield checks are currently healthy.", "impact": "No immediate intervention is required." },
+        "market_reference": { "reason": "This is market reference data rather than an operational SKU.", "impact": "Use it for pricing research; no publishing action is needed." }
       },
       "coverageCount": "{count} channels",
       "queueSummaryLabel": "Operational queue filters",
@@ -3509,7 +3594,31 @@
         "daysAgo": "{count}d ago"
       },
       "emptyDecisionAllReady": "No operational models need handling.",
-      "emptyDecisionFiltered": "No models match the current filters."
+      "emptyDecisionFiltered": "No models match the current filters.",
+      "insights": {
+        "healthEyebrow": "Operational health",
+        "healthTitle": "Supply readiness",
+        "channelEyebrow": "Distribution mix",
+        "channelTitle": "Recommended channel coverage",
+        "covered": "Covered",
+        "unlisted": "Unlisted",
+        "risk": "At risk",
+        "viewDetails": "View matrix",
+        "noChannelData": "No channel data yet.",
+        "unassigned": "Unassigned",
+        "structureEyebrow": "Platform structure",
+        "structureTitle": "Model operations footprint",
+        "riskEyebrow": "Action signals",
+        "riskTitle": "Risk composition",
+        "models": "Models",
+        "modelsHint": "in current scope",
+        "providers": "Providers",
+        "providersHint": "model owners",
+        "channels": "Channels",
+        "channelsHint": "with active coverage",
+        "listed": "Listed",
+        "listedHint": "active sales links"
+      }
     },
     "decision": {
       "status": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1602,6 +1602,9 @@
         "operational": "运营模型"
       },
       "kpi": {
+        "activeModelSkus": {
+          "label": "活跃模型 SKU"
+        },
         "channelCoverage": "渠道覆盖",
         "channelCoverageHint": "可用采购渠道数量",
         "listingLinks": "挂售链路",
@@ -2258,6 +2261,19 @@
         "previous": "上一页",
         "summary": "共 {total} 个元模型，第 {current} / {pages} 页"
       },
+      "priceSources": {
+        "coverage": "{sources} 个价格源 · 覆盖 {skus} 个 SKU",
+        "hint": "默认按价格源聚合展示该元模型的 SKU 报价；计费维度和用量档位已汇总到同一 SKU。",
+        "empty": "当前元模型暂无有效价格。",
+        "unknown": "未命名价格源",
+        "unknownSku": "未命名 SKU",
+        "sourceSummary": "覆盖 {skus} 个 SKU",
+        "coveragePath": "价格覆盖：元模型 → 价格源 → SKU 报价",
+        "sourceLabel": "价格源",
+        "input": "输入",
+        "output": "输出",
+        "cache": "缓存"
+      },
       "status": {
         "active": "可用",
         "deprecated": "弃用",
@@ -2274,6 +2290,7 @@
         "metaModel": "元模型",
         "metaModels": "元模型",
         "releaseDate": "发布日期",
+        "priceSources": "模型价格源",
         "status": "状态",
         "vendor": "厂商"
       }
@@ -3470,7 +3487,53 @@
       }
     },
     "overview": {
+      "kicker": "平台运营脉搏",
+      "title": "大模型运营总览",
+      "subtitle": "实时掌握模型供给、渠道分发、收益表现与运营风险。",
+      "live": "实时",
       "kpi": {
+        "activeModelSkus": {
+          "label": "活跃模型 SKU"
+        },
+        "activeListings": {
+          "label": "活跃挂售"
+        },
+        "channels": {
+          "label": "活跃渠道"
+        },
+        "channelCoverageRate": {
+          "label": "渠道覆盖率"
+        },
+        "listingCoverageRate": {
+          "label": "挂售覆盖率"
+        },
+        "medianYield": {
+          "label": "收益率中位数"
+        },
+        "metaModels": {
+          "label": "元模型"
+        },
+        "overallYield": {
+          "label": "整体收益率"
+        },
+        "operationalModels": {
+          "label": "可运营模型"
+        },
+        "priceSources": {
+          "label": "启用价格源"
+        },
+        "priceSourceHealthRate": {
+          "label": "价格源健康率"
+        },
+        "riskPoints": {
+          "label": "运营风险点"
+        },
+        "unlistedModels": {
+          "label": "未挂售模型"
+        },
+        "unresolvedYieldModels": {
+          "label": "无法计算收益率"
+        },
         "needsAction": {
           "label": "运营待处理"
         },
@@ -3493,7 +3556,29 @@
         "lastUpdate": "数据时间",
         "model": "模型",
         "procurement": "采购",
-        "yield": "收益率"
+        "yield": "收益率",
+        "recommendation": "运营建议"
+      },
+      "priority": {
+        "urgent": "立即处理",
+        "attention": "需要复核",
+        "normal": "持续关注"
+      },
+      "yieldTip": {
+        "label": "收益率口径：",
+        "formula": "（售价 ×（1 − 平台佣金 − 服务费 − 税率）− 采购成本 × 结算比例）÷ 售价。",
+        "requirement": "税率、结算比例或采购/售价缺失时，不展示收益率。"
+      },
+      "advice": {
+        "no_supply": { "reason": "尚未配置可用的采购渠道。", "impact": "该模型无法可靠地销售或进行成本比较。" },
+        "currency_unresolved": { "reason": "渠道价格缺少币种换算汇率。", "impact": "收益率和最低成本比较暂不可靠。" },
+        "platform_fee_unresolved": { "reason": "平台手续费规则尚未配置完整。", "impact": "挂售决策前无法计算可信的收益率。" },
+        "low_yield": { "reason": "当前挂售收益率低于设定的预警阈值。", "impact": "该挂售可能拉低利润，应复核售价或采购渠道。" },
+        "not_lowest_channel": { "reason": "当前挂售未使用成本最低的可用采购渠道。", "impact": "切换供给渠道可在不调整售价的前提下改善收益。" },
+        "unlisted": { "reason": "采购链路已就绪，但尚未建立有效挂售。", "impact": "该模型当前不能对外销售。" },
+        "single_channel": { "reason": "当前只有 {channels} 个可用采购渠道。", "impact": "该渠道不可用时，模型供给会中断。" },
+        "ready": { "reason": "渠道覆盖、挂售和收益检查目前均正常。", "impact": "暂不需要额外运营动作。" },
+        "market_reference": { "reason": "这是市场参考数据，不是当前运营 SKU。", "impact": "可用于定价调研，无需进行挂售操作。" }
       },
       "coverageCount": "{count} 个渠道",
       "queueSummaryLabel": "运营待办筛选",
@@ -3517,7 +3602,31 @@
         "daysAgo": "{count} 天前"
       },
       "emptyDecisionAllReady": "当前没有需要处理的运营模型。",
-      "emptyDecisionFiltered": "当前筛选条件下没有匹配的模型。"
+      "emptyDecisionFiltered": "当前筛选条件下没有匹配的模型。",
+      "insights": {
+        "healthEyebrow": "运营健康度",
+        "healthTitle": "供给就绪度",
+        "channelEyebrow": "分发结构",
+        "channelTitle": "推荐渠道覆盖",
+        "covered": "已覆盖",
+        "unlisted": "未挂售",
+        "risk": "有风险",
+        "viewDetails": "查看矩阵",
+        "noChannelData": "暂无渠道数据。",
+        "unassigned": "未分配",
+        "structureEyebrow": "平台结构",
+        "structureTitle": "模型运营规模",
+        "riskEyebrow": "行动信号",
+        "riskTitle": "风险构成",
+        "models": "模型",
+        "modelsHint": "当前范围内",
+        "providers": "厂商",
+        "providersHint": "元模型归属",
+        "channels": "渠道",
+        "channelsHint": "有活跃覆盖",
+        "listed": "已挂售",
+        "listedHint": "有效销售链路"
+      }
     },
     "decision": {
       "status": {

--- a/frontend/tests/llmOpsMonitor.test.js
+++ b/frontend/tests/llmOpsMonitor.test.js
@@ -119,3 +119,46 @@ test('labels market references without implying a missing listing', () => {
     /function currentListingText\(row\) \{\s*if \(!isOperationalRow\(row\)\) \{\s*return t\('llmOps\.decision\.status\.market_reference'\)/
   )
 })
+
+test('opens read-only model details instead of the resale editing workspace', () => {
+  assert.match(
+    monitorDashboardSource,
+    /function handleRowClick\(row\)[\s\S]*?section: 'modelWorkbench'/
+  )
+  assert.doesNotMatch(
+    monitorDashboardSource,
+    /function handleRowClick\(row\)[\s\S]*?emit\('navigateToWorkspace'/
+  )
+})
+
+test('does not render an unresolved overall yield as zero', () => {
+  const monitorComposableSource = readFileSync(
+    new URL('../src/composables/useLLMOpsMonitor.js', import.meta.url),
+    'utf8'
+  )
+
+  assert.match(
+    monitorComposableSource,
+    /function formatPercent\(value\) \{\s*if \(value === null \|\| value === undefined \|\| value === ''\) return '-'/
+  )
+})
+
+test('includes the first-phase coverage and health indicators', () => {
+  const monitorComposableSource = readFileSync(
+    new URL('../src/composables/useLLMOpsMonitor.js', import.meta.url),
+    'utf8'
+  )
+
+  for (const key of [
+    'active_model_skus',
+    'operational_models',
+    'channel_coverage_rate',
+    'listing_coverage_rate',
+    'unlisted_models',
+    'median_yield',
+    'unresolved_yield_models',
+    'price_source_health_rate'
+  ]) {
+    assert.match(monitorComposableSource, new RegExp(`key: '${key}'`))
+  }
+})


### PR DESCRIPTION
## Summary
- Rebuild the LLM Ops overview around platform scale, supply health, channel distribution, risks, and actionable model operations.
- Correct revenue-rate semantics and expose unavailable calculations explicitly, with formula tips and read-only detail drill-downs.
- Add meta-model price-source coverage, grouping source → SKU quotes with clearer labels, rounded values, and responsive expanded layouts.

Closes #332

## Test plan
- [x] `.venv/bin/pytest backend/llm_ops/tests/test_views.py -k 'meta_model' -q`
- [x] `node --test frontend/tests/llmOpsMonitor.test.js`
- [x] `npm run build`
- [x] ego-browser local acceptance: desktop, 1280px, and 960px alignment and overflow checks