### PR TITLE
Bind channel pricing to selected regional offers

### DIFF
--- a/backend/llm_ops/serializers.py
+++ b/backend/llm_ops/serializers.py
@@ -43,6 +43,7 @@ from .models import (
     ResaleListingPriceRevision,
     ResalePlatform,
     ResaleWorkflowConfig,
+    SourceSkuOffering,
     UsageReconciliationRecord,
 )
 from .price_table_validation import (
@@ -731,13 +732,13 @@ class LLMModelSerializer(serializers.ModelSerializer):
         read_only=True,
         allow_null=True,
     )
-    sku_display_name = serializers.CharField(
-        source="sku.display_name",
+    sku_region = serializers.CharField(
+        source="sku.region",
         read_only=True,
         allow_null=True,
     )
-    sku_region = serializers.CharField(
-        source="sku.region",
+    sku_display_name = serializers.CharField(
+        source="sku.display_name",
         read_only=True,
         allow_null=True,
     )
@@ -859,6 +860,11 @@ class ModelPriceItemSerializer(serializers.ModelSerializer):
     )
     sku_code = serializers.CharField(
         source="sku.canonical_sku_code",
+        read_only=True,
+        allow_null=True,
+    )
+    sku_region = serializers.CharField(
+        source="sku.region",
         read_only=True,
         allow_null=True,
     )
@@ -1489,6 +1495,32 @@ class ProcurementChannelSerializer(serializers.ModelSerializer):
         return attrs
 
 
+def get_or_create_channel_offering(channel, model, source_offering):
+    """Return a stable channel offering for a selected source offer."""
+    offering, _created = ChannelOffering.objects.get_or_create(
+        channel=channel,
+        offering_key=f"source-{source_offering.id}",
+        defaults={
+            "meta_model": model.meta_model,
+            "model": model,
+            "source_offering": source_offering,
+            "display_name": (
+                source_offering.exposed_model_name
+                or source_offering.sku.display_name
+                or model.name
+            ),
+        },
+    )
+    if (
+        offering.meta_model_id != model.meta_model_id
+        or offering.source_offering_id != source_offering.id
+    ):
+        raise serializers.ValidationError(
+            {"source_offering": "Selected source offering is already in use."}
+        )
+    return offering
+
+
 class ChannelModelPriceSerializer(serializers.ModelSerializer):
     """Serializer for channel model listing and price overrides."""
 
@@ -1533,6 +1565,27 @@ class ChannelModelPriceSerializer(serializers.ModelSerializer):
         source="offering.display_name",
         read_only=True,
     )
+    source_offering = serializers.PrimaryKeyRelatedField(
+        queryset=SourceSkuOffering.objects.select_related("sku", "source"),
+        write_only=True,
+        required=False,
+        allow_null=True,
+    )
+    source_offering_id = serializers.IntegerField(
+        source="offering.source_offering_id",
+        read_only=True,
+        allow_null=True,
+    )
+    source_sku_code = serializers.CharField(
+        source="offering.source_offering.sku.canonical_sku_code",
+        read_only=True,
+        allow_null=True,
+    )
+    source_sku_region = serializers.CharField(
+        source="offering.source_offering.sku.region",
+        read_only=True,
+        allow_null=True,
+    )
 
     class Meta:
         model = ChannelModelPrice
@@ -1570,6 +1623,7 @@ class ChannelModelPriceSerializer(serializers.ModelSerializer):
             "offering",
             getattr(self.instance, "offering", None),
         )
+        source_offering = attrs.get("source_offering")
         if offering and channel and offering.channel_id != channel.id:
             raise serializers.ValidationError(
                 {"offering": "Offering must belong to the same channel."}
@@ -1586,9 +1640,49 @@ class ChannelModelPriceSerializer(serializers.ModelSerializer):
                     )
                 }
             )
+        if source_offering and model:
+            if source_offering.sku.meta_model_id != model.meta_model_id:
+                raise serializers.ValidationError(
+                    {
+                        "source_offering": (
+                            "Source offering must belong to the model "
+                            "meta model."
+                        )
+                    }
+                )
+            if offering and offering.source_offering_id not in {
+                None,
+                source_offering.id,
+            }:
+                raise serializers.ValidationError(
+                    {
+                        "source_offering": (
+                            "Source offering must match the selected channel "
+                            "offering."
+                        )
+                    }
+                )
+            price_source = attrs.get(
+                "price_source",
+                getattr(self.instance, "price_source", None),
+            )
+            if price_source and source_offering.source_id != price_source.id:
+                raise serializers.ValidationError(
+                    {
+                        "source_offering": (
+                            "Source offering must belong to the selected "
+                            "price source."
+                        )
+                    }
+                )
         if channel and model:
             unique_offering = offering
-            if unique_offering is None:
+            if unique_offering is None and source_offering is not None:
+                unique_offering = ChannelOffering.objects.filter(
+                    channel=channel,
+                    offering_key=f"source-{source_offering.id}",
+                ).first()
+            elif unique_offering is None:
                 unique_offering = ChannelOffering.objects.filter(
                     channel=channel,
                     meta_model=model.meta_model,
@@ -1614,12 +1708,26 @@ class ChannelModelPriceSerializer(serializers.ModelSerializer):
         return attrs
 
     def create(self, validated_data):
+        source_offering = validated_data.pop("source_offering", None)
         validated_data["meta_model"] = validated_data["model"].meta_model
+        if source_offering and not validated_data.get("offering"):
+            validated_data["offering"] = get_or_create_channel_offering(
+                validated_data["channel"],
+                validated_data["model"],
+                source_offering,
+            )
         return super().create(validated_data)
 
     def update(self, instance, validated_data):
+        source_offering = validated_data.pop("source_offering", None)
         model = validated_data.get("model", instance.model)
         validated_data["meta_model"] = model.meta_model
+        if source_offering and not validated_data.get("offering"):
+            validated_data["offering"] = get_or_create_channel_offering(
+                validated_data.get("channel", instance.channel),
+                model,
+                source_offering,
+            )
         return super().update(instance, validated_data)
 
 

--- a/backend/llm_ops/services.py
+++ b/backend/llm_ops/services.py
@@ -2283,6 +2283,17 @@ def current_model_price_items_for_channel_price(
     price: ChannelModelPrice,
 ) -> list[ModelPriceItem]:
     """Return current price items for the selected procurement source."""
+    source_offering_id = getattr(price.offering, "source_offering_id", None)
+    if source_offering_id:
+        rows = list(
+            ModelPriceItem.objects.filter(
+                offering_id=source_offering_id,
+                is_current=True,
+            ).order_by("dimension", "tier_start", "id")
+        )
+        if rows:
+            return selected_price_item_group(rows, model=price.model)
+        return []
     if price.price_source_id:
         rows = current_price_items_for_model(
             price.model,

--- a/backend/llm_ops/tests/test_channel_offerings.py
+++ b/backend/llm_ops/tests/test_channel_offerings.py
@@ -11,7 +11,10 @@ from llm_ops.models import (
     LLMModel,
     LLMProvider,
     MetaModel,
+    ModelSku,
+    PriceCollectionSource,
     ProcurementChannel,
+    SourceSkuOffering,
 )
 
 
@@ -155,6 +158,75 @@ class ChannelOfferingAPITests(TestCase):
         custom_price.refresh_from_db()
         self.assertEqual(default_price.settlement_ratio, Decimal("0.5"))
         self.assertEqual(custom_price.settlement_ratio, Decimal("0.7"))
+
+    def test_bulk_upsert_binds_selected_source_offering(self):
+        source = PriceCollectionSource.objects.create(
+            name="Aliyun official",
+            slug="aliyun-official-region-test",
+            provider=self.provider,
+        )
+        sku = ModelSku.objects.create(
+            provider=self.provider,
+            meta_model=self.meta_model,
+            canonical_sku_code="deepseek-v4-flash",
+            upstream_model_name="deepseek-v4-flash",
+            display_name="DeepSeek V4 Flash",
+            region="Japan",
+        )
+        source_offering = SourceSkuOffering.objects.create(
+            source=source,
+            sku=sku,
+            provider=self.provider,
+            exposed_model_name="deepseek-v4-flash",
+        )
+
+        response = self.client.post(
+            reverse("channel-model-price-bulk-upsert"),
+            {
+                "items": [
+                    {
+                        "channel": self.channel.id,
+                        "model": self.model.id,
+                        "price_source": source.id,
+                        "source_offering": source_offering.id,
+                    }
+                ]
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200, response.data)
+        price = ChannelModelPrice.objects.get()
+        self.assertEqual(
+            price.offering.source_offering_id,
+            source_offering.id,
+        )
+        self.assertEqual(response.data[0]["offering"], price.offering_id)
+        self.assertEqual(
+            response.data[0]["source_offering_id"],
+            source_offering.id,
+        )
+
+        response = self.client.post(
+            reverse("channel-model-price-bulk-upsert"),
+            {
+                "items": [
+                    {
+                        "channel": self.channel.id,
+                        "model": self.model.id,
+                        "price_source": source.id,
+                        "source_offering": source_offering.id,
+                        "settlement_ratio": "0.6",
+                    }
+                ]
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertEqual(ChannelModelPrice.objects.count(), 1)
+        price.refresh_from_db()
+        self.assertEqual(price.settlement_ratio, Decimal("0.6"))
 
     def _create_offering(self, key, name):
         response = self.client.post(

--- a/backend/llm_ops/tests/test_services.py
+++ b/backend/llm_ops/tests/test_services.py
@@ -9,6 +9,7 @@ from django.test.utils import CaptureQueriesContext
 from llm_ops.models import (
     ChannelModelPrice,
     ChannelModelPriceHistory,
+    ChannelOffering,
     ChannelPriceItem,
     LLMModel,
     LLMProvider,
@@ -686,6 +687,63 @@ class LLMOpsPricingServiceTests(TestCase):
         self.assertEqual(items[0].base_price_item, selected_item)
         self.assertEqual(items[0].unit_price, Decimal("1.500000"))
         self.assertEqual(cost, Decimal("1.500000"))
+
+    def test_sync_does_not_mix_regions_for_selected_source_offering(self):
+        source = PriceCollectionSource.objects.create(
+            name="Regional supplier",
+            slug="regional-supplier",
+            provider=self.provider,
+        )
+        offerings = []
+        for region, amount in (("Global", "9"), ("Japan", "3")):
+            sku = ModelSku.objects.create(
+                provider=self.provider,
+                meta_model=self.model.meta_model,
+                canonical_sku_code="gpt-4o",
+                upstream_model_name="gpt-4o",
+                display_name=f"GPT-4o {region}",
+                region=region,
+            )
+            offering = SourceSkuOffering.objects.create(
+                source=source,
+                sku=sku,
+                provider=self.provider,
+                exposed_model_name="gpt-4o",
+            )
+            ModelPriceItem.objects.create(
+                provider=self.provider,
+                sku=sku,
+                offering=offering,
+                meta_model=self.model.meta_model,
+                source=source,
+                dimension=ModelPriceItem.DIMENSION_TEXT_INPUT,
+                billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
+                currency="USD",
+                unit_price=Decimal(amount),
+                price_fingerprint=f"region-{region}",
+                is_current=True,
+            )
+            offerings.append(offering)
+        channel_offering = ChannelOffering.objects.create(
+            channel=self.channel,
+            meta_model=self.model.meta_model,
+            model=self.model,
+            source_offering=offerings[1],
+            offering_key="japan",
+            display_name="Japan",
+        )
+        price = ChannelModelPrice.objects.create(
+            channel=self.channel,
+            model=self.model,
+            offering=channel_offering,
+            price_source=source,
+            settlement_ratio=Decimal("1"),
+        )
+
+        items = sync_channel_price_items(price)
+
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].unit_price, Decimal("3"))
 
     def test_sync_selects_price_group_matching_model_base_prices(self):
         source = PriceCollectionSource.objects.create(

--- a/backend/llm_ops/views.py
+++ b/backend/llm_ops/views.py
@@ -105,6 +105,7 @@ from .serializers import (
     ResaleWorkflowConfigSerializer,
     UsageReconciliationRecordSerializer,
     YunceCollectionRequestSerializer,
+    get_or_create_channel_offering,
 )
 from .services import (
     OPERATION_SCOPE_MARKET_REFERENCE,
@@ -1555,6 +1556,8 @@ class ChannelModelPriceViewSet(
             "model",
             "model__provider",
             "offering",
+            "offering__source_offering",
+            "offering__source_offering__sku",
             "price_source",
         )
         channel = self.request.query_params.get("channel")
@@ -1650,6 +1653,12 @@ class ChannelModelPriceViewSet(
                     existing_queryset = existing_queryset.filter(
                         offering_id=item.get("offering")
                     )
+                elif item.get("source_offering") is not None:
+                    existing_queryset = existing_queryset.filter(
+                        offering__source_offering_id=item.get(
+                            "source_offering"
+                        )
+                    )
                 else:
                     existing_queryset = existing_queryset.filter(
                         offering__is_default=True
@@ -1664,6 +1673,13 @@ class ChannelModelPriceViewSet(
                 serializer.is_valid(raise_exception=True)
                 data = serializer.validated_data
                 offering = data.get("offering")
+                source_offering = data.get("source_offering")
+                if offering is None and source_offering is not None:
+                    offering = get_or_create_channel_offering(
+                        data["channel"],
+                        data["model"],
+                        source_offering,
+                    )
                 if offering is None:
                     offering, _created = ChannelOffering.objects.get_or_create(
                         channel=data["channel"],
@@ -1684,7 +1700,8 @@ class ChannelModelPriceViewSet(
                 defaults = {
                     key: value
                     for key, value in data.items()
-                    if key not in {"channel", "model", "offering"}
+                    if key
+                    not in {"channel", "model", "offering", "source_offering"}
                 }
                 defaults["meta_model"] = data["model"].meta_model
                 price, created = ChannelModelPrice.objects.update_or_create(

--- a/frontend/src/components/llm-ops/ChannelManagement.vue
+++ b/frontend/src/components/llm-ops/ChannelManagement.vue
@@ -191,6 +191,7 @@
       :meta-models="metaModels"
       :models="models"
       :channel-prices="channelPrices"
+      :channel-offerings="channelOfferings"
       :channel-price-items="channelPriceItems"
       :price-items="priceItems"
       :display-currency="displayCurrency"

--- a/frontend/src/components/llm-ops/ChannelModelDrawer.vue
+++ b/frontend/src/components/llm-ops/ChannelModelDrawer.vue
@@ -379,11 +379,23 @@
                         {{ t('llmOps.channelModelDrawer.noAvailableUpstream') }}
                       </span>
                     </div>
+                    <CompactSelect
+                      v-if="item.sourceOfferingOptions?.length > 1"
+                      :model-value="item.selectedSourceOfferingId || ''"
+                      :options="item.sourceOfferingOptions"
+                      :placeholder="t('llmOps.channelModelDrawer.selectRegion')"
+                      @change="
+                        (value) => selectSourceOffering(item.group.key, value)
+                      "
+                    />
                     <div v-if="item.model" class="batch-price-preview">
                       <span>
                         {{
                           t('llmOps.channelModelDrawer.upstreamSummary', {
-                            value: batchUpstreamPriceSummary(item.model)
+                            value: batchUpstreamPriceSummary(
+                              item.model,
+                              item.selectedSourceOfferingId
+                            )
                           })
                         }}
                       </span>
@@ -392,7 +404,8 @@
                           t('llmOps.channelModelDrawer.costSummary', {
                             value: batchPendingDraftPriceSummary(
                               newDraft,
-                              item.model
+                              item.model,
+                              item.selectedSourceOfferingId
                             )
                           })
                         }}
@@ -586,7 +599,9 @@
                   </strong>
                   <strong>
                     <em>{{ t('llmOps.channelModelDrawer.upstream') }}</em>
-                    {{ upstreamPriceSummary(row.model) }}
+                    {{
+                      upstreamPriceSummary(row.model, row.draft.source_offering)
+                    }}
                   </strong>
                 </div>
                 <div class="channel-model-ability-summary">
@@ -613,7 +628,10 @@
                     }}</span>
                     <div class="mt-1 space-y-1 font-mono">
                       <p
-                        v-for="item in providerPriceSummary(row.model)"
+                        v-for="item in providerPriceSummary(
+                          row.model,
+                          row.draft.source_offering
+                        )"
                         :key="item.label"
                       >
                         <span class="text-slate-400">{{ item.label }}</span>
@@ -870,7 +888,12 @@
                                 </span>
                               </div>
                               <strong v-else class="price-tier-missing">
-                                {{ upstreamPriceSummary(row.model) }}
+                                {{
+                                  upstreamPriceSummary(
+                                    row.model,
+                                    row.draft.source_offering
+                                  )
+                                }}
                               </strong>
                             </div>
                           </div>
@@ -883,7 +906,14 @@
                         </span>
                         <span>
                           <em>{{ t('llmOps.channelModelDrawer.upstream') }}</em>
-                          <strong>{{ upstreamPriceSummary(row.model) }}</strong>
+                          <strong>
+                            {{
+                              upstreamPriceSummary(
+                                row.model,
+                                row.draft.source_offering
+                              )
+                            }}
+                          </strong>
                         </span>
                       </template>
                     </div>
@@ -996,6 +1026,10 @@ const props = defineProps({
     type: Array,
     default: () => []
   },
+  channelOfferings: {
+    type: Array,
+    default: () => []
+  },
   channelPriceItems: {
     type: Array,
     default: () => []
@@ -1023,6 +1057,7 @@ const selectedVendorKey = ref('')
 const modelSearch = ref('')
 const selectedModelKeys = ref(new Set())
 const selectedProviderByModelKey = ref({})
+const selectedSourceOfferingByModelKey = ref({})
 const modelDropdownOpen = ref(false)
 const modelDropdownRef = ref(null)
 const modelSearchInput = ref(null)
@@ -1225,6 +1260,7 @@ const {
   selectedModelCount,
   selectedModelOptions,
   selectedResolvedModels,
+  selectSourceOffering,
   toggleModelSelection,
   vendorOptions
 } = useChannelModelSelection({
@@ -1241,10 +1277,12 @@ const {
   modelSourceCategory,
   normalizeSearch,
   providerModelDescription,
+  priceItems: props.priceItems,
   providerPriceSummary,
   purchaseSourceLabel,
   selectedModelKeys,
   selectedProviderByModelKey,
+  selectedSourceOfferingByModelKey,
   selectedVendorKey,
   sourceCategoryBadge,
   t
@@ -1406,7 +1444,10 @@ function priceTierComparisonRows(row) {
   }
 
   append(row?.priceItems || [], 'costPrices')
-  append(providerPriceItemsForModel(row?.model), 'upstreamPrices')
+  append(
+    providerPriceItemsForModel(row?.model, row?.draft?.source_offering),
+    'upstreamPrices'
+  )
   return Array.from(tiers.values())
 }
 

--- a/frontend/src/composables/useChannelModelDrafts.js
+++ b/frontend/src/composables/useChannelModelDrafts.js
@@ -63,6 +63,9 @@ export function useChannelModelDrafts({
       price_source_name: '',
       price_source_category: '',
       price_source_endpoint_url: '',
+      source_offering: '',
+      source_sku_code: '',
+      source_sku_region: '',
       is_listed: false,
       price_mode: 'channel_default',
       currency: '',
@@ -88,6 +91,9 @@ export function useChannelModelDrafts({
       price_source_name: normalized.price_source_name || '',
       price_source_category: normalized.price_source_category || '',
       price_source_endpoint_url: normalized.price_source_endpoint_url || '',
+      source_offering: normalized.source_offering || '',
+      source_sku_code: normalized.source_sku_code || '',
+      source_sku_region: normalized.source_sku_region || '',
       is_configured: Boolean(normalized.is_configured),
       is_listed: Boolean(normalized.is_listed),
       price_mode: normalized.price_mode || 'channel_default',
@@ -180,6 +186,10 @@ export function useChannelModelDrafts({
         price?.price_source_category || getModelSourceCategory(model) || '',
       price_source_endpoint_url:
         price?.price_source_endpoint_url || model.source_endpoint_url || '',
+      source_offering:
+        price?.source_offering || price?.source_offering_id || '',
+      source_sku_code: price?.source_sku_code || '',
+      source_sku_region: price?.source_sku_region || '',
       is_configured: Boolean(price?.id),
       is_listed: price?.is_listed || false,
       price_mode: priceModeFromDraft(price || {}),
@@ -276,6 +286,8 @@ export function useChannelModelDrafts({
     delete clean.price_source_name
     delete clean.price_source_category
     delete clean.price_source_endpoint_url
+    delete clean.source_sku_code
+    delete clean.source_sku_region
     return clean
   }
 
@@ -287,6 +299,7 @@ export function useChannelModelDrafts({
         channel: getChannel().id
       },
       [
+        'source_offering',
         'settlement_ratio',
         'custom_input_price_per_million',
         'custom_output_price_per_million',

--- a/frontend/src/composables/useChannelModelNewDraft.js
+++ b/frontend/src/composables/useChannelModelNewDraft.js
@@ -80,14 +80,18 @@ export function useChannelModelNewDraft({
 
   function addSelectedModels() {
     if (!canAddSelectedModels.value) return
-    const modelsToAdd = selectedResolvedModels.value
-      .map((item) => item.model)
-      .filter(Boolean)
-    modelsToAdd.forEach((model) => {
-      drafts.value[model.id] = buildDraftForModel(model)
+    const modelsToAdd = selectedResolvedModels.value.filter(
+      (item) => item.model
+    )
+    modelsToAdd.forEach((item) => {
+      const model = item.model
+      drafts.value[model.id] = buildDraftForModel(
+        model,
+        item.selectedSourceOfferingId
+      )
       applyPriceMode(drafts.value[model.id])
     })
-    recentlyAddedModelId.value = modelsToAdd.at(-1)?.id || null
+    recentlyAddedModelId.value = modelsToAdd.at(-1)?.model?.id || null
     resetNewDraft()
     modelSearch.value = ''
     clearSelectedModels()
@@ -100,7 +104,10 @@ export function useChannelModelNewDraft({
     })
   }
 
-  function buildDraftForModel(model) {
+  function buildDraftForModel(model, sourceOfferingId = '') {
+    const sourcePriceItem = (props.priceItems || []).find(
+      (item) => String(item.offering) === String(sourceOfferingId)
+    )
     return {
       ...draftDefaults(model, null),
       is_configured: true,
@@ -110,6 +117,9 @@ export function useChannelModelNewDraft({
       price_source_name: model.source_name || '',
       price_source_category: modelSourceCategory(model) || '',
       price_source_endpoint_url: model.source_endpoint_url || '',
+      source_offering: sourceOfferingId || '',
+      source_sku_code: sourcePriceItem?.sku_code || '',
+      source_sku_region: sourcePriceItem?.sku_region || '',
       currency: newDraft.value.currency,
       settlement_ratio:
         newDraft.value.price_mode === 'discount'

--- a/frontend/src/composables/useChannelModelPricing.js
+++ b/frontend/src/composables/useChannelModelPricing.js
@@ -68,7 +68,11 @@ export function useChannelModelPricing({
         Number.POSITIVE_INFINITY
       )
     }
-    const previewItems = draftPricePreview(row?.draft, row?.model)
+    const previewItems = draftPricePreview(
+      row?.draft,
+      row?.model,
+      row?.draft?.source_offering
+    )
     if (!previewItems.length) {
       return translate('llmOps.channelModelDrawer.pendingCostGeneration')
     }
@@ -83,8 +87,8 @@ export function useChannelModelPricing({
     )
   }
 
-  function upstreamPriceSummary(model) {
-    const rows = providerPriceSummary(model)
+  function upstreamPriceSummary(model, sourceOfferingId = '') {
+    const rows = providerPriceSummary(model, sourceOfferingId)
     if (!rows.length) return '-'
     return priceSummaryText(rows, model, Number.POSITIVE_INFINITY)
   }
@@ -109,14 +113,14 @@ export function useChannelModelPricing({
     })
   }
 
-  function batchUpstreamPriceSummary(model) {
-    const rows = providerPriceSummary(model)
+  function batchUpstreamPriceSummary(model, sourceOfferingId = '') {
+    const rows = providerPriceSummary(model, sourceOfferingId)
     if (!rows.length) return '-'
     return batchPriceSummaryText(rows, model)
   }
 
-  function batchPendingDraftPriceSummary(draft, model) {
-    const rows = draftPricePreview(draft, model)
+  function batchPendingDraftPriceSummary(draft, model, sourceOfferingId = '') {
+    const rows = draftPricePreview(draft, model, sourceOfferingId)
     if (!rows.length) return '-'
     return batchPriceSummaryText(
       rows.map((item) => ({
@@ -226,8 +230,8 @@ export function useChannelModelPricing({
     return false
   }
 
-  function providerPriceSummary(model) {
-    const itemRows = providerPriceItemsForModel(model)
+  function providerPriceSummary(model, sourceOfferingId = '') {
+    const itemRows = providerPriceItemsForModel(model, sourceOfferingId)
     if (itemRows.length) {
       return channelPriceSummaryRows(itemRows)
     }
@@ -257,8 +261,17 @@ export function useChannelModelPricing({
     ])
   }
 
-  function providerPriceItemsForModel(model) {
+  function providerPriceItemsForModel(model, sourceOfferingId = '') {
     if (!model) return []
+    if (sourceOfferingId) {
+      return sortPriceItems(
+        props.priceItems.filter(
+          (item) =>
+            String(item.offering) === String(sourceOfferingId) &&
+            item.is_current !== false
+        )
+      )
+    }
     const exactRows = sortPriceItems(
       props.priceItems.filter(
         (item) =>
@@ -392,7 +405,7 @@ export function useChannelModelPricing({
     return ''
   }
 
-  function draftPricePreview(draft, model) {
+  function draftPricePreview(draft, model, sourceOfferingId = '') {
     if (!model) return []
     const targetCurrency =
       draft.currency || props.channel?.currency || model.currency
@@ -403,13 +416,15 @@ export function useChannelModelPricing({
       return discountPricePreview(
         model,
         targetCurrency,
-        Number(draft.settlement_ratio || 0)
+        Number(draft.settlement_ratio || 0),
+        sourceOfferingId
       )
     }
     return discountPricePreview(
       model,
       targetCurrency,
-      Number(props.channel?.settlement_ratio || 1)
+      Number(props.channel?.settlement_ratio || 1),
+      sourceOfferingId
     )
   }
 
@@ -423,9 +438,9 @@ export function useChannelModelPricing({
       .filter((item) => item.value !== '')
   }
 
-  function discountPricePreview(model, currency, ratio) {
+  function discountPricePreview(model, currency, ratio, sourceOfferingId = '') {
     if (!Number.isFinite(ratio) || ratio <= 0) return []
-    return providerPriceSummary(model)
+    return providerPriceSummary(model, sourceOfferingId)
       .map((item) => {
         const sourceCurrency = item.currency || model.currency || currency
         const baseAmount = convertAmountBetween(
@@ -483,8 +498,12 @@ export function useChannelModelPricing({
       row.draft.price_source_name ||
       row.model.price_source_name ||
       upstreamSourceLabel(row.model)
-    const version = row.model.sku_code || row.model.sku_display_name || ''
-    const region = row.model.sku_region || ''
+    const version =
+      row.draft.source_sku_code ||
+      row.model.sku_code ||
+      row.model.sku_display_name ||
+      ''
+    const region = row.draft.source_sku_region || row.model.sku_region || ''
     return [source, version, region].filter(Boolean).join(' · ')
   }
 

--- a/frontend/src/composables/useChannelModelSelection.js
+++ b/frontend/src/composables/useChannelModelSelection.js
@@ -15,9 +15,11 @@ export function useChannelModelSelection({
   normalizeSearch,
   providerModelDescription,
   providerPriceSummary,
+  priceItems,
   purchaseSourceLabel,
   selectedModelKeys,
   selectedProviderByModelKey,
+  selectedSourceOfferingByModelKey,
   selectedVendorKey,
   sourceCategoryBadge,
   t
@@ -123,10 +125,17 @@ export function useChannelModelSelection({
       const model = group.models.find(
         (item) => String(item.id) === String(selectedProviderId)
       )
+      const sourceOfferingOptions = sourceOfferingOptionsForModel(model)
       return {
         group,
         model: model || null,
-        options: providerOptionsForModelGroup(group)
+        options: providerOptionsForModelGroup(group),
+        sourceOfferingOptions,
+        selectedSourceOfferingId:
+          selectedSourceOfferingByModelKey.value[group.key] ||
+          (sourceOfferingOptions.length === 1
+            ? sourceOfferingOptions[0].value
+            : '')
       }
     })
   )
@@ -143,7 +152,12 @@ export function useChannelModelSelection({
   const canAddSelectedModels = computed(
     () =>
       selectedModelCount.value > 0 &&
-      selectedResolvedCount.value === selectedModelCount.value
+      selectedResolvedCount.value === selectedModelCount.value &&
+      selectedResolvedModels.value.every(
+        (item) =>
+          item.sourceOfferingOptions.length <= 1 ||
+          Boolean(item.selectedSourceOfferingId)
+      )
   )
 
   function providerOptionsForModelGroup(group) {
@@ -166,6 +180,44 @@ export function useChannelModelSelection({
           model.currency
         ].join(' ')
       }))
+  }
+
+  function sourceOfferingOptionsForModel(model) {
+    if (!model) return []
+    const rows = (priceItems?.value || priceItems || []).filter((item) => {
+      return (
+        String(item.meta_model || '') === String(model.meta_model || '') &&
+        String(item.source || '') === String(model.source || '') &&
+        item.is_current !== false &&
+        item.offering
+      )
+    })
+    const regionalRows = rows.map((item) => ({
+      item,
+      region:
+        item.sku_region ||
+        item.spec?.deployment_scope ||
+        item.spec?.region ||
+        item.region ||
+        'Global'
+    }))
+    const options = new Map()
+    regionalRows.forEach(({ item, region }) => {
+      const id = String(item.offering)
+      if (options.has(id)) return
+      const sku = item.sku_code || item.sku_display_name || ''
+      options.set(id, {
+        label:
+          [region, sku].filter(Boolean).join(' · ') ||
+          item.offering_exposed_model_name ||
+          id,
+        value: item.offering,
+        description: item.offering_exposed_model_name || ''
+      })
+    })
+    return Array.from(options.values()).sort((left, right) =>
+      left.label.localeCompare(right.label)
+    )
   }
 
   function uniqueProviderModelsForGroup(group) {
@@ -222,6 +274,7 @@ export function useChannelModelSelection({
   function clearSelectedModels() {
     selectedModelKeys.value = new Set()
     selectedProviderByModelKey.value = {}
+    selectedSourceOfferingByModelKey.value = {}
   }
 
   function ensureDefaultProvider(group) {
@@ -235,11 +288,39 @@ export function useChannelModelSelection({
     const next = { ...selectedProviderByModelKey.value }
     delete next[key]
     selectedProviderByModelKey.value = next
+    const offerings = { ...selectedSourceOfferingByModelKey.value }
+    delete offerings[key]
+    selectedSourceOfferingByModelKey.value = offerings
   }
 
   function selectBatchPriceSourceModel(key, value) {
     selectedProviderByModelKey.value = {
       ...selectedProviderByModelKey.value,
+      [key]: value
+    }
+    const group = candidateMetaModelGroups.value.find(
+      (item) => item.key === key
+    )
+    const model = group?.models?.find(
+      (item) => String(item.id) === String(value)
+    )
+    const options = sourceOfferingOptionsForModel(model)
+    if (options.length === 1) {
+      selectSourceOffering(key, options[0].value)
+    } else if (
+      !options.some(
+        (option) =>
+          String(option.value) ===
+          String(selectedSourceOfferingByModelKey.value[key] || '')
+      )
+    ) {
+      selectSourceOffering(key, '')
+    }
+  }
+
+  function selectSourceOffering(key, value) {
+    selectedSourceOfferingByModelKey.value = {
+      ...selectedSourceOfferingByModelKey.value,
       [key]: value
     }
   }
@@ -254,6 +335,7 @@ export function useChannelModelSelection({
     isModelSelected,
     providerOptionsForModelGroup,
     selectBatchPriceSourceModel,
+    selectSourceOffering,
     selectVisibleModels,
     selectedCostModel,
     selectedModelCount,

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1444,6 +1444,7 @@
       "selectedMetaModels": "{count} meta models selected",
       "selectedModels": "Selected models",
       "selectedModelsHint": "Choose the actual channel upstream used by each meta model.",
+      "selectRegion": "Select regional price",
       "selectedShort": "{count} selected",
       "showAll": "Show all {count}",
       "sourceCategory": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1452,6 +1452,7 @@
       "selectedMetaModels": "已选 {count} 个元模型",
       "selectedModels": "已选模型",
       "selectedModelsHint": "为每个元模型指定实际使用的渠道上游。",
+      "selectRegion": "选择区域价格",
       "selectedShort": "已选 {count}",
       "showAll": "显示全部 {count}",
       "sourceCategory": {

--- a/frontend/tests/llmOpsChannelModelSelection.test.js
+++ b/frontend/tests/llmOpsChannelModelSelection.test.js
@@ -67,3 +67,88 @@ test('searches models after the former first-page cutoff', () => {
     ['model-30']
   )
 })
+
+test('requires a regional offer when one source has multiple regions', () => {
+  const model = {
+    id: 1,
+    code: 'deepseek-v4-flash',
+    name: 'DeepSeek V4 Flash',
+    meta_model: 1,
+    source: 10,
+    source_name: 'Aliyun official'
+  }
+  const selectedModelKeys = ref(new Set(['deepseek-v4-flash']))
+  const selectedProviderByModelKey = ref({ 'deepseek-v4-flash': 1 })
+  const selectedSourceOfferingByModelKey = ref({})
+  const priceItems = ref([])
+  const selection = useChannelModelSelection({
+    baseAvailableModels: ref([model]),
+    fuzzyScore: () => 1,
+    metaModelDisplayName: (value) => value.name,
+    metaModelForSourceModel: () => ({
+      code: 'deepseek-v4-flash',
+      name: 'DeepSeek V4 Flash'
+    }),
+    metaModelIdentityKey: (value) => value.code,
+    metaModelVendorKey: () => 'vendor',
+    metaModelVendorName: () => 'Vendor',
+    modalityLabel: (value) => value,
+    modelOptionSearchText: () => '',
+    modelSearch: ref(''),
+    modelSourceCategory: () => 'supplier',
+    normalizeSearch: (value) => String(value || '').toLowerCase(),
+    providerModelDescription: () => '',
+    priceItems,
+    providerPriceSummary: () => [],
+    purchaseSourceLabel: (value) => value.name,
+    selectedModelKeys,
+    selectedProviderByModelKey,
+    selectedSourceOfferingByModelKey,
+    selectedVendorKey: ref(''),
+    sourceCategoryBadge: () => '',
+    t: (key) => key
+  })
+
+  assert.equal(selection.canAddSelectedModels.value, true)
+
+  priceItems.value = [
+    { meta_model: 1, source: 10, offering: 20, sku_region: '' },
+    { meta_model: 1, source: 10, offering: 21, sku_region: 'Japan' }
+  ]
+
+  assert.equal(selection.canAddSelectedModels.value, false)
+  assert.equal(
+    selection.selectedResolvedModels.value[0].sourceOfferingOptions[0].label,
+    'Global'
+  )
+  selection.selectSourceOffering('deepseek-v4-flash', 21)
+  assert.equal(selection.canAddSelectedModels.value, true)
+
+  priceItems.value = [
+    {
+      meta_model: 1,
+      source: 10,
+      offering: 20,
+      sku_region: 'Global',
+      is_current: false
+    },
+    {
+      meta_model: 1,
+      source: 10,
+      offering: 21,
+      sku_region: 'Japan',
+      is_current: true
+    }
+  ]
+
+  selectedSourceOfferingByModelKey.value = {}
+  assert.equal(
+    selection.selectedResolvedModels.value[0].sourceOfferingOptions.length,
+    1
+  )
+  assert.equal(
+    selection.selectedResolvedModels.value[0].selectedSourceOfferingId,
+    21
+  )
+  assert.equal(selection.canAddSelectedModels.value, true)
+})


### PR DESCRIPTION
## Summary

- Require a regional source-offer choice when a selected upstream has multiple current offers.
- Persist the selected offer on the channel offering and expose its SKU and region.
- Base preview and synchronization costs on the exact selected offer.
- Add backend API/service and frontend selection regression coverage.

Closes #346

## Test plan

- [x] `.venv/bin/pytest backend/llm_ops/tests/test_channel_offerings.py backend/llm_ops/tests/test_services.py`
- [x] `node --test tests/llmOpsChannelModelSelection.test.js`
- [x] `npm run typecheck`
- [x] `npm run build`