### PR TITLE
fix(quotation): preserve precise discounts and signatures

### DIFF
--- a/backend/quotation/migrations/0033_alter_quotationitem_discount_percent.py
+++ b/backend/quotation/migrations/0033_alter_quotationitem_discount_percent.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("quotation", "0032_quotationnote"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="quotationitem",
+            name="discount_percent",
+            field=models.DecimalField(
+                decimal_places=4,
+                default=0,
+                max_digits=7,
+            ),
+        ),
+    ]

--- a/backend/quotation/models.py
+++ b/backend/quotation/models.py
@@ -650,7 +650,7 @@ class QuotationItem(TimeStampedModel):
         max_digits=18, decimal_places=2, default=0
     )
     discount_percent = models.DecimalField(
-        max_digits=5, decimal_places=2, default=0
+        max_digits=7, decimal_places=4, default=0
     )
     net_unit_price = models.DecimalField(
         max_digits=18, decimal_places=2, default=0

--- a/backend/quotation/serializers.py
+++ b/backend/quotation/serializers.py
@@ -379,8 +379,8 @@ class QuotationItemWriteSerializer(serializers.Serializer):
         default=Decimal("0"),
     )
     discount_percent = serializers.DecimalField(
-        max_digits=5,
-        decimal_places=2,
+        max_digits=7,
+        decimal_places=4,
         min_value=Decimal("0"),
         max_value=Decimal("100"),
         default=Decimal("0"),

--- a/backend/quotation/services/export_renderer.py
+++ b/backend/quotation/services/export_renderer.py
@@ -812,20 +812,26 @@ def render_quotation_xlsx(
             return ""
         return format(Decimal(str(value_)).normalize(), "f")
 
-    def numeric_value(value_):
+    def numeric_value(value_, *, decimal_places=2):
         if value_ in (None, ""):
             return None
         rounded = Decimal(str(value_)).quantize(
-            Decimal("0.01"),
+            Decimal(1).scaleb(-decimal_places),
             rounding=ROUND_HALF_UP,
         )
         if rounded == rounded.to_integral():
             return int(rounded)
         return float(rounded)
 
-    def numeric_format(value_, *, grouped=False, suffix=""):
+    def numeric_format(
+        value_,
+        *,
+        decimal_places=2,
+        grouped=False,
+        suffix="",
+    ):
         rounded = Decimal(str(value_ or 0)).quantize(
-            Decimal("0.01"),
+            Decimal(1).scaleb(-decimal_places),
             rounding=ROUND_HALF_UP,
         )
         places = max(-rounded.normalize().as_tuple().exponent, 0)
@@ -1074,7 +1080,10 @@ def render_quotation_xlsx(
                 numeric_value(item.get("qty")) if description else None,
                 money(item.get("list_price")) if description else None,
                 (
-                    numeric_value(item.get("discount_percent") or 0)
+                    numeric_value(
+                        item.get("discount_percent") or 0,
+                        decimal_places=4,
+                    )
                     if description
                     else None
                 ),
@@ -1098,6 +1107,7 @@ def render_quotation_xlsx(
             )
             sheet.cell(row, 5).number_format = numeric_format(
                 item.get("discount_percent"),
+                decimal_places=4,
                 suffix="%",
             )
             for column in (4, 6, 7):

--- a/backend/quotation/test_export_renderer.py
+++ b/backend/quotation/test_export_renderer.py
@@ -128,6 +128,31 @@ class QuotationTemplateRendererTests(TestCase):
         self.assertIn("A35:G35", merged_ranges)
         self.assertEqual(sheet.print_area, "'Quotation'!$A$1:$G$46")
 
+    def test_default_template_preserves_four_decimal_discount(self):
+        template = ensure_default_template()
+        snapshot = {
+            "currency": "MYR",
+            "items": [
+                {
+                    "type": "Software",
+                    "line_no": 1,
+                    "description": "Yearly license",
+                    "qty": "14.00",
+                    "list_price": "1574.07",
+                    "discount_percent": "71.7647",
+                    "net_unit_price": "444.44",
+                    "extended_price": "6222.16",
+                }
+            ],
+        }
+
+        content = render_quotation_xlsx(template, snapshot)
+
+        workbook = load_workbook(io.BytesIO(content), data_only=False)
+        sheet = workbook["Quotation"]
+        self.assertAlmostEqual(sheet["E23"].value, 71.7647)
+        self.assertEqual(sheet["E23"].number_format, '0.0000"%"')
+
     def test_estimates_wrapped_lines_for_long_notes(self):
         notes = "This is a long paragraph that must wrap across the merged notes area."
 

--- a/backend/quotation/test_hardening.py
+++ b/backend/quotation/test_hardening.py
@@ -87,6 +87,36 @@ class QuotationBoundaryTests(TestCase):
         assert Decimal(response.data["vat_amount"]) == Decimal("18.00")
         assert Decimal(response.data["grand_total"]) == Decimal("198.00")
 
+    def test_preserves_four_decimal_discount_percentage(self):
+        payload = quote_payload("QA-HARDEN-PRECISE-DISCOUNT")
+        payload["items"][0].update(
+            {
+                "qty": "14",
+                "list_price": "1574.07",
+                "discount_percent": "71.7647",
+            }
+        )
+
+        response = self.api.post(
+            "/api/v1/quotation/quotations",
+            payload,
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 201, response.data)
+        item = response.data["items"][0]
+        self.assertEqual(
+            Decimal(item["discount_percent"]),
+            Decimal("71.7647"),
+        )
+        self.assertEqual(Decimal(item["net_unit_price"]), Decimal("444.44"))
+        self.assertEqual(
+            Decimal(item["extended_price"]),
+            Decimal("6222.16"),
+        )
+        stored = Quotation.objects.get(pk=response.data["id"]).items.get()
+        self.assertEqual(stored.discount_percent, Decimal("71.7647"))
+
     def test_auto_numbering_is_deferred_until_formal_generation(self):
         first_payload = quote_payload("ignored-by-auto-numbering")
         first_payload["numbering_mode"] = "auto"

--- a/frontend/scripts/quotation-save-no-download.test.mjs
+++ b/frontend/scripts/quotation-save-no-download.test.mjs
@@ -48,6 +48,21 @@ test('saving and generating a quote does not download a file', () => {
   assert.doesNotMatch(chinese.quotation.app.quoteGenerated, /下载/)
 })
 
+test('precise discounts and signatures survive until saving succeeds', () => {
+  const saveStart = app.indexOf('async function handleSaveQuotation')
+  const saveEnd = app.indexOf('async function handleFeishuUploadDone')
+  const saveFlow = app.slice(saveStart, saveEnd)
+  const generateIndex = saveFlow.indexOf('await generateQuotationApi')
+  const clearSignatureIndex = saveFlow.indexOf(
+    'clearCurrentUserSignature(auth.currentUser.email)',
+  )
+
+  assert.match(create, /step="0\.0001"/)
+  assert.doesNotMatch(create, /clearCurrentUserSignature/)
+  assert.ok(generateIndex >= 0)
+  assert.ok(clearSignatureIndex > generateIndex)
+})
+
 test(
   'saving a quote refreshes the numbering context for the next quote',
   () => {

--- a/frontend/src/modules/quotation/App.vue
+++ b/frontend/src/modules/quotation/App.vue
@@ -65,6 +65,7 @@ import {
 import { useAuthStore } from './stores/auth'
 import { useQuotationI18n } from './composables/useQuotationI18n'
 import { saveContactTitle } from './utils/contactTitleStorage'
+import { clearCurrentUserSignature } from './utils/signatureStorage'
 
 const auth = useAuthStore()
 const { t, quoteStatusLabel } = useQuotationI18n()
@@ -685,10 +686,6 @@ async function handleSaveQuotation(newQuote: Quotation) {
         })
       : await createQuotationApi(ownedQuote)
 
-    if (wasCreate) {
-      clearCreateQuoteDraft(auth.currentUser.email)
-    }
-
     saveContactTitle(auth.currentUser.email, ownedQuote.issuerContactTitle)
 
     if (willGenerate) {
@@ -700,6 +697,14 @@ async function handleSaveQuotation(newQuote: Quotation) {
           draftQuoteNo: ownedQuote.quoteNo,
         },
       )
+    }
+
+    if (wasCreate) {
+      clearCreateQuoteDraft(auth.currentUser.email)
+    }
+    clearCurrentUserSignature(auth.currentUser.email)
+
+    if (willGenerate) {
       activeQuote.value = saved
       triggerToast(t('quotation.app.quoteGenerated', { quoteNo: saved.quoteNo }), 'success')
       selectedQuotationId.value = saved.id

--- a/frontend/src/modules/quotation/components/QuotationCreate.vue
+++ b/frontend/src/modules/quotation/components/QuotationCreate.vue
@@ -87,7 +87,7 @@ import {
   getBillingContactOptions,
   getBillingEmailOptions,
 } from '../utils/customerHistory'
-import { clearCurrentUserSignature, rememberUserSignature } from '../utils/signatureStorage'
+import { rememberUserSignature } from '../utils/signatureStorage'
 import { getSavedContactTitle } from '../utils/contactTitleStorage'
 import {
   loadCreateQuoteDraft,
@@ -1327,10 +1327,6 @@ function handleSubmit(status: 'Draft' | 'Generated') {
   }
 
   emit('saveQuote', newQuote)
-  issuerSignature.value = ''
-  if (props.currentUser?.email) {
-    clearCurrentUserSignature(props.currentUser.email)
-  }
 }
 
 function autoItemNumber(index: number, type: ItemType) {
@@ -2130,7 +2126,7 @@ const itemErrorEntries = computed(() =>
                       type="number"
                       min="0"
                       max="100"
-                      step="0.01"
+                      step="0.0001"
                       :value="item.discountPercent || ''"
                       placeholder="0"
                       class="w-full rounded-lg border border-dm-border bg-white p-2 font-mono text-dm-text focus:border-blue-500 focus:outline-hidden"


### PR DESCRIPTION
## Summary

- preserve quotation item discounts with four decimal places end to end, including API validation, database storage, and Excel export
- allow precise discount input without changing the existing Quote Desk layout or behavior
- clear draft context and issuer signatures only after quotation save/generation succeeds, so failed saves keep the user’s work intact

## Test plan

- [x] Quotation backend tests (413/413)
- [x] Quotation frontend tests (133/133)
- [x] Frontend TypeScript typecheck
- [x] Frontend production build
- [x] `git diff --check`
- [x] Verified create/read/delete API flow with `71.7647%` discount, `444.44` net unit price, and `6222.16` extended price

## Merge note

This PR is prioritized ahead of open quotation PR #363. Both branches currently have a `0033` Django migration derived from `0032`; after this PR merges, #363 should be rebased and its migration history reconciled before merging.
