### PR TITLE
feat(quotation): copy quotation into create form

### DIFF
--- a/frontend/scripts/quotation-save-no-download.test.mjs
+++ b/frontend/scripts/quotation-save-no-download.test.mjs
@@ -6,6 +6,13 @@ const app = readFileSync(
   new URL('../src/modules/quotation/App.vue', import.meta.url),
   'utf8',
 )
+const create = readFileSync(
+  new URL(
+    '../src/modules/quotation/components/QuotationCreate.vue',
+    import.meta.url,
+  ),
+  'utf8',
+)
 const quotationList = readFileSync(
   new URL(
     '../src/modules/quotation/components/QuotationList.vue',
@@ -78,4 +85,28 @@ test('imported quotations do not render the copy action', () => {
 
   assert.ok(copyStart >= 0)
   assert.match(copyBlock, /v-if="quote\.sourceType !== 'document_import'"/)
+})
+
+test('copy opens a create form without creating a quotation first', () => {
+  const copyStart = app.indexOf('async function handleCopyQuote')
+  const copyEnd = app.indexOf('function handleBackToList')
+  const copyFlow = app.slice(copyStart, copyEnd)
+
+  assert.ok(copyStart >= 0)
+  assert.ok(copyEnd > copyStart)
+  assert.match(copyFlow, /getQuotationApi\(id\)/)
+  assert.match(copyFlow, /copySourceQuote\.value = sourceQuote/)
+  assert.match(copyFlow, /router\.push\('\/quotation\/create'\)/)
+  assert.doesNotMatch(copyFlow, /copyQuotationApi/)
+  assert.doesNotMatch(copyFlow, /refreshQuotations/)
+})
+
+test('copied quotation data is treated as create-form prefill', () => {
+  assert.match(app, /:copy-quote="copySourceQuote"/)
+  assert.match(create, /copyQuote\?: Quotation \| null/)
+  assert.match(create, /function loadCopiedQuoteIntoForm\(/)
+  assert.match(create, /quoteNoMode\.value = 'auto'/)
+  assert.match(create, /quoteDate\.value = todayInput/)
+  assert.match(create, /applyingCreateDraft\.value = false\n    if \(quoteNoMode\.value === 'auto'\) regenerateQuoteNo\(\)/)
+  assert.match(create, /props\.editingQuote \|\| props\.copyQuote \|\| applyingCreateDraft\.value/)
 })

--- a/frontend/src/modules/quotation/App.vue
+++ b/frontend/src/modules/quotation/App.vue
@@ -54,7 +54,6 @@ import {
 } from './api/catalog'
 import {
   createQuotation as createQuotationApi,
-  copyQuotation as copyQuotationApi,
   deleteQuotation as deleteQuotationApi,
   generateQuotation as generateQuotationApi,
   getQuotation as getQuotationApi,
@@ -174,10 +173,17 @@ function syncTabFromRoute() {
   if (nextTab === 'create') {
     const editId = route.query.edit
     editingQuoteId.value = typeof editId === 'string' ? editId : null
+    if (!editingQuoteId.value) {
+      editingQuote.value = null
+    } else {
+      copySourceQuote.value = null
+    }
     return
   }
 
   editingQuoteId.value = null
+  editingQuote.value = null
+  copySourceQuote.value = null
 }
 
 const quotations = ref<Quotation[]>([])
@@ -194,6 +200,7 @@ const activeQuote = ref<Quotation | null>(null)
 const activeQuoteLoading = ref(false)
 const drawerQuoteId = ref<string | null>(null)
 const editingQuote = ref<Quotation | null>(null)
+const copySourceQuote = ref<Quotation | null>(null)
 const quotationFormContext = ref<Quotation[]>([])
 const quotationFormContextQuoteNumbers = ref<string[]>([])
 const lineItemDescriptionHistory = ref<LineItemDescriptionHistory[]>([])
@@ -538,6 +545,7 @@ async function handleLogout() {
   activeQuote.value = null
   drawerQuoteId.value = null
   editingQuote.value = null
+  copySourceQuote.value = null
   quotationFormContext.value = []
   quotationFormContextQuoteNumbers.value = []
   lineItemDescriptionHistory.value = []
@@ -567,7 +575,11 @@ function navClass(tab: string) {
 function goTab(tab: string, listFilters?: ListDateFilters) {
   selectedQuotationId.value = null
   drawerQuoteId.value = null
-  if (tab === 'create') editingQuoteId.value = null
+  if (tab === 'create') {
+    editingQuoteId.value = null
+    editingQuote.value = null
+    copySourceQuote.value = null
+  }
   if (tab === 'create') void loadQuotationFormContext()
   if (tab === 'list') {
     applyListDateFilters(listFilters)
@@ -706,6 +718,8 @@ async function handleSaveQuotation(newQuote: Quotation) {
     }
 
     editingQuoteId.value = null
+    editingQuote.value = null
+    copySourceQuote.value = null
     await refreshQuotations(quotationListQuery.value)
     if (wasCreate) await loadQuotationFormContext()
   } catch (error: unknown) {
@@ -896,6 +910,7 @@ function handleDeleteProductLine(productLine: QuoteProductLine) {
 }
 
 async function handleEditQuote(id: string) {
+  copySourceQuote.value = null
   editingQuoteId.value = id
   await loadEditingQuote(id)
   if (auth.embeddedAuth) {
@@ -907,19 +922,15 @@ async function handleEditQuote(id: string) {
 
 async function handleCopyQuote(id: string) {
   try {
-    const copied = await copyQuotationApi(id)
-    editingQuoteId.value = copied.id
-    editingQuote.value = copied
-    triggerToast(
-      t('quotation.app.quoteCopied', { quoteNo: copied.quoteNo }),
-      'success',
-    )
-    await refreshQuotations(quotationListQuery.value)
+    const sourceQuote = await getQuotationApi(id)
+    if (sourceQuote.sourceType === 'document_import') {
+      throw new Error('document-imported quotations cannot be copied')
+    }
+    editingQuoteId.value = null
+    editingQuote.value = null
+    copySourceQuote.value = sourceQuote
     if (auth.embeddedAuth) {
-      await router.push({
-        path: '/quotation/create',
-        query: { edit: copied.id },
-      })
+      await router.push('/quotation/create')
     } else {
       currentTab.value = 'create'
     }
@@ -932,6 +943,9 @@ async function handleCopyQuote(id: string) {
 }
 
 function handleBackToList() {
+  editingQuoteId.value = null
+  editingQuote.value = null
+  copySourceQuote.value = null
   if (auth.embeddedAuth) {
     router.push('/quotation/list')
     return
@@ -1211,6 +1225,7 @@ function reloadPage() {
           :history-has-more="quotationFormContextHasMore"
           :history-loading="quotationFormContextLoading"
           :editing-quote="editingQuote"
+          :copy-quote="copySourceQuote"
           :customer-prefill="customerPrefill"
           :current-user="auth.currentUser"
           :product-line-options="productLineOptions"

--- a/frontend/src/modules/quotation/components/QuotationCreate.vue
+++ b/frontend/src/modules/quotation/components/QuotationCreate.vue
@@ -112,6 +112,7 @@ const props = withDefaults(
     historyHasMore?: boolean
     historyLoading?: boolean
     editingQuote?: Quotation | null
+    copyQuote?: Quotation | null
     customerPrefill?: {
       company: string
       contact: string
@@ -132,6 +133,7 @@ const props = withDefaults(
     historyHasMore: false,
     historyLoading: false,
     editingQuote: null,
+    copyQuote: null,
     customerPrefill: null,
   },
 )
@@ -632,6 +634,68 @@ function loadEditingQuoteIntoForm(editingQuote: Quotation) {
   }))
 }
 
+function loadCopiedQuoteIntoForm(sourceQuote: Quotation) {
+  applyingCreateDraft.value = true
+  preferDraftQuoteNo.value = false
+  quoteNoMode.value = 'auto'
+  productLine.value =
+    sourceQuote.productLine ||
+    inferProductLineFromQuoteNumber(sourceQuote.quoteNo, props.productLineOptions)
+  projectName.value = sourceQuote.projectName
+  clientCompany.value = sourceQuote.clientCompany
+  contactPerson.value = sourceQuote.contactPerson
+  email.value = sourceQuote.email
+  billingCompany.value = sourceQuote.billingCompany || sourceQuote.clientCompany
+  billingContact.value = sourceQuote.billingContact || sourceQuote.contactPerson
+  billingEmail.value = sourceQuote.billingEmail || sourceQuote.email
+  region.value = sourceQuote.region || ''
+  industry.value = sourceQuote.industry || ''
+  salesperson.value = sourceQuote.salesperson
+  currency.value = ['CNY', 'USD', 'EUR'].includes(sourceQuote.currency)
+    ? sourceQuote.currency as 'CNY' | 'USD' | 'EUR'
+    : 'USD'
+  const loadedPaymentTermOption =
+    sourceQuote.paymentTermOption || inferPaymentTermOption(sourceQuote.paymentTerms || '')
+  paymentTermOption.value = loadedPaymentTermOption
+  paymentTermsCustom.value =
+    loadedPaymentTermOption === 'Others' ? sourceQuote.paymentTerms || '' : ''
+  vatRateInput.value = formatVatRateForInput(sourceQuote.vatRate)
+  taxLabel.value = resolveTaxLabel(sourceQuote.taxLabel)
+  const todayInput = formatDateInput(new Date())
+  quoteDate.value = todayInput
+  expireDate.value = getDefaultExpireDate(dateFromInput(todayInput))
+  quoteNo.value = getNextAutoQuoteNumber(
+    productLine.value,
+    dateFromInput(todayInput),
+    existingQuoteNumbers.value,
+  )
+  remarksDisclaimer.value = sourceQuote.remarksDisclaimer ?? ''
+  issuerCompanyName.value =
+    sourceQuote.issuerCompanyName ?? DEFAULT_ISSUER_COMPANY_NAME
+  issuerContactName.value =
+    sourceQuote.issuerContactName
+    || sourceQuote.salesperson
+    || props.currentUser?.name
+    || ''
+  issuerContactEmail.value =
+    sourceQuote.issuerContactEmail || props.currentUser?.email || ''
+  issuerContactTitle.value =
+    sourceQuote.issuerContactTitle || props.currentUser?.title || ''
+  issuerSignature.value = sourceQuote.issuerSignature ?? ''
+  items.value = JSON.parse(JSON.stringify(sourceQuote.items)).map(
+    (item: QuotationLineItem) => ({
+      ...item,
+      type: item.type === 'Software' ? 'Software' : 'Other',
+      name: '',
+      description: item.description || item.name || '',
+    }),
+  )
+  window.setTimeout(() => {
+    applyingCreateDraft.value = false
+    if (quoteNoMode.value === 'auto') regenerateQuoteNo()
+  }, 0)
+}
+
 function resetCreateForm() {
   preferDraftQuoteNo.value = false
   quoteNoMode.value = 'auto'
@@ -761,12 +825,12 @@ function applyCreateDraft(draft: CreateQuoteDraft) {
 }
 
 function persistCreateDraftSoon() {
-  if (props.editingQuote || applyingCreateDraft.value) return
+  if (props.editingQuote || props.copyQuote || applyingCreateDraft.value) return
   const emailKey = props.currentUser?.email
   if (!emailKey) return
   window.clearTimeout(createDraftSaveTimer)
   createDraftSaveTimer = window.setTimeout(() => {
-    if (props.editingQuote || applyingCreateDraft.value) return
+    if (props.editingQuote || props.copyQuote || applyingCreateDraft.value) return
     saveCreateQuoteDraft(emailKey, buildCreateDraftPayload())
   }, 300)
 }
@@ -793,13 +857,21 @@ onBeforeUnmount(() => {
 })
 
 watch(
-  () => [props.editingQuote?.id ?? null, props.currentUser?.email ?? null] as const,
-  ([editingQuoteId]) => {
+  () => [
+    props.editingQuote?.id ?? null,
+    props.copyQuote?.id ?? null,
+    props.currentUser?.email ?? null,
+  ] as const,
+  ([editingQuoteId, copyQuoteId]) => {
     if (editingQuoteId && props.editingQuote) {
       loadEditingQuoteIntoForm(props.editingQuote)
       return
     }
-    if (!editingQuoteId) {
+    if (copyQuoteId && props.copyQuote) {
+      loadCopiedQuoteIntoForm(props.copyQuote)
+      return
+    }
+    if (!editingQuoteId && !copyQuoteId) {
       initCreateForm()
     }
   },


### PR DESCRIPTION
## Background

The quotation copy action previously created a new quotation immediately through the copy endpoint. This made copying a side-effecting operation and prevented users from reviewing or editing copied content before persistence.

## Requirements covered

### Copy workflow

  * Copying reads the source quotation detail through GET only.
  * Copying opens the normal quotation creation form without creating a database record.
  * Customer, contact, billing, payment, tax, remarks, issuer, and line-item data are prefilled.
  * The copied quotation date defaults to the current date.
  * The preview quotation number is recalculated from the current date and product line.
  * Imported document quotations remain unavailable for copying.

### Draft and formal lifecycle

  * Saving as draft is the first operation that creates a new quotation record.
  * Copied content does not persist into the ordinary create-page local draft.
  * Existing formal quotation roots and `_R1`, `_R2` revision rules remain unchanged.

## Implementation

### Frontend

  * Replaced the copy endpoint call with quotation-detail loading.
  * Added isolated copy-form prefill state in the quotation workspace.
  * Reused the create form for copied content and prevented local draft persistence during prefill.
  * Added regression coverage for the no-create copy flow and copied-form state.

## Verification

### Automated tests

  * `npm run test:unit`: 158 passed.
  * `npm run test:quotation`: 129 passed.
  * `BASE_URL=http://localhost:18000 npx playwright test e2e/quotation.spec.js`: 6 passed.
  * `npm run typecheck`: passed.
  * `npm run build`: passed.
  * Related backend quotation tests: 45 passed, 2 skipped.
  * `git diff --check`: passed.

### Manual verification

Verified against the shared local service at `http://localhost:18000` after mounting the existing frontend runtime to this workspace:

  * Copying navigated to `/quotation/create` without `?edit`.
  * The current date and recalculated preview number were visible.
  * Returning to the list did not increase the quotation count.
  * Opening ordinary New Quote did not show copied customer data.

### Known repository-level test note

The full backend suite still has unrelated existing collection errors and failures outside the quotation copy files. The quotation-focused backend and all frontend verification listed above are green.

## Compatibility and risks

  * No backend API contract changes are introduced.
  * The existing formal-number and revision allocation remains backend-authoritative.
  * No migration is required.