### PR TITLE
Fix regional channel model price previews

### DIFF
--- a/frontend/src/components/llm-ops/ChannelModelDrawer.vue
+++ b/frontend/src/components/llm-ops/ChannelModelDrawer.vue
@@ -60,7 +60,6 @@
               <p class="mt-1 text-xs leading-5 text-slate-500">
                 {{ t('llmOps.channelModelDrawer.addDescription') }}
               </p>
-              <PriceMeaningGuide class="mt-3" />
             </div>
             <div class="flex flex-wrap gap-2 text-xs text-slate-500">
               <span class="summary-pill">
@@ -396,7 +395,8 @@
                           t('llmOps.channelModelDrawer.upstreamSummary', {
                             value: batchUpstreamPriceSummary(
                               item.model,
-                              item.selectedSourceOfferingId
+                              item.selectedSourceOfferingId,
+                              item.selectedSourceOfferingRegion
                             )
                           })
                         }}
@@ -407,7 +407,8 @@
                             value: batchPendingDraftPriceSummary(
                               newDraft,
                               item.model,
-                              item.selectedSourceOfferingId
+                              item.selectedSourceOfferingId,
+                              item.selectedSourceOfferingRegion
                             )
                           })
                         }}
@@ -1001,7 +1002,6 @@ import { asArray, errorMessage } from '@/utils/llmOpsPagination'
 
 import CompactSelect from './CompactSelect.vue'
 import OperationIconButton from './OperationIconButton.vue'
-import PriceMeaningGuide from './PriceMeaningGuide.vue'
 
 const props = defineProps({
   channel: {
@@ -1433,6 +1433,20 @@ function snapshotDrafts(source) {
 
 function priceTierComparisonRows(row) {
   const tiers = new Map()
+  const region = row?.draft?.source_sku_region || 'Global'
+  const normalizedRegion = normalizeRegion(region)
+  const boundSourceOfferingId =
+    row?.draft?.source_offering ||
+    (row?.priceItems || [])
+      .map((item) =>
+        (props.priceItems || []).find(
+          (candidate) =>
+            String(candidate.id || '') ===
+            String(item?.base_price_item || '')
+        )
+      )
+      .find((item) => item?.offering)?.offering ||
+    ''
   const append = (items, key) => {
     channelPriceTierRows(items).forEach((tier) => {
       const comparison = tiers.get(tier.rangeLabel) || {
@@ -1445,12 +1459,46 @@ function priceTierComparisonRows(row) {
     })
   }
 
-  append(row?.priceItems || [], 'costPrices')
   append(
-    providerPriceItemsForModel(row?.model, row?.draft?.source_offering),
+    (row?.priceItems || []).filter(
+      (item) =>
+        normalizedRegion ===
+        normalizeRegion(priceItemRegion(item, props.priceItems))
+    ),
+    'costPrices'
+  )
+  append(
+    providerPriceItemsForModel(
+      row?.model,
+      boundSourceOfferingId,
+      region
+    ),
     'upstreamPrices'
   )
   return Array.from(tiers.values())
+}
+
+function priceItemRegion(item, sourceItems = []) {
+  const sourceItem = (sourceItems || []).find(
+    (candidate) =>
+      String(candidate.id || '') === String(item?.base_price_item || '')
+  )
+  return (
+    item?.spec?.deployment_scope ||
+    item?.spec?.region ||
+    sourceItem?.spec?.deployment_scope ||
+    sourceItem?.spec?.region ||
+    item?.sku_region ||
+    item?.region ||
+    'Global'
+  )
+}
+
+function normalizeRegion(value) {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/^global$/, '全球')
 }
 
 function toggleModelDropdown() {

--- a/frontend/src/components/llm-ops/channelModelDrawer.css
+++ b/frontend/src/components/llm-ops/channelModelDrawer.css
@@ -106,7 +106,7 @@
 }
 
 .channel-model-drawer .batch-selection-row {
-  @apply grid gap-2 px-3 py-2.5 xl:grid-cols-[minmax(7.5rem,0.7fr)_minmax(10rem,0.95fr)_minmax(8rem,0.8fr)_minmax(13rem,1.45fr)] xl:items-center;
+  @apply grid gap-2 px-3 py-2.5 xl:grid-cols-[minmax(7.5rem,0.7fr)_minmax(10rem,0.95fr)_minmax(8rem,0.8fr)] xl:items-center;
 }
 
 .channel-model-drawer .batch-model-main {
@@ -122,7 +122,7 @@
 }
 
 .channel-model-drawer .batch-price-preview {
-  @apply grid min-w-0 gap-0.5 rounded-lg bg-slate-50 px-2.5 py-1.5 text-xs;
+  @apply grid min-w-0 gap-0.5 rounded-lg bg-slate-50 px-2.5 py-1.5 text-xs xl:col-span-3;
 }
 
 .channel-model-drawer .batch-price-preview span,

--- a/frontend/src/composables/useChannelModelPricing.js
+++ b/frontend/src/composables/useChannelModelPricing.js
@@ -113,14 +113,32 @@ export function useChannelModelPricing({
     })
   }
 
-  function batchUpstreamPriceSummary(model, sourceOfferingId = '') {
-    const rows = providerPriceSummary(model, sourceOfferingId)
+  function batchUpstreamPriceSummary(
+    model,
+    sourceOfferingId = '',
+    sourceOfferingRegion = ''
+  ) {
+    const rows = providerPriceSummary(
+      model,
+      sourceOfferingId,
+      sourceOfferingRegion
+    )
     if (!rows.length) return '-'
     return batchPriceSummaryText(rows, model)
   }
 
-  function batchPendingDraftPriceSummary(draft, model, sourceOfferingId = '') {
-    const rows = draftPricePreview(draft, model, sourceOfferingId)
+  function batchPendingDraftPriceSummary(
+    draft,
+    model,
+    sourceOfferingId = '',
+    sourceOfferingRegion = ''
+  ) {
+    const rows = draftPricePreview(
+      draft,
+      model,
+      sourceOfferingId,
+      sourceOfferingRegion
+    )
     if (!rows.length) return '-'
     return batchPriceSummaryText(
       rows.map((item) => ({
@@ -230,8 +248,16 @@ export function useChannelModelPricing({
     return false
   }
 
-  function providerPriceSummary(model, sourceOfferingId = '') {
-    const itemRows = providerPriceItemsForModel(model, sourceOfferingId)
+  function providerPriceSummary(
+    model,
+    sourceOfferingId = '',
+    sourceOfferingRegion = ''
+  ) {
+    const itemRows = providerPriceItemsForModel(
+      model,
+      sourceOfferingId,
+      sourceOfferingRegion
+    )
     if (itemRows.length) {
       return channelPriceSummaryRows(itemRows)
     }
@@ -261,14 +287,19 @@ export function useChannelModelPricing({
     ])
   }
 
-  function providerPriceItemsForModel(model, sourceOfferingId = '') {
+  function providerPriceItemsForModel(
+    model,
+    sourceOfferingId = '',
+    sourceOfferingRegion = ''
+  ) {
     if (!model) return []
     if (sourceOfferingId) {
       return sortPriceItems(
         props.priceItems.filter(
           (item) =>
             String(item.offering) === String(sourceOfferingId) &&
-            item.is_current !== false
+            item.is_current !== false &&
+            matchesSourceOfferingRegion(item, sourceOfferingRegion)
         )
       )
     }
@@ -280,6 +311,28 @@ export function useChannelModelPricing({
     )
     if (exactRows.length) return exactRows
     return fallbackPriceItemsForMetaModel(model)
+  }
+
+  function matchesSourceOfferingRegion(item, region) {
+    if (!region) return true
+    const normalizeRegion = (value) =>
+      String(value || '')
+        .trim()
+        .toLowerCase()
+        .replace(/^global$/, '全球')
+    const sourceItem = (props.priceItems || []).find(
+      (candidate) =>
+        String(candidate.id || '') === String(item.base_price_item || '')
+    )
+    const itemRegion =
+      item.spec?.deployment_scope ||
+      item.spec?.region ||
+      sourceItem?.spec?.deployment_scope ||
+      sourceItem?.spec?.region ||
+      item.sku_region ||
+      item.region ||
+      'Global'
+    return normalizeRegion(itemRegion) === normalizeRegion(region)
   }
 
   function fallbackPriceItemsForMetaModel(model) {
@@ -405,7 +458,12 @@ export function useChannelModelPricing({
     return ''
   }
 
-  function draftPricePreview(draft, model, sourceOfferingId = '') {
+  function draftPricePreview(
+    draft,
+    model,
+    sourceOfferingId = '',
+    sourceOfferingRegion = ''
+  ) {
     if (!model) return []
     const targetCurrency =
       draft.currency || props.channel?.currency || model.currency
@@ -417,14 +475,16 @@ export function useChannelModelPricing({
         model,
         targetCurrency,
         Number(draft.settlement_ratio || 0),
-        sourceOfferingId
+        sourceOfferingId,
+        sourceOfferingRegion
       )
     }
     return discountPricePreview(
       model,
       targetCurrency,
       Number(props.channel?.settlement_ratio || 1),
-      sourceOfferingId
+      sourceOfferingId,
+      sourceOfferingRegion
     )
   }
 
@@ -438,9 +498,15 @@ export function useChannelModelPricing({
       .filter((item) => item.value !== '')
   }
 
-  function discountPricePreview(model, currency, ratio, sourceOfferingId = '') {
+  function discountPricePreview(
+    model,
+    currency,
+    ratio,
+    sourceOfferingId = '',
+    sourceOfferingRegion = ''
+  ) {
     if (!Number.isFinite(ratio) || ratio <= 0) return []
-    return providerPriceSummary(model, sourceOfferingId)
+    return providerPriceSummary(model, sourceOfferingId, sourceOfferingRegion)
       .map((item) => {
         const sourceCurrency = item.currency || model.currency || currency
         const baseAmount = convertAmountBetween(

--- a/frontend/src/composables/useChannelModelRows.js
+++ b/frontend/src/composables/useChannelModelRows.js
@@ -60,11 +60,23 @@ export function useChannelModelRows({
 
   function channelPriceItemsForModel(model, draft) {
     if (!props.channel || !draft?.id) return []
+    const sourceOfferingId = String(draft.source_offering || '')
+    const matchingOfferingIds = new Set(
+      (props.channelOfferings || [])
+        .filter(
+          (offering) =>
+            !sourceOfferingId ||
+            String(offering.source_offering || '') === sourceOfferingId
+        )
+        .map((offering) => String(offering.id))
+    )
     return sortPriceItems(
       (props.channelPriceItems || []).filter(
         (item) =>
           String(item.channel) === String(props.channel.id) &&
           String(item.model) === String(model.id) &&
+          (!matchingOfferingIds.size ||
+            matchingOfferingIds.has(String(item.offering || ''))) &&
           item.is_current !== false
       )
     )

--- a/frontend/src/composables/useChannelModelSelection.js
+++ b/frontend/src/composables/useChannelModelSelection.js
@@ -135,6 +135,15 @@ export function useChannelModelSelection({
           selectedSourceOfferingByModelKey.value[group.key] ||
           (sourceOfferingOptions.length === 1
             ? sourceOfferingOptions[0].value
+            : ''),
+        selectedSourceOfferingRegion:
+          sourceOfferingOptions.find(
+            (option) =>
+              String(option.value) ===
+              String(selectedSourceOfferingByModelKey.value[group.key] || '')
+          )?.region ||
+          (sourceOfferingOptions.length === 1
+            ? sourceOfferingOptions[0].region
             : '')
       }
     })
@@ -195,9 +204,9 @@ export function useChannelModelSelection({
     const regionalRows = rows.map((item) => ({
       item,
       region:
-        item.sku_region ||
         item.spec?.deployment_scope ||
         item.spec?.region ||
+        item.sku_region ||
         item.region ||
         'Global'
     }))
@@ -206,11 +215,13 @@ export function useChannelModelSelection({
       const id = String(item.offering)
       if (options.has(id)) return
       const sku = item.sku_code || item.sku_display_name || ''
+      const displayRegion = normalizeRegionLabel(region)
       options.set(id, {
         label:
-          [region, sku].filter(Boolean).join(' · ') ||
+          [displayRegion, sku].filter(Boolean).join(' · ') ||
           item.offering_exposed_model_name ||
           id,
+        region,
         value: item.offering,
         description: item.offering_exposed_model_name || ''
       })
@@ -218,6 +229,11 @@ export function useChannelModelSelection({
     return Array.from(options.values()).sort((left, right) =>
       left.label.localeCompare(right.label)
     )
+  }
+
+  function normalizeRegionLabel(value) {
+    const normalized = String(value || '').trim()
+    return normalized.toLowerCase() === 'global' ? '全球' : normalized
   }
 
   function uniqueProviderModelsForGroup(group) {

--- a/frontend/tests/llmOpsChannelModelSelection.test.js
+++ b/frontend/tests/llmOpsChannelModelSelection.test.js
@@ -118,8 +118,10 @@ test('requires a regional offer when one source has multiple regions', () => {
 
   assert.equal(selection.canAddSelectedModels.value, false)
   assert.equal(
-    selection.selectedResolvedModels.value[0].sourceOfferingOptions[0].label,
-    'Global'
+    selection.selectedResolvedModels.value[0].sourceOfferingOptions.find(
+      (option) => String(option.value) === '20'
+    ).label,
+    '全球'
   )
   selection.selectSourceOffering('deepseek-v4-flash', 21)
   assert.equal(selection.canAddSelectedModels.value, true)

--- a/frontend/tests/llmOpsPriceMeaning.test.js
+++ b/frontend/tests/llmOpsPriceMeaning.test.js
@@ -31,8 +31,8 @@ const enLocale = JSON.parse(
   fs.readFileSync(new URL('../src/locales/en.json', import.meta.url))
 )
 
-test('price meaning guide is available in channel configuration and workbench', () => {
-  assert.match(drawerSource, /PriceMeaningGuide/)
+test('price meaning guide is available in the workbench without using drawer space', () => {
+  assert.doesNotMatch(drawerSource, /PriceMeaningGuide/)
   assert.match(workbenchSource, /PriceMeaningGuide/)
   assert.match(guideSource, /priceMeaningGuide/)
 })
@@ -52,7 +52,7 @@ test('price meaning copy explains dimensions and calculation chain in both local
   }
 })
 
-test('batch price previews wrap complete price details', () => {
+test('batch price previews occupy a full row and wrap complete details', () => {
   const previewRule = drawerStyles.match(
     /\.channel-model-drawer \.batch-price-preview span,[\s\S]*?\n}\n/
   )?.[0]
@@ -65,5 +65,9 @@ test('batch price previews wrap complete price details', () => {
   assert.match(
     drawerStyles,
     /batch-selection-row[\s\S]*xl:grid-cols-\[minmax\(7\.5rem,0\.7fr\)/
+  )
+  assert.match(
+    drawerStyles,
+    /batch-price-preview[\s\S]*xl:col-span-3/
   )
 })


### PR DESCRIPTION
## Summary

- Scope batch upstream and draft price previews to the selected source offering and its region.
- Keep price-tier comparisons and existing channel prices bound to the draft’s supply path.
- Improve regional labels and move batch price previews to their own row; add regression coverage.

Closes #351

## Test plan

- [x] `node --test tests/llmOpsChannelModelSelection.test.js tests/llmOpsPriceMeaning.test.js`
- [x] `npm run typecheck`
- [x] `npm run build`