### PR TITLE
fix(quotation): merge conflicting migration heads

### DIFF
--- a/backend/quotation/migrations/0034_merge_quotation_heads.py
+++ b/backend/quotation/migrations/0034_merge_quotation_heads.py
@@ -1,0 +1,10 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("quotation", "0033_alter_quotationitem_discount_percent"),
+        ("quotation", "0033_unique_auto_draft_quote_number"),
+    ]
+
+    operations = []

--- a/backend/quotation/test_migration_graph.py
+++ b/backend/quotation/test_migration_graph.py
@@ -1,0 +1,14 @@
+from django.db import connection
+from django.db.migrations.loader import MigrationLoader
+from django.test import SimpleTestCase
+
+
+class QuotationMigrationGraphTests(SimpleTestCase):
+    databases = {"default"}
+
+    def test_quotation_migrations_have_one_leaf(self):
+        loader = MigrationLoader(connection, ignore_no_migrations=True)
+
+        leaves = loader.graph.leaf_nodes("quotation")
+
+        self.assertEqual(len(leaves), 1, leaves)


### PR DESCRIPTION
## Summary\n\n- Add a no-op quotation merge migration that joins the two migrations currently numbered 0033.\n- Restore a single quotation migration leaf after PR #363 was merged alongside the discount-precision migration.\n- Add a regression test that fails whenever the quotation app has more than one migration leaf.\n\n## Deployment compatibility\n\n- Databases with neither parent applied will run both parent migrations before the merge.\n- Databases with one parent applied will run the remaining parent before the merge.\n- Databases with both parents applied will only record the no-op merge migration.\n- The merge migration contains no schema or data operation.\n\n## Verification\n\n- [x] Django migration conflict check\n- [x] Quotation migration leaf regression test on SQLite\n- [x] Quotation migration leaf regression test on PostgreSQL\n- [x] Full empty-database migration on SQLite\n- [x] Python compileall\n- [x] git diff --check\n\n## Notes\n\n- Follow-up deployment fix for #360 and #363.\n- Fixes the migration graph conflict observed in the failed v1.43.0 deployment run: https://github.com/HyperBDR/devmind/actions/runs/33739632443\n