### PR TITLE
fix(quotation): prevent duplicate automatic draft numbers

### DIFF
--- a/backend/quotation/migrations/0033_unique_auto_draft_quote_number.py
+++ b/backend/quotation/migrations/0033_unique_auto_draft_quote_number.py
@@ -1,0 +1,99 @@
+import re
+
+from django.db import migrations, models
+
+
+AUTO_NUMBER_PATTERN = re.compile(
+    r"^(.+\d{6})(?:\.(\d+))?(?:_R\d+)?$",
+    re.IGNORECASE,
+)
+
+
+def _record_sequence(used_sequences, quote_no):
+    """Record an automatic number in its root sequence."""
+    match = AUTO_NUMBER_PATTERN.match(str(quote_no or "").strip())
+    if not match:
+        return
+    root = match.group(1).lower()
+    used_sequences.setdefault(root, set()).add(int(match.group(2) or 0))
+
+
+def deduplicate_auto_draft_numbers(apps, schema_editor):
+    """Renumber duplicate automatic drafts before adding the constraint."""
+    quotation_model = apps.get_model("quotation", "Quotation")
+    version_model = apps.get_model("quotation", "QuotationVersion")
+    used_sequences = {}
+
+    for quote_no in quotation_model.objects.exclude(
+        quote_no__isnull=True,
+    ).exclude(quote_no="").values_list("quote_no", flat=True):
+        _record_sequence(used_sequences, quote_no)
+    for snapshot in version_model.objects.values_list(
+        "snapshot_json",
+        flat=True,
+    ):
+        if isinstance(snapshot, dict):
+            _record_sequence(used_sequences, snapshot.get("quote_no"))
+
+    drafts = quotation_model.objects.filter(
+        status="draft",
+        numbering_mode="auto",
+    ).exclude(draft_quote_no="").order_by("created_at", "id")
+    for draft_quote_no in drafts.values_list("draft_quote_no", flat=True):
+        _record_sequence(used_sequences, draft_quote_no)
+
+    seen = set()
+    for quotation in drafts.iterator():
+        current = quotation.draft_quote_no.strip()
+        normalized = current.lower()
+        if normalized not in seen:
+            seen.add(normalized)
+            continue
+
+        match = AUTO_NUMBER_PATTERN.match(current)
+        if match:
+            root = match.group(1)
+            root_key = root.lower()
+            used = used_sequences.setdefault(root_key, set())
+            suffix = 1
+            while suffix in used:
+                suffix += 1
+            replacement = f"{root}.{suffix}"
+            used.add(suffix)
+        else:
+            suffix = 1
+            while True:
+                ending = f".{suffix}"
+                replacement = f"{current[:120 - len(ending)]}{ending}"
+                if replacement.lower() not in seen:
+                    break
+                suffix += 1
+
+        quotation.draft_quote_no = replacement
+        quotation.save(update_fields=["draft_quote_no"])
+        seen.add(replacement.lower())
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("quotation", "0032_quotationnote"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            deduplicate_auto_draft_numbers,
+            migrations.RunPython.noop,
+        ),
+        migrations.AddConstraint(
+            model_name="quotation",
+            constraint=models.UniqueConstraint(
+                fields=("draft_quote_no",),
+                condition=(
+                    models.Q(status="draft")
+                    & models.Q(numbering_mode="auto")
+                    & ~models.Q(draft_quote_no="")
+                ),
+                name="quote_draft_auto_no_uniq",
+            ),
+        ),
+    ]

--- a/backend/quotation/models.py
+++ b/backend/quotation/models.py
@@ -609,6 +609,17 @@ class Quotation(TimeStampedModel):
                 name="quote_list_product_name",
             ),
         ]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["draft_quote_no"],
+                condition=(
+                    models.Q(status=QuoteStatus.DRAFT)
+                    & models.Q(numbering_mode=QuotationNumberingMode.AUTO)
+                    & ~models.Q(draft_quote_no="")
+                ),
+                name="quote_draft_auto_no_uniq",
+            ),
+        ]
 
     def delete(self, using=None, keep_parents=False):
         """Lock this quotation before Django collects related artifacts."""

--- a/backend/quotation/services/quotation_service.py
+++ b/backend/quotation/services/quotation_service.py
@@ -385,8 +385,13 @@ def build_quotation(
     return quotation
 
 
-def get_next_auto_quote_number(product_line: str, quote_date) -> str:
-    """Return the next globally unique number for a product line and date."""
+def _get_next_auto_quote_number(
+    product_line: str,
+    quote_date,
+    *,
+    include_drafts: bool,
+) -> str:
+    """Return the next number in one product-line and date sequence."""
     base = (
         f"{str(product_line or 'BDR').strip()}"
         f"{quote_date.day:02d}{quote_date.month:02d}"
@@ -402,12 +407,25 @@ def get_next_auto_quote_number(product_line: str, quote_date) -> str:
         quote_no__isnull=False,
         quote_no__gt="",
     ).exclude(status=QuoteStatus.DRAFT).values_list("quote_no", flat=True)
+    draft_numbers = []
+    if include_drafts:
+        draft_numbers = Quotation.objects.filter(
+            status=QuoteStatus.DRAFT,
+            numbering_mode=QuotationNumberingMode.AUTO,
+        ).exclude(draft_quote_no="").values_list(
+            "draft_quote_no",
+            flat=True,
+        )
     historical_snapshots = QuotationVersion.objects.values_list(
         "snapshot_json",
         flat=True,
     )
     for quote_no in current_numbers:
         match = number_pattern.match(str(quote_no))
+        if match:
+            used_sequences.add(int(match.group(1) or 0))
+    for draft_quote_no in draft_numbers:
+        match = number_pattern.match(str(draft_quote_no))
         if match:
             used_sequences.add(int(match.group(1) or 0))
     for snapshot in historical_snapshots:
@@ -423,6 +441,24 @@ def get_next_auto_quote_number(product_line: str, quote_date) -> str:
     while suffix in used_sequences:
         suffix += 1
     return f"{base}.{suffix}"
+
+
+def get_next_auto_quote_number(product_line: str, quote_date) -> str:
+    """Return the next formal number for a product line and date."""
+    return _get_next_auto_quote_number(
+        product_line,
+        quote_date,
+        include_drafts=False,
+    )
+
+
+def get_next_auto_draft_quote_number(product_line: str, quote_date) -> str:
+    """Return the next preview number, including existing auto drafts."""
+    return _get_next_auto_quote_number(
+        product_line,
+        quote_date,
+        include_drafts=True,
+    )
 
 
 def formalize_quotation(
@@ -495,7 +531,7 @@ def copy_quotation(
 ) -> Quotation:
     """Create an editable draft copy without historical artifacts."""
     copy_date = timezone.localdate()
-    quote_no = get_next_auto_quote_number(
+    quote_no = get_next_auto_draft_quote_number(
         quotation.product_line,
         copy_date,
     )
@@ -619,6 +655,17 @@ def update_quotation(
         if numbering_mode not in QuotationNumberingMode.values:
             raise ValueError("invalid numbering mode")
 
+        draft_scope_changed = (
+            data.get("product_line", locked.product_line)
+            != locked.product_line
+            or data.get("quote_date", locked.quote_date)
+            != locked.quote_date
+        )
+        switched_to_auto = (
+            numbering_mode == QuotationNumberingMode.AUTO
+            and locked.numbering_mode != QuotationNumberingMode.AUTO
+        )
+
         for field in QUOTATION_BUSINESS_FIELDS:
             if field in data:
                 setattr(locked, field, data[field])
@@ -632,8 +679,12 @@ def update_quotation(
         draft_candidate = str(draft_candidate or "").strip()
 
         if target_status == QuoteStatus.DRAFT:
-            if numbering_mode == QuotationNumberingMode.AUTO:
-                draft_candidate = get_next_auto_quote_number(
+            if numbering_mode == QuotationNumberingMode.AUTO and (
+                not locked.draft_quote_no
+                or draft_scope_changed
+                or switched_to_auto
+            ):
+                draft_candidate = get_next_auto_draft_quote_number(
                     data.get("product_line", locked.product_line),
                     data.get("quote_date", locked.quote_date),
                 )

--- a/backend/quotation/test_hardening.py
+++ b/backend/quotation/test_hardening.py
@@ -115,7 +115,7 @@ class QuotationBoundaryTests(TestCase):
         )
         self.assertEqual(second.status_code, 201, second.data)
         self.assertIsNone(second.data["quote_no"])
-        self.assertEqual(second.data["display_quote_no"], "BDR150726")
+        self.assertEqual(second.data["display_quote_no"], "BDR150726.1")
 
         generate = self.api.post(
             f"/api/v1/quotation/quotations/{first.data['id']}/generate",
@@ -132,6 +132,82 @@ class QuotationBoundaryTests(TestCase):
         )
         self.assertEqual(generate_other.status_code, 200, generate_other.data)
         self.assertEqual(generate_other.data["quote_no"], "BDR150726.1")
+
+    def test_editing_auto_draft_preserves_number_until_scope_changes(self):
+        payload = quote_payload("ignored-by-auto-numbering")
+        payload["numbering_mode"] = "auto"
+        first = self.api.post(
+            "/api/v1/quotation/quotations",
+            payload,
+            format="json",
+        )
+        second = self.api.post(
+            "/api/v1/quotation/quotations",
+            payload,
+            format="json",
+        )
+        self.assertEqual(first.data["display_quote_no"], "BDR150726")
+        self.assertEqual(second.data["display_quote_no"], "BDR150726.1")
+
+        edited = self.api.put(
+            f"/api/v1/quotation/quotations/{second.data['id']}",
+            {"project_name": "Edited draft"},
+            format="json",
+        )
+        self.assertEqual(edited.status_code, 200, edited.data)
+        self.assertEqual(edited.data["display_quote_no"], "BDR150726.1")
+
+        moved = self.api.put(
+            f"/api/v1/quotation/quotations/{second.data['id']}",
+            {
+                "quote_date": "2026-07-16",
+                "expire_date": "2026-08-16",
+            },
+            format="json",
+        )
+        self.assertEqual(moved.status_code, 200, moved.data)
+        self.assertEqual(moved.data["display_quote_no"], "BDR160726")
+
+        moved_product = self.api.put(
+            f"/api/v1/quotation/quotations/{second.data['id']}",
+            {"product_line": "CloudX"},
+            format="json",
+        )
+        self.assertEqual(moved_product.status_code, 200, moved_product.data)
+        self.assertEqual(
+            moved_product.data["display_quote_no"],
+            "CloudX160726",
+        )
+
+    def test_formal_numbers_remain_independent_from_draft_order(self):
+        payload = quote_payload("ignored-by-auto-numbering")
+        payload["numbering_mode"] = "auto"
+        first = self.api.post(
+            "/api/v1/quotation/quotations",
+            payload,
+            format="json",
+        )
+        second = self.api.post(
+            "/api/v1/quotation/quotations",
+            payload,
+            format="json",
+        )
+
+        generated_second = self.api.post(
+            f"/api/v1/quotation/quotations/{second.data['id']}/generate",
+            {"numbering_mode": "auto"},
+            format="json",
+        )
+        generated_first = self.api.post(
+            f"/api/v1/quotation/quotations/{first.data['id']}/generate",
+            {"numbering_mode": "auto"},
+            format="json",
+        )
+
+        self.assertEqual(generated_second.status_code, 200)
+        self.assertEqual(generated_second.data["quote_no"], "BDR150726")
+        self.assertEqual(generated_first.status_code, 200)
+        self.assertEqual(generated_first.data["quote_no"], "BDR150726.1")
 
     def test_auto_numbering_reserves_roots_from_formal_revision_history(self):
         payload = quote_payload("ignored-by-auto-numbering")
@@ -748,6 +824,44 @@ class QuotationRollbackTests(TestCase):
 
 class QuotationConcurrencyTests(TransactionTestCase):
     reset_sequences = True
+
+    @skipUnless(
+        connection.vendor == "postgresql",
+        "draft allocation locking requires PostgreSQL",
+    )
+    def test_concurrent_auto_drafts_receive_distinct_numbers(self):
+        users = [
+            User.objects.create_user(
+                username=f"draft-user-{index}",
+                email=f"draft-{index}@example.com",
+                password="password",
+            )
+            for index in range(2)
+        ]
+
+        def create_draft(user):
+            close_old_connections()
+            try:
+                api = APIClient()
+                api.force_authenticate(user=user)
+                payload = quote_payload("ignored-by-auto-numbering")
+                payload["numbering_mode"] = "auto"
+                response = api.post(
+                    "/api/v1/quotation/quotations",
+                    payload,
+                    format="json",
+                )
+                return response.status_code, response.data["display_quote_no"]
+            finally:
+                close_old_connections()
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            results = list(executor.map(create_draft, users))
+
+        assert sorted(results) == [
+            (201, "BDR150726"),
+            (201, "BDR150726.1"),
+        ]
 
     @skipUnless(
         connection.vendor == "postgresql",

--- a/backend/quotation/test_quotation_list.py
+++ b/backend/quotation/test_quotation_list.py
@@ -249,6 +249,44 @@ class QuotationListAPITests(TestCase):
             pk=imported.pk,
         ).count() == 1
 
+    def test_repeated_copy_uses_distinct_draft_numbers_without_revision(self):
+        copied_date = timezone.localdate()
+        base = (
+            f"BDR{copied_date.day:02d}{copied_date.month:02d}"
+            f"{copied_date.year % 100:02d}"
+        )
+        source = self._quote(4, status=QuoteStatus.ACCEPTED)
+        source.quote_no = f"{base}_R1"
+        source.save(update_fields=["quote_no"])
+
+        first = self.api.post(f"{self.url}/{source.pk}/copy")
+        second = self.api.post(f"{self.url}/{source.pk}/copy")
+
+        assert first.status_code == 201
+        assert second.status_code == 201
+        assert first.data["display_quote_no"] == f"{base}.1"
+        assert second.data["display_quote_no"] == f"{base}.2"
+        assert "_R1" not in first.data["display_quote_no"]
+        assert "_R1" not in second.data["display_quote_no"]
+
+    def test_form_context_includes_automatic_draft_numbers(self):
+        draft = self._quote(5)
+        draft.quote_no = None
+        draft.draft_quote_no = "BDR010726.1"
+        draft.numbering_mode = "auto"
+        draft.save(
+            update_fields=[
+                "quote_no",
+                "draft_quote_no",
+                "numbering_mode",
+            ]
+        )
+
+        response = self.api.get(self.form_context_url)
+
+        assert response.status_code == 200
+        assert response.data["quote_numbers"] == ["BDR010726.1"]
+
     def test_invalid_page_and_page_size(self):
         for query in (
             "page=0",

--- a/backend/quotation/views/quotations.py
+++ b/backend/quotation/views/quotations.py
@@ -51,6 +51,7 @@ from quotation.services.quotation_service import (
     build_quotation,
     copy_quotation,
     formalize_quotation,
+    get_next_auto_draft_quote_number,
     get_next_auto_quote_number,
     update_quotation,
 )
@@ -268,17 +269,26 @@ class QuotationListCreateView(APIView):
             draft_quote_no = data.pop("quote_no", "")
         else:
             data.pop("quote_no", None)
-        if numbering_mode == "auto":
-            draft_quote_no = get_next_auto_quote_number(
-                data["product_line"],
-                data["quote_date"],
-            )
         data["quote_no"] = None
-        data["draft_quote_no"] = draft_quote_no or ""
         data["numbering_mode"] = numbering_mode
         items = data.pop("items", [])
-        with transaction.atomic():
-            quotation = build_quotation(data=data, items_data=items)
+        for attempt in range(3):
+            try:
+                with transaction.atomic():
+                    if numbering_mode == "auto":
+                        draft_quote_no = get_next_auto_draft_quote_number(
+                            data["product_line"],
+                            data["quote_date"],
+                        )
+                    data["draft_quote_no"] = draft_quote_no or ""
+                    quotation = build_quotation(data=data, items_data=items)
+                break
+            except IntegrityError:
+                if attempt == 2:
+                    return Response(
+                        {"detail": "could not allocate a quotation draft"},
+                        status=status.HTTP_409_CONFLICT,
+                    )
         quotation = Quotation.objects.prefetch_related(
             "items", "documents__replicas", "versions"
         ).get(pk=quotation.pk)
@@ -325,6 +335,18 @@ class QuotationFormContextView(APIView):
             .exclude(quote_no="")
             .values_list("quote_no", flat=True)
         )
+        draft_quote_numbers = list(
+            filter_accessible_quotations(
+                request.user,
+                Quotation.objects.filter(
+                    status=QuoteStatus.DRAFT,
+                    numbering_mode="auto",
+                ),
+            )
+            .exclude(draft_quote_no="")
+            .values_list("draft_quote_no", flat=True)
+        )
+        quote_numbers.extend(draft_quote_numbers)
         return Response(
             {
                 "items": items,

--- a/frontend/scripts/quotation-draft-numbering.test.mjs
+++ b/frontend/scripts/quotation-draft-numbering.test.mjs
@@ -41,10 +41,14 @@ test('draft payloads keep predicted numbers outside formal quote_no', () => {
   assert.match(app, /draftQuoteNo: ownedQuote\.quoteNo/)
 })
 
-test('draft previews do not participate in frontend formal-number checks', () => {
+test('draft previews participate in frontend draft-number allocation', () => {
   assert.match(
     normalizedCreate,
-    /filter\(\(quote\) => quote\.status !== 'Draft'\)/,
+    /props\.existingQuoteNumbers\.length > 0 .* props\.quotations \.map\(\(quote\) => quote\.quoteNo\)/,
+  )
+  assert.match(
+    normalizedCreate,
+    /if \(draftLifecycleForm\.value && quoteNoMode\.value === 'auto'\) \{ preferDraftQuoteNo\.value = true quoteNo\.value = editingQuote\.quoteNo/,
   )
   assert.match(normalizedCreate, /draftLifecycleForm\.value \|\| quoteNoMode\.value === 'auto'/)
   assert.match(create, /quoteNumberHintDraft/)

--- a/frontend/scripts/quotation-list-detail-drawer.test.mjs
+++ b/frontend/scripts/quotation-list-detail-drawer.test.mjs
@@ -173,3 +173,15 @@ test('English quotation labels use concise CRM terminology', () => {
   assert.doesNotMatch(enLocale, /"tableSalesperson": "Sales rep"/)
   assert.doesNotMatch(enLocale, /"tableQuoteDate": "Date created"/)
 })
+
+test('draft quote numbers carry a localized suffix while formal numbers do not', async () => {
+  const zhLocale = await readFile(
+    new URL('../src/modules/quotation/locales/zh-CN.json', import.meta.url),
+    'utf8'
+  )
+
+  assert.match(list, /quote\.status === 'Draft'/)
+  assert.match(list, /quotation\.pages\.list\.draftSuffix/)
+  assert.match(enLocale, /"draftSuffix": " \(Draft\)"/)
+  assert.match(zhLocale, /"draftSuffix": "（草稿）"/)
+})

--- a/frontend/src/modules/quotation/components/QuotationCreate.vue
+++ b/frontend/src/modules/quotation/components/QuotationCreate.vue
@@ -306,7 +306,6 @@ const existingQuoteNumbers = computed(() =>
   props.existingQuoteNumbers.length > 0
     ? props.existingQuoteNumbers
     : props.quotations
-        .filter((quote) => quote.status !== 'Draft')
         .map((quote) => quote.quoteNo),
 )
 const draftLifecycleForm = computed(
@@ -617,11 +616,8 @@ function loadEditingQuoteIntoForm(editingQuote: Quotation) {
       || getDefaultExpireDate(dateFromInput(quoteDate.value))
     : getDefaultExpireDate(dateFromInput(todayInput))
   if (draftLifecycleForm.value && quoteNoMode.value === 'auto') {
-    quoteNo.value = getNextAutoQuoteNumber(
-      productLine.value,
-      dateFromInput(quoteDate.value),
-      existingQuoteNumbers.value,
-    )
+    preferDraftQuoteNo.value = true
+    quoteNo.value = editingQuote.quoteNo
   } else {
     quoteNo.value = editingQuote.quoteNo
   }

--- a/frontend/src/modules/quotation/components/QuotationList.vue
+++ b/frontend/src/modules/quotation/components/QuotationList.vue
@@ -1273,7 +1273,13 @@ function displayQuoteDate(quote: Quotation): string {
                   class="block truncate whitespace-nowrap font-mono font-semibold text-slate-700 transition group-hover:text-blue-700"
                   :title="quote.quoteNo"
                 >
-                  {{ quote.quoteNo }}
+                  <span>{{ quote.quoteNo }}</span>
+                  <span
+                    v-if="quote.status === 'Draft'"
+                    class="ml-1 font-sans text-xs font-medium text-dm-text-secondary"
+                  >
+                    {{ t('quotation.pages.list.draftSuffix') }}
+                  </span>
                 </p>
                 <p
                   v-if="exportProgressByQuote[quote.id]"

--- a/frontend/src/modules/quotation/locales/en.json
+++ b/frontend/src/modules/quotation/locales/en.json
@@ -282,6 +282,7 @@
         "quoteDateFromLabel": "From",
         "quoteDateToLabel": "To",
         "tableQuoteNo": "Quote number",
+        "draftSuffix": " (Draft)",
         "tableProjectName": "Project",
         "tableCustomer": "Customer",
         "tableContact": "Contact",

--- a/frontend/src/modules/quotation/locales/zh-CN.json
+++ b/frontend/src/modules/quotation/locales/zh-CN.json
@@ -282,6 +282,7 @@
         "quoteDateFromLabel": "从",
         "quoteDateToLabel": "至",
         "tableQuoteNo": "报价单号",
+        "draftSuffix": "（草稿）",
         "tableProjectName": "项目名称",
         "tableCustomer": "客户信息",
         "tableContact": "客户联系人",


### PR DESCRIPTION
## Summary

- Allocate automatic draft numbers from current formal numbers, formal version history, and existing automatic drafts.
- Preserve an existing automatic draft number during ordinary edits and reallocate it only when the product line or quotation date changes.
- Keep formal-number allocation independent from draft creation order and strip revision suffixes when copying revised quotations.
- Add a conditional database uniqueness constraint and migrate existing duplicate automatic draft numbers safely.
- Mark only draft quotation numbers with localized Chinese and English suffixes in the quotation list; formal quotation display remains unchanged.

## Verification

- Backend quotation tests: 50/50 passed.
- PostgreSQL concurrent automatic-draft allocation test: passed.
- Frontend quotation tests: 133/133 passed.
- Frontend typecheck: passed against the synchronized runtime.
- Python compileall: passed.
- git diff --check: passed.
- Chinese and English draft-label behavior verified at http://localhost:18000/quotation/list.

## Manual verification

Verified against the shared local service at http://localhost:18000:

- Repeatedly copying and saving the same formal quotation produced distinct draft numbers.
- Editing an automatic draft preserved its existing number.
- Copying a revised quotation did not inherit its revision suffix.
- Draft rows display the localized draft suffix, while formal rows remain unchanged.

## Known repository-level test note

The quotation-focused suites and checks listed above are green. The full repository test suite was not run. Django makemigrations --check still reports a pre-existing PublicAttachment.id drift unrelated to #360.

Closes #360