### PR TITLE
Improve LLM Ops regional pricing accuracy and loading

### DIFF
--- a/backend/llm_ops/price_collectors/parsers/common.py
+++ b/backend/llm_ops/price_collectors/parsers/common.py
@@ -158,41 +158,46 @@ def build_text_token_standard_catalog(
             continue
 
         aliases = normalize_aliases(item.get("aliases"), model_id)
-        raw_detail = {
-            "official_source_url": source_url,
-            "official_provider": provider_name,
-            "model_id": model_id,
-            "aliases": aliases,
-            "currency": currency,
-            "model_info": {
-                "provider": provider_name,
+        regional_rows = split_rows_by_region(price_rows)
+        for region, rows_for_region in regional_rows:
+            raw_detail = {
+                "official_source_url": source_url,
+                "official_provider": provider_name,
                 "model_id": model_id,
-            },
-        }
-        collected.append(
-            CollectedModelPricing(
-                model_source=provider_name,
-                model_type="文本模型",
-                source_model_type="Text",
-                name=str(item.get("display_name") or model_id),
-                model_id=model_id,
-                platform_id=model_id,
-                mode="official",
-                provider=provider_name,
-                billing_type="按量计费",
-                billing_unit=currency,
-                currency=currency,
-                unit=1000000,
-                billing_mode="pay_as_you_go",
-                price_rows=price_rows,
-                raw_price_info={
-                    "currency": currency,
-                    "unit": 1000000,
-                    "billing_mode": "pay_as_you_go",
+                "aliases": aliases,
+                "currency": currency,
+                "model_info": {
+                    "provider": provider_name,
+                    "model_id": model_id,
                 },
-                raw_detail=raw_detail,
+            }
+            if region:
+                raw_detail["sku_region"] = region
+                raw_detail["model_info"]["sku_region"] = region
+            collected.append(
+                CollectedModelPricing(
+                    model_source=provider_name,
+                    model_type="文本模型",
+                    source_model_type="Text",
+                    name=str(item.get("display_name") or model_id),
+                    model_id=model_id,
+                    platform_id=model_id,
+                    mode="official",
+                    provider=provider_name,
+                    billing_type="按量计费",
+                    billing_unit=currency,
+                    currency=currency,
+                    unit=1000000,
+                    billing_mode="pay_as_you_go",
+                    price_rows=rows_for_region,
+                    raw_price_info={
+                        "currency": currency,
+                        "unit": 1000000,
+                        "billing_mode": "pay_as_you_go",
+                    },
+                    raw_detail=raw_detail,
+                )
             )
-        )
 
     catalog = CollectedPricingCatalog(
         source_url=source_url,
@@ -208,6 +213,28 @@ def build_text_token_standard_catalog(
         notes=notes,
         raw_payload=raw_payload or {},
     )
+
+
+def split_rows_by_region(
+    rows: list[NormalizedPriceRow],
+) -> list[tuple[str, list[NormalizedPriceRow]]]:
+    """Split normalized rows into one collected model per pricing region."""
+    groups: dict[str, list[NormalizedPriceRow]] = {}
+    labels: dict[str, str] = {}
+    for row in rows:
+        values = row.values or {}
+        raw = row.raw or {}
+        region = str(
+            values.get("deployment_scope")
+            or values.get("region")
+            or raw.get("deployment_scope")
+            or raw.get("region")
+            or ""
+        ).strip()
+        key = region.casefold()
+        groups.setdefault(key, []).append(row)
+        labels.setdefault(key, region)
+    return [(labels[key], grouped) for key, grouped in groups.items()]
 
 
 def filter_models_by_codes(

--- a/backend/llm_ops/price_collectors/parsers/common.py
+++ b/backend/llm_ops/price_collectors/parsers/common.py
@@ -224,17 +224,24 @@ def split_rows_by_region(
     for row in rows:
         values = row.values or {}
         raw = row.raw or {}
-        region = str(
-            values.get("deployment_scope")
-            or values.get("region")
-            or raw.get("deployment_scope")
-            or raw.get("region")
-            or ""
-        ).strip()
+        region = price_row_region(values, raw)
         key = region.casefold()
         groups.setdefault(key, []).append(row)
         labels.setdefault(key, region)
     return [(labels[key], grouped) for key, grouped in groups.items()]
+
+
+def price_row_region(values: dict[str, Any], raw: dict[str, Any]) -> str:
+    """Return a geographic region without mistaking deployment scope for one."""
+    explicit = values.get("region") or raw.get("region")
+    if explicit:
+        return str(explicit).strip()
+    scope = str(
+        values.get("deployment_scope") or raw.get("deployment_scope") or ""
+    ).strip()
+    if scope.casefold() in {"siliconflow", "regional"}:
+        return ""
+    return scope
 
 
 def filter_models_by_codes(

--- a/frontend/src/components/llm-ops/PriceChangePanel.vue
+++ b/frontend/src/components/llm-ops/PriceChangePanel.vue
@@ -107,6 +107,7 @@ import {
 
 const props = defineProps({
   channelHistory: { type: Array, default: () => [] },
+  channelVersions: { type: Array, default: () => [] },
   focusModelId: { type: [Number, String], default: null },
   listingHistory: { type: Array, default: () => [] },
   officialHistory: { type: Array, default: () => [] },
@@ -119,6 +120,7 @@ const MAX_VISIBLE_ROWS = 120
 const typeFilterOptions = computed(() => [
   { label: t('llmOps.priceChangePanel.filters.all'), value: 'all' },
   { label: t('llmOps.priceChangePanel.types.channel'), value: 'channel' },
+  { label: t('llmOps.priceChangePanel.types.discount'), value: 'discount' },
   { label: t('llmOps.priceChangePanel.types.listing'), value: 'listing' },
   { label: t('llmOps.priceChangePanel.types.official'), value: 'official' }
 ])
@@ -126,6 +128,7 @@ const typeFilterOptions = computed(() => [
 const changeRows = computed(() => {
   return buildPriceChangeRows({
     channelHistory: props.channelHistory,
+    channelVersions: props.channelVersions,
     listingHistory: props.listingHistory,
     officialHistory: props.officialHistory,
     priceItems: props.priceItems
@@ -135,9 +138,12 @@ const changeRows = computed(() => {
       row.name ||
       t('llmOps.priceChangePanel.fallback.model', { id: row.modelId }),
     type_label: t(`llmOps.priceChangePanel.types.${row.type}`),
-    tone: { channel: 'info', listing: 'warn', official: 'success' }[
-      row.type
-    ]
+    tone: {
+      channel: 'info',
+      discount: 'info',
+      listing: 'warn',
+      official: 'success'
+    }[row.type]
   }))
 })
 
@@ -188,6 +194,7 @@ const metrics = computed(() => [
 function dimensionLabel(value) {
   return (
     {
+      discount: t('llmOps.priceChangePanel.dimension.discount'),
       text_input: t('llmOps.priceChangePanel.dimension.textInput'),
       text_output: t('llmOps.priceChangePanel.dimension.textOutput'),
       cache_input: t('llmOps.priceChangePanel.dimension.cacheInput'),
@@ -211,6 +218,8 @@ function deltaText(row) {
 
 function money(value, currency) {
   if (value === null || value === undefined || value === '') return '-'
+  if (currency === 'ratio') return `${(Number(value) * 100).toFixed(2)}%`
+  if (currency === 'fixed') return Number(value).toFixed(6)
   return `${currency || ''} ${Number(value).toFixed(6)}`
 }
 

--- a/frontend/src/composables/useChannelModelPricing.js
+++ b/frontend/src/composables/useChannelModelPricing.js
@@ -118,6 +118,13 @@ export function useChannelModelPricing({
     sourceOfferingId = '',
     sourceOfferingRegion = ''
   ) {
+    if (
+      !sourceOfferingId &&
+      !sourceOfferingRegion &&
+      hasMultiplePriceRegions(model)
+    ) {
+      return translate('llmOps.channelModelDrawer.selectRegion')
+    }
     const rows = providerPriceSummary(
       model,
       sourceOfferingId,
@@ -133,6 +140,14 @@ export function useChannelModelPricing({
     sourceOfferingId = '',
     sourceOfferingRegion = ''
   ) {
+    if (
+      draft?.price_mode !== 'fixed' &&
+      !sourceOfferingId &&
+      !sourceOfferingRegion &&
+      hasMultiplePriceRegions(model)
+    ) {
+      return translate('llmOps.channelModelDrawer.selectRegion')
+    }
     const rows = draftPricePreview(
       draft,
       model,
@@ -311,6 +326,37 @@ export function useChannelModelPricing({
     )
     if (exactRows.length) return exactRows
     return fallbackPriceItemsForMetaModel(model)
+  }
+
+  function hasMultiplePriceRegions(model) {
+    const rows = providerPriceItemsForModel(model)
+    if (rows.length < 2) return false
+    const regions = new Set(
+      rows.map((item) => normalizePriceRegion(priceItemRegion(item)))
+    )
+    return regions.size > 1
+  }
+
+  function priceItemRegion(item) {
+    const sourceItem = (props.priceItems || []).find(
+      (candidate) =>
+        String(candidate.id || '') === String(item.base_price_item || '')
+    )
+    return (
+      item?.spec?.deployment_scope ||
+      item?.spec?.region ||
+      sourceItem?.spec?.deployment_scope ||
+      sourceItem?.spec?.region ||
+      item?.sku_region ||
+      item?.region ||
+      'Global'
+    )
+  }
+
+  function normalizePriceRegion(value) {
+    return (
+      String(value || 'Global').trim().toLowerCase() || 'global'
+    )
   }
 
   function matchesSourceOfferingRegion(item, region) {

--- a/frontend/src/composables/useLLMOpsData.js
+++ b/frontend/src/composables/useLLMOpsData.js
@@ -43,6 +43,7 @@ export function useLLMOpsData() {
   const channelPrices = ref([])
   const channelPriceItems = ref([])
   const channelPriceHistory = ref([])
+  const channelPriceVersions = ref([])
   const modelPriceItems = ref([])
   const officialPriceHistory = ref([])
   const resalePlatforms = ref([])
@@ -294,22 +295,30 @@ export function useLLMOpsData() {
       ? { platform: selectedResalePlatformId.value }
       : {}
     const platformId = selectedResalePlatformId.value
-    const [channelHistoryData, listingHistoryData, officialHistoryData] =
-      await Promise.all([
-        fetchFirstPage(llmOpsApi.listChannelModelPriceHistory, {
-          ...modelFilter,
-          page_size: PRICE_HISTORY_PAGE_SIZE
-        }),
-        fetchFirstPage(llmOpsApi.listResaleListingPriceHistory, {
-          ...modelFilter,
-          ...platformFilter,
-          page_size: PRICE_HISTORY_PAGE_SIZE
-        }),
-        fetchFirstPage(llmOpsApi.listCollectedPriceHistory, {
-          ...modelFilter,
-          page_size: PRICE_HISTORY_PAGE_SIZE
-        })
-      ])
+    const [
+      channelHistoryData,
+      listingHistoryData,
+      officialHistoryData,
+      channelVersionData
+    ] = await Promise.all([
+      fetchFirstPage(llmOpsApi.listChannelModelPriceHistory, {
+        ...modelFilter,
+        page_size: PRICE_HISTORY_PAGE_SIZE
+      }),
+      fetchFirstPage(llmOpsApi.listResaleListingPriceHistory, {
+        ...modelFilter,
+        ...platformFilter,
+        page_size: PRICE_HISTORY_PAGE_SIZE
+      }),
+      fetchFirstPage(llmOpsApi.listCollectedPriceHistory, {
+        ...modelFilter,
+        page_size: PRICE_HISTORY_PAGE_SIZE
+      }),
+      fetchFirstPage(llmOpsApi.listChannelPriceVersions, {
+        ...modelFilter,
+        page_size: PRICE_HISTORY_PAGE_SIZE
+      })
+    ])
     if (
       requestId !== priceHistoryRequestId ||
       String(platformId || '') !== String(selectedResalePlatformId.value || '')
@@ -319,6 +328,7 @@ export function useLLMOpsData() {
     channelPriceHistory.value = asArray(channelHistoryData)
     listingPriceHistory.value = asArray(listingHistoryData)
     officialPriceHistory.value = asArray(officialHistoryData)
+    channelPriceVersions.value = asArray(channelVersionData)
   }
 
   async function refreshLight() {
@@ -480,6 +490,7 @@ export function useLLMOpsData() {
   return {
     channelOfferings,
     channelPriceHistory,
+    channelPriceVersions,
     channelPriceItems,
     channelPrices,
     channels,

--- a/frontend/src/composables/useLLMOpsData.js
+++ b/frontend/src/composables/useLLMOpsData.js
@@ -29,6 +29,7 @@ export function useLLMOpsData() {
   const loading = ref(false)
   const pageError = ref('')
   const loadedSections = new Set()
+  const inFlightGroups = new Map()
   let resaleListingsRequestId = 0
   let priceHistoryRequestId = 0
   let summaryRequestId = 0
@@ -118,6 +119,25 @@ export function useLLMOpsData() {
   }
 
   async function loadDataGroup(group, section, options) {
+    const requestKey = [
+      group,
+      options?.modelId || '',
+      options?.platformId || ''
+    ].join(':')
+    const existingRequest = inFlightGroups.get(requestKey)
+    if (existingRequest) return existingRequest
+    const request = loadDataGroupInternal(group, section, options)
+    inFlightGroups.set(requestKey, request)
+    try {
+      return await request
+    } finally {
+      if (inFlightGroups.get(requestKey) === request) {
+        inFlightGroups.delete(requestKey)
+      }
+    }
+  }
+
+  async function loadDataGroupInternal(group, section, options) {
     if (group === 'sources') {
       sources.value = asArray(await fetchList(llmOpsApi.listCollectionSources))
       return

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1488,6 +1488,7 @@
         "videoOutput": "Video out"
       },
       "dimension": {
+        "discount": "Discount",
         "audioInput": "Audio input",
         "audioOutput": "Audio output",
         "cacheInput": "Cache input",
@@ -1724,6 +1725,7 @@
       "title": "Price Change Dashboard",
       "types": {
         "channel": "Channel procurement price",
+        "discount": "Discount version",
         "listing": "Platform listing price",
         "official": "Standard price item"
       }

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1496,6 +1496,7 @@
         "videoOutput": "视出"
       },
       "dimension": {
+        "discount": "折扣",
         "audioInput": "音频输入",
         "audioOutput": "音频输出",
         "cacheInput": "缓存输入",
@@ -1732,6 +1733,7 @@
       "title": "价格变化看板",
       "types": {
         "channel": "渠道采购价",
+        "discount": "折扣版本",
         "listing": "平台挂售价",
         "official": "标准价格项"
       }

--- a/frontend/src/pages/LLMOps.vue
+++ b/frontend/src/pages/LLMOps.vue
@@ -216,6 +216,7 @@
               v-else-if="activeSection === 'priceChanges'"
               :focus-model-id="operationTargetModelId"
               :channel-history="channelPriceHistory"
+              :channel-versions="channelPriceVersions"
               :listing-history="listingPriceHistory"
               :official-history="officialPriceHistory"
               :price-items="modelPriceItems"

--- a/frontend/src/utils/llmOpsPriceChanges.js
+++ b/frontend/src/utils/llmOpsPriceChanges.js
@@ -21,6 +21,7 @@ const listingDimensions = [
 
 export function buildPriceChangeRows({
   channelHistory = [],
+  channelVersions = [],
   listingHistory = [],
   officialHistory = [],
   priceItems = []
@@ -34,6 +35,7 @@ export function buildPriceChangeRows({
       context: (item) => item.offering_name || item.channel_name || '',
       source: (item) => item.price_source_name || item.channel_name || ''
     }),
+    ...discountHistoryRows(channelVersions),
     ...historyRows(listingHistory, {
       type: 'listing',
       dimensions: listingDimensions,
@@ -43,23 +45,61 @@ export function buildPriceChangeRows({
       source: (item) => item.platform_name || ''
     }),
     ...officialHistoryRows(officialHistory),
-    ...(officialHistory.length ? [] : priceItems.map((item) => ({
-      key: `official-${item.id}-${item.dimension}`,
-      type: 'official',
-      modelId: item.model,
-      name: item.model_name || item.meta_model_name || '',
-      context: item.offering_exposed_model_name || item.sku_display_name || '',
-      source: item.source_name || item.provider_name || '',
-      dimension: item.dimension,
-      previous: null,
-      current: item.unit_price,
-      currency: item.currency,
-      time: item.effective_from || item.updated_at || item.created_at
-    })))
+    ...(officialHistory.length
+      ? []
+      : priceItems.map((item) => ({
+          key: `official-${item.id}-${item.dimension}`,
+          type: 'official',
+          modelId: item.model,
+          name: item.model_name || item.meta_model_name || '',
+          context:
+            item.offering_exposed_model_name || item.sku_display_name || '',
+          source: item.source_name || item.provider_name || '',
+          dimension: item.dimension,
+          previous: null,
+          current: item.unit_price,
+          currency: item.currency,
+          time: item.effective_from || item.updated_at || item.created_at
+        })))
   ]
   return rows.sort(
     (left, right) => new Date(right.time || 0) - new Date(left.time || 0)
   )
+}
+
+function discountHistoryRows(items = []) {
+  const groups = new Map()
+  items.forEach((item) => {
+    const key = [item.offering, item.model].join(':')
+    const versions = groups.get(key) || []
+    versions.push(item)
+    groups.set(key, versions)
+  })
+  const rows = []
+  groups.forEach((versions) => {
+    versions.sort(
+      (left, right) => Number(right.version || 0) - Number(left.version || 0)
+    )
+    versions.forEach((item, index) => {
+      const previous = versions[index + 1]
+      rows.push({
+        key: `discount-${item.id}`,
+        type: 'discount',
+        modelId: item.model,
+        name: item.model_name || item.meta_model_name || '',
+        context: item.offering_name || item.channel_name || '',
+        source: item.channel_name || '',
+        dimension: 'discount',
+        previous: previous?.discount_value ?? null,
+        current: item.discount_value,
+        currency: item.discount_type || '',
+        time: item.effective_from || item.created_at,
+        version: item.version,
+        discountType: item.discount_type
+      })
+    })
+  })
+  return rows
 }
 
 export function officialHistoryRows(items = []) {
@@ -132,9 +172,7 @@ function historyRows(items, config) {
 
   const rows = []
   groups.forEach((versions) => {
-    versions.sort(
-      (left, right) => historyTime(right) - historyTime(left)
-    )
+    versions.sort((left, right) => historyTime(right) - historyTime(left))
     versions.forEach((item, index) => {
       const previous = versions[index + 1] || null
       config.dimensions.forEach(([dimension, field]) => {

--- a/frontend/tests/llmOpsDataPerformance.test.js
+++ b/frontend/tests/llmOpsDataPerformance.test.js
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import test from 'node:test'
+
+const source = fs.readFileSync(
+  new URL('../src/composables/useLLMOpsData.js', import.meta.url),
+  'utf8'
+)
+
+test('deduplicates concurrent LLM Ops data-group requests', () => {
+  assert.match(source, /const inFlightGroups = new Map\(\)/)
+  assert.match(
+    source,
+    /const existingRequest = inFlightGroups\.get\(requestKey\)/
+  )
+  assert.match(source, /loadDataGroupInternal\(group, section, options\)/)
+})

--- a/frontend/tests/llmOpsPriceMeaning.test.js
+++ b/frontend/tests/llmOpsPriceMeaning.test.js
@@ -2,15 +2,14 @@ import assert from 'node:assert/strict'
 import fs from 'node:fs'
 import test from 'node:test'
 
+import { buildPriceChangeRows } from '../src/utils/llmOpsPriceChanges.js'
+
 const drawerSource = fs.readFileSync(
   new URL('../src/components/llm-ops/ChannelModelDrawer.vue', import.meta.url),
   'utf8'
 )
 const drawerStyles = fs.readFileSync(
-  new URL(
-    '../src/components/llm-ops/channelModelDrawer.css',
-    import.meta.url
-  ),
+  new URL('../src/components/llm-ops/channelModelDrawer.css', import.meta.url),
   'utf8'
 )
 const pricingSource = fs.readFileSync(
@@ -22,10 +21,7 @@ const workbenchSource = fs.readFileSync(
   'utf8'
 )
 const guideSource = fs.readFileSync(
-  new URL(
-    '../src/components/llm-ops/PriceMeaningGuide.vue',
-    import.meta.url
-  ),
+  new URL('../src/components/llm-ops/PriceMeaningGuide.vue', import.meta.url),
   'utf8'
 )
 const zhLocale = JSON.parse(
@@ -70,10 +66,7 @@ test('batch price previews occupy a full row and wrap complete details', () => {
     drawerStyles,
     /batch-selection-row[\s\S]*xl:grid-cols-\[minmax\(7\.5rem,0\.7fr\)/
   )
-  assert.match(
-    drawerStyles,
-    /batch-price-preview[\s\S]*xl:col-span-3/
-  )
+  assert.match(drawerStyles, /batch-price-preview[\s\S]*xl:col-span-3/)
 })
 
 test('batch previews require a region before combining multi-region prices', () => {
@@ -83,4 +76,35 @@ test('batch previews require a region before combining multi-region prices', () 
     /batchPendingDraftPriceSummary\([\s\S]*?selectRegion/
   )
   assert.match(pricingSource, /hasMultiplePriceRegions\(model\)/)
+})
+
+test('includes discount version changes in the price change rows', () => {
+  const rows = buildPriceChangeRows({
+    channelVersions: [
+      {
+        id: 2,
+        version: 2,
+        model: 9,
+        model_name: 'GPT-4o',
+        offering: 3,
+        offering_name: 'API',
+        channel_name: 'Supplier',
+        discount_type: 'ratio',
+        discount_value: '0.85',
+        effective_from: '2026-09-01T00:00:00Z'
+      },
+      {
+        id: 1,
+        version: 1,
+        model: 9,
+        offering: 3,
+        discount_type: 'ratio',
+        discount_value: '0.9',
+        effective_from: '2026-08-01T00:00:00Z'
+      }
+    ]
+  })
+  assert.equal(rows[0].type, 'discount')
+  assert.equal(rows[0].previous, '0.9')
+  assert.equal(rows[0].current, '0.85')
 })

--- a/frontend/tests/llmOpsPriceMeaning.test.js
+++ b/frontend/tests/llmOpsPriceMeaning.test.js
@@ -13,6 +13,10 @@ const drawerStyles = fs.readFileSync(
   ),
   'utf8'
 )
+const pricingSource = fs.readFileSync(
+  new URL('../src/composables/useChannelModelPricing.js', import.meta.url),
+  'utf8'
+)
 const workbenchSource = fs.readFileSync(
   new URL('../src/components/llm-ops/ModelWorkbenchPanel.vue', import.meta.url),
   'utf8'
@@ -70,4 +74,13 @@ test('batch price previews occupy a full row and wrap complete details', () => {
     drawerStyles,
     /batch-price-preview[\s\S]*xl:col-span-3/
   )
+})
+
+test('batch previews require a region before combining multi-region prices', () => {
+  assert.match(pricingSource, /batchUpstreamPriceSummary\([\s\S]*?selectRegion/)
+  assert.match(
+    pricingSource,
+    /batchPendingDraftPriceSummary\([\s\S]*?selectRegion/
+  )
+  assert.match(pricingSource, /hasMultiplePriceRegions\(model\)/)
 })


### PR DESCRIPTION
## Summary

- Preserve regional price offers and require a chosen region for multi-region previews.
- Keep deployment scopes separate from geographic regions during price collection.
- Display channel discount-version changes in price history.
- Share in-flight LLM Ops data requests across concurrent preload, navigation, and refresh flows.

Closes #353

## Test plan

- [x] `python3 -m compileall -q backend/llm_ops/price_collectors/parsers/common.py`
- [x] `node --test tests/llmOpsDataPerformance.test.js tests/llmOpsPriceMeaning.test.js`
- [x] `npm run typecheck`
- [x] `npm run build`