### PR TITLE
fix(llm-ops): normalize Aliyun regional price schedules

### DIFF
--- a/backend/llm_ops/collection_services.py
+++ b/backend/llm_ops/collection_services.py
@@ -2253,6 +2253,8 @@ def upsert_collected_sku(
             "meta_model": meta_model,
             "upstream_model_name": upstream_name,
             "display_name": display_name,
+            "access_region": sku_access_region(item),
+            "deployment_scope": sku_deployment_scope(item),
             "variant_type": sku_variant_type(source),
             "capabilities": {},
             "evidence": sku_evidence(source=source, source_url=source_url),
@@ -2273,6 +2275,14 @@ def upsert_collected_sku(
         if not sku.upstream_model_name and upstream_name:
             sku.upstream_model_name = upstream_name
             changed_fields.append("upstream_model_name")
+        access_region = sku_access_region(item)
+        if access_region and sku.access_region != access_region:
+            sku.access_region = access_region
+            changed_fields.append("access_region")
+        deployment_scope = sku_deployment_scope(item)
+        if deployment_scope and sku.deployment_scope != deployment_scope:
+            sku.deployment_scope = deployment_scope
+            changed_fields.append("deployment_scope")
     variant_type = sku_variant_type(source)
     if (
         not routing_locked
@@ -2354,6 +2364,26 @@ def sku_region(item: CollectedModelPricing) -> str:
         or model_info.get("deployment_region")
     )
     return str(value or "").strip()
+
+
+def sku_access_region(item: CollectedModelPricing) -> str:
+    """Return the normalized API access region for one collected SKU."""
+    for row in item.price_rows:
+        values = row.values or {}
+        value = values.get("access_region")
+        if value:
+            return str(value).strip()
+    return sku_region(item)
+
+
+def sku_deployment_scope(item: CollectedModelPricing) -> str:
+    """Return the normalized inference deployment scope for one SKU."""
+    for row in item.price_rows:
+        values = row.values or {}
+        value = values.get("deployment_scope")
+        if value:
+            return str(value).strip()
+    return ""
 
 
 def sku_mode(item: CollectedModelPricing) -> str:
@@ -2493,6 +2523,8 @@ def ensure_model_sku_for_model(
             "meta_model": model.meta_model,
             "upstream_model_name": upstream_name,
             "display_name": display_name,
+            "access_region": sku_access_region(item),
+            "deployment_scope": sku_deployment_scope(item),
             "variant_type": sku_variant_type(source),
             "capabilities": {},
             "evidence": sku_evidence(source=source, source_url=source_url),
@@ -2513,6 +2545,14 @@ def ensure_model_sku_for_model(
         if not sku.upstream_model_name and upstream_name:
             sku.upstream_model_name = upstream_name
             changed_fields.append("upstream_model_name")
+        access_region = sku_access_region(item)
+        if access_region and sku.access_region != access_region:
+            sku.access_region = access_region
+            changed_fields.append("access_region")
+        deployment_scope = sku_deployment_scope(item)
+        if deployment_scope and sku.deployment_scope != deployment_scope:
+            sku.deployment_scope = deployment_scope
+            changed_fields.append("deployment_scope")
     variant_type = sku_variant_type(source)
     if (
         not routing_locked
@@ -3334,6 +3374,7 @@ def price_item_payloads_from_row(
             values,
             common,
             spec=row_price_spec(row),
+            pricing_condition=row_pricing_condition(row),
         )
     if row.kind == "image_token":
         return image_token_price_item_payloads(item, values, common)
@@ -3384,6 +3425,7 @@ def token_price_item_payloads(
     common: dict,
     *,
     spec: dict | None = None,
+    pricing_condition: dict | None = None,
 ) -> list[dict]:
     """Build token input/output price item payloads."""
     payloads = []
@@ -3408,6 +3450,7 @@ def token_price_item_payloads(
                 billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
                 unit_price=price_per_million(input_price, item.unit),
                 spec=spec,
+                pricing_condition=pricing_condition,
                 tier_start=primary_range[0],
                 tier_end=primary_range[1],
             )
@@ -3420,6 +3463,7 @@ def token_price_item_payloads(
                 billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
                 unit_price=price_per_million(output_price, item.unit),
                 spec=spec,
+                pricing_condition=pricing_condition,
                 tier_start=primary_range[0],
                 tier_end=primary_range[1],
             )
@@ -3432,6 +3476,7 @@ def token_price_item_payloads(
                 billing_unit=ModelPriceItem.UNIT_PER_1M_TOKENS,
                 unit_price=price_per_million(cache_price, item.unit),
                 spec=spec,
+                pricing_condition=pricing_condition,
                 tier_start=primary_range[0],
                 tier_end=primary_range[1],
             )
@@ -3463,6 +3508,7 @@ def row_price_spec(row) -> dict:
     spec = {}
     for key in (
         "currency",
+        "access_region",
         "deployment_scope",
         "region",
         "market",
@@ -3490,6 +3536,18 @@ def row_price_spec(row) -> dict:
         if usage_conditions:
             spec["usage_conditions"] = usage_conditions
     return spec
+
+
+def row_pricing_condition(row) -> dict:
+    """Return the normalized condition controlling one collected price."""
+    values = row.values or {}
+    raw = row.raw or {}
+    condition = values.get("pricing_condition")
+    if not isinstance(condition, dict):
+        condition = raw.get("pricing_condition")
+    if isinstance(condition, dict) and condition:
+        return dict(condition)
+    return {"type": "always", "code": "all_time"}
 
 
 def image_token_price_item_payloads(
@@ -3642,6 +3700,7 @@ def price_item_payload(
     billing_unit: str,
     unit_price: Decimal | None,
     spec: dict | None = None,
+    pricing_condition: dict | None = None,
     tier_start: Decimal | None = None,
     tier_end: Decimal | None = None,
 ) -> dict:
@@ -3659,6 +3718,7 @@ def price_item_payload(
         "tier_start": tier_start,
         "tier_end": tier_end,
         "spec": spec or {},
+        "pricing_condition": pricing_condition or {},
         "is_current": True,
     }
 
@@ -3693,6 +3753,7 @@ def model_price_item_fingerprint(payload: dict) -> str:
         "tier_start": str(payload["tier_start"] or ""),
         "tier_end": str(payload["tier_end"] or ""),
         "spec": payload.get("spec") or {},
+        "pricing_condition": payload.get("pricing_condition") or {},
     }
     encoded = json.dumps(
         price_payload,

--- a/backend/llm_ops/migrations/0016_normalized_price_location_condition.py
+++ b/backend/llm_ops/migrations/0016_normalized_price_location_condition.py
@@ -1,0 +1,37 @@
+from django.db import migrations, models
+
+
+def backfill_access_regions(apps, schema_editor):
+    """Keep legacy SKU region values available through the new field."""
+    model_sku = apps.get_model("llm_ops", "ModelSku")
+    model_sku.objects.exclude(region="").filter(access_region="").update(
+        access_region=models.F("region"),
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("llm_ops", "0015_procurement_channel_contract_fx"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="modelsku",
+            name="access_region",
+            field=models.CharField(blank=True, default="", max_length=80),
+        ),
+        migrations.AddField(
+            model_name="modelsku",
+            name="deployment_scope",
+            field=models.CharField(blank=True, default="", max_length=80),
+        ),
+        migrations.AddField(
+            model_name="modelpriceitem",
+            name="pricing_condition",
+            field=models.JSONField(blank=True, default=dict),
+        ),
+        migrations.RunPython(
+            backfill_access_regions,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/backend/llm_ops/models.py
+++ b/backend/llm_ops/models.py
@@ -443,6 +443,12 @@ class ModelSku(models.Model):
         default=VARIANT_UNKNOWN,
     )
     region = models.CharField(max_length=80, blank=True, default="")
+    access_region = models.CharField(max_length=80, blank=True, default="")
+    deployment_scope = models.CharField(
+        max_length=80,
+        blank=True,
+        default="",
+    )
     mode = models.CharField(max_length=80, blank=True, default="")
     api_type = models.CharField(max_length=80, blank=True, default="")
     capabilities = models.JSONField(blank=True, default=dict)
@@ -854,6 +860,7 @@ class ModelPriceItem(models.Model):
         null=True,
     )
     spec = models.JSONField(blank=True, default=dict)
+    pricing_condition = models.JSONField(blank=True, default=dict)
     source_url = models.URLField(max_length=1000, blank=True, default="")
     raw_payload = models.JSONField(blank=True, default=dict)
     price_fingerprint = models.CharField(max_length=64, db_index=True)

--- a/backend/llm_ops/price_collectors/parsers/aliyun.py
+++ b/backend/llm_ops/price_collectors/parsers/aliyun.py
@@ -18,6 +18,19 @@ from .common import (
 PRICING_URL = "https://help.aliyun.com/zh/model-studio/model-pricing"
 DEFAULT_CURRENCY = "CNY"
 IGNORED_SUPPLIER_PREFIXES = {"siliconflow", "vanchin"}
+DOMESTIC_ACCESS_REGION = "cn-beijing"
+DOMESTIC_DEPLOYMENT_SCOPE = "china_mainland"
+PRICING_TIMEZONE = "Asia/Shanghai"
+REGIONAL_SECTION_NAMES = (
+    "华北2",
+    "北京",
+    "新加坡",
+    "德国",
+    "弗吉尼亚",
+    "美国",
+    "日本",
+    "东京",
+)
 
 
 class AliyunPriceCatalogCollector:
@@ -81,13 +94,15 @@ def fetch_text(url: str) -> str:
 
 def extract_models(page_html: str) -> list[dict[str, Any]]:
     """Extract Aliyun text model price rows from HTML tables."""
-    tables = re.findall(
-        r"<table.*?>.*?</table>",
-        page_html,
-        flags=re.DOTALL | re.IGNORECASE,
-    )
     models: dict[str, dict[str, Any]] = {}
-    for table in tables:
+    tables = pricing_tables_with_regions(page_html)
+    has_regional_sections = any(
+        is_regional_section(section_name)
+        for section_name, _ in tables
+    )
+    for section_name, table in tables:
+        if has_regional_sections and not is_beijing_section(section_name):
+            continue
         header_map: dict[str, int] = {}
         for row in expand_rows(table):
             if len(row) < 4:
@@ -105,20 +120,35 @@ def extract_models(page_html: str) -> list[dict[str, Any]]:
                 continue
             input_cell = row[header_map["input_price"]]
             output_cell = row[header_map["output_price"]]
-            input_price = parse_price(input_cell)
-            output_price = parse_price(output_cell)
-            if input_price is None or output_price is None:
+            condition_prices = parse_condition_prices(
+                input_cell,
+                output_cell,
+            )
+            if not condition_prices:
                 continue
             token_range = normalize_token_range(
                 value_at(row, header_map.get("input_range")),
             )
             scope = value_at(row, header_map.get("scope"))
+            if scope and not is_domestic_deployment_scope(scope):
+                continue
             currency = detect_currency(
                 input_cell,
                 output_cell,
                 scope,
                 model_id,
             )
+            price_rows = [
+                price_row(
+                    input_price=prices["input_price"],
+                    output_price=prices["output_price"],
+                    token_range=token_range,
+                    currency=currency,
+                    condition=pricing_condition(code),
+                )
+                for code, prices in condition_prices
+            ]
+            primary = condition_prices[0][1]
             upsert_model(
                 models,
                 {
@@ -126,21 +156,14 @@ def extract_models(page_html: str) -> list[dict[str, Any]]:
                     "model_name": model_id,
                     "display_name": display_name(model_id),
                     "aliases": [model_id],
-                    "input_price_per_million": input_price,
-                    "output_price_per_million": output_price,
-                    "price_rows": [
-                        price_row(
-                            input_price=input_price,
-                            output_price=output_price,
-                            token_range=token_range,
-                            currency=currency,
-                            deployment_scope=scope,
-                        )
-                    ],
+                    "input_price_per_million": primary["input_price"],
+                    "output_price_per_million": primary["output_price"],
+                    "price_rows": price_rows,
                     "currency": currency,
                     "notes": (
                         "Extracted from Aliyun Bailian official pricing "
-                        f"table; deployment_scope={scope or '-'}."
+                        "table; access_region=cn-beijing; "
+                        "deployment_scope=china_mainland."
                     ),
                 },
             )
@@ -152,6 +175,46 @@ def extract_models(page_html: str) -> list[dict[str, Any]]:
             key=lambda candidate: candidate["model_name"].lower(),
         )
     ]
+
+
+def pricing_tables_with_regions(
+    page_html: str,
+) -> list[tuple[str, str]]:
+    """Return pricing tables paired with their nearest preceding h4."""
+    pattern = re.compile(
+        r"<h4\b[^>]*>.*?</h4>|<table\b[^>]*>.*?</table>",
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+    section_name = ""
+    tables = []
+    for match in pattern.finditer(page_html):
+        fragment = match.group(0)
+        if fragment.lower().startswith("<h4"):
+            section_name = clean_cell_text(fragment)
+            continue
+        tables.append((section_name, fragment))
+    return tables
+
+
+def is_regional_section(value: str) -> bool:
+    """Return whether a heading identifies an Aliyun access region."""
+    normalized = re.sub(r"\s+", "", str(value or ""))
+    return any(name in normalized for name in REGIONAL_SECTION_NAMES)
+
+
+def is_beijing_section(value: str) -> bool:
+    """Return whether a heading is Aliyun's Beijing access region."""
+    normalized = re.sub(r"\s+", "", str(value or ""))
+    return "华北2" in normalized and "北京" in normalized
+
+
+def is_domestic_deployment_scope(value: str) -> bool:
+    """Return whether a row is explicitly deployed in mainland China."""
+    normalized = re.sub(r"[\s_-]+", "", str(value or "")).casefold()
+    return any(
+        marker in normalized
+        for marker in ("中国内地", "中国大陆", "国内", "chinamainland")
+    )
 
 
 def _merge_model_rows(item: dict[str, Any]) -> dict[str, Any]:
@@ -371,24 +434,95 @@ def parse_price(text: str) -> str | None:
     return match.group(1) if match else None
 
 
+def parse_condition_prices(
+    input_cell: str,
+    output_cell: str,
+) -> list[tuple[str, dict[str, str]]]:
+    """Parse fixed or peak/off-peak token prices from two cells."""
+    input_prices = labeled_prices(input_cell)
+    output_prices = labeled_prices(output_cell)
+    if input_prices or output_prices:
+        rows = []
+        for code in ("peak", "off_peak"):
+            input_price = input_prices.get(code)
+            output_price = output_prices.get(code)
+            if input_price is not None and output_price is not None:
+                rows.append(
+                    (
+                        code,
+                        {
+                            "input_price": input_price,
+                            "output_price": output_price,
+                        },
+                    )
+                )
+        return rows
+
+    input_price = parse_price(input_cell)
+    output_price = parse_price(output_cell)
+    if input_price is None or output_price is None:
+        return []
+    return [
+        (
+            "all_time",
+            {
+                "input_price": input_price,
+                "output_price": output_price,
+            },
+        )
+    ]
+
+
+def labeled_prices(text: str) -> dict[str, str]:
+    """Return Aliyun peak/off-peak labels mapped to numeric prices."""
+    labels = {
+        "peak": "忙时",
+        "off_peak": "闲时",
+    }
+    prices = {}
+    cleaned = str(text or "").replace(",", "")
+    for code, label in labels.items():
+        match = re.search(
+            rf"{label}\s*([0-9]+(?:\.[0-9]+)?)",
+            cleaned,
+        )
+        if match:
+            prices[code] = match.group(1)
+    return prices
+
+
+def pricing_condition(code: str) -> dict[str, str]:
+    """Return the normalized pricing condition for one Aliyun row."""
+    if code == "all_time":
+        return {"type": "always", "code": "all_time"}
+    labels = {"peak": "忙时", "off_peak": "闲时"}
+    return {
+        "type": "provider_schedule",
+        "code": code,
+        "label": labels[code],
+        "timezone": PRICING_TIMEZONE,
+    }
+
+
 def price_row(
     *,
     input_price: str,
     output_price: str,
     token_range: str,
     currency: str,
-    deployment_scope: str,
-) -> dict[str, str]:
+    condition: dict[str, str],
+) -> dict[str, Any]:
     """Build a parsed text-token price row."""
     row = {
         "input_price_per_million": input_price,
         "output_price_per_million": output_price,
         "cache_hit_price_per_million": cache_hit_price(input_price),
         "currency": currency,
+        "access_region": DOMESTIC_ACCESS_REGION,
+        "deployment_scope": DOMESTIC_DEPLOYMENT_SCOPE,
+        "region": DOMESTIC_ACCESS_REGION,
+        "pricing_condition": condition,
     }
-    if deployment_scope:
-        row["deployment_scope"] = deployment_scope
-        row["region"] = deployment_scope
     if token_range:
         row["input_token_range"] = token_range
         row["output_token_range"] = token_range
@@ -492,11 +626,11 @@ def upsert_model(
         append_price_row(existing, row)
 
 
-def append_price_row(item: dict[str, Any], row: dict[str, str]) -> None:
+def append_price_row(item: dict[str, Any], row: dict[str, Any]) -> None:
     """Append a unique tiered price row to an existing item."""
     rows = item.setdefault("price_rows", [])
-    fingerprint = tuple(sorted(row.items()))
-    existing_fingerprints = {tuple(sorted(value.items())) for value in rows}
+    fingerprint = repr(sorted(row.items()))
+    existing_fingerprints = {repr(sorted(value.items())) for value in rows}
     if fingerprint not in existing_fingerprints:
         rows.append(row)
 

--- a/backend/llm_ops/price_collectors/parsers/common.py
+++ b/backend/llm_ops/price_collectors/parsers/common.py
@@ -293,7 +293,7 @@ def text_token_price_rows(item: dict[str, Any]):
     return [build_text_token_row(item, values)]
 
 
-def normalize_text_token_values(row: dict[str, Any]) -> dict[str, str]:
+def normalize_text_token_values(row: dict[str, Any]) -> dict[str, Any]:
     """Normalize provider token price keys to platform price dimensions."""
     values = {}
     for source_key, target_key in (
@@ -310,6 +310,7 @@ def normalize_text_token_values(row: dict[str, Any]) -> dict[str, str]:
             values[key] = value
     for key in (
         "currency",
+        "access_region",
         "deployment_scope",
         "region",
         "market",
@@ -319,12 +320,15 @@ def normalize_text_token_values(row: dict[str, Any]) -> dict[str, str]:
         value = str(row.get(key) or "").strip()
         if value:
             values[key] = value
+    condition = row.get("pricing_condition")
+    if isinstance(condition, dict) and condition:
+        values["pricing_condition"] = dict(condition)
     return values
 
 
 def build_text_token_row(
     item: dict[str, Any],
-    values: dict[str, str],
+    values: dict[str, Any],
 ) -> NormalizedPriceRow:
     """Build a normalized price row for text-token pricing."""
     model_id = str(

--- a/backend/llm_ops/serializers.py
+++ b/backend/llm_ops/serializers.py
@@ -737,6 +737,16 @@ class LLMModelSerializer(serializers.ModelSerializer):
         read_only=True,
         allow_null=True,
     )
+    sku_access_region = serializers.CharField(
+        source="sku.access_region",
+        read_only=True,
+        allow_null=True,
+    )
+    sku_deployment_scope = serializers.CharField(
+        source="sku.deployment_scope",
+        read_only=True,
+        allow_null=True,
+    )
     sku_display_name = serializers.CharField(
         source="sku.display_name",
         read_only=True,
@@ -868,6 +878,16 @@ class ModelPriceItemSerializer(serializers.ModelSerializer):
         read_only=True,
         allow_null=True,
     )
+    sku_access_region = serializers.CharField(
+        source="sku.access_region",
+        read_only=True,
+        allow_null=True,
+    )
+    sku_deployment_scope = serializers.CharField(
+        source="sku.deployment_scope",
+        read_only=True,
+        allow_null=True,
+    )
     offering_exposed_model_name = serializers.CharField(
         source="offering.exposed_model_name",
         read_only=True,
@@ -935,6 +955,18 @@ class ModelPriceItemSerializer(serializers.ModelSerializer):
     def validate_unit_price(self, value):
         if value < Decimal("0"):
             raise serializers.ValidationError("unit_price must be >= 0.")
+        return value
+
+    def validate_pricing_condition(self, value):
+        if not isinstance(value, dict):
+            raise serializers.ValidationError(
+                "pricing_condition must be an object."
+            )
+        for key in ("type", "code", "timezone", "label"):
+            if key in value and not isinstance(value[key], str):
+                raise serializers.ValidationError(
+                    f"pricing_condition.{key} must be a string."
+                )
         return value
 
     def validate(self, attrs):

--- a/backend/llm_ops/services.py
+++ b/backend/llm_ops/services.py
@@ -1265,7 +1265,10 @@ def _schedule_from_source_items(
 
     tiers = []
     for item in source_items:
-        spec = item.spec or {}
+        spec = dict(item.spec or {})
+        condition = normalized_pricing_condition(item)
+        if condition:
+            spec["pricing_condition"] = condition
         if item.tier_type == ModelPriceItem.TIER_USAGE_RANGE:
             spec = with_usage_range_spec(spec)
         item_currency = currency
@@ -1696,8 +1699,26 @@ def selected_price_item_for_channel_model(
         item for item in items if item.tier_type == ModelPriceItem.TIER_FLAT
     ]
     if flat_items:
-        return sorted(flat_items, key=lambda item: item.id)[0]
+        unconditional = [
+            item
+            for item in flat_items
+            if normalized_pricing_condition(item).get("code") == "all_time"
+        ]
+        candidates = unconditional or flat_items
+        return sorted(
+            candidates,
+            key=lambda item: (item.unit_price, -item.id),
+            reverse=True,
+        )[0]
     return None
+
+
+def normalized_pricing_condition(item: ModelPriceItem) -> dict:
+    """Return a safe pricing-condition object from persisted JSON."""
+    condition = item.pricing_condition or {}
+    if not isinstance(condition, dict):
+        return {}
+    return dict(condition)
 
 
 def calculate_usage_cost(
@@ -2484,7 +2505,10 @@ def channel_price_payload_from_base_item(
         currency,
         base_item,
     )
-    spec = base_item.spec or {}
+    spec = dict(base_item.spec or {})
+    condition = normalized_pricing_condition(base_item)
+    if condition:
+        spec["pricing_condition"] = condition
     if base_item.tier_type == ModelPriceItem.TIER_USAGE_RANGE:
         spec = with_usage_range_spec(spec)
     return {

--- a/backend/llm_ops/tests/test_aliyun_price_collector.py
+++ b/backend/llm_ops/tests/test_aliyun_price_collector.py
@@ -1,0 +1,132 @@
+from django.test import SimpleTestCase
+
+from llm_ops.price_collectors.parsers.aliyun import extract_models
+
+
+ALIYUN_REGIONAL_PRICING_HTML = """
+<section>
+  <h4>华北 2（北京）</h4>
+  <table>
+    <tr>
+      <th>模型 ID（Model ID）</th>
+      <th>输入单价（每百万 Token）</th>
+      <th>输出单价（每百万 Token）</th>
+      <th>免费额度</th>
+    </tr>
+    <tr>
+      <td>deepseek-v4-flash-0731</td>
+      <td><p>忙时 3 元</p><p>闲时 1.5 元</p></td>
+      <td><p>忙时 9 元</p><p>闲时 4.5 元</p></td>
+      <td>100 万 Token</td>
+    </tr>
+    <tr>
+      <td>deepseek-v4-flash</td>
+      <td>1 元</td>
+      <td>2 元</td>
+      <td>100 万 Token</td>
+    </tr>
+  </table>
+</section>
+<section>
+  <h4>新加坡</h4>
+  <table>
+    <tr>
+      <th>模型 ID（Model ID）</th>
+      <th>服务部署范围</th>
+      <th>输入单价（每百万 Token）</th>
+      <th>输出单价（每百万 Token）</th>
+    </tr>
+    <tr>
+      <td>deepseek-v4-flash-0731</td>
+      <td>国际</td>
+      <td><p>忙时 3.208 元</p><p>闲时 1.604 元</p></td>
+      <td><p>忙时 9.625 元</p><p>闲时 4.813 元</p></td>
+    </tr>
+  </table>
+</section>
+<section>
+  <h4>日本（东京）</h4>
+  <table>
+    <tr>
+      <th>模型 ID（Model ID）</th>
+      <th>服务部署范围</th>
+      <th>输入单价（每百万 Token）</th>
+      <th>输出单价（每百万 Token）</th>
+    </tr>
+    <tr>
+      <td>deepseek-v4-flash</td>
+      <td>日本</td>
+      <td>1.499 元</td>
+      <td>2.998 元</td>
+    </tr>
+  </table>
+</section>
+"""
+
+
+class AliyunPriceCollectorTests(SimpleTestCase):
+    def test_collects_only_beijing_prices_with_normalized_location(self):
+        models = extract_models(ALIYUN_REGIONAL_PRICING_HTML)
+
+        self.assertEqual(
+            [model["model_id"] for model in models],
+            ["deepseek-v4-flash", "deepseek-v4-flash-0731"],
+        )
+        for model in models:
+            for row in model["price_rows"]:
+                self.assertEqual(row["access_region"], "cn-beijing")
+                self.assertEqual(
+                    row["deployment_scope"],
+                    "china_mainland",
+                )
+                self.assertEqual(row["region"], "cn-beijing")
+
+    def test_keeps_peak_and_off_peak_prices_as_structured_conditions(self):
+        models = extract_models(ALIYUN_REGIONAL_PRICING_HTML)
+        model = next(
+            item
+            for item in models
+            if item["model_id"] == "deepseek-v4-flash-0731"
+        )
+
+        self.assertEqual(len(model["price_rows"]), 2)
+        rows = {
+            row["pricing_condition"]["code"]: row
+            for row in model["price_rows"]
+        }
+        self.assertEqual(set(rows), {"peak", "off_peak"})
+        self.assertEqual(rows["peak"]["input_price_per_million"], "3")
+        self.assertEqual(rows["peak"]["output_price_per_million"], "9")
+        self.assertEqual(
+            rows["peak"]["cache_hit_price_per_million"],
+            "0.3",
+        )
+        self.assertEqual(
+            rows["off_peak"]["input_price_per_million"],
+            "1.5",
+        )
+        self.assertEqual(
+            rows["off_peak"]["output_price_per_million"],
+            "4.5",
+        )
+        self.assertEqual(
+            rows["off_peak"]["cache_hit_price_per_million"],
+            "0.15",
+        )
+        self.assertEqual(
+            rows["peak"]["pricing_condition"]["timezone"],
+            "Asia/Shanghai",
+        )
+
+    def test_marks_fixed_prices_as_all_time(self):
+        models = extract_models(ALIYUN_REGIONAL_PRICING_HTML)
+        model = next(
+            item
+            for item in models
+            if item["model_id"] == "deepseek-v4-flash"
+        )
+
+        self.assertEqual(
+            model["price_rows"][0]["pricing_condition"],
+            {"type": "always", "code": "all_time"},
+        )

--- a/backend/llm_ops/tests/test_services.py
+++ b/backend/llm_ops/tests/test_services.py
@@ -688,6 +688,88 @@ class LLMOpsPricingServiceTests(TestCase):
         self.assertEqual(items[0].unit_price, Decimal("1.500000"))
         self.assertEqual(cost, Decimal("1.500000"))
 
+    def test_channel_preserves_conditional_prices_and_uses_safe_default(self):
+        source = PriceCollectionSource.objects.create(
+            name="Aliyun Official",
+            slug="aliyun-conditional-official",
+            provider=self.provider,
+            source_category=(
+                PriceCollectionSource.SOURCE_CATEGORY_OFFICIAL_PROVIDER
+            ),
+            currency="CNY",
+        )
+        price = ChannelModelPrice.objects.create(
+            channel=self.channel,
+            model=self.model,
+            price_source=source,
+            currency="CNY",
+            settlement_ratio=Decimal("1"),
+        )
+        source_items = []
+        dimensions = (
+            ModelPriceItem.DIMENSION_TEXT_INPUT,
+            ModelPriceItem.DIMENSION_TEXT_OUTPUT,
+            ModelPriceItem.DIMENSION_CACHE_INPUT,
+        )
+        for code, values in (
+            ("peak", ("3", "9", "0.3")),
+            ("off_peak", ("1.5", "4.5", "0.15")),
+        ):
+            for dimension, value in zip(dimensions, values, strict=True):
+                source_items.append(
+                    ModelPriceItem.objects.create(
+                        provider=self.provider,
+                        model=self.model,
+                        meta_model=self.model.meta_model,
+                        source=source,
+                        dimension=dimension,
+                        billing_unit=(
+                            ModelPriceItem.UNIT_PER_1M_TOKENS
+                        ),
+                        currency="CNY",
+                        unit_price=Decimal(value),
+                        spec={
+                            "access_region": "cn-beijing",
+                            "deployment_scope": "china_mainland",
+                        },
+                        pricing_condition={
+                            "type": "provider_schedule",
+                            "code": code,
+                            "timezone": "Asia/Shanghai",
+                        },
+                        price_fingerprint=f"{code}-{dimension}",
+                        is_current=True,
+                    )
+                )
+
+        schedule = resolve_channel_price_schedule(
+            self.channel,
+            self.model,
+            override=price,
+            source_items=source_items,
+        )
+        unit_prices = resolve_channel_model_price(
+            self.channel,
+            self.model,
+            override=price,
+            source_items=source_items,
+        )
+
+        self.assertEqual(len(schedule.tiers), 6)
+        self.assertEqual(
+            {
+                tier.spec["pricing_condition"]["code"]
+                for tier in schedule.tiers
+            },
+            {"peak", "off_peak"},
+        )
+        self.assertEqual(unit_prices.input_per_million, Decimal("3"))
+        self.assertEqual(unit_prices.output_per_million, Decimal("9"))
+        self.assertEqual(
+            unit_prices.cache_input_per_million,
+            Decimal("0.3"),
+        )
+
     def test_sync_does_not_mix_regions_for_selected_source_offering(self):
         source = PriceCollectionSource.objects.create(
             name="Regional supplier",
@@ -1182,7 +1264,6 @@ class LLMOpsPricingServiceTests(TestCase):
             ),
             original_ids,
         )
-
 
     def test_marks_channel_item_comparison_unknown_for_currency_mismatch(self):
         ModelPriceItem.objects.create(

--- a/backend/llm_ops/tests/test_skill_runner.py
+++ b/backend/llm_ops/tests/test_skill_runner.py
@@ -378,7 +378,7 @@ class ModelPriceSkillRunnerTests(SimpleTestCase):
         )
         self.assertEqual(payload["models"][0]["model_id"], "qwen-new-2026")
 
-    def test_aliyun_provider_adapter_preserves_multi_market_prices(self):
+    def test_aliyun_provider_adapter_keeps_only_domestic_prices(self):
         payload = collect_vendor_price_catalog(
             "aliyun",
             {
@@ -392,12 +392,13 @@ class ModelPriceSkillRunnerTests(SimpleTestCase):
         model = payload["models"][0]
         self.assertEqual(model["model_id"], "qwen-plus")
         rows = model["price_rows"]
-        self.assertEqual(len(rows), 2)
+        self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0]["values"]["currency"], "CNY")
-        self.assertEqual(rows[0]["values"]["deployment_scope"], "中国内地")
-        self.assertEqual(rows[1]["values"]["currency"], "USD")
-        self.assertEqual(rows[1]["values"]["deployment_scope"], "国际")
-        self.assertEqual(rows[1]["values"]["input_price"], "0.12")
+        self.assertEqual(
+            rows[0]["values"]["deployment_scope"],
+            "china_mainland",
+        )
+        self.assertEqual(rows[0]["values"]["access_region"], "cn-beijing")
 
     def test_aliyun_vendor_skill_returns_standard_catalog_json(self):
         payload = run_vendor_pricing_skill(

--- a/backend/llm_ops/tests/test_source_collectors.py
+++ b/backend/llm_ops/tests/test_source_collectors.py
@@ -650,6 +650,78 @@ class PriceCollectionSkuPersistenceTests(TestCase):
         self.assertEqual(input_item.model.sku, sku)
         self.assertEqual(input_item.unit_price, Decimal("1.000000"))
 
+    def test_persists_location_and_conditional_price_rows(self):
+        conditions = (
+            ("peak", "3", "9", "0.3"),
+            ("off_peak", "1.5", "4.5", "0.15"),
+        )
+        rows = [
+            NormalizedPriceRow(
+                kind="text_token",
+                values={
+                    "input_price": input_price,
+                    "output_price": output_price,
+                    "cache_hit_input_price": cache_price,
+                    "currency": "CNY",
+                    "access_region": "cn-beijing",
+                    "deployment_scope": "china_mainland",
+                    "region": "cn-beijing",
+                    "pricing_condition": {
+                        "type": "provider_schedule",
+                        "code": code,
+                        "timezone": "Asia/Shanghai",
+                    },
+                },
+                raw={"currency": "CNY"},
+            )
+            for code, input_price, output_price, cache_price in conditions
+        ]
+        base = self.collected_item()
+        item = CollectedModelPricing(
+            **{
+                **base.__dict__,
+                "price_rows": rows,
+                "raw_detail": {
+                    **base.raw_detail,
+                    "sku_region": "cn-beijing",
+                },
+            }
+        )
+
+        offering, _ = upsert_collected_offering(
+            item,
+            source=self.source,
+            source_url=self.source.endpoint_url,
+            meta_model=self.meta_model,
+        )
+        price_items = sync_model_price_items(
+            item,
+            source=self.source,
+            offering=offering,
+            source_url=self.source.endpoint_url,
+        )
+
+        self.assertEqual(len(price_items), 6)
+        self.assertEqual(offering.sku.access_region, "cn-beijing")
+        self.assertEqual(
+            offering.sku.deployment_scope,
+            "china_mainland",
+        )
+        self.assertEqual(
+            {
+                price_item.pricing_condition["code"]
+                for price_item in price_items
+            },
+            {"peak", "off_peak"},
+        )
+        self.assertEqual(
+            {
+                price_item.spec["access_region"]
+                for price_item in price_items
+            },
+            {"cn-beijing"},
+        )
+
     def test_auto_source_sync_refreshes_dependent_channel_price_items(self):
         first = self.collected_item()
         catalog = mock.Mock(

--- a/backend/llm_ops/tests/test_tier_pricing.py
+++ b/backend/llm_ops/tests/test_tier_pricing.py
@@ -456,6 +456,66 @@ class TieredPricingKernelTests(SimpleTestCase):
 
         self.assertEqual(prices.input_per_million, Decimal("5"))
 
+    def test_named_provider_condition_selects_requested_price(self):
+        schedule = PriceSchedule(
+            tiers=(
+                self._flat_tier(
+                    "3",
+                    {
+                        "pricing_condition": {
+                            "type": "provider_schedule",
+                            "code": "peak",
+                        }
+                    },
+                ),
+                self._flat_tier(
+                    "1.5",
+                    {
+                        "pricing_condition": {
+                            "type": "provider_schedule",
+                            "code": "off_peak",
+                        }
+                    },
+                ),
+            )
+        )
+
+        prices = resolve_usage_unit_prices(
+            schedule,
+            UsageContext(pricing_condition_code="off_peak"),
+        )
+
+        self.assertEqual(prices.input_per_million, Decimal("1.5"))
+
+    def test_named_provider_condition_defaults_to_highest_price(self):
+        schedule = PriceSchedule(
+            tiers=(
+                self._flat_tier(
+                    "3",
+                    {
+                        "pricing_condition": {
+                            "type": "provider_schedule",
+                            "code": "peak",
+                        }
+                    },
+                ),
+                self._flat_tier(
+                    "1.5",
+                    {
+                        "pricing_condition": {
+                            "type": "provider_schedule",
+                            "code": "off_peak",
+                        }
+                    },
+                ),
+            )
+        )
+
+        with self.assertLogs("llm_ops.tier_pricing", level="WARNING"):
+            prices = resolve_usage_unit_prices(schedule, UsageContext())
+
+        self.assertEqual(prices.input_per_million, Decimal("3"))
+
     def test_overlapping_time_rules_warn_and_choose_highest_price(self):
         window = {
             "time_windows": [

--- a/backend/llm_ops/tier_pricing.py
+++ b/backend/llm_ops/tier_pricing.py
@@ -91,6 +91,7 @@ class UsageContext:
     video_output_seconds: Decimal | int | str = ZERO
     occurred_at: datetime | None = None
     timezone: str = "UTC"
+    pricing_condition_code: str = ""
 
 
 @dataclass(frozen=True)
@@ -215,7 +216,11 @@ def resolve_usage_price_tier(
     conditional_tiers = tuple(
         tier
         for tier in tiers
-        if tier.spec.get("usage_conditions") or tier.spec.get("time_windows")
+        if (
+            tier.spec.get("usage_conditions")
+            or tier.spec.get("time_windows")
+            or tier.spec.get("pricing_condition")
+        )
     )
     if conditional_tiers:
         conditional_matches = tuple(
@@ -288,6 +293,12 @@ def _usage_matches_conditions(
 
 def _usage_matches_tier(usage: UsageContext, tier: PriceTier) -> bool:
     """Match all quantity and local-time conditions on a price rule."""
+    pricing_condition = tier.spec.get("pricing_condition")
+    if pricing_condition and not _usage_matches_pricing_condition(
+        usage,
+        pricing_condition,
+    ):
+        return False
     conditions = tier.spec.get("usage_conditions")
     if conditions and not _usage_matches_conditions(usage, conditions):
         return False
@@ -299,6 +310,21 @@ def _usage_matches_tier(usage: UsageContext, tier: PriceTier) -> bool:
     ):
         return False
     return True
+
+
+def _usage_matches_pricing_condition(
+    usage: UsageContext,
+    condition: object,
+) -> bool:
+    """Match a named provider condition selected by the channel caller."""
+    if not isinstance(condition, dict):
+        return False
+    code = str(condition.get("code") or "").strip()
+    condition_type = str(condition.get("type") or "").strip()
+    if condition_type == "always" or code == "all_time":
+        return True
+    selected_code = str(usage.pricing_condition_code or "").strip()
+    return bool(selected_code and selected_code == code)
 
 
 def _usage_matches_time_windows(

--- a/frontend/src/components/llm-ops/ChannelModelDrawer.vue
+++ b/frontend/src/components/llm-ops/ChannelModelDrawer.vue
@@ -1441,8 +1441,7 @@ function priceTierComparisonRows(row) {
       .map((item) =>
         (props.priceItems || []).find(
           (candidate) =>
-            String(candidate.id || '') ===
-            String(item?.base_price_item || '')
+            String(candidate.id || '') === String(item?.base_price_item || '')
         )
       )
       .find((item) => item?.offering)?.offering ||
@@ -1468,11 +1467,7 @@ function priceTierComparisonRows(row) {
     'costPrices'
   )
   append(
-    providerPriceItemsForModel(
-      row?.model,
-      boundSourceOfferingId,
-      region
-    ),
+    providerPriceItemsForModel(row?.model, boundSourceOfferingId, region),
     'upstreamPrices'
   )
   return Array.from(tiers.values())
@@ -1484,10 +1479,13 @@ function priceItemRegion(item, sourceItems = []) {
       String(candidate.id || '') === String(item?.base_price_item || '')
   )
   return (
+    item?.spec?.access_region ||
     item?.spec?.deployment_scope ||
     item?.spec?.region ||
+    sourceItem?.spec?.access_region ||
     sourceItem?.spec?.deployment_scope ||
     sourceItem?.spec?.region ||
+    item?.sku_access_region ||
     item?.sku_region ||
     item?.region ||
     'Global'

--- a/frontend/src/components/llm-ops/SourcePriceDrawer.vue
+++ b/frontend/src/components/llm-ops/SourcePriceDrawer.vue
@@ -379,7 +379,11 @@ function queueSearch(value) {
 function schedules(priceItems) {
   return buildSourcePriceSchedules(priceItems, {
     defaultScope: t('llmOps.sourcePriceDrawer.defaultScope'),
-    flat: t('llmOps.sourcePriceDrawer.allUsage')
+    flat: t('llmOps.sourcePriceDrawer.allUsage'),
+    peak: t('llmOps.sourcePriceDrawer.conditions.peak'),
+    offPeak: t('llmOps.sourcePriceDrawer.conditions.offPeak'),
+    beijing: t('llmOps.sourcePriceDrawer.locations.beijing'),
+    chinaMainland: t('llmOps.sourcePriceDrawer.locations.chinaMainland')
   })
 }
 

--- a/frontend/src/composables/useChannelModelPricing.js
+++ b/frontend/src/composables/useChannelModelPricing.js
@@ -343,10 +343,13 @@ export function useChannelModelPricing({
         String(candidate.id || '') === String(item.base_price_item || '')
     )
     return (
+      item?.spec?.access_region ||
       item?.spec?.deployment_scope ||
       item?.spec?.region ||
+      sourceItem?.spec?.access_region ||
       sourceItem?.spec?.deployment_scope ||
       sourceItem?.spec?.region ||
+      item?.sku_access_region ||
       item?.sku_region ||
       item?.region ||
       'Global'
@@ -355,7 +358,9 @@ export function useChannelModelPricing({
 
   function normalizePriceRegion(value) {
     return (
-      String(value || 'Global').trim().toLowerCase() || 'global'
+      String(value || 'Global')
+        .trim()
+        .toLowerCase() || 'global'
     )
   }
 
@@ -371,10 +376,13 @@ export function useChannelModelPricing({
         String(candidate.id || '') === String(item.base_price_item || '')
     )
     const itemRegion =
+      item.spec?.access_region ||
       item.spec?.deployment_scope ||
       item.spec?.region ||
+      sourceItem?.spec?.access_region ||
       sourceItem?.spec?.deployment_scope ||
       sourceItem?.spec?.region ||
+      item.sku_access_region ||
       item.sku_region ||
       item.region ||
       'Global'

--- a/frontend/src/composables/useChannelModelSelection.js
+++ b/frontend/src/composables/useChannelModelSelection.js
@@ -204,8 +204,10 @@ export function useChannelModelSelection({
     const regionalRows = rows.map((item) => ({
       item,
       region:
+        item.spec?.access_region ||
         item.spec?.deployment_scope ||
         item.spec?.region ||
+        item.sku_access_region ||
         item.sku_region ||
         item.region ||
         'Global'

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -2683,6 +2683,14 @@
       "searchPlaceholder": "Search meta model, provider, or code",
       "allUsage": "All usage",
       "defaultScope": "Mainland China / default",
+      "conditions": {
+        "peak": "Peak",
+        "offPeak": "Off-peak"
+      },
+      "locations": {
+        "beijing": "China North 2 (Beijing)",
+        "chinaMainland": "Mainland China"
+      },
       "priceItemCount": "{count} current price items",
       "tierCount": "{count} tiers",
       "actions": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -2691,6 +2691,14 @@
       "searchPlaceholder": "搜索元模型、厂商或 code",
       "allUsage": "全部用量",
       "defaultScope": "中国内地 / 默认",
+      "conditions": {
+        "peak": "忙时",
+        "offPeak": "闲时"
+      },
+      "locations": {
+        "beijing": "华北 2（北京）",
+        "chinaMainland": "中国内地"
+      },
       "priceItemCount": "{count} 条当前价格项",
       "tierCount": "{count} 个阶梯",
       "actions": {

--- a/frontend/src/utils/channelPriceCatalog.js
+++ b/frontend/src/utils/channelPriceCatalog.js
@@ -23,7 +23,8 @@ export function channelPriceTierRows(priceItems = []) {
         item.tier_type || 'flat',
         item.tier_start || '',
         item.tier_end || '',
-        specLabel
+        specLabel,
+        pricingConditionCode(item)
       ].join(':')
       const tier = tiers.get(key) || {
         prices: [],
@@ -48,6 +49,7 @@ export function channelPriceTierRows(priceItems = []) {
 export function priceSpecLabel(spec = {}) {
   if (!spec || typeof spec !== 'object') return ''
   const values = [
+    spec.access_region,
     spec.region,
     spec.deployment_scope,
     spec.scope,
@@ -63,10 +65,19 @@ export function priceSpecLabel(spec = {}) {
 
 export function channelPriceItemLabel(item = {}) {
   const label = priceDimensionLabel(item.dimension)
+  const hasCondition = !['', 'all_time'].includes(pricingConditionCode(item))
   const tierLabel =
-    item.tier_type === 'usage_range' ? `${tierRangeLabel(item)} ` : ''
+    item.tier_type === 'usage_range' || hasCondition
+      ? `${tierRangeLabel(item)} `
+      : ''
   const specLabel = priceSpecLabel(item.spec)
   return [tierLabel + label, specLabel].filter(Boolean).join(' · ')
+}
+
+function pricingConditionCode(item = {}) {
+  return String(
+    item.pricing_condition?.code || item.spec?.pricing_condition?.code || ''
+  )
 }
 
 function channelPriceItemSort(left, right) {

--- a/frontend/src/utils/sourcePriceCatalog.js
+++ b/frontend/src/utils/sourcePriceCatalog.js
@@ -19,7 +19,7 @@ const DIMENSION_ORDER = [
 export function buildSourcePriceSchedules(priceItems = [], labels = {}) {
   const variants = new Map()
   priceItems.forEach((item) => {
-    const identity = variantIdentity(item)
+    const identity = variantIdentity(item, labels)
     if (!variants.has(identity.key)) {
       variants.set(identity.key, {
         key: identity.key,
@@ -34,7 +34,8 @@ export function buildSourcePriceSchedules(priceItems = [], labels = {}) {
       item.tier_type,
       item.tier_start ?? '',
       item.tier_end ?? '',
-      stableJson(priceSpec(item.spec))
+      stableJson(priceSpec(item.spec)),
+      stableJson(pricingCondition(item))
     ].join('|')
     let tier = variant.tiers.find((candidate) => candidate.key === tierKey)
     if (!tier) {
@@ -42,6 +43,7 @@ export function buildSourcePriceSchedules(priceItems = [], labels = {}) {
         key: tierKey,
         billing_unit: item.billing_unit,
         range_label: tierRangeLabel(item, labels),
+        pricing_condition: pricingCondition(item),
         prices: []
       }
       variant.tiers.push(tier)
@@ -67,19 +69,27 @@ export function buildSourcePriceSchedules(priceItems = [], labels = {}) {
 }
 
 export function tierRangeLabel(item, labels = {}) {
+  const condition = pricingCondition(item)
+  const conditionLabel = pricingConditionLabel(condition, labels)
   if (item.tier_type !== 'usage_range') {
-    return labels.flat || 'All usage'
+    return conditionLabel || labels.flat || 'All usage'
   }
   const start = compactNumber(item.tier_start ?? 0)
   const end = item.tier_end === null ? '∞' : compactNumber(item.tier_end)
-  return `[${start}, ${end})`
+  return [conditionLabel, `[${start}, ${end})`].filter(Boolean).join(' · ')
 }
 
-function variantIdentity(item) {
+function variantIdentity(item, labels = {}) {
   const spec = priceSpec(item.spec)
   const scopeParts = [
-    item.spec?.deployment_scope,
-    item.spec?.region,
+    locationLabel(
+      item.sku_access_region || item.spec?.access_region || item.sku_region,
+      labels
+    ),
+    locationLabel(
+      item.sku_deployment_scope || item.spec?.deployment_scope,
+      labels
+    ),
     ...Object.entries(spec).map(([key, value]) => `${key}: ${value}`)
   ].filter(Boolean)
   const uniqueParts = Array.from(new Set(scopeParts.map(String)))
@@ -96,7 +106,13 @@ function priceSpec(spec = {}) {
       .filter(([key, value]) => {
         return (
           !TIER_SPEC_KEYS.has(key) &&
-          !['currency', 'deployment_scope', 'region'].includes(key) &&
+          ![
+            'currency',
+            'access_region',
+            'deployment_scope',
+            'pricing_condition',
+            'region'
+          ].includes(key) &&
           value !== '' &&
           value !== null &&
           value !== undefined
@@ -104,6 +120,30 @@ function priceSpec(spec = {}) {
       })
       .sort(([left], [right]) => left.localeCompare(right))
   )
+}
+
+function pricingCondition(item = {}) {
+  const condition = item.pricing_condition || item.spec?.pricing_condition
+  return condition && typeof condition === 'object' ? condition : {}
+}
+
+function pricingConditionLabel(condition = {}, labels = {}) {
+  const code = condition.code || ''
+  if (!code || code === 'all_time') return ''
+  const conditionLabels = {
+    peak: labels.peak || condition.label || 'Peak',
+    off_peak: labels.offPeak || condition.label || 'Off-peak'
+  }
+  return conditionLabels[code] || condition.label || code
+}
+
+function locationLabel(value, labels = {}) {
+  const normalized = String(value || '').trim()
+  const locationLabels = {
+    'cn-beijing': labels.beijing || 'cn-beijing',
+    china_mainland: labels.chinaMainland || 'china_mainland'
+  }
+  return locationLabels[normalized] || normalized
 }
 
 function compactNumber(value) {

--- a/frontend/tests/llmOpsSourcePriceCatalog.test.js
+++ b/frontend/tests/llmOpsSourcePriceCatalog.test.js
@@ -281,6 +281,60 @@ test('labels flat and usage-range prices explicitly', () => {
   )
 })
 
+test('groups peak prices under one Beijing schedule with clear labels', () => {
+  const items = [
+    ['peak', 'text_input', '3'],
+    ['peak', 'text_output', '9'],
+    ['peak', 'cache_input', '0.3'],
+    ['off_peak', 'text_input', '1.5'],
+    ['off_peak', 'text_output', '4.5'],
+    ['off_peak', 'cache_input', '0.15']
+  ].map(([code, dimension, unit_price]) => ({
+    sku_code: 'deepseek-v4-flash-0731',
+    sku_access_region: 'cn-beijing',
+    sku_deployment_scope: 'china_mainland',
+    dimension,
+    billing_unit: 'per_1m_tokens',
+    currency: 'CNY',
+    unit_price,
+    tier_type: 'flat',
+    pricing_condition: {
+      type: 'provider_schedule',
+      code,
+      timezone: 'Asia/Shanghai'
+    },
+    spec: {
+      access_region: 'cn-beijing',
+      deployment_scope: 'china_mainland'
+    }
+  }))
+
+  const schedules = buildSourcePriceSchedules(items, {
+    flat: '全部用量',
+    peak: '忙时',
+    offPeak: '闲时',
+    beijing: '华北 2（北京）',
+    chinaMainland: '中国内地'
+  })
+
+  assert.equal(schedules.length, 1)
+  assert.match(schedules[0].scope_label, /华北 2（北京）/)
+  assert.match(schedules[0].scope_label, /中国内地/)
+  assert.deepEqual(
+    schedules[0].tiers.map((tier) => tier.range_label),
+    ['忙时', '闲时']
+  )
+  assert.deepEqual(
+    schedules[0].tiers.map((tier) =>
+      tier.prices.map((price) => price.dimension)
+    ),
+    [
+      ['text_input', 'text_output', 'cache_input'],
+      ['text_input', 'text_output', 'cache_input']
+    ]
+  )
+})
+
 test('keeps every channel price tier when summarizing one dimension', () => {
   const items = [
     ['text_input', '3', '0', '32000'],
@@ -349,6 +403,38 @@ test('groups channel prices by usage tier for side-by-side display', () => {
       rangeLabel: '[32,000, ∞)'
     }
   ])
+})
+
+test('keeps peak and off-peak channel prices in separate rows', () => {
+  const items = [
+    ['peak', '忙时', 'text_input', '3'],
+    ['peak', '忙时', 'text_output', '9'],
+    ['off_peak', '闲时', 'text_input', '1.5'],
+    ['off_peak', '闲时', 'text_output', '4.5']
+  ].map(([code, label, dimension, unit_price]) => ({
+    dimension,
+    unit_price,
+    currency: 'CNY',
+    tier_type: 'flat',
+    spec: {
+      access_region: 'cn-beijing',
+      deployment_scope: 'china_mainland',
+      pricing_condition: {
+        type: 'provider_schedule',
+        code,
+        label,
+        timezone: 'Asia/Shanghai'
+      }
+    }
+  }))
+
+  const rows = channelPriceTierRows(items)
+
+  assert.equal(rows.length, 2)
+  assert.deepEqual(
+    rows.map((row) => row.rangeLabel),
+    ['忙时 · cn-beijing · china_mainland', '闲时 · cn-beijing · china_mainland']
+  )
 })
 
 test('renders configured channel prices as grouped tier comparisons', () => {


### PR DESCRIPTION
## Summary

- restrict Alibaba Cloud domestic collection to the Beijing access region and mainland China deployment scope
- persist access region and deployment scope separately, with a migration for legacy SKU region data
- preserve fixed, peak, and off-peak supplier conditions through collection, channel pricing, API serialization, and localized UI schedules
- use an explicit named condition when supplied and a conservative highest-price fallback otherwise

Closes #361

## Test plan

- [x] `pytest` — 101 focused LLM Ops backend tests
- [x] `manage.py makemigrations llm_ops --check --dry-run`
- [x] `npm run test:unit` — 171 frontend unit tests
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] ESLint on changed frontend files
- [x] `git diff --check`