### PR TITLE
fix(quotation): order draft number migration

### DIFF
--- a/backend/quotation/migrations/0034_unique_auto_draft_quote_number.py
+++ b/backend/quotation/migrations/0034_unique_auto_draft_quote_number.py
@@ -76,7 +76,7 @@ def deduplicate_auto_draft_numbers(apps, schema_editor):
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("quotation", "0032_quotationnote"),
+        ("quotation", "0033_alter_quotationitem_discount_percent"),
     ]
 
     operations = [

--- a/backend/quotation/test_migration_graph.py
+++ b/backend/quotation/test_migration_graph.py
@@ -1,0 +1,14 @@
+from django.db import connection
+from django.db.migrations.loader import MigrationLoader
+from django.test import SimpleTestCase
+
+
+class QuotationMigrationGraphTests(SimpleTestCase):
+    databases = {"default"}
+
+    def test_quotation_migrations_have_one_leaf(self):
+        loader = MigrationLoader(connection, ignore_no_migrations=True)
+
+        leaves = loader.graph.leaf_nodes("quotation")
+
+        self.assertEqual(len(leaves), 1, leaves)


### PR DESCRIPTION
## Summary\n\n- Rename the duplicate-numbered quotation migration from 0033_unique_auto_draft_quote_number to 0034_unique_auto_draft_quote_number.\n- Make the renamed 0034 migration depend on 0033_alter_quotationitem_discount_percent, producing one linear migration chain.\n- Add a regression test that requires the quotation app to have exactly one migration leaf.\n\n## Migration order\n\n0032_quotationnote\n→ 0033_alter_quotationitem_discount_percent\n→ 0034_unique_auto_draft_quote_number\n\nThe failed v1.43.0 deployment stopped while Django was building the migration graph, before either conflicting 0033 migration was applied. This change contains no empty merge migration.\n\n## Verification\n\n- [x] Quotation migration graph test on PostgreSQL\n- [x] Clean-database migration and migration graph test on SQLite\n- [x] Upgrade from quotation 0032 applies 0033 and then 0034 successfully\n- [x] Quotation backend tests (30/30)\n- [x] Python compileall\n- [x] git diff --check\n\n## Notes\n\n- Supersedes the closed PR #366.\n- Follow-up for #360 and #363.\n- Failed deployment run: https://github.com/HyperBDR/devmind/actions/runs/33739632443\n- Django makemigrations --check still reports pre-existing PublicAttachment and SALS model drift unrelated to this change.\n