### PR TITLE
Fix LLM Ops version and channel pricing views

### DIFF
--- a/backend/llm_ops/serializers.py
+++ b/backend/llm_ops/serializers.py
@@ -726,6 +726,26 @@ class LLMModelSerializer(serializers.ModelSerializer):
         read_only=True,
         allow_null=True,
     )
+    sku_code = serializers.CharField(
+        source="sku.canonical_sku_code",
+        read_only=True,
+        allow_null=True,
+    )
+    sku_display_name = serializers.CharField(
+        source="sku.display_name",
+        read_only=True,
+        allow_null=True,
+    )
+    sku_region = serializers.CharField(
+        source="sku.region",
+        read_only=True,
+        allow_null=True,
+    )
+    sku_upstream_model_name = serializers.CharField(
+        source="sku.upstream_model_name",
+        read_only=True,
+        allow_null=True,
+    )
     business_source_category = serializers.SerializerMethodField()
     business_source_category_label = serializers.SerializerMethodField()
 
@@ -1635,6 +1655,16 @@ class ChannelOfferingSerializer(serializers.ModelSerializer):
     )
     source_offering_key = serializers.CharField(
         source="source_offering.id",
+        read_only=True,
+        allow_null=True,
+    )
+    source_sku_code = serializers.CharField(
+        source="source_offering.sku.canonical_sku_code",
+        read_only=True,
+        allow_null=True,
+    )
+    source_sku_region = serializers.CharField(
+        source="source_offering.sku.region",
         read_only=True,
         allow_null=True,
     )

--- a/backend/llm_ops/tests/test_views.py
+++ b/backend/llm_ops/tests/test_views.py
@@ -2530,6 +2530,16 @@ class LLMOpsViewTests(TestCase):
             {item["offering_name"] for item in options},
             {"Primary route", "Backup route"},
         )
+        self.assertEqual(
+            {item["channel_offer_count"] for item in options},
+            {2},
+        )
+        diagnostic = next(
+            item
+            for item in response.data["agione"]["diagnostics"]
+            if item["model_id"] == model.id
+        )
+        self.assertEqual(diagnostic["coverage_count"], 1)
 
     def test_channel_ratio_update_resyncs_listed_price_items(self):
         provider = LLMProvider.objects.create(name="OpenAI", code="openai")

--- a/backend/llm_ops/views.py
+++ b/backend/llm_ops/views.py
@@ -4189,7 +4189,7 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
 
         models = list(
             LLMModel.objects.filter(is_active=True)
-            .select_related("meta_model", "provider")
+            .select_related("meta_model", "provider", "sku")
             .order_by("provider__name", "name", "id")
         )
         model_updated_at_by_id = {
@@ -4350,8 +4350,19 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
                 key=lambda item: (
                     item.get("requires_currency_conversion", False),
                     item["estimated_cost"],
+                    item.get("channel_id", 0),
+                    item.get("offering_id") or 0,
                 )
             )
+            offer_counts = {}
+            for option in options:
+                channel_id = option.get("channel_id")
+                offer_counts[channel_id] = offer_counts.get(channel_id, 0) + 1
+            for option in options:
+                option["channel_offer_count"] = offer_counts.get(
+                    option.get("channel_id"),
+                    1,
+                )
             best = _select_best_option(options) if options else None
             requires_currency_conversion = bool(
                 any(
@@ -4364,6 +4375,17 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
                     "model_id": model.id,
                     "model_name": model.name,
                     "model_code": model.code,
+                    "sku_code": getattr(model.sku, "canonical_sku_code", "")
+                    if model.sku_id
+                    else "",
+                    "sku_region": getattr(model.sku, "region", "")
+                    if model.sku_id
+                    else "",
+                    "upstream_model_name": (
+                        getattr(model.sku, "upstream_model_name", "")
+                        if model.sku_id
+                        else model.code
+                    ),
                     "meta_model_id": model.meta_model_id,
                     "meta_model_name": model.meta_model.name,
                     "meta_model_code": model.meta_model.code,
@@ -4557,6 +4579,9 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
         diagnostics = []
         for row in procurement_rows:
             options = row["options"]
+            channel_coverage_count = len(
+                {option["channel_id"] for option in options}
+            )
             best_channel = row["best_channel"]
             active_model_listings = selected_platform_listings_by_model.get(
                 row["model_id"],
@@ -4590,7 +4615,7 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
             if not is_monitor_scope:
                 status_payload = _diagnostic_status(
                     best_channel=best_channel,
-                    coverage_count=len(options),
+                    coverage_count=channel_coverage_count,
                     is_agione_listed=bool(active_model_listings),
                     has_lowest_listing=has_lowest_listing,
                     operation_scope=scope_payload["operation_scope"],
@@ -4702,7 +4727,7 @@ class SummaryAPIView(LLMOpsPermissionMixin, APIView):
                 "requires_currency_conversion": row[
                     "requires_currency_conversion"
                 ],
-                "coverage_count": len(options),
+                "coverage_count": channel_coverage_count,
                 "is_agione_listed": bool(active_model_listings),
                 "has_lowest_listing": has_lowest_listing,
                 "active_listing_count": len(active_model_listings),

--- a/frontend/src/api/llmOps.js
+++ b/frontend/src/api/llmOps.js
@@ -147,6 +147,13 @@ export const llmOpsApi = {
     return apiClient.get(`${base}/model-price-items/`, paramsOrEmpty(params))
   },
 
+  listCollectedPriceHistory(params) {
+    return apiClient.get(
+      `${base}/collected-price-history/`,
+      paramsOrEmpty(params)
+    )
+  },
+
   updateModelPriceItem(id, payload) {
     return apiClient.patch(`${base}/model-price-items/${id}/`, payload)
   },

--- a/frontend/src/components/llm-ops/ChannelPriceCompareDrawer.vue
+++ b/frontend/src/components/llm-ops/ChannelPriceCompareDrawer.vue
@@ -187,6 +187,7 @@ import {
 import { useI18n } from 'vue-i18n'
 
 import {
+  channelOfferingForOption,
   compareChannelOptions,
   optionFreshness,
   savingsPercent
@@ -289,6 +290,10 @@ function contractContext(offer) {
     sameId(item.channel, offer.channel_id)
   )
   const offering =
+    channelOfferingForOption(candidates, offer) ||
+    candidates.find((item) =>
+      sameId(item.meta_model, props.row?.meta_model_id)
+    ) ||
     candidates.find((item) => sameId(item.model, props.row?.model_id)) ||
     candidates[0]
   const ratio = Number(offer.settlement_ratio)

--- a/frontend/src/components/llm-ops/ChannelPriceMatrixPanel.vue
+++ b/frontend/src/components/llm-ops/ChannelPriceMatrixPanel.vue
@@ -140,6 +140,15 @@
                 <p class="mt-1 text-xs text-slate-500">
                   {{ row.provider_name }} · {{ row.model_code }}
                 </p>
+                <p
+                  v-if="row.sku_code || row.sku_region"
+                  class="mt-1 text-[11px] text-slate-400"
+                >
+                  {{ row.sku_code || row.upstream_model_name }}
+                  <template v-if="row.sku_region">
+                    · {{ row.sku_region }}
+                  </template>
+                </p>
                 <p class="mt-1 text-[11px] text-slate-400">
                   {{
                     t('llmOps.channelPriceMatrixPanel.coverageSummary', {
@@ -166,6 +175,14 @@
                   </strong>
                   <span class="price-cell-meta">
                     {{ freshnessLabel(optionFor(row, channel)) }}
+                    <template v-if="offerCount(row, channel) > 1">
+                      ·
+                      {{
+                        t('llmOps.channelPriceMatrixPanel.offerCount', {
+                          count: offerCount(row, channel)
+                        })
+                      }}
+                    </template>
                   </span>
                   <span class="price-cell-tags">
                     <span v-if="isBest(row, channel)" class="is-best">
@@ -229,8 +246,10 @@ import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import {
+  bestOptionForChannel,
   effectiveMatrixAction,
   hasStaleChannelPrice,
+  optionsForChannel,
   optionFreshness
 } from '@/utils/llmOpsChannelPriceMatrix'
 import { asArray } from '@/utils/llmOpsPagination'
@@ -359,9 +378,11 @@ const metrics = computed(() => {
 })
 
 function optionFor(row, channel) {
-  return (row.options || []).find(
-    (option) => String(option.channel_id) === String(channel.id)
-  )
+  return bestOptionForChannel(row, channel.id)
+}
+
+function offerCount(row, channel) {
+  return optionsForChannel(row, channel.id).length
 }
 
 function isBest(row, channel) {

--- a/frontend/src/components/llm-ops/ModelWorkbenchPanel.vue
+++ b/frontend/src/components/llm-ops/ModelWorkbenchPanel.vue
@@ -139,7 +139,15 @@
                     {{ offering.display_name }}
                   </div>
                   <div class="font-mono text-[11px] text-slate-500">
-                    {{ offering.offering_key }}
+                    {{
+                      [
+                        offering.offering_key,
+                        offering.source_sku_code,
+                        offering.source_sku_region
+                      ]
+                        .filter(Boolean)
+                        .join(' · ')
+                    }}
                   </div>
                 </td>
                 <td class="table-cell">

--- a/frontend/src/components/llm-ops/PriceChangePanel.vue
+++ b/frontend/src/components/llm-ops/PriceChangePanel.vue
@@ -109,6 +109,7 @@ const props = defineProps({
   channelHistory: { type: Array, default: () => [] },
   focusModelId: { type: [Number, String], default: null },
   listingHistory: { type: Array, default: () => [] },
+  officialHistory: { type: Array, default: () => [] },
   priceItems: { type: Array, default: () => [] }
 })
 
@@ -126,6 +127,7 @@ const changeRows = computed(() => {
   return buildPriceChangeRows({
     channelHistory: props.channelHistory,
     listingHistory: props.listingHistory,
+    officialHistory: props.officialHistory,
     priceItems: props.priceItems
   }).map((row) => ({
     ...row,

--- a/frontend/src/composables/useChannelModelDisplay.js
+++ b/frontend/src/composables/useChannelModelDisplay.js
@@ -86,6 +86,8 @@ export function useChannelModelDisplay({
         option.models.map((model) => model.provider_name).join(' '),
         option.models.map((model) => model.provider_code).join(' '),
         option.models.map((model) => model.source_name).join(' '),
+        option.models.map((model) => model.sku_code).join(' '),
+        option.models.map((model) => model.sku_region).join(' '),
         option.models.map((model) => modelSourceCategory(model)).join(' '),
         modalityLabel(option.modality)
       ]
@@ -95,11 +97,15 @@ export function useChannelModelDisplay({
   }
 
   function providerModelDescription(model) {
+    const sku = model.sku_display_name || model.sku_code || ''
+    const region = model.sku_region || ''
     return [
       hasKnownSourceCategory(modelSourceCategory(model))
         ? sourceCategoryLabel(modelSourceCategory(model))
         : null,
-      model.currency || translate('llmOps.channelModelDrawer.defaultCurrency')
+      model.currency || translate('llmOps.channelModelDrawer.defaultCurrency'),
+      sku,
+      region
     ]
       .filter(Boolean)
       .join(' · ')

--- a/frontend/src/composables/useChannelModelPricing.js
+++ b/frontend/src/composables/useChannelModelPricing.js
@@ -471,15 +471,21 @@ export function useChannelModelPricing({
     if (!model) {
       return translate('llmOps.channelModelDrawer.noUpstreamSelected')
     }
-    return upstreamSourceLabel(model)
+    const version = model.sku_code || model.sku_display_name || ''
+    const region = model.sku_region || ''
+    return [upstreamSourceLabel(model), version, region]
+      .filter(Boolean)
+      .join(' · ')
   }
 
   function channelRowSourceLabel(row) {
-    return (
+    const source =
       row.draft.price_source_name ||
       row.model.price_source_name ||
-      purchaseSourceLabel(row.model)
-    )
+      upstreamSourceLabel(row.model)
+    const version = row.model.sku_code || row.model.sku_display_name || ''
+    const region = row.model.sku_region || ''
+    return [source, version, region].filter(Boolean).join(' · ')
   }
 
   function modelSourceCategory(model) {

--- a/frontend/src/composables/useLLMOpsData.js
+++ b/frontend/src/composables/useLLMOpsData.js
@@ -44,6 +44,7 @@ export function useLLMOpsData() {
   const channelPriceItems = ref([])
   const channelPriceHistory = ref([])
   const modelPriceItems = ref([])
+  const officialPriceHistory = ref([])
   const resalePlatforms = ref([])
   const resaleWorkflowConfig = ref(null)
   const listings = ref([])
@@ -293,17 +294,22 @@ export function useLLMOpsData() {
       ? { platform: selectedResalePlatformId.value }
       : {}
     const platformId = selectedResalePlatformId.value
-    const [channelHistoryData, listingHistoryData] = await Promise.all([
-      fetchFirstPage(llmOpsApi.listChannelModelPriceHistory, {
-        ...modelFilter,
-        page_size: PRICE_HISTORY_PAGE_SIZE
-      }),
-      fetchFirstPage(llmOpsApi.listResaleListingPriceHistory, {
-        ...modelFilter,
-        ...platformFilter,
-        page_size: PRICE_HISTORY_PAGE_SIZE
-      })
-    ])
+    const [channelHistoryData, listingHistoryData, officialHistoryData] =
+      await Promise.all([
+        fetchFirstPage(llmOpsApi.listChannelModelPriceHistory, {
+          ...modelFilter,
+          page_size: PRICE_HISTORY_PAGE_SIZE
+        }),
+        fetchFirstPage(llmOpsApi.listResaleListingPriceHistory, {
+          ...modelFilter,
+          ...platformFilter,
+          page_size: PRICE_HISTORY_PAGE_SIZE
+        }),
+        fetchFirstPage(llmOpsApi.listCollectedPriceHistory, {
+          ...modelFilter,
+          page_size: PRICE_HISTORY_PAGE_SIZE
+        })
+      ])
     if (
       requestId !== priceHistoryRequestId ||
       String(platformId || '') !== String(selectedResalePlatformId.value || '')
@@ -312,6 +318,7 @@ export function useLLMOpsData() {
     }
     channelPriceHistory.value = asArray(channelHistoryData)
     listingPriceHistory.value = asArray(listingHistoryData)
+    officialPriceHistory.value = asArray(officialHistoryData)
   }
 
   async function refreshLight() {
@@ -486,6 +493,7 @@ export function useLLMOpsData() {
     loading,
     metaModels,
     modelPriceItems,
+    officialPriceHistory,
     models,
     invalidateSectionCache,
     normalizeDisplayCurrency,

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1922,6 +1922,7 @@
         "platform": "Listing platform"
       },
       "coverageSummary": "{covered} / {total} channels",
+      "offerCount": "{count} offers",
       "drawer": {
         "contractFx": "Contract FX",
         "currentChannel": "Current listing channel",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1930,6 +1930,7 @@
         "platform": "挂售平台"
       },
       "coverageSummary": "{covered} / {total} 个渠道",
+      "offerCount": "{count} 个货源",
       "drawer": {
         "contractFx": "合同汇率",
         "currentChannel": "当前挂售渠道",

--- a/frontend/src/pages/LLMOps.vue
+++ b/frontend/src/pages/LLMOps.vue
@@ -217,6 +217,7 @@
               :focus-model-id="operationTargetModelId"
               :channel-history="channelPriceHistory"
               :listing-history="listingPriceHistory"
+              :official-history="officialPriceHistory"
               :price-items="modelPriceItems"
             />
 
@@ -444,6 +445,7 @@ const {
   loading,
   metaModels,
   modelPriceItems,
+  officialPriceHistory,
   models,
   normalizeDisplayCurrency,
   pageError,

--- a/frontend/src/utils/llmOpsChannelPriceMatrix.js
+++ b/frontend/src/utils/llmOpsChannelPriceMatrix.js
@@ -55,6 +55,36 @@ export function compareChannelOptions(row = {}, dimension = 'input') {
     .sort((left, right) => Number(left[field]) - Number(right[field]))
 }
 
+export function optionsForChannel(row = {}, channelId) {
+  return (row.options || [])
+    .filter((option) => String(option.channel_id) === String(channelId))
+    .slice()
+    .sort((left, right) => {
+      const leftCost = Number(left.estimated_cost)
+      const rightCost = Number(right.estimated_cost)
+      if (Number.isFinite(leftCost) && Number.isFinite(rightCost)) {
+        return leftCost - rightCost
+      }
+      return String(left.offering_name || '').localeCompare(
+        String(right.offering_name || '')
+      )
+    })
+}
+
+export function bestOptionForChannel(row = {}, channelId) {
+  return optionsForChannel(row, channelId)[0] || null
+}
+
+export function channelOfferingForOption(offerings = [], option = {}) {
+  return (
+    offerings.find(
+      (offering) =>
+        String(offering.channel) === String(option.channel_id) &&
+        String(offering.id) === String(option.offering_id)
+    ) || null
+  )
+}
+
 export function savingsPercent(row = {}, dimension = 'input') {
   const channelId = row.current_listing?.channel_id
   if (channelId === null || channelId === undefined) return null

--- a/frontend/src/utils/llmOpsPriceChanges.js
+++ b/frontend/src/utils/llmOpsPriceChanges.js
@@ -22,6 +22,7 @@ const listingDimensions = [
 export function buildPriceChangeRows({
   channelHistory = [],
   listingHistory = [],
+  officialHistory = [],
   priceItems = []
 } = {}) {
   const rows = [
@@ -41,7 +42,8 @@ export function buildPriceChangeRows({
       context: (item) => item.channel_name || item.platform_name || '',
       source: (item) => item.platform_name || ''
     }),
-    ...priceItems.map((item) => ({
+    ...officialHistoryRows(officialHistory),
+    ...(officialHistory.length ? [] : priceItems.map((item) => ({
       key: `official-${item.id}-${item.dimension}`,
       type: 'official',
       modelId: item.model,
@@ -53,11 +55,63 @@ export function buildPriceChangeRows({
       current: item.unit_price,
       currency: item.currency,
       time: item.effective_from || item.updated_at || item.created_at
-    }))
+    })))
   ]
   return rows.sort(
     (left, right) => new Date(right.time || 0) - new Date(left.time || 0)
   )
+}
+
+export function officialHistoryRows(items = []) {
+  const dimensions = [
+    ['text_input', 'input_price'],
+    ['text_output', 'output_price'],
+    ['cache_input', 'cache_input_price'],
+    ['image_input', 'image_input_price'],
+    ['image_output', 'image_output_price'],
+    ['audio_input', 'audio_input_price'],
+    ['audio_output', 'audio_output_price'],
+    ['video_input', 'video_input_price'],
+    ['video_output', 'video_output_price']
+  ]
+  const groups = new Map()
+  items.forEach((item) => {
+    const key = [
+      item.source,
+      item.offering || 'default',
+      item.source_platform_id,
+      item.model
+    ].join(':')
+    const versions = groups.get(key) || []
+    versions.push(item)
+    groups.set(key, versions)
+  })
+  const rows = []
+  groups.forEach((versions) => {
+    versions.sort((left, right) => historyTime(right) - historyTime(left))
+    versions.forEach((item, index) => {
+      const previous = versions[index + 1] || null
+      const currentValues = flattenHistoryValues(item)
+      const previousValues = flattenHistoryValues(previous)
+      dimensions.forEach(([dimension, field]) => {
+        if (!hasValue(currentValues[field])) return
+        rows.push({
+          key: `official-${item.id}-${dimension}`,
+          type: 'official',
+          modelId: item.model,
+          name: item.model_name || item.meta_model_name || '',
+          context: item.source_model_name || item.sku_code || '',
+          source: item.source_name || item.provider_name || '',
+          dimension,
+          previous: previousValues[field] ?? null,
+          current: currentValues[field],
+          currency: item.currency,
+          time: item.effective_from || item.collected_at
+        })
+      })
+    })
+  })
+  return rows
 }
 
 export function priceChangeDelta(row) {
@@ -116,4 +170,21 @@ function numericValue(value) {
   if (!hasValue(value)) return null
   const number = Number(value)
   return Number.isFinite(number) ? number : null
+}
+
+function flattenHistoryValues(item) {
+  if (!item) return {}
+  const values = (item.normalized_price_rows || []).reduce((result, row) => {
+    Object.entries(row?.values || {}).forEach(([key, value]) => {
+      if (key !== 'currency' && hasValue(value)) result[key] = value
+    })
+    return result
+  }, {})
+  if (
+    !hasValue(values.cache_input_price) &&
+    hasValue(values.cache_hit_input_price)
+  ) {
+    values.cache_input_price = values.cache_hit_input_price
+  }
+  return values
 }

--- a/frontend/tests/llmOpsChannelPriceMatrix.test.js
+++ b/frontend/tests/llmOpsChannelPriceMatrix.test.js
@@ -3,9 +3,12 @@ import { readFileSync } from 'node:fs'
 import test from 'node:test'
 
 import {
+  channelOfferingForOption,
   compareChannelOptions,
   effectiveMatrixAction,
+  bestOptionForChannel,
   optionFreshness,
+  optionsForChannel,
   savingsPercent
 } from '../src/utils/llmOpsChannelPriceMatrix.js'
 import { dataGroupsForSection } from '../src/utils/llmOpsSectionData.js'
@@ -94,6 +97,37 @@ test('sorts comparable offers by the selected pricing dimension', () => {
   assert.deepEqual(
     compareChannelOptions(row, 'output').map((item) => item.channel_id),
     [3, 1, 2]
+  )
+})
+
+test('selects the cheapest offer within a channel and preserves all offers', () => {
+  const row = {
+    options: [
+      { channel_id: 1, offering_id: 2, estimated_cost: 5 },
+      { channel_id: 1, offering_id: 1, estimated_cost: 3 },
+      { channel_id: 2, offering_id: 3, estimated_cost: 1 }
+    ]
+  }
+
+  assert.deepEqual(
+    optionsForChannel(row, 1).map((item) => item.offering_id),
+    [1, 2]
+  )
+  assert.equal(bestOptionForChannel(row, 1).offering_id, 1)
+})
+
+test('matches comparison details to the selected channel offering', () => {
+  const offerings = [
+    { id: 1, channel: 3, display_name: 'DeepSeek R1' },
+    { id: 6, channel: 3, display_name: 'DeepSeek V4 Flash' }
+  ]
+
+  assert.equal(
+    channelOfferingForOption(offerings, {
+      channel_id: 3,
+      offering_id: 6
+    }).display_name,
+    'DeepSeek V4 Flash'
   )
 })
 

--- a/frontend/tests/llmOpsConsoleConsistency.test.js
+++ b/frontend/tests/llmOpsConsoleConsistency.test.js
@@ -111,6 +111,67 @@ test('builds distinguishable price changes for every pricing dimension', () => {
   assert.ok(Math.abs(priceChangeDelta(listing) - 0.3) < Number.EPSILON * 2)
 })
 
+test('builds official price changes from collected history versions', () => {
+  const rows = buildPriceChangeRows({
+    officialHistory: [
+      {
+        id: 2,
+        source: 4,
+        source_name: 'DeepSeek Official',
+        offering: 8,
+        source_platform_id: 'deepseek-v4-flash',
+        model: 7,
+        model_name: 'DeepSeek V4 Flash',
+        currency: 'CNY',
+        normalized_price_rows: [
+          {
+            values: {
+              input_price: '1.2',
+              output_price: '2.4',
+              cache_hit_input_price: '0.12'
+            }
+          }
+        ],
+        effective_from: '2026-08-21T02:00:00Z'
+      },
+      {
+        id: 1,
+        source: 4,
+        source_name: 'DeepSeek Official',
+        offering: 8,
+        source_platform_id: 'deepseek-v4-flash',
+        model: 7,
+        model_name: 'DeepSeek V4 Flash',
+        currency: 'CNY',
+        normalized_price_rows: [
+          {
+            values: {
+              input_price: '1',
+              output_price: '2',
+              cache_hit_input_price: '0.1'
+            }
+          }
+        ],
+        effective_from: '2026-08-20T02:00:00Z'
+      }
+    ]
+  })
+  const input = rows.find((row) => row.dimension === 'text_input')
+  const cache = rows.find((row) => row.dimension === 'cache_input')
+  assert.equal(input.previous, '1')
+  assert.equal(input.current, '1.2')
+  assert.equal(input.source, 'DeepSeek Official')
+  assert.equal(cache.previous, '0.1')
+  assert.equal(cache.current, '0.12')
+})
+
+test('passes collected official history from the page data composable', () => {
+  assert.match(
+    pageSource,
+    /const\s*\{[\s\S]*?officialPriceHistory[\s\S]*?\}\s*=\s*useLLMOpsData\(\)/
+  )
+})
+
 test('labels listing KPIs as workflow scope and counts supply candidates', () => {
   assert.match(listingDisplaySource, /workflowCandidates/)
   assert.match(listingDisplaySource, /candidateModels/)


### PR DESCRIPTION
## Summary

- distinguish base models from dated/versioned SKUs while preserving official model IDs
- expose regional price offers and price-change history in the LLM Ops console
- align channel comparison and listing filters with price source, provider, model, region, and offer identity
- add backend and frontend regression coverage for multi-offer pricing

## Verification

- frontend unit tests: 162 passed
- frontend typecheck passed
- frontend production build passed
- backend targeted serializers/views tests: 60 passed
- ego-browser task spaces 132 and 133: version/SKU, regional prices, price history, matrix details, and channel filtering verified

Closes #341