### PR TITLE
Optimize LLM Ops channel detail loading

### DIFF
--- a/backend/llm_ops/tests/test_views.py
+++ b/backend/llm_ops/tests/test_views.py
@@ -1270,6 +1270,90 @@ class LLMOpsViewTests(TestCase):
             ResaleListing.objects.filter(id=channel_listing.id).exists(),
         )
 
+    def test_channel_detail_collections_filter_by_channel(self):
+        provider = LLMProvider.objects.create(
+            name="OpenAI",
+            code="openai-channel-filter",
+        )
+        model = LLMModel.objects.create(
+            provider=provider,
+            name="GPT Filter",
+            code="gpt-filter",
+        )
+        first_channel = ProcurementChannel.objects.create(
+            name="First Channel",
+            code="first-channel",
+        )
+        second_channel = ProcurementChannel.objects.create(
+            name="Second Channel",
+            code="second-channel",
+        )
+        first_offering = ChannelOffering.objects.create(
+            channel=first_channel,
+            meta_model=model.meta_model,
+            model=model,
+            offering_key="first",
+            display_name="First offering",
+        )
+        second_offering = ChannelOffering.objects.create(
+            channel=second_channel,
+            meta_model=model.meta_model,
+            model=model,
+            offering_key="second",
+            display_name="Second offering",
+        )
+        ChannelModelPrice.objects.create(
+            channel=first_channel,
+            model=model,
+            offering=first_offering,
+        )
+        ChannelModelPrice.objects.create(
+            channel=second_channel,
+            model=model,
+            offering=second_offering,
+        )
+        price_item_kwargs = {
+            "model": model,
+            "meta_model": model.meta_model,
+            "dimension": ModelPriceItem.DIMENSION_TEXT_INPUT,
+            "billing_unit": ModelPriceItem.UNIT_PER_1M_TOKENS,
+            "currency": "USD",
+            "unit_price": "1",
+            "price_fingerprint": "channel-filter-",
+        }
+        ChannelPriceItem.objects.create(
+            channel=first_channel,
+            offering=first_offering,
+            **{**price_item_kwargs, "price_fingerprint": "channel-filter-1"},
+        )
+        ChannelPriceItem.objects.create(
+            channel=second_channel,
+            offering=second_offering,
+            **{**price_item_kwargs, "price_fingerprint": "channel-filter-2"},
+        )
+
+        for route_name in (
+            "channel-offering-list",
+            "channel-model-price-list",
+            "channel-price-item-list",
+        ):
+            response = self.client.get(
+                reverse(route_name),
+                {
+                    "channel": first_channel.id,
+                    "is_effective": "true",
+                    "page_size": 200,
+                },
+            )
+
+            self.assertEqual(response.status_code, 200)
+            results = response.data["results"]
+            self.assertTrue(results)
+            self.assertEqual(
+                {item["channel"] for item in results},
+                {first_channel.id},
+            )
+
     def test_channel_update_records_configuration_audit(self):
         channel = ProcurementChannel.objects.create(
             name="Default Channel",

--- a/frontend/src/components/llm-ops/ChannelManagement.vue
+++ b/frontend/src/components/llm-ops/ChannelManagement.vue
@@ -389,7 +389,7 @@ async function openChannelModelManagement(channel) {
   openingChannelId.value = channel.id
   try {
     if (props.prepareModelManagement) {
-      await props.prepareModelManagement()
+      await props.prepareModelManagement(channel.id)
     }
     selectedChannelForModels.value = channel
   } catch (error) {

--- a/frontend/src/components/llm-ops/ChannelPriceCompareDrawer.vue
+++ b/frontend/src/components/llm-ops/ChannelPriceCompareDrawer.vue
@@ -187,7 +187,6 @@ import {
 import { useI18n } from 'vue-i18n'
 
 import {
-  channelOfferingForOption,
   compareChannelOptions,
   optionFreshness,
   savingsPercent
@@ -214,8 +213,7 @@ const props = defineProps({
   option: { type: Object, default: null },
   dimension: { type: String, default: 'input' },
   action: { type: String, default: 'keep' },
-  actionText: { type: String, default: '' },
-  channelOfferings: { type: Array, default: () => [] }
+  actionText: { type: String, default: '' }
 })
 
 const emit = defineEmits(['apply', 'close', 'view-detail'])
@@ -286,33 +284,15 @@ function freshnessLabel(offer) {
 }
 
 function contractContext(offer) {
-  const candidates = props.channelOfferings.filter((item) =>
-    sameId(item.channel, offer.channel_id)
-  )
-  const offering =
-    channelOfferingForOption(candidates, offer) ||
-    candidates.find((item) =>
-      sameId(item.meta_model, props.row?.meta_model_id)
-    ) ||
-    candidates.find((item) => sameId(item.model, props.row?.model_id)) ||
-    candidates[0]
   const ratio = Number(offer.settlement_ratio)
   return {
-    offering: offering?.display_name || offering?.offering_key || '-',
-    pricingRule: t(
-      'llmOps.channelPriceMatrixPanel.drawer.currentChannelRule'
-    ),
+    offering: offer.offering_name || offer.offering_key || '-',
+    pricingRule: t('llmOps.channelPriceMatrixPanel.drawer.currentChannelRule'),
     contractFx: offer.exchange_rate || '-',
     settlementRatio: Number.isFinite(ratio)
       ? `${(ratio * 100).toFixed(2)}%`
       : '-'
   }
-}
-
-function sameId(left, right) {
-  if (left === null || left === undefined) return false
-  if (right === null || right === undefined) return false
-  return String(left) === String(right)
 }
 
 function close() {

--- a/frontend/src/components/llm-ops/ChannelPriceMatrixPanel.vue
+++ b/frontend/src/components/llm-ops/ChannelPriceMatrixPanel.vue
@@ -233,7 +233,6 @@
       :dimension="priceDimension"
       :action="compareRow ? effectiveAction(compareRow) : 'keep'"
       :action-text="compareRow ? actionLabel(effectiveAction(compareRow)) : ''"
-      :channel-offerings="channelOfferings"
       @close="closeCompare"
       @view-detail="openModelDetail"
       @apply="runAction"
@@ -259,8 +258,7 @@ import CompactSelect from './CompactSelect.vue'
 
 const props = defineProps({
   summary: { type: Object, default: () => ({}) },
-  channels: { type: Array, default: () => [] },
-  channelOfferings: { type: Array, default: () => [] }
+  channels: { type: Array, default: () => [] }
 })
 
 const emit = defineEmits(['navigate-to-detail', 'navigate-to-section'])

--- a/frontend/src/composables/useLLMOpsData.js
+++ b/frontend/src/composables/useLLMOpsData.js
@@ -285,13 +285,7 @@ export function useLLMOpsData() {
     }
     const tasks = dataGroupsForChannelModelManagement()
       .filter((group) => {
-        if (group === 'channelPricing') {
-          return (
-            !asArray(channelPrices.value).length ||
-            !asArray(channelPriceItems.value).length ||
-            !asArray(channelOfferings.value).length
-          )
-        }
+        if (group === 'channelPricing') return true
         return !asArray(groupValues[group]?.value).length
       })
       .map((group) => loadDataGroup(group, 'channels', {}))
@@ -415,14 +409,10 @@ export function useLLMOpsData() {
 
   async function refreshChannelManagementData() {
     try {
-      const [channelData] = await Promise.all([
-        fetchList(llmOpsApi.listChannels),
-        refreshChannelPricingData()
-      ])
+      const channelData = await fetchList(llmOpsApi.listChannels)
       channels.value = asArray(channelData)
-      refreshResaleListings().catch((error) => {
-        showError(errorMessage(error, t('llmOps.dataErrors.refreshListings')))
-      })
+      loadedSections.clear()
+      loadedSections.add('channels')
     } catch (error) {
       showError(errorMessage(error, t('llmOps.dataErrors.refreshChannels')))
     }

--- a/frontend/src/composables/useLLMOpsData.js
+++ b/frontend/src/composables/useLLMOpsData.js
@@ -122,7 +122,8 @@ export function useLLMOpsData() {
     const requestKey = [
       group,
       options?.modelId || '',
-      options?.platformId || ''
+      options?.platformId || '',
+      options?.channelId || ''
     ].join(':')
     const existingRequest = inFlightGroups.get(requestKey)
     if (existingRequest) return existingRequest
@@ -171,7 +172,7 @@ export function useLLMOpsData() {
       return
     }
     if (group === 'channelPricing') {
-      await refreshChannelPricingData()
+      await refreshChannelPricingData(options.channelId)
       return
     }
     if (group === 'modelPrices') {
@@ -195,11 +196,15 @@ export function useLLMOpsData() {
     }
   }
 
-  async function refreshChannelPricingData() {
+  async function refreshChannelPricingData(channelId = null) {
+    const params = channelId ? { channel: channelId } : {}
     const [offerings, prices, items] = await Promise.all([
-      fetchList(llmOpsApi.listChannelOfferings),
-      fetchList(llmOpsApi.listChannelModelPrices),
-      fetchList(llmOpsApi.listChannelPriceItems, { is_effective: 'true' })
+      fetchList(llmOpsApi.listChannelOfferings, params),
+      fetchList(llmOpsApi.listChannelModelPrices, params),
+      fetchList(llmOpsApi.listChannelPriceItems, {
+        ...params,
+        is_effective: 'true'
+      })
     ])
     channelOfferings.value = asArray(offerings)
     channelPrices.value = asArray(prices)
@@ -276,7 +281,7 @@ export function useLLMOpsData() {
     })
   }
 
-  function preloadChannelModelData() {
+  function preloadChannelModelData(channelId) {
     const groupValues = {
       metaModels,
       modelPrices: modelPriceItems,
@@ -288,7 +293,13 @@ export function useLLMOpsData() {
         if (group === 'channelPricing') return true
         return !asArray(groupValues[group]?.value).length
       })
-      .map((group) => loadDataGroup(group, 'channels', {}))
+      .map((group) =>
+        loadDataGroup(
+          group,
+          'channels',
+          group === 'channelPricing' ? { channelId } : {}
+        )
+      )
 
     return Promise.all(tasks)
   }

--- a/frontend/src/pages/LLMOps.vue
+++ b/frontend/src/pages/LLMOps.vue
@@ -188,7 +188,6 @@
               v-else-if="activeSection === 'channelMatrix'"
               :summary="summary"
               :channels="channels"
-              :channel-offerings="channelOfferings"
               @navigate-to-detail="openChannelListingDetail"
               @navigate-to-section="onNavigateToSection"
             />

--- a/frontend/src/utils/llmOpsSectionData.js
+++ b/frontend/src/utils/llmOpsSectionData.js
@@ -1,7 +1,7 @@
 const SECTION_DATA_GROUPS = {
   audit: ['channels'],
-  channelMatrix: ['platforms', 'channels', 'channelPricing', 'summary'],
-  channels: ['channels', 'models', 'channelPricing', 'modelPrices'],
+  channelMatrix: ['platforms', 'channels', 'summary'],
+  channels: ['channels'],
   collectionHealth: ['sources', 'runs'],
   globalConfig: ['sources'],
   listingRisk: ['platforms', 'summary'],

--- a/frontend/tests/llmOpsChannelPriceMatrix.test.js
+++ b/frontend/tests/llmOpsChannelPriceMatrix.test.js
@@ -144,13 +144,18 @@ test('calculates savings against the currently listed channel', () => {
   assert.equal(savingsPercent({ options: row.options }, 'input'), null)
 })
 
-test('loads contract pricing data only when the matrix is opened', () => {
+test('uses summary pricing without loading full contract collections', () => {
   assert.deepEqual(dataGroupsForSection('channelMatrix'), [
     'platforms',
     'channels',
-    'channelPricing',
     'summary'
   ])
+  assert.doesNotMatch(
+    pageSource.match(/<ChannelPriceMatrixPanel[\s\S]*?\/>/)?.[0] || '',
+    /:channel-offerings=/
+  )
+  assert.doesNotMatch(matrixSource, /channelOfferings/)
+  assert.match(drawerSource, /offer\.offering_name/)
 })
 
 test('connects dimension pricing, comparison details, and model drill-down', () => {

--- a/frontend/tests/llmOpsResilience.test.js
+++ b/frontend/tests/llmOpsResilience.test.js
@@ -129,13 +129,8 @@ test('loads publishing-only data when the resale workspace opens', () => {
   ])
 })
 
-test('loads channel pricing data for the contract editor', () => {
-  assert.deepEqual(dataGroupsForSection('channels'), [
-    'channels',
-    'models',
-    'channelPricing',
-    'modelPrices'
-  ])
+test('loads channel model details only when model management opens', () => {
+  assert.deepEqual(dataGroupsForSection('channels'), ['channels'])
   assert.deepEqual(dataGroupsForChannelModelManagement(), [
     'providers',
     'metaModels',
@@ -147,6 +142,16 @@ test('loads channel pricing data for the contract editor', () => {
     llmOpsPageSource,
     /:prepare-model-management="preloadChannelModelData"/
   )
+  assert.match(
+    llmOpsDataSource,
+    /if \(group === 'channelPricing'\) return true/
+  )
+  const refreshChannelBlock = llmOpsDataSource.match(
+    /async function refreshChannelManagementData\(\)[\s\S]*?\n[ ]{2}}/
+  )?.[0]
+  assert.ok(refreshChannelBlock)
+  assert.doesNotMatch(refreshChannelBlock, /refreshChannelPricingData/)
+  assert.doesNotMatch(refreshChannelBlock, /refreshResaleListings/)
 })
 
 test('does not pass unused model price items to the listing status board', () => {
@@ -255,10 +260,7 @@ test('refreshes platform-bound data in every platform-aware section', () => {
 })
 
 test('keeps the persisted platform until platform options have loaded', () => {
-  assert.match(
-    resalePublishingSource,
-    /if \(!platforms\.length\) return/
-  )
+  assert.match(resalePublishingSource, /if \(!platforms\.length\) return/)
   assert.match(
     llmOpsDataSource,
     /const selectedResalePlatformId = ref\([\s\S]*readStorage\('llm_ops_resale_platform'\)/

--- a/frontend/tests/llmOpsResilience.test.js
+++ b/frontend/tests/llmOpsResilience.test.js
@@ -146,6 +146,14 @@ test('loads channel model details only when model management opens', () => {
     llmOpsDataSource,
     /if \(group === 'channelPricing'\) return true/
   )
+  assert.match(
+    llmOpsDataSource,
+    /function preloadChannelModelData\(channelId\)[\s\S]*group === 'channelPricing'[\s\S]*loadDataGroup[\s\S]*channelId/
+  )
+  assert.match(
+    llmOpsDataSource,
+    /refreshChannelPricingData\(options\.channelId\)/
+  )
   const refreshChannelBlock = llmOpsDataSource.match(
     /async function refreshChannelManagementData\(\)[\s\S]*?\n[ ]{2}}/
   )?.[0]

--- a/frontend/tests/llmOpsSourcePriceCatalog.test.js
+++ b/frontend/tests/llmOpsSourcePriceCatalog.test.js
@@ -157,8 +157,21 @@ test('waits for deferred channel model data before opening its drawer', () => {
   assert.match(channelManagementSource, /prepareModelManagement/)
   assert.match(
     channelManagementSource,
-    /await props\.prepareModelManagement\(\)/
+    /await props\.prepareModelManagement\(channel\.id\)/
   )
+  assert.match(
+    dataComposableSource,
+    /refreshChannelPricingData\(options\.channelId\)/
+  )
+  assert.match(
+    dataComposableSource,
+    /fetchList\(llmOpsApi\.listChannelOfferings, params\)/
+  )
+  assert.match(
+    dataComposableSource,
+    /fetchList\(llmOpsApi\.listChannelModelPrices, params\)/
+  )
+  assert.match(dataComposableSource, /is_effective: 'true'/)
   assert.match(channelManagementSource, /openingChannelId/)
 })
 


### PR DESCRIPTION
## Summary
- 将转发渠道首屏收敛为仅加载渠道列表
- 打开模型管理时按当前 channelId 请求报价、渠道模型价格和有效价格项
- 保留公共模型/厂商目录请求去重，并补充前后端回归测试

Closes #355

## Test plan
- [x] Frontend unit tests (167/167)
- [x] Frontend typecheck
- [x] Frontend production build
- [x] Backend LLM Ops view tests (114/114)
- [x] ESLint and Python compile checks
