### PR TITLE
Improve channel price preview layout

### DIFF
--- a/frontend/src/components/llm-ops/ChannelModelDrawer.vue
+++ b/frontend/src/components/llm-ops/ChannelModelDrawer.vue
@@ -362,6 +362,7 @@
                         selectedProviderByModelKey[item.group.key] || ''
                       "
                       :options="item.options"
+                      class-name="batch-upstream-select"
                       :placeholder="
                         t('llmOps.channelModelDrawer.selectChannelUpstream')
                       "
@@ -383,6 +384,7 @@
                       v-if="item.sourceOfferingOptions?.length > 1"
                       :model-value="item.selectedSourceOfferingId || ''"
                       :options="item.sourceOfferingOptions"
+                      class-name="batch-region-select"
                       :placeholder="t('llmOps.channelModelDrawer.selectRegion')"
                       @change="
                         (value) => selectSourceOffering(item.group.key, value)

--- a/frontend/src/components/llm-ops/channelModelDrawer.css
+++ b/frontend/src/components/llm-ops/channelModelDrawer.css
@@ -106,7 +106,7 @@
 }
 
 .channel-model-drawer .batch-selection-row {
-  @apply grid gap-2 px-3 py-2.5 xl:grid-cols-[minmax(7.5rem,0.58fr)_minmax(9.5rem,0.62fr)_minmax(0,1.8fr)] xl:items-center;
+  @apply grid gap-2 px-3 py-2.5 xl:grid-cols-[minmax(7.5rem,0.7fr)_minmax(10rem,0.95fr)_minmax(8rem,0.8fr)_minmax(13rem,1.45fr)] xl:items-center;
 }
 
 .channel-model-drawer .batch-model-main {
@@ -136,6 +136,11 @@
 
 .channel-model-drawer .batch-price-preview strong {
   @apply font-semibold text-slate-800;
+}
+
+.channel-model-drawer .batch-upstream-select,
+.channel-model-drawer .batch-region-select {
+  @apply min-w-0;
 }
 
 .channel-model-drawer .batch-price-preview.muted span,

--- a/frontend/tests/llmOpsPriceMeaning.test.js
+++ b/frontend/tests/llmOpsPriceMeaning.test.js
@@ -60,4 +60,10 @@ test('batch price previews wrap complete price details', () => {
   assert.match(previewRule, /whitespace-normal/)
   assert.match(previewRule, /break-words/)
   assert.doesNotMatch(previewRule, /truncate/)
+  assert.match(drawerSource, /class-name="batch-region-select"/)
+  assert.match(drawerSource, /class-name="batch-upstream-select"/)
+  assert.match(
+    drawerStyles,
+    /batch-selection-row[\s\S]*xl:grid-cols-\[minmax\(7\.5rem,0\.7fr\)/
+  )
 })


### PR DESCRIPTION
## Summary
- Split batch selection into model, upstream, region, and price columns on desktop.
- Allow long price previews to wrap instead of truncating or widening the layout.
- Keep narrow-screen layout readable with responsive stacking.

Closes #348

## Test plan
- [x] node --test tests/llmOpsPriceMeaning.test.js
- [x] npm run build
- [x] ego-browser desktop and 390px UI verification